### PR TITLE
Use ephemeral file input for import/merge to fix non-working "Fusionner les données" click

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,6 @@
         <section id="siteList" class="list-grid" aria-live="polite"></section>
       </main>
 
-      <input id="importDataInput" class="sr-only" type="file" accept=".su" />
 
       <button id="openCreateSite" class="fab" type="button" aria-label="Créer un site">+</button>
 

--- a/js/app.js
+++ b/js/app.js
@@ -142,14 +142,10 @@
     const mergeDataButton = requireElement("mergeDataButton");
     const exportDataButton = requireElement("exportDataButton");
     const quitButton = requireElement("quitButton");
-    const importDataInput = requireElement("importDataInput");
     let importMode = "replace";
 
     function setImportMode(mode) {
       importMode = mode === "merge" ? "merge" : "replace";
-      if (importDataInput) {
-        importDataInput.dataset.importMode = importMode;
-      }
     }
 
     function resetImportMode() {
@@ -190,13 +186,17 @@
     }
 
     async function handleImportFile(event) {
-      const [file] = Array.from(event.target.files || []);
+      const sourceInput = event.target;
+      const [file] = Array.from(sourceInput.files || []);
       if (!file) {
         resetImportMode();
+        if (sourceInput.dataset.ephemeral === "true") {
+          sourceInput.remove();
+        }
         return;
       }
 
-      const activeImportMode = event.target.dataset.importMode === "merge" ? "merge" : importMode;
+      const activeImportMode = sourceInput.dataset.importMode === "merge" ? "merge" : importMode;
 
       try {
         const text = await file.text();
@@ -213,8 +213,11 @@
       } catch (error) {
         UiService.showToast("Importation impossible.");
       } finally {
-        event.target.value = "";
+        sourceInput.value = "";
         resetImportMode();
+        if (sourceInput.dataset.ephemeral === "true") {
+          sourceInput.remove();
+        }
       }
     }
 
@@ -226,13 +229,26 @@
     }
 
     function openImportFilePicker(mode) {
-      if (!importDataInput) {
-        return;
-      }
-
       closeHomeMenu();
       setImportMode(mode);
-      importDataInput.value = "";
+
+      const importDataInput = document.createElement("input");
+      importDataInput.type = "file";
+      importDataInput.accept = ".su";
+      importDataInput.dataset.importMode = importMode;
+      importDataInput.dataset.ephemeral = "true";
+      importDataInput.className = "sr-only";
+      document.body.appendChild(importDataInput);
+
+      importDataInput.addEventListener("change", handleImportFile, { once: true });
+      importDataInput.addEventListener(
+        "cancel",
+        () => {
+          resetImportMode();
+          importDataInput.remove();
+        },
+        { once: true },
+      );
 
       try {
         if (typeof importDataInput.showPicker === "function") {
@@ -317,21 +333,16 @@
       });
     }
 
-    if (importDataButton && importDataInput) {
+    if (importDataButton) {
       importDataButton.addEventListener("click", () => {
         openImportFilePicker("replace");
       });
     }
 
-    if (mergeDataButton && importDataInput) {
+    if (mergeDataButton) {
       mergeDataButton.addEventListener("click", () => {
         openImportFilePicker("merge");
       });
-    }
-
-    if (importDataInput) {
-      importDataInput.addEventListener("change", handleImportFile);
-      importDataInput.addEventListener("cancel", resetImportMode);
     }
 
     if (quitButton) {


### PR DESCRIPTION
### Motivation
- Certaines plateformes/navigateurs bloquaient l'ouverture du champ fichier masqué réutilisé, rendant le bouton `Fusionner les données` non fiable; l'intention est de rendre l'ouverture du file picker robuste sur mobile et navigateurs stricts.

### Description
- Supprimé l'`input#exportDataInput` statique du HTML et retiré la dépendance globale à cet élément dans `index.html` et `js/app.js` en faveur d'un sélecteur créé à la demande.
- Implémenté dans `openImportFilePicker` la création d'un `input[type=file]` éphémère avec `dataset.importMode` et `dataset.ephemeral`, et attachement d'écouteurs `change` et `cancel` (avec `{ once: true }`) pour déclencher le traitement et nettoyer l'élément après usage.
- Mis à jour `handleImportFile` pour utiliser l'élément source (`event.target`) comme `sourceInput`, appliquer le mode `merge`/`replace` à partir de `dataset.importMode`, et supprimer l'input éphémère après sélection ou annulation.
- Simplifié les écouteurs du menu d'accueil pour que `importDataButton` et `mergeDataButton` appellent tous deux `openImportFilePicker` sans dépendre d'un input fichier persistant.

### Testing
- Exécuté `node --check js/app.js` to verify there are no syntax errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00413f934832aacb4c8a4859a7a7d)