### PR TITLE
Add Code label to page 3 form

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -20,6 +20,7 @@
         <section class="surface-card form-card">
           <form id="detailForm" class="responsive-form" novalidate>
             <label class="input-group">
+              <span>Code</span>
               <input id="codeInput" name="code" type="text" maxlength="40" required aria-label="Code" />
             </label>
             <label class="input-group input-group--wide">


### PR DESCRIPTION
### Motivation
- Rendre visible le libellé `Code` au‑dessus du premier champ de texte dans la card formulaire de la page 3 pour améliorer l'accessibilité et la lisibilité.

### Description
- Ajout d'un `<span>Code</span>` immédiatement au dessus de l'input `codeInput` dans `page3.html` et aucun autre champ ou mise en page n'a été modifié.

### Testing
- Exécuté `git diff --check`, vérifié le markup dans `page3.html` et commis la modification, toutes les vérifications automatisées sont passées.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf7ac522c832a99591653b5d4235c)