### PR TITLE
Remove Qté hors BTRS column from page 3 export

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -48,7 +48,6 @@
               <td>${escapeHtml(detail.designation)}</td>
               <td>${escapeHtml(detail.qteSortie)}</td>
               <td>${escapeHtml(detail.unite)}</td>
-              <td>${escapeHtml(detail.qteHorsBtrs)}</td>
               <td>${escapeHtml(detail.qtePosee)}</td>
               <td>${escapeHtml(detail.qteRetour)}</td>
               <td>${escapeHtml(detail.observation)}</td>
@@ -72,7 +71,6 @@
           <th>Désignation</th>
           <th>Qté Sortie</th>
           <th>Unité</th>
-          <th>Qté hors BTRS</th>
           <th>Qté posée</th>
           <th>Qté Retour</th>
           <th>Observation</th>


### PR DESCRIPTION
### Motivation
- Remove the `Qté hors BTRS` column from the exported Excel file produced by page 3 while leaving the on-screen table and other behaviors unchanged.

### Description
- Edit `js/app.js` to update `buildDetailExcelContent` by removing the `qteHorsBtrs` cell from each data row and the `Qté hors BTRS` header so the exported `.xls` no longer contains that column.

### Testing
- Ran `node --check js/app.js` with no syntax errors and reviewed the `git diff` before committing the change (`Remove hors BTRS column from page 3 export`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0bd7d254832aab6e1cbab371987a)