### PR TITLE
Afficher un toast selon le résultat Firestore à la création d'un site

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -329,16 +329,24 @@
 
     searchInput.addEventListener("input", renderSites);
 
-    siteForm.addEventListener("submit", (event) => {
+    siteForm.addEventListener("submit", async (event) => {
       event.preventDefault();
       const name = siteNameInput.value.trim();
       if (!name) {
         siteFormError.textContent = "Veuillez remplir ce champ";
         return;
       }
-      StorageService.createSite(name);
+      const creationResult = await StorageService.createSiteWithSyncStatus(name);
+      if (!creationResult) {
+        siteFormError.textContent = "Nom du site invalide.";
+        return;
+      }
       siteDialog.close();
-      UiService.showToast("Site créé avec succès.");
+      UiService.showToast(
+        creationResult.savedToFirestore
+          ? "Site créé et enregistré dans Firestore (page 1)."
+          : "Site créé en local. Échec d'enregistrement Firestore (page 1).",
+      );
       renderSites();
     });
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -175,7 +175,7 @@
       if (saveOfflineOnError) {
         queueOperation(operation);
       }
-      return;
+      return false;
     }
 
     try {
@@ -233,11 +233,13 @@
       });
 
       await batch.commit();
+      return true;
     } catch (error) {
       console.error("Firestore write failed:", error);
       if (saveOfflineOnError) {
         queueOperation(operation);
       }
+      return false;
     }
   }
 
@@ -399,7 +401,7 @@
     await initFirebaseSync();
   }
 
-  function createSite(name) {
+  function buildSite(name) {
     const siteName = sanitizeText(name, true);
     if (!siteName) {
       return null;
@@ -413,15 +415,42 @@
       dateCreation: timestamp,
       dateModification: timestamp,
     };
+    return site;
+  }
 
-    state.cache.sites[siteId] = site;
+  function createSite(name) {
+    const site = buildSite(name);
+    if (!site) {
+      return null;
+    }
+
+    state.cache.sites[site.id] = site;
     notifyChange();
 
     writeOperation([
-      { path: `${PAGE1_PATH}/${siteId}`, value: site },
+      { path: `${PAGE1_PATH}/${site.id}`, value: site },
     ], true);
 
     return clone(site);
+  }
+
+  async function createSiteWithSyncStatus(name) {
+    const site = buildSite(name);
+    if (!site) {
+      return null;
+    }
+
+    state.cache.sites[site.id] = site;
+    notifyChange();
+
+    const savedToFirestore = await writeOperation([
+      { path: `${PAGE1_PATH}/${site.id}`, value: site },
+    ], true);
+
+    return {
+      site: clone(site),
+      savedToFirestore,
+    };
   }
 
   function removeSite(siteId) {
@@ -731,6 +760,7 @@
     getSite,
     getItem,
     createSite,
+    createSiteWithSyncStatus,
     removeSite,
     createItem,
     removeItem,


### PR DESCRIPTION
### Motivation
- Permettre au flux de création de site (page 1) d'informer l'utilisateur si l'enregistrement a bien été propagé vers Firestore ou s'il a été enregistré seulement en local.

### Description
- Ajout de `buildSite` pour factoriser la construction de l'objet site et conservation de `createSite` pour compatibilité.
- Ajout de `createSiteWithSyncStatus` qui crée le site localement puis retourne le statut d'enregistrement Firestore (`savedToFirestore`).
- `writeOperation` retourne désormais un booléen (`true` si le `batch.commit()` Firestore a réussi, `false` sinon) pour piloter le feedback utilisateur.
- Mise à jour du traitement du `submit` du formulaire sur la page d'accueil (`siteForm`) pour appeler `createSiteWithSyncStatus` de façon `async` et afficher un toast distinct selon que l'écriture Firestore ait réussi ou échoué.

### Testing
- Vérification de la syntaxe avec `node --check js/storage.js` et `node --check js/app.js`, les deux vérifications ont réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c586a10be0832a94cb712a4a52fa6c)