### PR TITLE
Allow Firebase Realtime Database writes without client authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,6 @@
     </div>
 
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-database-compat.js"></script>
     <script src="js/storage.js"></script>
     <script src="js/ui.js"></script>

--- a/js/storage.js
+++ b/js/storage.js
@@ -7,8 +7,6 @@
 
   const state = {
     initialized: false,
-    authReady: false,
-    uid: null,
     online: true,
     cache: {
       sites: {},
@@ -19,8 +17,6 @@
     unsubscribers: [],
     offlineQueue: [],
     firebaseListenersAttached: false,
-    authPromise: null,
-    authRetryTimeoutId: null,
     networkListenersAttached: false,
   };
 
@@ -144,7 +140,7 @@
   }
 
   function hasFirebase() {
-    return !!(window.firebase && window.firebase.database && window.firebase.auth);
+    return !!(window.firebase && window.firebase.database);
   }
 
   function queueOperation(operation) {
@@ -153,7 +149,7 @@
   }
 
   async function writeOperation(operation, saveOfflineOnError) {
-    if (!hasFirebase() || !state.authReady || !state.online) {
+    if (!hasFirebase() || !state.online) {
       if (saveOfflineOnError) {
         queueOperation(operation);
       }
@@ -175,7 +171,7 @@
   }
 
   async function flushOfflineQueue() {
-    if (!state.offlineQueue.length || !state.authReady || !hasFirebase()) {
+    if (!state.offlineQueue.length || !hasFirebase()) {
       return;
     }
 
@@ -189,7 +185,7 @@
   }
 
   function canDelete(record) {
-    return !!record && record.ownerId === state.uid;
+    return !!record;
   }
 
   function attachRealtimeListeners(db) {
@@ -218,34 +214,6 @@
     state.firebaseListenersAttached = true;
   }
 
-  async function ensureFirebaseAuth(firebase) {
-    if (state.authReady) {
-      return true;
-    }
-
-    if (!state.authPromise) {
-      state.authPromise = firebase
-        .auth()
-        .signInAnonymously()
-        .then(() => {
-          state.uid = firebase.auth().currentUser ? firebase.auth().currentUser.uid : null;
-          state.authReady = true;
-          state.online = true;
-          return true;
-        })
-        .catch(() => {
-          state.authReady = false;
-          state.online = false;
-          return false;
-        })
-        .finally(() => {
-          state.authPromise = null;
-        });
-    }
-
-    return state.authPromise;
-  }
-
   async function initFirebaseSync() {
     if (!hasFirebase()) {
       state.online = false;
@@ -268,22 +236,8 @@
       firebase.initializeApp(config);
     }
 
-    const authenticated = await ensureFirebaseAuth(firebase);
-    if (!authenticated) {
-      if (state.authRetryTimeoutId) {
-        window.clearTimeout(state.authRetryTimeoutId);
-      }
-      state.authRetryTimeoutId = window.setTimeout(() => {
-        initFirebaseSync();
-      }, 5000);
-      return;
-    }
-    if (state.authRetryTimeoutId) {
-      window.clearTimeout(state.authRetryTimeoutId);
-      state.authRetryTimeoutId = null;
-    }
-
     const db = firebase.database();
+    state.online = true;
     attachRealtimeListeners(db);
 
     if (!state.networkListenersAttached) {
@@ -326,7 +280,6 @@
       nom: siteName,
       dateCreation: timestamp,
       dateModification: timestamp,
-      ownerId: state.uid,
     };
 
     state.cache.sites[siteId] = site;
@@ -377,7 +330,6 @@
       numero: `OUT-${cleanNumber}`,
       dateCreation: timestamp,
       dateModification: timestamp,
-      ownerId: state.uid,
     };
 
     if (!state.cache.items[siteId]) {
@@ -444,7 +396,6 @@
       observation: "",
       dateCreation: timestamp,
       dateModification: timestamp,
-      ownerId: state.uid,
     };
 
     if (!state.cache.details[siteId]) {

--- a/page2.html
+++ b/page2.html
@@ -65,7 +65,6 @@
     </div>
 
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-database-compat.js"></script>
     <script src="js/storage.js"></script>
     <script src="js/ui.js"></script>

--- a/page3.html
+++ b/page3.html
@@ -84,7 +84,6 @@
     </div>
 
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-database-compat.js"></script>
     <script src="js/storage.js"></script>
     <script src="js/ui.js"></script>


### PR DESCRIPTION
### Motivation
- The app could not persist new records when Firebase anonymous authentication failed, leaving the database empty for pages 1/2/3. 
- The goal is to let any user add/update/delete data from the client without requiring sign-in so entries are reliably written to Realtime Database. 
- Client-side owner-based deletion and ownerId tracking were preventing free edits and created an implicit dependency on auth state.

### Description
- Removed Firebase Auth SDK usage from the three HTML pages and kept only `firebase-app` and `firebase-database` includes. 
- Simplified `js/storage.js` by removing auth-related state and logic (`authReady`, `uid`, `authPromise`, `authRetryTimeoutId`) and the `ensureFirebaseAuth` function and anonymous sign-in flow. 
- Changed `hasFirebase()` to check only for `window.firebase.database`, removed `ownerId` assignment when creating sites/items/details, and made `canDelete()` accept any existing record (no UID check). 
- Adjusted write/flush logic to no longer depend on auth state and to attach realtime listeners and flush the offline queue directly after initializing the database connection.

### Testing
- Ran `node --check js/storage.js` to validate the modified JavaScript had no syntax errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5716ddc50832a84f95dada73900e3)