### PR TITLE
Fix page 3 qteRetour when editing qteSortie

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -452,11 +452,12 @@ async function updateDetail(siteId, itemId, detailId, changes) {
 
   const qteSortie = Number('qteSortie' in next ? next.qteSortie : current.qteSortie) || 0;
   const qtePosee = Math.min(Number('qtePosee' in next ? next.qtePosee : current.qtePosee) || 0, qteSortie);
-  const qteRetour = Math.max(0, qteSortie - qtePosee);
+  const rawQteRetour = Number('qteRetour' in next ? next.qteRetour : current.qteRetour) || 0;
+  const qteRetour = 'qteRetour' in next ? Math.min(Math.max(0, rawQteRetour), qteSortie) : Math.max(0, rawQteRetour);
 
   next.qteSortie = qteSortie;
   next.qtePosee = qtePosee;
-  next.qteRetour = Math.min(qteRetour, qteSortie);
+  next.qteRetour = qteRetour;
   next.dateModification = nowIso();
   next.updatedAt = serverTimestamp();
 


### PR DESCRIPTION
### Motivation
- Empêcher que la modification de `qteSortie` sur la page 3 réécrive automatiquement la valeur de `qteRetour` afin de laisser l'utilisateur conserver une valeur de retour déjà saisie.

### Description
- Dans `js/storage.js` la logique d'`updateDetail` a été ajustée pour calculer `rawQteRetour` à partir des `changes` ou de la valeur courante et pour n'écraser/borner `qteRetour` que lorsque le champ `qteRetour` est explicitement présent dans `changes`, sinon la valeur existante est préservée (avec normalisation non-négative).

### Testing
- Exécution de `node --check js/storage.js` passée sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c822e4ac08832a8cfee75c80006de8)