### PR TITLE
Fix Firestore sync when anonymous auth is unavailable

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -149,18 +149,19 @@
 
   async function ensureFirebaseAuth(firebase) {
     if (!hasFirebaseAuth()) {
-      return;
+      return true;
     }
 
     if (firebase.auth().currentUser) {
-      return;
+      return true;
     }
 
     try {
       await firebase.auth().signInAnonymously();
+      return true;
     } catch (error) {
-      state.online = false;
-      console.error("Firebase anonymous sign-in failed:", error);
+      console.error("Firebase anonymous sign-in failed. Continuing without auth:", error);
+      return false;
     }
   }
 
@@ -233,6 +234,7 @@
 
       await batch.commit();
     } catch (error) {
+      console.error("Firestore write failed:", error);
       if (saveOfflineOnError) {
         queueOperation(operation);
       }
@@ -364,9 +366,6 @@
     }
 
     await ensureFirebaseAuth(firebase);
-    if (hasFirebaseAuth() && !firebase.auth().currentUser) {
-      return;
-    }
     const firestore = firebase.firestore();
     await ensureFirestoreDocuments(firestore);
     state.online = true;


### PR DESCRIPTION
### Motivation
- The app could remain local-only when Firebase anonymous authentication was unavailable, preventing data from being visible to other users.
- Initialization previously aborted if no auth session existed, which blocked Firestore hydration and realtime listeners.

### Description
- Change `ensureFirebaseAuth` to return a boolean and avoid forcing an initialization abort when anonymous sign-in fails, allowing Firestore to continue initializing without an auth session.
- Remove the early exit that prevented continuing when `firebase.auth().currentUser` was not present, so hydration and listeners run even if anonymous auth is disabled.
- Add explicit `console.error` logging for failed Firestore batch writes to aid diagnosis when writes are rejected.

### Testing
- Verified `js/storage.js` parses with Node via `node -e "const fs=require('fs'); new Function(fs.readFileSync('js/storage.js','utf8')); console.log('storage.js syntax OK')"` which printed `storage.js syntax OK` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c583fa4c34832abfc9165d6e66e174)