### PR TITLE
Empêcher la duplication lors de la création (site, OUT, désignation)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -332,9 +332,12 @@
       }
 
       try {
-        const createdSiteId = await StorageService.createSite(name);
-        if (!createdSiteId) {
-          siteFormError.textContent = 'Création impossible. Vérifiez le nom du site.';
+        const result = await StorageService.createSite(name);
+        if (!result?.ok) {
+          siteFormError.textContent =
+            result?.reason === 'duplicate_site'
+              ? 'Ce nom de site existe déjà.'
+              : 'Création impossible. Vérifiez le nom du site.';
           return;
         }
 
@@ -515,9 +518,12 @@
         itemFormError.textContent = 'Veuillez saisir au moins 4 chiffres.';
         return;
       }
-      const createdItemId = await StorageService.createItem(siteId, value);
-      if (!createdItemId) {
-        itemFormError.textContent = 'Veuillez saisir au moins 4 chiffres.';
+      const result = await StorageService.createItem(siteId, value);
+      if (!result?.ok) {
+        itemFormError.textContent =
+          result?.reason === 'duplicate_out'
+            ? 'Ce N° OUT existe déjà pour ce site.'
+            : 'Veuillez saisir au moins 4 chiffres.';
         return;
       }
       itemDialog.close();
@@ -713,12 +719,19 @@
         detailFormError.textContent = 'Veuillez remplir la désignation.';
         return;
       }
-      await StorageService.createDetail(siteId, itemId, {
+      const result = await StorageService.createDetail(siteId, itemId, {
         code: requireElement('codeInput').value,
         designation: designationInput.value,
         qteSortie: requireElement('qteSortieInput').value,
         unite: requireElement('uniteInput').value,
       });
+      if (!result?.ok) {
+        detailFormError.textContent =
+          result?.reason === 'duplicate_designation'
+            ? 'Cette désignation existe déjà pour ce N° OUT.'
+            : 'Création impossible. Vérifiez la désignation.';
+        return;
+      }
       detailForm.reset();
       requireElement('uniteInput').value = 'm';
       UiService.showToast('Ligne ajoutée et synchronisée.');

--- a/js/storage.js
+++ b/js/storage.js
@@ -64,6 +64,33 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+function isDuplicateSiteName(name) {
+  const normalized = sanitizeText(name, true);
+  if (!normalized) {
+    return false;
+  }
+  return state.sites.some((site) => sanitizeText(site.nom, true) === normalized);
+}
+
+function isDuplicateItemNumber(siteId, numero) {
+  const normalized = sanitizeText(numero, true);
+  if (!normalized) {
+    return false;
+  }
+  const items = state.itemsBySite.get(siteId) || [];
+  return items.some((item) => sanitizeText(item.numero, true) === normalized);
+}
+
+function isDuplicateDetailDesignation(siteId, itemId, designation) {
+  const normalized = sanitizeText(designation, true);
+  if (!normalized) {
+    return false;
+  }
+  const detailsKey = `${siteId}:${itemId}`;
+  const details = state.detailsByItem.get(detailsKey) || [];
+  return details.some((detail) => sanitizeText(detail.designation, true) === normalized);
+}
+
 function uid() {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 10);
 }
@@ -249,7 +276,10 @@ function subscribeDetailCounts(siteId, onChange, onError) {
 async function createSite(name) {
   const siteName = sanitizeText(name, true);
   if (!siteName) {
-    return null;
+    return { ok: false, reason: 'invalid_name' };
+  }
+  if (isDuplicateSiteName(siteName)) {
+    return { ok: false, reason: 'duplicate_site' };
   }
   const timestamp = nowIso();
   const sitesRef = makePageItemsCollection('page1');
@@ -263,7 +293,7 @@ async function createSite(name) {
     updatedAt: serverTimestamp(),
   });
   await persistFullSnapshot();
-  return created.id;
+  return { ok: true, id: created.id };
 }
 
 async function removeSite(siteId) {
@@ -280,14 +310,18 @@ async function removeSite(siteId) {
 async function createItem(siteId, numberValue) {
   const cleanNumber = sanitizeDigits(sanitizeText(numberValue, true).replace(/^OUT-/, ''));
   if (cleanNumber.length < 4) {
-    return null;
+    return { ok: false, reason: 'invalid_out' };
+  }
+  const numero = `OUT-${cleanNumber}`;
+  if (isDuplicateItemNumber(siteId, numero)) {
+    return { ok: false, reason: 'duplicate_out' };
   }
 
   const timestamp = nowIso();
   const itemsRef = makePageItemsCollection('page2');
   const created = await addDoc(itemsRef, {
     siteId,
-    numero: `OUT-${cleanNumber}`,
+    numero,
     ownerId: state.userId,
     createdBy: state.userId,
     dateCreation: timestamp,
@@ -296,7 +330,7 @@ async function createItem(siteId, numberValue) {
     updatedAt: serverTimestamp(),
   });
   await persistFullSnapshot();
-  return created.id;
+  return { ok: true, id: created.id };
 }
 
 async function removeItem(_siteId, itemId) {
@@ -311,6 +345,14 @@ async function removeItem(_siteId, itemId) {
 }
 
 async function createDetail(siteId, itemId, payload) {
+  const designation = sanitizeText(payload.designation, true);
+  if (!designation) {
+    return { ok: false, reason: 'invalid_designation' };
+  }
+  if (isDuplicateDetailDesignation(siteId, itemId, designation)) {
+    return { ok: false, reason: 'duplicate_designation' };
+  }
+
   const detailsKey = `${siteId}:${itemId}`;
   const details = state.detailsByItem.get(detailsKey) || [];
   const nextChamp = details.length + 1;
@@ -322,7 +364,7 @@ async function createDetail(siteId, itemId, payload) {
     itemId,
     champ: nextChamp,
     code: sanitizeText(payload.code, true),
-    designation: sanitizeText(payload.designation, true),
+    designation,
     qteSortie: payload.qteSortie === '' ? '' : sanitizeNumber(payload.qteSortie),
     unite: sanitizeText(payload.unite || 'm', false) || 'm',
     qteHorsBtrs: '',
@@ -337,7 +379,7 @@ async function createDetail(siteId, itemId, payload) {
     updatedAt: serverTimestamp(),
   });
   await persistFullSnapshot();
-  return created.id;
+  return { ok: true, id: created.id };
 }
 
 async function updateDetail(siteId, itemId, detailId, changes) {


### PR DESCRIPTION
### Motivation
- Empêcher la création d’entrées en double pour les entités principales (nom de site, N° OUT par site, désignation par OUT) afin d’assurer l’intégrité des données.
- Améliorer l’expérience utilisateur en renvoyant des erreurs de validation explicites plutôt qu’un simple échec générique.

### Description
- Ajout de contrôles de doublons dans `js/storage.js` avec les utilitaires `isDuplicateSiteName`, `isDuplicateItemNumber` et `isDuplicateDetailDesignation` qui comparent des valeurs normalisées.
- Les fonctions `createSite`, `createItem` et `createDetail` retournent désormais un objet structuré (`{ ok: true, id }` ou `{ ok: false, reason }`) et effectuent la validation anti-duplication avant insertion dans Firestore.
- Mise à jour de `js/app.js` pour consommer les nouveaux retours structurés et afficher des messages d’erreur dédiés pour `duplicate_site`, `duplicate_out` et `duplicate_designation` dans les formulaires correspondants.
- Conservation des règles de sanitization existantes (`sanitizeText`, `sanitizeDigits`, etc.) et intégration de la validation côté service avant `addDoc`.

### Testing
- Vérification de la syntaxe JavaScript via `node --check js/app.js && node --check js/storage.js && node --check js/ui.js` qui a réussi.
- Tests manuels des flux de création (site, OUT, désignation) couverts par les modifications UI pour afficher les erreurs de validation; les contrôles anti-duplication se déclenchent et empêchent l’insertion lorsqu’ils s’appliquent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c81a82b5b8832ab7781ec1a1bc5551)