### PR TITLE
Enable Firebase anonymous auth to restore realtime sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
     </div>
 
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-database-compat.js"></script>
     <script src="js/storage.js"></script>
     <script src="js/ui.js"></script>

--- a/js/storage.js
+++ b/js/storage.js
@@ -143,6 +143,27 @@
     return !!(window.firebase && window.firebase.database);
   }
 
+  function hasFirebaseAuth() {
+    return !!(window.firebase && window.firebase.auth);
+  }
+
+  async function ensureFirebaseAuth(firebase) {
+    if (!hasFirebaseAuth()) {
+      return;
+    }
+
+    if (firebase.auth().currentUser) {
+      return;
+    }
+
+    try {
+      await firebase.auth().signInAnonymously();
+    } catch (error) {
+      state.online = false;
+      console.error("Firebase anonymous sign-in failed:", error);
+    }
+  }
+
   function queueOperation(operation) {
     state.offlineQueue.push(operation);
     persistOfflineQueue();
@@ -236,6 +257,10 @@
       firebase.initializeApp(config);
     }
 
+    await ensureFirebaseAuth(firebase);
+    if (hasFirebaseAuth() && !firebase.auth().currentUser) {
+      return;
+    }
     const db = firebase.database();
     state.online = true;
     attachRealtimeListeners(db);

--- a/page2.html
+++ b/page2.html
@@ -65,6 +65,7 @@
     </div>
 
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-database-compat.js"></script>
     <script src="js/storage.js"></script>
     <script src="js/ui.js"></script>

--- a/page3.html
+++ b/page3.html
@@ -84,6 +84,7 @@
     </div>
 
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-database-compat.js"></script>
     <script src="js/storage.js"></script>
     <script src="js/ui.js"></script>


### PR DESCRIPTION
### Motivation
- Realtime writes were not appearing after creating records, likely because Firebase Realtime Database rules require an authenticated user and unauthenticated writes were rejected silently.
- The storage bootstrap attempted to attach realtime listeners and write without guaranteeing authentication, causing local saves to remain local.

### Description
- Added the `firebase-auth-compat` script to `index.html`, `page2.html` and `page3.html` to include the Auth SDK in pages that use Firebase. 
- Implemented `hasFirebaseAuth()` and `ensureFirebaseAuth(firebase)` in `js/storage.js` to detect the Auth SDK and perform `signInAnonymously()` when needed. 
- Made `initFirebaseSync()` await `ensureFirebaseAuth()` and abort realtime setup when auth is required but sign-in did not complete, preventing silent failed writes and incorrect online state.
- Error handling was added to set `state.online = false` and log a console error if anonymous sign-in fails.

### Testing
- Checked JavaScript syntax with `node --check js/storage.js`, which succeeded. 
- Checked JavaScript syntax with `node --check js/app.js`, which succeeded. 
- Checked JavaScript syntax with `node --check js/ui.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c573f98ed8832aa49ba69d3a76d4df)