### PR TITLE
Hide import file picker control

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,7 +52,18 @@ button {
 }
 
 .file-picker-input {
-  display: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .app-shell {

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
             accept=".su,.json,application/json"
             tabindex="-1"
             aria-hidden="true"
+            hidden
           />
         </div>
       </header>


### PR DESCRIPTION
### Motivation
- Remove the visible "choose file" control that appears next to the three-dot header menu while keeping the import behavior intact.

### Description
- Add `hidden` to the `#importDataInput` element in `index.html` and replace `display: none` with a robust visually-hidden implementation for `.file-picker-input` in `css/style.css` so the input remains available to the existing import logic but is not rendered by the browser.

### Testing
- Ran `git diff -- index.html css/style.css` and committed the change with `git commit -m "Hide import file picker control"`, both of which succeeded; no automated UI tests were executed for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00df34a30832ab2cbfe59fbbec0a7)