### PR TITLE
Remove unavailable line-count toast on item list

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -550,9 +550,7 @@
         detailCountsByItem = counts;
         renderItems();
       },
-      () => {
-        UiService.showToast('Comptage des lignes indisponible.');
-      },
+      () => {},
     );
   }
 


### PR DESCRIPTION
### Motivation
- Prevent the UI from showing the toast message `Comptage des lignes indisponible.` when `subscribeDetailCounts` fails on the item list page. 

### Description
- Replaced the failure callback for `StorageService.subscribeDetailCounts` with a no-op (`() => {}`) in `js/app.js` so the toast is no longer displayed. 

### Testing
- Ran `rg -n "Comptage des lignes indisponible" js/app.js` which returned no results (successfully confirming the string was removed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c811e36c44832abceb730eeb17a357)