### PR TITLE
Simplify page 2 export action

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -229,26 +229,8 @@
     const itemNumberInput = requireElement("itemNumberInput");
     const itemFormError = requireElement("itemFormError");
     const openExportItems = requireElement("openExportItems");
-    const exportItemsPanel = requireElement("exportItemsPanel");
-    const siteExportMenu = requireElement("siteExportMenu");
 
     siteTitle.textContent = site.nom;
-
-    function closeExportMenu() {
-      if (!exportItemsPanel || !openExportItems) {
-        return;
-      }
-      exportItemsPanel.hidden = true;
-      openExportItems.setAttribute("aria-expanded", "false");
-    }
-
-    function openExportMenu() {
-      if (!exportItemsPanel || !openExportItems) {
-        return;
-      }
-      exportItemsPanel.hidden = false;
-      openExportItems.setAttribute("aria-expanded", "true");
-    }
 
     function formatSiteExportUnit(unit) {
       const normalizedUnit = String(unit || "").trim().toLowerCase();
@@ -258,14 +240,7 @@
       return normalizedUnit || "m";
     }
 
-    function shouldExportSiteDetail(detail, mode) {
-      if (mode === "returns-only") {
-        return Number(detail.qteRetour) !== 0;
-      }
-      return true;
-    }
-
-    function buildSiteExportRows(mode) {
+    function buildSiteExportRows() {
       const currentSite = StorageService.getSite(siteId);
       if (!currentSite) {
         return [];
@@ -276,7 +251,7 @@
           return [];
         }
 
-        return item.details.filter((detail) => shouldExportSiteDetail(detail, mode)).map((detail) => ({
+        return item.details.map((detail) => ({
           out: item.numero,
           champ: detail.champ,
           code: detail.code,
@@ -290,20 +265,16 @@
       });
     }
 
-    function exportItems(mode) {
+    function exportItems() {
       const currentSite = StorageService.getSite(siteId);
       if (!currentSite) {
         UiService.navigate("index.html");
         return;
       }
 
-      const rows = buildSiteExportRows(mode);
+      const rows = buildSiteExportRows();
       if (!rows.length) {
-        UiService.showToast(
-          mode === "returns-only"
-            ? "Aucune ligne avec Qté Retour différente de 0."
-            : "Aucun sous-élément avec des données à exporter.",
-        );
+        UiService.showToast("Aucun sous-élément avec des données à exporter.");
         return;
       }
 
@@ -377,27 +348,8 @@
       }
     });
 
-    if (openExportItems && exportItemsPanel) {
-      openExportItems.addEventListener("click", () => {
-        if (exportItemsPanel.hidden) {
-          openExportMenu();
-          return;
-        }
-        closeExportMenu();
-      });
-
-      exportItemsPanel.querySelectorAll("[data-export-mode]").forEach((button) => {
-        button.addEventListener("click", () => {
-          closeExportMenu();
-          exportItems(button.dataset.exportMode);
-        });
-      });
-
-      document.addEventListener("click", (event) => {
-        if (!siteExportMenu.contains(event.target)) {
-          closeExportMenu();
-        }
-      });
+    if (openExportItems) {
+      openExportItems.addEventListener("click", exportItems);
     }
 
     itemForm.addEventListener("submit", (event) => {

--- a/page2.html
+++ b/page2.html
@@ -22,15 +22,9 @@
             <h2>Sous-éléments</h2>
             <p id="itemCount">0 élément</p>
           </div>
-          <div class="export-menu" id="siteExportMenu">
-            <button type="button" id="openExportItems" class="btn btn-success" aria-haspopup="true" aria-expanded="false">
-              Exporter
-            </button>
-            <div class="export-menu__panel" id="exportItemsPanel" hidden>
-              <button type="button" class="export-menu__option" data-export-mode="all">Tous</button>
-              <button type="button" class="export-menu__option" data-export-mode="returns-only">Les retour Seulement</button>
-            </div>
-          </div>
+          <button type="button" id="openExportItems" class="btn btn-success">
+            Exporter
+          </button>
         </section>
 
         <section id="itemList" class="list-grid" aria-live="polite"></section>


### PR DESCRIPTION
### Motivation
- The export UI on page 2 exposed a dropdown with choices and a "returns-only" filter which the product requested to remove in favor of a single action that exports all sub-elements to OUT.
- The change should be minimal and avoid altering other pages or export formats.

### Description
- Replace the export menu in `page2.html` with a single `Exporter` button and remove the menu panel markup. 
- Simplify `js/app.js` by removing the menu open/close helpers and the `returns-only` branch, and make `buildSiteExportRows()` always include every detail row. 
- Change `exportItems()` to call the simplified `buildSiteExportRows()` with no mode and wire the `openExportItems` click directly to `exportItems()`. 
- Only `page2.html` and `js/app.js` were modified to implement the behavior while keeping existing export file generation untouched.

### Testing
- Ran `node --check js/app.js` and it completed without syntax errors. 
- Ran `node --check js/storage.js` and it completed without syntax errors. 
- Ran `node --check js/ui.js` and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc063b9dd0832a83518f3944f87b9c)