### PR TITLE
Hide import file input next to home menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,13 +52,7 @@ button {
 }
 
 .file-picker-input {
-  position: fixed;
-  top: 0;
-  left: -9999px;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
-  pointer-events: none;
+  display: none;
 }
 
 .app-shell {


### PR DESCRIPTION
### Motivation
- Remove the visible native file input sitting next to the three-dot menu so only the small three-dot trigger remains visible while preserving the existing import behavior.

### Description
- Replace the offscreen positioning rules for `.file-picker-input` with `display: none;` in `css/style.css` so the input remains in the DOM but is visually hidden and functional via the existing `showPicker()` / `click()` logic.

### Testing
- Ran `git diff --check` and `git status --short` to validate the change and committed the update successfully; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00bcf4b84832a81533811a308f1a5)