### PR TITLE
Remove merge and quit options from home menu and delete merge import logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,8 @@
             <button id="importDataButton" class="header-menu__option" type="button" role="menuitem">
               Importer les données
             </button>
-            <button id="mergeDataButton" class="header-menu__option" type="button" role="menuitem">
-              Fusionner les données
-            </button>
             <button id="exportDataButton" class="header-menu__option" type="button" role="menuitem">
               Exporter les données
-            </button>
-            <button id="quitButton" class="header-menu__option" type="button" role="menuitem">
-              Quiter
             </button>
           </div>
           <input
@@ -40,16 +34,6 @@
             class="file-picker-input"
             type="file"
             accept=".su,.json,application/json"
-            data-import-mode="replace"
-            tabindex="-1"
-            aria-hidden="true"
-          />
-          <input
-            id="mergeDataInput"
-            class="file-picker-input"
-            type="file"
-            accept=".su,.json,application/json"
-            data-import-mode="merge"
             tabindex="-1"
             aria-hidden="true"
           />

--- a/js/app.js
+++ b/js/app.js
@@ -139,11 +139,8 @@
     const homeMenuButton = requireElement("homeMenuButton");
     const homeMenuPanel = requireElement("homeMenuPanel");
     const importDataButton = requireElement("importDataButton");
-    const mergeDataButton = requireElement("mergeDataButton");
     const exportDataButton = requireElement("exportDataButton");
-    const quitButton = requireElement("quitButton");
     const importDataInput = requireElement("importDataInput");
-    const mergeDataInput = requireElement("mergeDataInput");
 
     function formatExportFileName() {
       const now = new Date();
@@ -185,20 +182,16 @@
         return;
       }
 
-      const activeImportMode = sourceInput.dataset.importMode === "merge" ? "merge" : "replace";
-
       try {
         const text = await file.text();
         const payload = JSON.parse(text);
-        const action =
-          activeImportMode === "merge" ? StorageService.mergeImportData : StorageService.importData;
-        const imported = action(payload);
+        const imported = StorageService.importData(payload);
         if (!imported) {
           UiService.showToast("Fichier .su invalide.");
           return;
         }
         renderSites();
-        UiService.showToast(activeImportMode === "merge" ? "Données fusionnées." : "Données importées.");
+        UiService.showToast("Données importées.");
       } catch (error) {
         UiService.showToast("Importation impossible.");
       } finally {
@@ -213,26 +206,25 @@
       UiService.showToast("Exportation lancée.");
     }
 
-    function openImportFilePicker(mode) {
+    function openImportFilePicker() {
       closeHomeMenu();
-      const picker = mode === "merge" ? mergeDataInput : importDataInput;
-      if (!picker) {
+      if (!importDataInput) {
         UiService.showToast("Importation impossible.");
         return;
       }
 
-      picker.value = "";
+      importDataInput.value = "";
 
       try {
-        if (typeof picker.showPicker === "function") {
-          picker.showPicker();
+        if (typeof importDataInput.showPicker === "function") {
+          importDataInput.showPicker();
           return;
         }
       } catch (error) {
         // Certains navigateurs refusent showPicker sur certains contextes.
       }
 
-      picker.click();
+      importDataInput.click();
     }
 
     function renderSites() {
@@ -306,28 +298,11 @@
       });
     }
 
-    [importDataInput, mergeDataInput].forEach((input) => {
-      if (input) {
-        input.addEventListener("change", handleImportFile);
-      }
-    });
+    importDataInput.addEventListener("change", handleImportFile);
 
     if (importDataButton) {
       importDataButton.addEventListener("click", () => {
-        openImportFilePicker("replace");
-      });
-    }
-
-    if (mergeDataButton) {
-      mergeDataButton.addEventListener("click", () => {
-        openImportFilePicker("merge");
-      });
-    }
-
-    if (quitButton) {
-      quitButton.addEventListener("click", () => {
-        closeHomeMenu();
-        window.confirm("Voulez vous vraiment quiter?");
+        openImportFilePicker();
       });
     }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -107,111 +107,6 @@
     return new Date(Math.max(...timestamps)).toISOString();
   }
 
