### PR TITLE
Add mobile-first offline “Suivi Matériel” web app (3 pages, localStorage CRUD, responsive UI)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,413 @@
+:root {
+  --bg: #f4f7fb;
+  --surface: #ffffff;
+  --surface-muted: #eef3f8;
+  --primary: #59b8ff;
+  --primary-dark: #278dda;
+  --text: #1f2a37;
+  --text-muted: #6b7280;
+  --success: #21b66f;
+  --danger: #e5484d;
+  --border: #d8e2ec;
+  --shadow: 0 10px 30px rgba(31, 42, 55, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #e9f6ff 0%, var(--bg) 30%, var(--bg) 100%);
+  color: var(--text);
+  font-family: "Roboto", sans-serif;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell--wide {
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.app-header {
+  min-height: 8vh;
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  color: #fff;
+  box-shadow: var(--shadow);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.4rem, 5vw, 2rem);
+  text-align: center;
+}
+
+.app-header--detail {
+  justify-content: flex-start;
+  gap: 1rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.25rem;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.85rem;
+}
+
+.back-button,
+.icon-button {
+  border: 0;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
+}
+
+.page-content {
+  flex: 1;
+  padding: 1rem 1rem 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.page-content--wide {
+  padding-bottom: 2rem;
+}
+
+.surface-card,
+.list-card,
+.modal-content {
+  background: var(--surface);
+  border: 1px solid rgba(216, 226, 236, 0.7);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+}
+
+.surface-card,
+.form-card,
+.table-card,
+.search-panel {
+  padding: 1rem;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-heading h2,
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.section-heading p,
+.modal-header p {
+  margin: 0.3rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.input-group span {
+  font-size: 0.92rem;
+  color: var(--text-muted);
+}
+
+.input-group input,
+.input-group select,
+.cell-input,
+.cell-textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 0.85rem 0.95rem;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-group input:focus,
+.input-group select:focus,
+.cell-input:focus,
+.cell-textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(89, 184, 255, 0.18);
+}
+
+.list-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.list-card {
+  padding: 1rem;
+  background: linear-gradient(160deg, #59b8ff 0%, #2b90dc 100%);
+  color: #fff;
+}
+
+.list-card__button {
+  border: 0;
+  background: transparent;
+  width: 100%;
+  padding: 0;
+  color: inherit;
+  text-align: left;
+}
+
+.list-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+}
+
+.list-card__meta {
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.88rem;
+}
+
+.list-card__meta small {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.list-card__actions {
+  margin-top: 0.9rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn,
+.btn-danger {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.8rem 1.25rem;
+  font-weight: 700;
+}
+
+.btn-success {
+  color: #fff;
+  background: var(--success);
+}
+
+.btn-danger {
+  color: #fff;
+  background: var(--danger);
+  padding: 0.7rem 1rem;
+}
+
+.btn-ghost {
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+
+.fab {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.5rem;
+  width: 4rem;
+  height: 4rem;
+  border: 0;
+  border-radius: 50%;
+  background: #fff;
+  color: var(--primary-dark);
+  font-size: 2rem;
+  box-shadow: 0 12px 25px rgba(39, 141, 218, 0.28);
+}
+
+.modal-card {
+  width: min(92vw, 28rem);
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.modal-card::backdrop {
+  background: rgba(15, 23, 42, 0.44);
+}
+
+.modal-content {
+  padding: 1rem;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.modal-actions,
+.form-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.form-footer {
+  grid-column: 1 / -1;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.form-error {
+  min-height: 1.2rem;
+  margin: 0.4rem 0 0;
+  color: var(--danger);
+  font-size: 0.9rem;
+}
+
+.empty-state {
+  padding: 1.25rem;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.responsive-form {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.input-group--wide {
+  grid-column: 1 / -1;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  min-width: 1100px;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.85rem 0.6rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.data-table th {
+  position: sticky;
+  top: 0;
+  background: var(--surface-muted);
+  z-index: 1;
+}
+
+.field-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  background: rgba(89, 184, 255, 0.18);
+  color: var(--primary-dark);
+  font-weight: 700;
+}
+
+.cell-input,
+.cell-textarea {
+  min-width: 8rem;
+  padding: 0.7rem 0.8rem;
+}
+
+.cell-textarea {
+  min-height: 5rem;
+  resize: vertical;
+}
+
+.readonly-value,
+.meta-value {
+  display: inline-block;
+  min-width: 6rem;
+  padding: 0.75rem 0.2rem;
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 1rem;
+  transform: translate(-50%, 110%);
+  background: #111827;
+  color: #fff;
+  padding: 0.8rem 1rem;
+  border-radius: 999px;
+  opacity: 0;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.toast--visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (min-width: 768px) {
+  .page-content {
+    padding: 1.5rem 1.5rem 7rem;
+  }
+
+  .list-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .responsive-form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,1 +1,59 @@
- 
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body data-page="home">
+    <div class="app-shell">
+      <header class="app-header">
+        <h1>Suivi Matériel</h1>
+      </header>
+
+      <main class="page-content">
+        <section class="search-panel surface-card">
+          <label class="input-group">
+            <span class="sr-only">Recherche</span>
+            <input id="searchInput" type="search" placeholder="Recherche..." autocomplete="off" />
+          </label>
+        </section>
+
+        <section class="section-heading">
+          <div>
+            <h2>Sites enregistrés</h2>
+            <p id="siteCount">0 site</p>
+          </div>
+        </section>
+
+        <section id="siteList" class="list-grid" aria-live="polite"></section>
+      </main>
+
+      <button id="openCreateSite" class="fab" type="button" aria-label="Créer un site">+</button>
+
+      <dialog id="siteDialog" class="modal-card">
+        <form method="dialog" class="modal-content" id="siteForm">
+          <div class="modal-header">
+            <h2>Entrer nom du site</h2>
+            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
+          </div>
+          <label class="input-group">
+            <span>Nom du site</span>
+            <input id="siteNameInput" name="siteName" type="text" maxlength="80" />
+          </label>
+          <p id="siteFormError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions">
+            <button type="submit" class="btn btn-success">Créer</button>
+          </div>
+        </form>
+      </dialog>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script src="js/app.js"></script>
+  </body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,323 @@
+(function () {
+  const { StorageService, UiService } = window;
+
+  function requireElement(id) {
+    return document.getElementById(id);
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function setCountText(element, count, singular, plural) {
+    element.textContent = `${count} ${count > 1 ? plural : singular}`;
+  }
+
+  function setupBackButtons() {
+    document.querySelectorAll("[data-back]").forEach((button) => {
+      button.addEventListener("click", () => {
+        UiService.navigate(button.dataset.back);
+      });
+    });
+  }
+
+  function initHomePage() {
+    const searchInput = requireElement("searchInput");
+    const siteList = requireElement("siteList");
+    const siteCount = requireElement("siteCount");
+    const siteDialog = requireElement("siteDialog");
+    const siteForm = requireElement("siteForm");
+    const siteNameInput = requireElement("siteNameInput");
+    const siteFormError = requireElement("siteFormError");
+
+    function renderSites() {
+      const query = searchInput.value.trim().toUpperCase();
+      const sites = StorageService.getSites().filter((site) => site.nom.includes(query));
+      setCountText(siteCount, sites.length, "site", "sites");
+
+      if (!sites.length) {
+        UiService.renderEmptyState(
+          siteList,
+          query ? "Aucun site ne correspond à votre recherche." : "Aucun site enregistré pour le moment.",
+        );
+        return;
+      }
+
+      siteList.innerHTML = sites
+        .map(
+          (site) => `
+            <article class="list-card">
+              <button class="list-card__button" type="button" data-site-open="${site.id}">
+                <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
+                <div class="list-card__meta">
+                  <span>Créé le ${UiService.formatDate(site.dateCreation)}</span>
+                  <small>Modifié le ${UiService.formatDate(site.dateModification)}</small>
+                  <small>${site.items.length} sous-élément(s)</small>
+                </div>
+              </button>
+              <div class="list-card__actions">
+                <button class="btn-danger" type="button" data-site-delete="${site.id}">Supprimer</button>
+              </div>
+            </article>
+          `,
+        )
+        .join("");
+
+      siteList.querySelectorAll("[data-site-open]").forEach((button) => {
+        button.addEventListener("click", () => {
+          UiService.navigate(`page2.html?siteId=${encodeURIComponent(button.dataset.siteOpen)}`);
+        });
+      });
+
+      siteList.querySelectorAll("[data-site-delete]").forEach((button) => {
+        button.addEventListener("click", () => {
+          StorageService.removeSite(button.dataset.siteDelete);
+          UiService.showToast("Site supprimé.");
+          renderSites();
+        });
+      });
+    }
+
+    requireElement("openCreateSite").addEventListener("click", () => {
+      siteForm.reset();
+      siteFormError.textContent = "";
+      siteDialog.showModal();
+      siteNameInput.focus();
+    });
+
+    searchInput.addEventListener("input", renderSites);
+
+    siteForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const name = siteNameInput.value.trim();
+      if (!name) {
+        siteFormError.textContent = "Veuillez remplir ce champ";
+        return;
+      }
+      StorageService.createSite(name);
+      siteDialog.close();
+      UiService.showToast("Site créé avec succès.");
+      renderSites();
+    });
+
+    renderSites();
+  }
+
+  function initSiteDetailPage() {
+    const params = UiService.getQueryParams();
+    const siteId = params.get("siteId");
+    const site = StorageService.getSite(siteId);
+    if (!site) {
+      UiService.navigate("index.html");
+      return;
+    }
+
+    const siteTitle = requireElement("siteTitle");
+    const itemList = requireElement("itemList");
+    const itemCount = requireElement("itemCount");
+    const itemDialog = requireElement("itemDialog");
+    const itemForm = requireElement("itemForm");
+    const itemNumberInput = requireElement("itemNumberInput");
+    const itemFormError = requireElement("itemFormError");
+
+    siteTitle.textContent = site.nom;
+
+    function renderItems() {
+      const nextSite = StorageService.getSite(siteId);
+      if (!nextSite) {
+        UiService.navigate("index.html");
+        return;
+      }
+
+      setCountText(itemCount, nextSite.items.length, "élément", "éléments");
+
+      if (!nextSite.items.length) {
+        UiService.renderEmptyState(itemList, "Aucun sous-élément pour cette liste.");
+        return;
+      }
+
+      itemList.innerHTML = nextSite.items
+        .map(
+          (item) => `
+            <article class="list-card">
+              <button class="list-card__button" type="button" data-item-open="${item.id}">
+                <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
+                <div class="list-card__meta">
+                  <span>Créé le ${UiService.formatDate(item.dateCreation)}</span>
+                  <small>Modifié le ${UiService.formatDate(item.dateModification)}</small>
+                  <small>${item.details.length} ligne(s)</small>
+                </div>
+              </button>
+              <div class="list-card__actions">
+                <button class="btn-danger" type="button" data-item-delete="${item.id}">Supprimer</button>
+              </div>
+            </article>
+          `,
+        )
+        .join("");
+
+      itemList.querySelectorAll("[data-item-open]").forEach((button) => {
+        button.addEventListener("click", () => {
+          UiService.navigate(
+            `page3.html?siteId=${encodeURIComponent(siteId)}&itemId=${encodeURIComponent(button.dataset.itemOpen)}`,
+          );
+        });
+      });
+
+      itemList.querySelectorAll("[data-item-delete]").forEach((button) => {
+        button.addEventListener("click", () => {
+          StorageService.removeItem(siteId, button.dataset.itemDelete);
+          UiService.showToast("Élément supprimé.");
+          renderItems();
+        });
+      });
+    }
+
+    requireElement("openCreateItem").addEventListener("click", () => {
+      itemForm.reset();
+      itemFormError.textContent = "";
+      itemDialog.showModal();
+      itemNumberInput.focus();
+    });
+
+    itemForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const value = itemNumberInput.value.trim();
+      if (!value) {
+        itemFormError.textContent = "Veuillez remplir ce champ";
+        return;
+      }
+      StorageService.createItem(siteId, value);
+      itemDialog.close();
+      UiService.showToast("Numéro OUT ajouté.");
+      renderItems();
+    });
+
+    renderItems();
+  }
+
+  function initItemDetailPage() {
+    const params = UiService.getQueryParams();
+    const siteId = params.get("siteId");
+    const itemId = params.get("itemId");
+    const site = StorageService.getSite(siteId);
+    const item = StorageService.getItem(siteId, itemId);
+
+    if (!site || !item) {
+      UiService.navigate("index.html");
+      return;
+    }
+
+    requireElement("itemTitle").textContent = `${site.nom} · ${item.numero}`;
+    requireElement("itemBackButton").addEventListener("click", () => {
+      UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
+    });
+
+    const detailForm = requireElement("detailForm");
+    const detailFormError = requireElement("detailFormError");
+    const detailCount = requireElement("detailCount");
+    const detailTableBody = requireElement("detailTableBody");
+
+    function renderTable() {
+      const nextItem = StorageService.getItem(siteId, itemId);
+      if (!nextItem) {
+        UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
+        return;
+      }
+
+      setCountText(detailCount, nextItem.details.length, "ligne", "lignes");
+
+      if (!nextItem.details.length) {
+        detailTableBody.innerHTML = `<tr><td colspan="11"><div class="empty-state">Aucune ligne enregistrée.</div></td></tr>`;
+        return;
+      }
+
+      detailTableBody.innerHTML = nextItem.details
+        .map(
+          (detail) => `
+            <tr data-detail-id="${detail.id}">
+              <td><span class="field-badge">${detail.champ}</span></td>
+              <td><input class="cell-input" data-field="code" value="${escapeHtml(detail.code)}" /></td>
+              <td><input class="cell-input" data-field="designation" value="${escapeHtml(detail.designation)}" /></td>
+              <td>
+                <div>
+                  <input class="cell-input" data-field="qteSortie" type="number" min="0" step="1" value="${detail.qteSortie}" />
+                  <small class="meta-value">${escapeHtml(detail.unite)}</small>
+                </div>
+              </td>
+              <td><input class="cell-input" data-field="qteHorsBtrs" type="number" min="0" step="1" value="${detail.qteHorsBtrs}" placeholder="N/A" /></td>
+              <td><span class="readonly-value">${detail.qtePosee}</span></td>
+              <td><input class="cell-input" data-field="qteRetour" type="number" min="0" step="1" value="${detail.qteRetour}" /></td>
+              <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
+              <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
+              <td><textarea class="cell-textarea" data-field="observation">${escapeHtml(detail.observation)}</textarea></td>
+              <td><button class="btn-danger" type="button" data-detail-delete="${detail.id}">Supprimer</button></td>
+            </tr>
+          `,
+        )
+        .join("");
+
+      detailTableBody.querySelectorAll("[data-field]").forEach((field) => {
+        field.addEventListener("change", (event) => {
+          const row = event.target.closest("tr");
+          const fieldName = event.target.dataset.field;
+          StorageService.updateDetail(siteId, itemId, row.dataset.detailId, {
+            [fieldName]: event.target.value,
+          });
+          renderTable();
+        });
+      });
+
+      detailTableBody.querySelectorAll("[data-detail-delete]").forEach((button) => {
+        button.addEventListener("click", () => {
+          StorageService.removeDetail(siteId, itemId, button.dataset.detailDelete);
+          UiService.showToast("Ligne supprimée.");
+          renderTable();
+        });
+      });
+    }
+
+    detailForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const formData = new FormData(detailForm);
+      const payload = Object.fromEntries(formData.entries());
+
+      if (!payload.code || !payload.designation || payload.qteSortie === "") {
+        detailFormError.textContent = "Veuillez remplir tous les champs obligatoires.";
+        return;
+      }
+
+      StorageService.createDetail(siteId, itemId, payload);
+      detailForm.reset();
+      requireElement("uniteInput").value = "m";
+      detailFormError.textContent = "";
+      UiService.showToast("Ligne enregistrée.");
+      renderTable();
+    });
+
+    renderTable();
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    UiService.bindDialogCloser();
+    setupBackButtons();
+    const page = document.body.dataset.page;
+
+    if (page === "home") {
+      initHomePage();
+      return;
+    }
+    if (page === "site-detail") {
+      initSiteDetailPage();
+      return;
+    }
+    if (page === "item-detail") {
+      initItemDetailPage();
+    }
+  });
+})();

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,211 @@
+(function () {
+  const STORAGE_KEY = "suivi-materiel-data";
+
+  function safeTrim(value) {
+    return String(value || "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function sanitizeText(value, uppercase) {
+    const cleaned = safeTrim(value).replace(/[<>]/g, "");
+    return uppercase ? cleaned.toUpperCase() : cleaned;
+  }
+
+  function sanitizeNumber(value) {
+    if (value === "" || value === null || value === undefined) {
+      return "";
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+  }
+
+  function now() {
+    return new Date().toISOString();
+  }
+
+  function uid() {
+    return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+  }
+
+  function readState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      return [];
+    }
+  }
+
+  function writeState(state) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    return state;
+  }
+
+  function getSites() {
+    return readState();
+  }
+
+  function createSite(name) {
+    const siteName = sanitizeText(name, true);
+    const timestamp = now();
+    const site = {
+      id: uid(),
+      nom: siteName,
+      dateCreation: timestamp,
+      dateModification: timestamp,
+      items: [],
+    };
+    const state = readState();
+    state.unshift(site);
+    writeState(state);
+    return site;
+  }
+
+  function removeSite(siteId) {
+    const next = readState().filter((site) => site.id !== siteId);
+    writeState(next);
+  }
+
+  function getSite(siteId) {
+    return readState().find((site) => site.id === siteId) || null;
+  }
+
+  function createItem(siteId, numberValue) {
+    const state = readState();
+    const site = state.find((entry) => entry.id === siteId);
+    if (!site) {
+      return null;
+    }
+    const timestamp = now();
+    const cleanNumber = sanitizeText(numberValue, true).replace(/^OUT-/, "");
+    const item = {
+      id: uid(),
+      numero: `OUT-${cleanNumber}`,
+      dateCreation: timestamp,
+      dateModification: timestamp,
+      details: [],
+    };
+    site.items.unshift(item);
+    site.dateModification = timestamp;
+    writeState(state);
+    return item;
+  }
+
+  function removeItem(siteId, itemId) {
+    const state = readState();
+    const site = state.find((entry) => entry.id === siteId);
+    if (!site) {
+      return;
+    }
+    site.items = site.items.filter((item) => item.id !== itemId);
+    site.dateModification = now();
+    writeState(state);
+  }
+
+  function getItem(siteId, itemId) {
+    const site = getSite(siteId);
+    if (!site) {
+      return null;
+    }
+    return site.items.find((item) => item.id === itemId) || null;
+  }
+
+  function createDetail(siteId, itemId, payload) {
+    const state = readState();
+    const site = state.find((entry) => entry.id === siteId);
+    const item = site && site.items.find((entry) => entry.id === itemId);
+    if (!site || !item) {
+      return null;
+    }
+    const timestamp = now();
+    const detail = {
+      id: uid(),
+      champ: item.details.length + 1,
+      code: sanitizeText(payload.code, true),
+      designation: sanitizeText(payload.designation, false),
+      qteSortie: sanitizeNumber(payload.qteSortie),
+      unite: sanitizeText(payload.unite || "m", false) || "m",
+      qteHorsBtrs: "",
+      qteRetour: 0,
+      qtePosee: sanitizeNumber(payload.qteSortie),
+      observation: "",
+      dateCreation: timestamp,
+      dateModification: timestamp,
+    };
+    item.details.push(detail);
+    item.dateModification = timestamp;
+    site.dateModification = timestamp;
+    writeState(state);
+    return detail;
+  }
+
+  function updateDetail(siteId, itemId, detailId, changes) {
+    const state = readState();
+    const site = state.find((entry) => entry.id === siteId);
+    const item = site && site.items.find((entry) => entry.id === itemId);
+    const detail = item && item.details.find((entry) => entry.id === detailId);
+    if (!site || !item || !detail) {
+      return null;
+    }
+
+    if ("code" in changes) {
+      detail.code = sanitizeText(changes.code, true);
+    }
+    if ("designation" in changes) {
+      detail.designation = sanitizeText(changes.designation, false);
+    }
+    if ("qteSortie" in changes) {
+      detail.qteSortie = sanitizeNumber(changes.qteSortie);
+    }
+    if ("unite" in changes) {
+      detail.unite = sanitizeText(changes.unite, false) || "m";
+    }
+    if ("qteHorsBtrs" in changes) {
+      detail.qteHorsBtrs = changes.qteHorsBtrs === "" ? "" : sanitizeNumber(changes.qteHorsBtrs);
+    }
+    if ("qteRetour" in changes) {
+      detail.qteRetour = sanitizeNumber(changes.qteRetour);
+    }
+    if ("observation" in changes) {
+      detail.observation = sanitizeText(changes.observation, false);
+    }
+
+    detail.qtePosee = Math.max(0, sanitizeNumber(detail.qteSortie) - sanitizeNumber(detail.qteRetour));
+    detail.dateModification = now();
+    item.dateModification = detail.dateModification;
+    site.dateModification = detail.dateModification;
+    writeState(state);
+    return detail;
+  }
+
+  function removeDetail(siteId, itemId, detailId) {
+    const state = readState();
+    const site = state.find((entry) => entry.id === siteId);
+    const item = site && site.items.find((entry) => entry.id === itemId);
+    if (!site || !item) {
+      return;
+    }
+    item.details = item.details
+      .filter((detail) => detail.id !== detailId)
+      .map((detail, index) => ({ ...detail, champ: index + 1 }));
+    const timestamp = now();
+    item.dateModification = timestamp;
+    site.dateModification = timestamp;
+    writeState(state);
+  }
+
+  window.StorageService = {
+    getSites,
+    getSite,
+    createSite,
+    removeSite,
+    createItem,
+    getItem,
+    removeItem,
+    createDetail,
+    updateDetail,
+    removeDetail,
+  };
+})();

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,53 @@
+(function () {
+  function formatDate(dateValue) {
+    if (!dateValue) {
+      return "--";
+    }
+    return new Intl.DateTimeFormat("fr-FR", {
+      dateStyle: "short",
+      timeStyle: "short",
+    }).format(new Date(dateValue));
+  }
+
+  function getQueryParams() {
+    return new URLSearchParams(window.location.search);
+  }
+
+  function showToast(message) {
+    const toast = document.getElementById("toast");
+    if (!toast) {
+      return;
+    }
+    toast.textContent = message;
+    toast.classList.add("toast--visible");
+    window.clearTimeout(showToast.timeoutId);
+    showToast.timeoutId = window.setTimeout(() => {
+      toast.classList.remove("toast--visible");
+    }, 2200);
+  }
+
+  function renderEmptyState(container, message) {
+    container.innerHTML = `<div class="empty-state">${message}</div>`;
+  }
+
+  function bindDialogCloser() {
+    document.querySelectorAll("[data-close-dialog]").forEach((button) => {
+      button.addEventListener("click", () => {
+        button.closest("dialog")?.close();
+      });
+    });
+  }
+
+  function navigate(url) {
+    window.location.href = url;
+  }
+
+  window.UiService = {
+    formatDate,
+    getQueryParams,
+    showToast,
+    renderEmptyState,
+    bindDialogCloser,
+    navigate,
+  };
+})();

--- a/page2.html
+++ b/page2.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Détail liste - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body data-page="site-detail">
+    <div class="app-shell">
+      <header class="app-header app-header--detail">
+        <button class="back-button" type="button" data-back="index.html" aria-label="Retour">←</button>
+        <div>
+          <p class="eyebrow">Liste sélectionnée</p>
+          <h1 id="siteTitle">Chargement...</h1>
+        </div>
+      </header>
+
+      <main class="page-content">
+        <section class="section-heading">
+          <div>
+            <h2>Sous-éléments</h2>
+            <p id="itemCount">0 élément</p>
+          </div>
+        </section>
+
+        <section id="itemList" class="list-grid" aria-live="polite"></section>
+      </main>
+
+      <button id="openCreateItem" class="fab" type="button" aria-label="Ajouter un numéro OUT">+</button>
+
+      <dialog id="itemDialog" class="modal-card">
+        <form method="dialog" class="modal-content" id="itemForm">
+          <div class="modal-header">
+            <h2>N° OUT-</h2>
+            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
+          </div>
+          <label class="input-group">
+            <span>Numéro</span>
+            <input id="itemNumberInput" name="itemNumber" type="text" maxlength="40" placeholder="001" />
+          </label>
+          <p id="itemFormError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions">
+            <button type="submit" class="btn btn-success">Créer</button>
+          </div>
+        </form>
+      </dialog>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script src="js/app.js"></script>
+  </body>
+</html>

--- a/page3.html
+++ b/page3.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Détail complet - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body data-page="item-detail">
+    <div class="app-shell app-shell--wide">
+      <header class="app-header app-header--detail">
+        <button class="back-button" type="button" id="itemBackButton" aria-label="Retour">←</button>
+        <div>
+          <p class="eyebrow">Détail complet</p>
+          <h1 id="itemTitle">Chargement...</h1>
+        </div>
+      </header>
+
+      <main class="page-content page-content--wide">
+        <section class="surface-card form-card">
+          <div class="section-heading">
+            <div>
+              <h2>Ajouter une ligne</h2>
+              <p>Enregistrement local automatique après création et modification.</p>
+            </div>
+          </div>
+
+          <form id="detailForm" class="responsive-form" novalidate>
+            <label class="input-group">
+              <span>Code</span>
+              <input id="codeInput" name="code" type="text" maxlength="40" required />
+            </label>
+            <label class="input-group input-group--wide">
+              <span>Désignation</span>
+              <input id="designationInput" name="designation" type="text" maxlength="120" required />
+            </label>
+            <label class="input-group">
+              <span>Qté Sortie</span>
+              <input id="qteSortieInput" name="qteSortie" type="number" min="0" step="1" required />
+            </label>
+            <label class="input-group">
+              <span>Unité</span>
+              <select id="uniteInput" name="unite">
+                <option value="m">m</option>
+                <option value="Pcs">Pcs</option>
+              </select>
+            </label>
+            <div class="form-footer">
+              <p id="detailFormError" class="form-error" aria-live="polite"></p>
+              <button type="submit" class="btn btn-success">Enregistrer</button>
+            </div>
+          </form>
+        </section>
+
+        <section class="surface-card table-card">
+          <div class="section-heading">
+            <div>
+              <h2>Tableau des données</h2>
+              <p id="detailCount">0 ligne</p>
+            </div>
+          </div>
+          <div class="table-wrapper">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Champ</th>
+                  <th>Code</th>
+                  <th>Désignation</th>
+                  <th>Qté Sortie</th>
+                  <th>Qté hors BTRS</th>
+                  <th>Qté posée</th>
+                  <th>Qté Retour</th>
+                  <th>Date création</th>
+                  <th>Date modification</th>
+                  <th>Observation</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody id="detailTableBody"></tbody>
+            </table>
+          </div>
+        </section>
+      </main>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script src="js/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a lightweight, mobile-first (Android-optimized) web app to create and manage matériel lists fully offline without a backend using localStorage.
- Offer a modern, responsive UI with dialogs, floating action buttons and an editable data table to meet the requested UX and workflow for sites → OUT items → detail rows.

### Description
- Added three pages: `index.html` (site list + search + create), `page2.html` (site detail with OUT items) and `page3.html` (item detail with form + editable table).
- Added `css/style.css` implementing the Material-inspired responsive design, cards, FAB, dialogs, and table styles.
- Implemented `js/storage.js` with a `StorageService` providing a localStorage-backed JSON model and full CRUD for sites, items and detail rows, including sanitization, UID generation, ISO timestamps, and automatic `qtePosee` calculation.
- Implemented `js/ui.js` with small UI helpers (`formatDate`, toast, empty-state renderer, dialog closer and navigation) and `js/app.js` wiring UI behavior: search, dialogs, validation, navigation between pages, table rendering and inline editing; added `escapeHtml` and switched to `change` events for stable saves.

### Testing
- Performed JavaScript syntax checks with `node --check js/storage.js && node --check js/ui.js && node --check js/app.js`, which completed successfully.
- Performed a smoke test by serving the project with a simple HTTP server and requesting `index.html`, which returned an HTTP 200 response confirming files are servable.
- No automated unit tests were included in this change set. Manual UI and workflow testing is recommended in a browser or on an Android device to validate UX and localStorage behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bae5e90b74832a8ed5145260720fc2)