### PR TITLE
Ajout de la colonne « Ecart » (page 3) et suppression du recalcul automatique des quantités

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,12 @@
     element.textContent = `${count} ${count > 1 ? plural : singular}`;
   }
 
+  function computeEcart(detail) {
+    const qtePosee = Number(detail?.qtePosee) || 0;
+    const qteRetour = Number(detail?.qteRetour) || 0;
+    return qtePosee - qteRetour;
+  }
+
   function setupBackButtons() {
     document.querySelectorAll('[data-back]').forEach((button) => {
       button.addEventListener('click', () => {
@@ -660,7 +666,7 @@
       updateCount(filteredDetails.length, currentDetails.length);
 
       if (!filteredDetails.length) {
-        detailTableBody.innerHTML = `<tr><td colspan="10"><div class="empty-state">${currentDetails.length ? 'Aucune désignation ne correspond à votre recherche.' : 'Aucune ligne enregistrée.'}</div></td></tr>`;
+        detailTableBody.innerHTML = `<tr><td colspan="11"><div class="empty-state">${currentDetails.length ? 'Aucune désignation ne correspond à votre recherche.' : 'Aucune ligne enregistrée.'}</div></td></tr>`;
         return;
       }
 
@@ -677,8 +683,9 @@
                   <small class="meta-value">${escapeHtml(detail.unite)}</small>
                 </div>
               </td>
-              <td><input class="cell-input" data-field="qtePosee" type="number" min="0" max="${escapeHtml(detail.qteSortie)}" step="1" value="${detail.qtePosee}" /></td>
-              <td><input class="cell-input" data-field="qteRetour" type="number" min="0" max="${escapeHtml(detail.qteSortie)}" step="1" value="${detail.qteRetour}" /></td>
+              <td><input class="cell-input" data-field="qtePosee" type="number" min="0" step="1" value="${detail.qtePosee}" /></td>
+              <td><input class="cell-input" data-field="qteRetour" type="number" min="0" step="1" value="${detail.qteRetour}" /></td>
+              <td><input class="cell-input" type="number" value="${computeEcart(detail)}" readonly aria-label="Ecart" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td><textarea class="cell-textarea" data-field="observation">${escapeHtml(detail.observation)}</textarea></td>
@@ -699,24 +706,6 @@
           }
 
           let nextValue = event.target.value;
-
-          if (fieldName === 'qteRetour') {
-            const qteSortie = Number(currentDetail.qteSortie) || 0;
-            const qteRetour = Number(nextValue) || 0;
-            if (qteRetour > qteSortie) {
-              nextValue = String(qteSortie);
-              UiService.showToast('La Qté Retour ne peut pas dépasser la Qté Sortie.');
-            }
-          }
-
-          if (fieldName === 'qtePosee') {
-            const qteSortie = Number(currentDetail.qteSortie) || 0;
-            const qtePosee = Number(nextValue) || 0;
-            if (qtePosee > qteSortie) {
-              nextValue = String(qteSortie);
-              UiService.showToast('La Qté posée ne peut pas dépasser la Qté Sortie.');
-            }
-          }
 
           await StorageService.updateDetail(siteId, itemId, row.dataset.detailId, {
             [fieldName]: nextValue,

--- a/js/storage.js
+++ b/js/storage.js
@@ -450,14 +450,6 @@ async function updateDetail(siteId, itemId, detailId, changes) {
     next.observation = sanitizeText(changes.observation, false);
   }
 
-  const qteSortie = Number('qteSortie' in next ? next.qteSortie : current.qteSortie) || 0;
-  const qtePosee = Math.min(Number('qtePosee' in next ? next.qtePosee : current.qtePosee) || 0, qteSortie);
-  const rawQteRetour = Number('qteRetour' in next ? next.qteRetour : current.qteRetour) || 0;
-  const qteRetour = 'qteRetour' in next ? Math.min(Math.max(0, rawQteRetour), qteSortie) : Math.max(0, rawQteRetour);
-
-  next.qteSortie = qteSortie;
-  next.qtePosee = qtePosee;
-  next.qteRetour = qteRetour;
   next.dateModification = nowIso();
   next.updatedAt = serverTimestamp();
 

--- a/page3.html
+++ b/page3.html
@@ -68,6 +68,7 @@
                   <th>Qté Sortie</th>
                   <th>Qté posée</th>
                   <th>Qté Retour</th>
+                  <th>Ecart</th>
                   <th>Date création</th>
                   <th>Date modification</th>
                   <th>Observation</th>


### PR DESCRIPTION
### Motivation
- Sur la page 3, afficher un champ `Ecart` entre `Qté Retour` et `Date création` qui reflète `Qté posée - Qté retour` sans être modifiable.
- Éviter les réajustements automatiques et les bornes forcées sur `qtePosee`/`qteRetour` pour laisser l'utilisateur saisir librement les quantités.

### Description
- Ajout de l'entête `Ecart` dans le tableau de `page3.html` positionnée entre `Qté Retour` et `Date création`.
- Implémentation de `computeEcart(detail)` dans `js/app.js` et affichage d'une cellule en lecture seule qui montre `qtePosee - qteRetour` pour chaque ligne.
- Suppression des contrôles côté UI qui réécrivaient/contraignaient `qtePosee` et `qteRetour` lors de la saisie dans `js/app.js`.
- Suppression de la logique de recalcul/clamping automatique de `qtePosee` et `qteRetour` dans `js/storage.js` et ajustement du `colspan` de l'état vide (10 → 11).

### Testing
- Vérification de la syntaxe JS avec `node --check js/app.js` qui a réussi.
- Vérification de la syntaxe JS avec `node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c826b7a6dc832ab677c6821697a441)