### PR TITLE
Page 2: Use "Ligne/Lignes" label for detail counts

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -453,7 +453,7 @@
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
-                  <span>${detailCountsByItem[item.id] || 0} sous-élément${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span>
+                  <span>${detailCountsByItem[item.id] || 0} Ligne${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span>
                   <span>Créé le ${UiService.formatDate(item.dateCreation)}</span>
                   <small>Modifié le ${UiService.formatDate(item.dateModification)}</small>
                 </div>
@@ -551,7 +551,7 @@
         renderItems();
       },
       () => {
-        UiService.showToast('Comptage des sous-éléments indisponible.');
+        UiService.showToast('Comptage des lignes indisponible.');
       },
     );
   }


### PR DESCRIPTION
### Motivation
- Afficher sur la page 2, dans le détail de la liste, le libellé de comptage en tant que nombre de lignes du tableau de données (ex. `0 Ligne`) plutôt que « sous-élément(s) », pour correspondre au comptage réel des lignes de la page 3.

### Description
- Modifié `js/app.js` pour remplacer le texte du compteur dans les cartes d'OUT de `sous-élément(s)` à `Ligne(s)` et pour ajuster le message d'erreur lié au comptage en `Comptage des lignes indisponible.`.

### Testing
- Exécuté `node --check js/app.js` avec succès pour valider la syntaxe du fichier modifié.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c80f61cdd0832ab79fb2113dc73912)