### PR TITLE
Use dynamic file input and showPicker for .su import/merge

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,6 @@
         <section id="siteList" class="list-grid" aria-live="polite"></section>
       </main>
 
-      <input id="importDataInput" type="file" accept=".su" hidden />
-
       <button id="openCreateSite" class="fab" type="button" aria-label="Créer un site">+</button>
 
       <dialog id="siteDialog" class="modal-card">

--- a/js/app.js
+++ b/js/app.js
@@ -142,7 +142,6 @@
     const mergeDataButton = requireElement("mergeDataButton");
     const exportDataButton = requireElement("exportDataButton");
     const quitButton = requireElement("quitButton");
-    const importDataInput = requireElement("importDataInput");
     let importMode = "replace";
 
     function formatExportFileName() {
@@ -179,8 +178,10 @@
     }
 
     async function handleImportFile(event) {
+      const input = event.target;
       const [file] = Array.from(event.target.files || []);
       if (!file) {
+        input.remove();
         return;
       }
 
@@ -200,7 +201,8 @@
         UiService.showToast("Importation impossible.");
       } finally {
         importMode = "replace";
-        event.target.value = "";
+        input.value = "";
+        input.remove();
       }
     }
 
@@ -209,6 +211,37 @@
       const serialized = JSON.stringify(payload, null, 2);
       downloadSuFile(formatExportFileName(), serialized);
       UiService.showToast("Exportation lancée.");
+    }
+
+    function openImportFilePicker(mode) {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = ".su";
+      input.className = "sr-only";
+      input.tabIndex = -1;
+      input.setAttribute("aria-hidden", "true");
+      input.addEventListener("change", handleImportFile, { once: true });
+      document.body.appendChild(input);
+
+      importMode = mode;
+      if (homeMenuPanel) {
+        homeMenuPanel.hidden = true;
+      }
+      if (homeMenuButton) {
+        homeMenuButton.setAttribute("aria-expanded", "false");
+      }
+
+      if (typeof input.showPicker === "function") {
+        try {
+          input.showPicker();
+          return;
+        } catch (error) {
+          input.click();
+          return;
+        }
+      }
+
+      input.click();
     }
 
     function renderSites() {
@@ -282,20 +315,15 @@
       });
     }
 
-    if (importDataButton && importDataInput) {
+    if (importDataButton) {
       importDataButton.addEventListener("click", () => {
-        closeHomeMenu();
-        importMode = "replace";
-        importDataInput.click();
+        openImportFilePicker("replace");
       });
-      importDataInput.addEventListener("change", handleImportFile);
     }
 
-    if (mergeDataButton && importDataInput) {
+    if (mergeDataButton) {
       mergeDataButton.addEventListener("click", () => {
-        closeHomeMenu();
-        importMode = "merge";
-        importDataInput.click();
+        openImportFilePicker("merge");
       });
     }
 


### PR DESCRIPTION
### Motivation
- Replace the persistent hidden `input#exportDataInput`/`input#importDataInput` pattern with on-demand file pickers to avoid leaving file inputs in the DOM and to support modern picker APIs.
- Improve the import/merge UX by closing the home menu when launching the picker and by allowing multiple sequential imports without stale input state.
- Ensure temporary inputs are cleaned up after use and that `importMode` is handled explicitly.

### Description
- Remove the static `input#importDataInput` element from `index.html` and stop referencing it from `js/app.js`.
- Add `openImportFilePicker(mode)` which creates a temporary `input[type=file]` configured for `.su` files, uses `input.showPicker()` when available with a fallback to `input.click()`, and attaches a one-time `change` listener to `handleImportFile`.
- Update `handleImportFile` to use the event target as the created input, clear its value, remove it from the DOM on completion, and reset `importMode` appropriately.
- Wire `importDataButton` and `mergeDataButton` to call `openImportFilePicker("replace")` and `openImportFilePicker("merge")` respectively, and keep existing export and menu behaviors unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff29d838c832aa9066968facc9b3f)