### PR TITLE
Remove standalone import file picker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,20 +51,6 @@ button {
   border: 0;
 }
 
-.file-picker-input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-  opacity: 0;
-  pointer-events: none;
-}
 
 .app-shell {
   height: 100vh;

--- a/index.html
+++ b/index.html
@@ -29,15 +29,6 @@
               Exporter les données
             </button>
           </div>
-          <input
-            id="importDataInput"
-            class="file-picker-input"
-            type="file"
-            accept=".su,.json,application/json"
-            tabindex="-1"
-            aria-hidden="true"
-            hidden
-          />
         </div>
       </header>
 

--- a/js/app.js
+++ b/js/app.js
@@ -140,7 +140,6 @@
     const homeMenuPanel = requireElement("homeMenuPanel");
     const importDataButton = requireElement("importDataButton");
     const exportDataButton = requireElement("exportDataButton");
-    const importDataInput = requireElement("importDataInput");
 
     function formatExportFileName() {
       const now = new Date();
@@ -175,10 +174,10 @@
       window.setTimeout(() => URL.revokeObjectURL(link.href), 0);
     }
 
-    async function handleImportFile(event) {
-      const sourceInput = event.target;
-      const [file] = Array.from(sourceInput.files || []);
+    async function handleImportFile(fileInput) {
+      const [file] = Array.from(fileInput.files || []);
       if (!file) {
+        fileInput.remove();
         return;
       }
 
@@ -195,7 +194,8 @@
       } catch (error) {
         UiService.showToast("Importation impossible.");
       } finally {
-        sourceInput.value = "";
+        fileInput.value = "";
+        fileInput.remove();
       }
     }
 
@@ -208,23 +208,28 @@
 
     function openImportFilePicker() {
       closeHomeMenu();
-      if (!importDataInput) {
-        UiService.showToast("Importation impossible.");
-        return;
-      }
 
-      importDataInput.value = "";
+      const fileInput = document.createElement("input");
+      fileInput.type = "file";
+      fileInput.accept = ".su,.json,application/json";
+      fileInput.hidden = true;
+      fileInput.tabIndex = -1;
+      fileInput.setAttribute("aria-hidden", "true");
+      fileInput.addEventListener("change", () => {
+        handleImportFile(fileInput);
+      }, { once: true });
+      document.body.appendChild(fileInput);
 
       try {
-        if (typeof importDataInput.showPicker === "function") {
-          importDataInput.showPicker();
+        if (typeof fileInput.showPicker === "function") {
+          fileInput.showPicker();
           return;
         }
       } catch (error) {
         // Certains navigateurs refusent showPicker sur certains contextes.
       }
 
-      importDataInput.click();
+      fileInput.click();
     }
 
     function renderSites() {
@@ -298,7 +303,6 @@
       });
     }
 
-    importDataInput.addEventListener("change", handleImportFile);
 
     if (importDataButton) {
       importDataButton.addEventListener("click", () => {


### PR DESCRIPTION
### Motivation

- The UI exposed a hidden `<input type="file">` element outside the three-dots header menu which made the file-picker available outside the intended menu action.

### Description

- Removed the static file input element from `index.html` so no file selector exists outside the menu anymore.
- Deleted the unused `.file-picker-input` CSS rules from `css/style.css`.
- Reworked `js/app.js` to create a temporary `input[type=file]` dynamically when the user clicks `Importer les données`, call the import handler with that input, and remove the element after use.
- Updated the import handler signature to accept the created file input and clean up its value and DOM node when finished, and removed the old global `importDataInput` usage and event binding.

### Testing

- Ran syntax checks: `node --check js/app.js`, `node --check js/ui.js`, and `node --check js/storage.js`, all succeeded. 
- Verified the app still builds / parses and the import flow now uses a dynamically-created file input (manual browser verification recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c010367bc8832a9a1aadc298c2b8af)