### PR TITLE
Rendre Qté posée éditable et contraindre à Qté Sortie (page 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -365,7 +365,7 @@
                 </div>
               </td>
               <td><input class="cell-input" data-field="qteHorsBtrs" type="number" min="0" step="1" value="${detail.qteHorsBtrs}" placeholder="N/A" /></td>
-              <td><span class="readonly-value">${detail.qtePosee}</span></td>
+              <td><input class="cell-input" data-field="qtePosee" type="number" min="0" max="${detail.qteSortie}" step="1" value="${detail.qtePosee}" /></td>
               <td><input class="cell-input" data-field="qteRetour" type="number" min="0" max="${detail.qteSortie}" step="1" value="${detail.qteRetour}" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
@@ -397,10 +397,21 @@
             }
           }
 
+          if (fieldName === "qtePosee") {
+            const qteSortie = Number(currentDetail.qteSortie) || 0;
+            const qtePosee = Number(nextValue) || 0;
+            if (qtePosee > qteSortie) {
+              nextValue = String(qteSortie);
+              UiService.showToast("La Qté posée ne peut pas dépasser la Qté Sortie.");
+            }
+          }
+
           if (fieldName === "qteSortie") {
             const qteSortie = Number(nextValue) || 0;
             if ((Number(currentDetail.qteRetour) || 0) > qteSortie) {
               UiService.showToast("La Qté Retour a été ajustée à la Qté Sortie.");
+            } else if ((Number(currentDetail.qtePosee) || 0) > qteSortie) {
+              UiService.showToast("La Qté posée a été ajustée à la Qté Sortie.");
             }
           }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -168,6 +168,9 @@
       if (sanitizeNumber(detail.qteRetour) > detail.qteSortie) {
         detail.qteRetour = detail.qteSortie;
       }
+      if (sanitizeNumber(detail.qtePosee) > detail.qteSortie) {
+        detail.qtePosee = detail.qteSortie;
+      }
     }
     if ("unite" in changes) {
       detail.unite = sanitizeText(changes.unite, false) || "m";
@@ -177,12 +180,20 @@
     }
     if ("qteRetour" in changes) {
       detail.qteRetour = Math.min(sanitizeNumber(changes.qteRetour), sanitizeNumber(detail.qteSortie));
+      detail.qtePosee = Math.max(0, sanitizeNumber(detail.qteSortie) - sanitizeNumber(detail.qteRetour));
+    }
+    if ("qtePosee" in changes) {
+      detail.qtePosee = Math.min(sanitizeNumber(changes.qtePosee), sanitizeNumber(detail.qteSortie));
+      detail.qteRetour = Math.max(0, sanitizeNumber(detail.qteSortie) - sanitizeNumber(detail.qtePosee));
     }
     if ("observation" in changes) {
       detail.observation = sanitizeText(changes.observation, false);
     }
 
-    detail.qtePosee = Math.max(0, sanitizeNumber(detail.qteSortie) - sanitizeNumber(detail.qteRetour));
+    if (!("qteRetour" in changes) && !("qtePosee" in changes)) {
+      detail.qtePosee = Math.min(sanitizeNumber(detail.qtePosee), sanitizeNumber(detail.qteSortie));
+      detail.qteRetour = Math.max(0, sanitizeNumber(detail.qteSortie) - sanitizeNumber(detail.qtePosee));
+    }
     detail.dateModification = now();
     item.dateModification = detail.dateModification;
     site.dateModification = detail.dateModification;


### PR DESCRIPTION
### Motivation
- Rendre la cellule "Qté posée" cliquable/éditable dans le tableau de la page 3 tout en s'assurant que sa valeur ne dépasse jamais la "Qté Sortie".
- Maintenir la cohérence entre `qtePosee` et `qteRetour` lors des modifications pour éviter des états invalides.

### Description
- Remplacement de l'affichage en lecture seule de `Qté posée` par un champ numérique éditable dans le tableau de la page 3 (fichier modifié : `js/app.js`).
- Ajout d'une validation côté interface pour empêcher la saisie d'une `qtePosee` supérieure à la `qteSortie` et affichage d'un message via `UiService.showToast` (dans `js/app.js`).
- Mise à jour de la logique de stockage (`js/storage.js`) pour borner `qtePosee` à `qteSortie`, recalculer `qteRetour` lorsque `qtePosee` change, et ajuster `qtePosee`/`qteRetour` automatiquement quand `qteSortie` est modifiée.
- Les autres champs et comportements du tableau n'ont pas été modifiés.

### Testing
- Vérification de syntaxe avec `node --check js/app.js && node --check js/storage.js && node --check js/ui.js` : succès.
- Test ciblé de la logique `StorageService.updateDetail` exécuté dans une VM Node (création de site/item/detail, mise à jour de `qtePosee` et `qteSortie`) pour valider le clamp et la synchronisation `qtePosee` / `qteRetour` : succès (tests automatisés passés).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafa63b0bc832a86a7e7c543686d8b)