### PR TITLE
Improve Firestore realtime hydration across clients

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -294,6 +294,28 @@
     ]);
   }
 
+
+  async function hydrateCacheFromFirestore(firestore) {
+    if (state.offlineQueue.length) {
+      return;
+    }
+
+    try {
+      const [sitesSnapshot, itemsSnapshot, detailsSnapshot] = await Promise.all([
+        firestore.collection("app_data").doc("page1_sites").get(),
+        firestore.collection("app_data").doc("page2_items").get(),
+        firestore.collection("app_data").doc("page3_details").get(),
+      ]);
+
+      state.cache.sites = sitesSnapshot.exists ? (sitesSnapshot.data() || {}) : {};
+      state.cache.items = itemsSnapshot.exists ? (itemsSnapshot.data() || {}) : {};
+      state.cache.details = detailsSnapshot.exists ? (detailsSnapshot.data() || {}) : {};
+      notifyChange();
+    } catch (error) {
+      console.error("Firestore hydration failed:", error);
+    }
+  }
+
   function attachRealtimeListeners(firestore) {
     if (state.firebaseListenersAttached) {
       return;
@@ -348,6 +370,7 @@
     const firestore = firebase.firestore();
     await ensureFirestoreDocuments(firestore);
     state.online = true;
+    await hydrateCacheFromFirestore(firestore);
     attachRealtimeListeners(firestore);
 
     if (!state.networkListenersAttached) {


### PR DESCRIPTION
### Motivation
- Ensure users see others' changes faster by populating the local cache from Firestore before attaching realtime listeners. 
- Preserve offline-first behavior so local queued writes are not overwritten by a remote snapshot.

### Description
- Add `hydrateCacheFromFirestore(firestore)` in `js/storage.js` to fetch `page1_sites`, `page2_items` and `page3_details` documents and update `state.cache` then call `notifyChange()`.
- Skip hydration when `state.offlineQueue` is non-empty to avoid clobbering local pending writes.
- Call `hydrateCacheFromFirestore` from `initFirebaseSync()` immediately after `ensureFirestoreDocuments()` and before `attachRealtimeListeners()` so the page reflects the latest shared data faster.

### Testing
- Executed a syntax/runtime smoke check with `node -e "const fs=require('fs'); new Function(fs.readFileSync('js/storage.js','utf8')); console.log('ok')"` which printed `ok` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c580529afc832a88a7c3c91c4b76a4)