### PR TITLE
Remove 'Qté hors BTRS' from page 2 export and normalize exported units

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -95,7 +95,6 @@
             <td>${escapeHtml(row.designation)}</td>
             <td>${escapeHtml(row.qteSortie)}</td>
             <td>${escapeHtml(row.unite)}</td>
-            <td>${escapeHtml(row.qteHorsBtrs)}</td>
             <td>${escapeHtml(row.qtePosee)}</td>
             <td>${escapeHtml(row.qteRetour)}</td>
             <td>${escapeHtml(row.observation)}</td>
@@ -120,7 +119,6 @@
           <th>Désignation</th>
           <th>Qté Sortie</th>
           <th>Unité</th>
-          <th>Qté hors BTRS</th>
           <th>Qté posée</th>
           <th>Qté Retour</th>
           <th>Observation</th>
@@ -252,6 +250,21 @@
       openExportItems.setAttribute("aria-expanded", "true");
     }
 
+    function formatSiteExportUnit(unit) {
+      const normalizedUnit = String(unit || "").trim().toLowerCase();
+      if (normalizedUnit === "pcs") {
+        return "pcs";
+      }
+      return normalizedUnit || "m";
+    }
+
+    function shouldExportSiteDetail(detail, mode) {
+      if (mode === "returns-only") {
+        return Number(detail.qteRetour) !== 0;
+      }
+      return true;
+    }
+
     function buildSiteExportRows(mode) {
       const currentSite = StorageService.getSite(siteId);
       if (!currentSite) {
@@ -263,20 +276,17 @@
           return [];
         }
 
-        return item.details
-          .filter((detail) => (mode === "returns-only" ? Number(detail.qteRetour) !== 0 : true))
-          .map((detail) => ({
-            out: item.numero,
-            champ: detail.champ,
-            code: detail.code,
-            designation: detail.designation,
-            qteSortie: detail.qteSortie,
-            unite: detail.unite,
-            qteHorsBtrs: detail.qteHorsBtrs,
-            qtePosee: detail.qtePosee,
-            qteRetour: detail.qteRetour,
-            observation: detail.observation,
-          }));
+        return item.details.filter((detail) => shouldExportSiteDetail(detail, mode)).map((detail) => ({
+          out: item.numero,
+          champ: detail.champ,
+          code: detail.code,
+          designation: detail.designation,
+          qteSortie: detail.qteSortie,
+          unite: formatSiteExportUnit(detail.unite),
+          qtePosee: detail.qtePosee,
+          qteRetour: detail.qteRetour,
+          observation: detail.observation,
+        }));
       });
     }
 


### PR DESCRIPTION
### Motivation
- Remove the `Qté hors BTRS` column from the exported Excel file generated on page 2 so the exported layout matches the requested format. 
- Ensure the two export modes on page 2 (`Tous` and `Les retour seulement`) are handled consistently by the same row-building logic. 
- Normalize exported unit labels to `m` / `pcs` while leaving all other behavior and pages unchanged.

### Description
- Removed the `qteHorsBtrs` column from the HTML table header and row output in `buildSiteExcelContent` in `js/app.js`.
- Introduced `formatSiteExportUnit` to normalize unit values to `m`/`pcs` and `shouldExportSiteDetail` to centralize the mode filter logic in `js/app.js`.
- Reworked `buildSiteExportRows` to use the new helper functions and to stop including `qteHorsBtrs` in exported rows, keeping other fields and export modes intact.
- All changes are contained in `js/app.js` and do not alter export behavior for other pages.

### Testing
- Ran `node --check js/app.js` to validate the modified script syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc01b77c9c832ab3ddc2845e614967)