### PR TITLE
Add error handling for site creation and prevent dialog auto-close

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       <button id="openCreateSite" class="fab" type="button" aria-label="Créer un site">+</button>
 
       <dialog id="siteDialog" class="modal-card">
-        <form method="dialog" class="modal-content" id="siteForm">
+        <form class="modal-content" id="siteForm">
           <div class="modal-header">
             <h2>Entrer nom du site</h2>
             <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>

--- a/js/app.js
+++ b/js/app.js
@@ -328,9 +328,20 @@
         siteFormError.textContent = 'Veuillez remplir ce champ';
         return;
       }
-      await StorageService.createSite(name);
-      siteDialog.close();
-      UiService.showToast('Site créé et partagé en temps réel.');
+
+      try {
+        const createdSiteId = await StorageService.createSite(name);
+        if (!createdSiteId) {
+          siteFormError.textContent = 'Création impossible. Vérifiez le nom du site.';
+          return;
+        }
+
+        siteDialog.close();
+        UiService.showToast('Site créé et partagé en temps réel.');
+      } catch (error) {
+        console.error('Erreur lors de la création du site :', error);
+        siteFormError.textContent = "Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.";
+      }
     });
 
     StorageService.subscribeSites(


### PR DESCRIPTION
### Motivation
- Ensure failures during site creation are surfaced to the user instead of letting the dialog silently close, and prevent the form from auto-closing the dialog so errors can be displayed.

### Description
- Removed `method="dialog"` from the site creation `<form>` in `index.html` so the dialog no longer closes automatically on submit.
- Wrapped the call to `StorageService.createSite` in a `try/catch` in `js/app.js` and awaited its return value.
- Added a check for the returned `createdSiteId` to display an error in `#siteFormError` when creation fails and only close the dialog on success, and logged storage errors with `console.error`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fc7c0668832a8cf1f79fd751398a)