### PR TITLE
Afficher le nombre de sous-éléments sur les pages liste 1 et 2

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -142,6 +142,7 @@
     const exportDataButton = requireElement('exportDataButton');
 
     let currentSites = [];
+    let itemCountsBySite = {};
 
     function formatExportFileName() {
       const now = new Date();
@@ -257,6 +258,7 @@
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
+                  <span>${itemCountsBySite[site.id] || 0} sous-élément${(itemCountsBySite[site.id] || 0) > 1 ? 's' : ''}</span>
                   <span>Créé le ${UiService.formatDate(site.dateCreation)}</span>
                   <small>Modifié le ${UiService.formatDate(site.dateModification)}</small>
                 </div>
@@ -353,6 +355,16 @@
         UiService.showToast('Synchronisation Firefox indisponible.');
       },
     );
+
+    StorageService.subscribeItemCounts(
+      (counts) => {
+        itemCountsBySite = counts;
+        renderSites();
+      },
+      () => {
+        UiService.showToast('Comptage des sous-éléments indisponible.');
+      },
+    );
   }
 
   function initSiteDetailPage() {
@@ -375,6 +387,7 @@
 
     let currentSite = StorageService.getSite(siteId);
     let currentItems = [];
+    let detailCountsByItem = {};
 
     siteTitle.textContent = currentSite ? currentSite.nom : 'Chargement...';
 
@@ -440,6 +453,7 @@
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
+                  <span>${detailCountsByItem[item.id] || 0} sous-élément${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span>
                   <span>Créé le ${UiService.formatDate(item.dateCreation)}</span>
                   <small>Modifié le ${UiService.formatDate(item.dateModification)}</small>
                 </div>
@@ -527,6 +541,17 @@
       },
       () => {
         UiService.showToast('Synchronisation Firefox indisponible.');
+      },
+    );
+
+    StorageService.subscribeDetailCounts(
+      siteId,
+      (counts) => {
+        detailCountsByItem = counts;
+        renderItems();
+      },
+      () => {
+        UiService.showToast('Comptage des sous-éléments indisponible.');
       },
     );
   }

--- a/js/storage.js
+++ b/js/storage.js
@@ -169,6 +169,32 @@ function subscribeItems(siteId, onChange, onError) {
   );
 }
 
+function subscribeItemCounts(onChange, onError) {
+  const itemsRef = makePageItemsCollection('page2');
+  const q = query(itemsRef, orderBy('dateModification', 'desc'));
+
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      const counts = {};
+      snapshot.docs.forEach((docSnap) => {
+        const item = normalizeDocData(docSnap);
+        const key = String(item.siteId || '');
+        if (!key) {
+          return;
+        }
+        counts[key] = (counts[key] || 0) + 1;
+      });
+      onChange(clone(counts));
+    },
+    (error) => {
+      if (typeof onError === 'function') {
+        onError(error);
+      }
+    },
+  );
+}
+
 function subscribeDetails(siteId, itemId, onChange, onError) {
   const detailsRef = makePageItemsCollection('page3');
   const q = query(
@@ -185,6 +211,32 @@ function subscribeDetails(siteId, itemId, onChange, onError) {
       const details = snapshot.docs.map(normalizeDocData);
       state.detailsByItem.set(detailsKey, details);
       onChange(clone(details));
+    },
+    (error) => {
+      if (typeof onError === 'function') {
+        onError(error);
+      }
+    },
+  );
+}
+
+function subscribeDetailCounts(siteId, onChange, onError) {
+  const detailsRef = makePageItemsCollection('page3');
+  const q = query(detailsRef, where('siteId', '==', siteId), orderBy('champ', 'asc'));
+
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      const counts = {};
+      snapshot.docs.forEach((docSnap) => {
+        const detail = normalizeDocData(docSnap);
+        const key = String(detail.itemId || '');
+        if (!key) {
+          return;
+        }
+        counts[key] = (counts[key] || 0) + 1;
+      });
+      onChange(clone(counts));
     },
     (error) => {
       if (typeof onError === 'function') {
@@ -516,7 +568,9 @@ window.StorageService = {
   getItem,
   subscribeSites,
   subscribeItems,
+  subscribeItemCounts,
   subscribeDetails,
+  subscribeDetailCounts,
   createSite,
   removeSite,
   createItem,


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité des listes en affichant, directement dans chaque carte, le nombre de sous-éléments associés (OUTs et détails). 

### Description
- Ajout de deux nouvelles souscriptions Firestore `subscribeItemCounts` et `subscribeDetailCounts` dans `js/storage.js` qui comptent respectivement les éléments de `page2` groupés par `siteId` et les éléments de `page3` groupés par `itemId`.
- Exposition des nouvelles API via `StorageService` et intégration dans `initHomePage` et `initSiteDetailPage` dans `js/app.js` pour maintenir des compteurs temps réel.
- Affichage des compteurs dans le rendu des cartes sur la page d’accueil (site) et la page détail (OUT), avec gestion simple du pluriel (`0/1/2 sous-élément(s)`).
- Mise à jour du rendu pour re-render lors des changements de compteurs et maintien du comportement existant (recherche, création, suppression, export).

### Testing
- Vérification de la syntaxe JavaScript avec `node --check js/app.js` qui a réussi.
- Vérification de la syntaxe JavaScript avec `node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c805f207ac832abba37e2a08bf947b)