### PR TITLE
Make page 3 designation column multiline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -474,6 +474,13 @@ button {
   resize: vertical;
 }
 
+.cell-textarea--designation {
+  min-width: 12rem;
+  min-height: 4.25rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .readonly-value,
 .meta-value {
   display: inline-block;

--- a/js/app.js
+++ b/js/app.js
@@ -596,7 +596,7 @@
             <tr data-detail-id="${detail.id}">
               <td><span class="field-badge">${detail.champ}</span></td>
               <td><input class="cell-input" data-field="code" value="${escapeHtml(detail.code)}" /></td>
-              <td><input class="cell-input" data-field="designation" value="${escapeHtml(detail.designation)}" /></td>
+              <td><textarea class="cell-textarea cell-textarea--designation" data-field="designation">${escapeHtml(detail.designation)}</textarea></td>
               <td>
                 <div>
                   <input class="cell-input" data-field="qteSortie" type="number" min="0" step="1" value="${escapeHtml(detail.qteSortie)}" />


### PR DESCRIPTION
### Motivation
- Les longues valeurs du champ `Désignation` dans le tableau de la page 3 ne s’affichaient pas correctement sur une seule ligne; il faut permettre l’affichage et l’édition sur plusieurs lignes pour améliorer lisibilité et saisie.

### Description
- Remplacement de l’`input` par un `textarea` pour la cellule `designation` dans `page3` table rendering (`js/app.js`).
- Ajout d’une classe CSS dédiée `.cell-textarea--designation` avec `white-space: pre-wrap` et `overflow-wrap: anywhere` et dimensions minimales pour assurer le retour à la ligne et une hauteur lisible (`css/style.css`).
- Aucune logique métier modifiée; les gestionnaires d’événements existants utilisant `data-field` continuent de fonctionner avec le `textarea`.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` — OK.
- Exécution de la vérification de diff avec `git diff --check` — OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c012b72fdc832aac08b3412931f380)