### PR TITLE
Restrict OUT numbers to digits; default Qté posée=0; move search into table card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -333,6 +333,10 @@ button {
   max-width: 28rem;
 }
 
+.search-panel--inline {
+  padding-inline: 0;
+}
+
 .table-wrapper {
   overflow-x: auto;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -185,6 +185,13 @@
       itemNumberInput.focus();
     });
 
+    itemNumberInput.addEventListener("input", () => {
+      const digitsOnly = itemNumberInput.value.replace(/\D/g, "");
+      if (itemNumberInput.value !== digitsOnly) {
+        itemNumberInput.value = digitsOnly;
+      }
+    });
+
     itemForm.addEventListener("submit", (event) => {
       event.preventDefault();
       const value = itemNumberInput.value.trim();
@@ -192,7 +199,15 @@
         itemFormError.textContent = "Veuillez remplir ce champ";
         return;
       }
-      StorageService.createItem(siteId, value);
+      if (!/^\d+$/.test(value)) {
+        itemFormError.textContent = "Veuillez saisir des chiffres uniquement.";
+        return;
+      }
+      const createdItem = StorageService.createItem(siteId, value);
+      if (!createdItem) {
+        itemFormError.textContent = "Veuillez saisir des chiffres uniquement.";
+        return;
+      }
       itemDialog.close();
       UiService.showToast("Numéro OUT ajouté.");
       renderItems();

--- a/js/storage.js
+++ b/js/storage.js
@@ -20,6 +20,10 @@
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
   }
 
+  function sanitizeDigits(value) {
+    return String(value || "").replace(/\D/g, "");
+  }
+
   function now() {
     return new Date().toISOString();
   }
@@ -79,7 +83,10 @@
       return null;
     }
     const timestamp = now();
-    const cleanNumber = sanitizeText(numberValue, true).replace(/^OUT-/, "");
+    const cleanNumber = sanitizeDigits(sanitizeText(numberValue, true).replace(/^OUT-/, ""));
+    if (!cleanNumber) {
+      return null;
+    }
     const item = {
       id: uid(),
       numero: `OUT-${cleanNumber}`,
@@ -129,7 +136,7 @@
       unite: sanitizeText(payload.unite || "m", false) || "m",
       qteHorsBtrs: "",
       qteRetour: 0,
-      qtePosee: sanitizeNumber(payload.qteSortie),
+      qtePosee: 0,
       observation: "",
       dateCreation: timestamp,
       dateModification: timestamp,

--- a/page2.html
+++ b/page2.html
@@ -37,7 +37,15 @@
           </div>
           <label class="input-group">
             <span>Numéro</span>
-            <input id="itemNumberInput" name="itemNumber" type="text" maxlength="40" placeholder="001" />
+            <input
+              id="itemNumberInput"
+              name="itemNumber"
+              type="text"
+              inputmode="numeric"
+              pattern="[0-9]*"
+              maxlength="40"
+              placeholder="001"
+            />
           </label>
           <p id="itemFormError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions">

--- a/page3.html
+++ b/page3.html
@@ -18,17 +18,9 @@
 
       <main class="page-content page-content--wide">
         <section class="surface-card form-card">
-          <div class="section-heading">
-            <div>
-              <h2>Ajouter une ligne</h2>
-              <p>Enregistrement local automatique après création et modification.</p>
-            </div>
-          </div>
-
           <form id="detailForm" class="responsive-form" novalidate>
             <label class="input-group">
-              <span>Code</span>
-              <input id="codeInput" name="code" type="text" maxlength="40" required />
+              <input id="codeInput" name="code" type="text" maxlength="40" required aria-label="Code" />
             </label>
             <label class="input-group input-group--wide">
               <span>Désignation</span>
@@ -52,13 +44,6 @@
           </form>
         </section>
 
-        <section class="surface-card search-panel">
-          <label class="input-group">
-            <span>Recherche</span>
-            <input id="detailSearchInput" type="text" placeholder="Rechercher..." autocomplete="off" />
-          </label>
-        </section>
-
         <section class="surface-card table-card">
           <div class="section-heading">
             <div>
@@ -66,6 +51,12 @@
               <p id="detailCount">0 ligne</p>
             </div>
             <button type="button" id="exportDetailsButton" class="btn btn-success">Exporter</button>
+          </div>
+          <div class="search-panel search-panel--inline">
+            <label class="input-group">
+              <span>Recherche</span>
+              <input id="detailSearchInput" type="text" placeholder="Rechercher..." autocomplete="off" />
+            </label>
           </div>
           <div class="table-wrapper">
             <table class="data-table">


### PR DESCRIPTION
### Motivation
- Empêcher la création de numéros OUT contenant des caractères non numériques en validant côté UI et stockage.
- Faire en sorte que la `Qté posée` soit `0` par défaut lors de la création d'une ligne pour correspondre au comportement attendu.
- Supprimer le texte demandé dans le formulaire de création de la page 3 et placer le champ de recherche dans la même carte que le tableau pour respecter la mise en page demandée.
- Limiter les modifications aux pages 2 et 3 et aux fichiers JS/CSS nécessaires.

### Description
- Sur `page2.html` : ajout de `inputmode="numeric"` et `pattern="[0-9]*"` sur l'input du numéro OUT pour favoriser la saisie chiffrée côté UI.
- Dans `js/app.js` : ajout d'un écouteur d'`input` qui filtre les caractères non numériques et validation à la soumission pour accepter uniquement des chaînes composées de chiffres.
- Dans `js/storage.js` : ajout de la fonction `sanitizeDigits` et nettoyage/validation côté stockage pour n'accepter que des chiffres et refuser la création d'items vides ou non numériques; `qtePosee` est initialisé à `0` lors de la création d'une ligne (`createDetail`).
- Dans `page3.html` : suppression des textes demandés dans le formulaire de création (en-tête et phrase d'enregistrement automatique), retrait du label visible `Code` (le champ reste fonctionnel) et déplacement du champ de recherche à l'intérieur de la même carte que le tableau; ajout d'une classe CSS `.search-panel--inline` dans `css/style.css` pour ajuster l'alignement.

### Testing
- `node --check js/app.js` completed successfully.
- `node --check js/storage.js` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf5605d88832ab4c9079365971c1a)