### PR TITLE
Fix import and merge file picker actions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,6 +51,16 @@ button {
   border: 0;
 }
 
+.file-picker-input {
+  position: fixed;
+  top: 0;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .app-shell {
   height: 100vh;
   display: flex;

--- a/index.html
+++ b/index.html
@@ -35,6 +35,24 @@
               Quiter
             </button>
           </div>
+          <input
+            id="importDataInput"
+            class="file-picker-input"
+            type="file"
+            accept=".su,.json,application/json"
+            data-import-mode="replace"
+            tabindex="-1"
+            aria-hidden="true"
+          />
+          <input
+            id="mergeDataInput"
+            class="file-picker-input"
+            type="file"
+            accept=".su,.json,application/json"
+            data-import-mode="merge"
+            tabindex="-1"
+            aria-hidden="true"
+          />
         </div>
       </header>
 

--- a/js/app.js
+++ b/js/app.js
@@ -142,15 +142,8 @@
     const mergeDataButton = requireElement("mergeDataButton");
     const exportDataButton = requireElement("exportDataButton");
     const quitButton = requireElement("quitButton");
-    let importMode = "replace";
-
-    function setImportMode(mode) {
-      importMode = mode === "merge" ? "merge" : "replace";
-    }
-
-    function resetImportMode() {
-      setImportMode("replace");
-    }
+    const importDataInput = requireElement("importDataInput");
+    const mergeDataInput = requireElement("mergeDataInput");
 
     function formatExportFileName() {
       const now = new Date();
@@ -189,14 +182,10 @@
       const sourceInput = event.target;
       const [file] = Array.from(sourceInput.files || []);
       if (!file) {
-        resetImportMode();
-        if (sourceInput.dataset.ephemeral === "true") {
-          sourceInput.remove();
-        }
         return;
       }
 
-      const activeImportMode = sourceInput.dataset.importMode === "merge" ? "merge" : importMode;
+      const activeImportMode = sourceInput.dataset.importMode === "merge" ? "merge" : "replace";
 
       try {
         const text = await file.text();
@@ -214,10 +203,6 @@
         UiService.showToast("Importation impossible.");
       } finally {
         sourceInput.value = "";
-        resetImportMode();
-        if (sourceInput.dataset.ephemeral === "true") {
-          sourceInput.remove();
-        }
       }
     }
 
@@ -230,36 +215,24 @@
 
     function openImportFilePicker(mode) {
       closeHomeMenu();
-      setImportMode(mode);
+      const picker = mode === "merge" ? mergeDataInput : importDataInput;
+      if (!picker) {
+        UiService.showToast("Importation impossible.");
+        return;
+      }
 
-      const importDataInput = document.createElement("input");
-      importDataInput.type = "file";
-      importDataInput.accept = ".su";
-      importDataInput.dataset.importMode = importMode;
-      importDataInput.dataset.ephemeral = "true";
-      importDataInput.className = "sr-only";
-      document.body.appendChild(importDataInput);
-
-      importDataInput.addEventListener("change", handleImportFile, { once: true });
-      importDataInput.addEventListener(
-        "cancel",
-        () => {
-          resetImportMode();
-          importDataInput.remove();
-        },
-        { once: true },
-      );
+      picker.value = "";
 
       try {
-        if (typeof importDataInput.showPicker === "function") {
-          importDataInput.showPicker();
+        if (typeof picker.showPicker === "function") {
+          picker.showPicker();
           return;
         }
       } catch (error) {
-        // Certains navigateurs refusent showPicker sur un input fichier masqué.
+        // Certains navigateurs refusent showPicker sur certains contextes.
       }
 
-      importDataInput.click();
+      picker.click();
     }
 
     function renderSites() {
@@ -332,6 +305,12 @@
         exportAllData();
       });
     }
+
+    [importDataInput, mergeDataInput].forEach((input) => {
+      if (input) {
+        input.addEventListener("change", handleImportFile);
+      }
+    });
 
     if (importDataButton) {
       importDataButton.addEventListener("click", () => {


### PR DESCRIPTION
### Motivation
- The import and merge actions relied on dynamically-created hidden file inputs which can be blocked by some browsers/webviews, causing the "Importer les données" and "Fusionner les données" options to fail. 
- A more reliable flow is to provide persistent, hidden file inputs per mode and trigger them from the menu so the browser can open the picker consistently.

### Description
- Added two persistent file inputs in `index.html` with ids `importDataInput` and `mergeDataInput` and broadened their `accept` to `.su,.json,application/json`. 
- Added a `.file-picker-input` CSS rule in `css/style.css` to keep the inputs off-screen but usable by the browser. 
- Updated `js/app.js` to stop creating ephemeral inputs and instead target the persistent inputs, read `data-import-mode` from the input, reset `value` after handling, and attach `change` listeners to the persistent inputs. 
- Kept the existing import/merge business logic and user feedback while simplifying the picker flow and preserving separate replace vs merge modes.

### Testing
- Ran `node --check js/app.js` which succeeded. 
- Ran `node --check js/storage.js` which succeeded. 
- Ran `node --check js/ui.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0078d0efc832abdfd87fb91b6de5f)