### PR TITLE
Fix page 2 detail line counter query for detail counts

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -222,7 +222,7 @@ function subscribeDetails(siteId, itemId, onChange, onError) {
 
 function subscribeDetailCounts(siteId, onChange, onError) {
   const detailsRef = makePageItemsCollection('page3');
-  const q = query(detailsRef, where('siteId', '==', siteId), orderBy('champ', 'asc'));
+  const q = query(detailsRef, where('siteId', '==', siteId));
 
   return onSnapshot(
     q,


### PR DESCRIPTION
### Motivation
- The page 2 counter for "Ligne(s)" could stay at `0 Ligne` because the Firestore query used `orderBy('champ')`, which interfered with reliable realtime counting of detail rows from page 3.

### Description
- Remove `orderBy('champ')` from the query in `subscribeDetailCounts` in `js/storage.js` so the query only filters by `siteId` and counts detail documents grouped by `itemId`.

### Testing
- Ran `node --check js/storage.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c813e5c36c832a8574a8ca09b45460)