-  function getEarliestTimestamp(...values) {
-    const timestamps = values
-      .filter(Boolean)
-      .map((value) => new Date(value).getTime())
-      .filter((value) => Number.isFinite(value));
-
-    if (!timestamps.length) {
-      return now();
-    }
-
-    return new Date(Math.min(...timestamps)).toISOString();
-  }
-
-  function detailSignature(detail) {
-    return [
-      sanitizeNumber(detail.champ),
-      sanitizeText(detail.code, true),
-      sanitizeText(detail.designation, true),
-      detail.qteSortie === '' ? '' : sanitizeNumber(detail.qteSortie),
-      sanitizeText(detail.unite || 'm', false) || 'm',
-    ].join('|');
-  }
-
-  function mergeDetailRecords(existingDetail, incomingDetail) {
-    const useIncoming = new Date(incomingDetail.dateModification || 0).getTime()
-      >= new Date(existingDetail.dateModification || 0).getTime();
-    const preferredDetail = useIncoming ? incomingDetail : existingDetail;
-
-    return {
-      ...existingDetail,
-      ...preferredDetail,
-      id: existingDetail.id || incomingDetail.id || uid(),
-      dateCreation: getEarliestTimestamp(existingDetail.dateCreation, incomingDetail.dateCreation),
-      dateModification: getLatestTimestamp(existingDetail.dateModification, incomingDetail.dateModification),
-    };
-  }
-
-  function mergeItemRecords(existingItem, incomingItem) {
-    const mergedDetails = clone(existingItem.details || []);
-
-    (incomingItem.details || []).forEach((incomingDetail) => {
-      const matchingIndex = mergedDetails.findIndex(
-        (existingDetail) =>
-          existingDetail.id === incomingDetail.id || detailSignature(existingDetail) === detailSignature(incomingDetail),
-      );
-
-      if (matchingIndex >= 0) {
-        mergedDetails[matchingIndex] = mergeDetailRecords(mergedDetails[matchingIndex], incomingDetail);
-        return;
-      }
-
-      mergedDetails.push(clone(incomingDetail));
-    });
-
-    const useIncoming = new Date(incomingItem.dateModification || 0).getTime()
-      >= new Date(existingItem.dateModification || 0).getTime();
-    const preferredItem = useIncoming ? incomingItem : existingItem;
-
-    return {
-      ...existingItem,
-      ...preferredItem,
-      id: existingItem.id || incomingItem.id || uid(),
-      numero: sanitizeText(preferredItem.numero || existingItem.numero, true),
-      dateCreation: getEarliestTimestamp(existingItem.dateCreation, incomingItem.dateCreation),
-      dateModification: getLatestTimestamp(existingItem.dateModification, incomingItem.dateModification),
-      details: mergedDetails.map((detail, index) => ({
-        ...detail,
-        champ: index + 1,
-      })),
-    };
-  }
-
-  function mergeSiteRecords(existingSite, incomingSite) {
-    const mergedItems = clone(existingSite.items || []);
-
-    (incomingSite.items || []).forEach((incomingItem) => {
-      const matchingIndex = mergedItems.findIndex(
-        (existingItem) => existingItem.id === incomingItem.id || existingItem.numero === incomingItem.numero,
-      );
-
-      if (matchingIndex >= 0) {
-        mergedItems[matchingIndex] = mergeItemRecords(mergedItems[matchingIndex], incomingItem);
-        return;
-      }
-
-      mergedItems.push(clone(incomingItem));
-    });
-
-    const useIncoming = new Date(incomingSite.dateModification || 0).getTime()
-      >= new Date(existingSite.dateModification || 0).getTime();
-    const preferredSite = useIncoming ? incomingSite : existingSite;
-
-    return {
-      ...existingSite,
-      ...preferredSite,
-      id: existingSite.id || incomingSite.id || uid(),
-      nom: sanitizeText(preferredSite.nom || existingSite.nom, true),
-      dateCreation: getEarliestTimestamp(existingSite.dateCreation, incomingSite.dateCreation),
-      dateModification: getLatestTimestamp(existingSite.dateModification, incomingSite.dateModification),
-      items: mergedItems.sort(
-        (left, right) => new Date(right.dateModification || 0).getTime() - new Date(left.dateModification || 0).getTime(),
-      ),
-    };
-  }
-
   async function init() {
     if (state.initialized) {
       return null;
@@ -414,35 +309,6 @@
     return true;
   }
 
-  function mergeImportData(payload) {
-    const source = payload && typeof payload === 'object' && 'data' in payload ? payload.data : payload;
-    const normalized = normalizeImportedData(source);
-    if (!normalized) {
-      return false;
-    }
-
-    const mergedSites = clone(state.data);
-
-    normalized.forEach((incomingSite) => {
-      const matchingIndex = mergedSites.findIndex(
-        (existingSite) => existingSite.id === incomingSite.id || existingSite.nom === incomingSite.nom,
-      );
-
-      if (matchingIndex >= 0) {
-        mergedSites[matchingIndex] = mergeSiteRecords(mergedSites[matchingIndex], incomingSite);
-        return;
-      }
-
-      mergedSites.push(clone(incomingSite));
-    });
-
-    state.data = mergedSites.sort(
-      (left, right) => new Date(right.dateModification || 0).getTime() - new Date(left.dateModification || 0).getTime(),
-    );
-    persist();
-    return true;
-  }
-
   window.StorageService = {
     init,
     getSites,
@@ -457,6 +323,5 @@
     removeDetail,
     exportData,
     importData,
-    mergeImportData,
   };
 })();


### PR DESCRIPTION
### Motivation

- The three-dot menu should only expose `Importer les données` and `Exporter les données`, so merge and quit actions must be removed from the UI.
- The file-selection flow should use a single import picker rather than separate merge/replace pickers to simplify the UX.
- The merge import behaviour is being removed end-to-end, so corresponding storage merge helpers and the `mergeImportData` API must be deleted.

### Description

- Remove `Fusionner les données` and `Quiter` buttons and the extra `mergeDataInput` file input from `index.html` so only import/export remain.
- Update `js/app.js` to use a single import file picker (`importDataInput`), remove handlers for the merge button and quit button, always call `StorageService.importData` from `handleImportFile`, and show a unified toast message `"Données importées."` after import.
- Remove merging helpers and APIs from `js/storage.js`, including the internal merge functions and the `mergeImportData` export, so storage no longer supports merging imported payloads.

### Testing

- Ran `node --check js/app.js` and `node --check js/storage.js`, and both checks completed without syntax errors.
- Searched the codebase for merge/quit artefacts with `rg -n "merge|Merge|quiter|Quiter|quitButton|mergeData|mergeImportData|detailSignature|getEarliestTimestamp" js index.html css` to confirm removal of related symbols and the search returned no remaining usage.
- Verified the app UI code paths still support `Importer` and `Exporter` flows and that the single import picker is wired to `handleImportFile` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00a1ab104832a9ea3ef46c238d386)