### PR TITLE
Met en évidence l'écart sur la page 3 et ajoute la colonne Ecart à l'export Excel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -469,6 +469,11 @@ button {
   padding: 0.7rem 0.8rem;
 }
 
+.cell-input--ecart-alert {
+  background: #ffd9d9;
+  border-color: #f08e8e;
+}
+
 .cell-textarea {
   min-height: 5rem;
   resize: vertical;

--- a/js/app.js
+++ b/js/app.js
@@ -56,6 +56,7 @@
               <td>${escapeHtml(detail.unite)}</td>
               <td>${escapeHtml(detail.qtePosee)}</td>
               <td>${escapeHtml(detail.qteRetour)}</td>
+              <td>${escapeHtml(computeEcart(detail))}</td>
               <td>${escapeHtml(detail.observation)}</td>
             </tr>
           `,
@@ -79,6 +80,7 @@
           <th>Unité</th>
           <th>Qté posée</th>
           <th>Qté Retour</th>
+          <th>Ecart</th>
           <th>Observation</th>
         </tr>
       </thead>
@@ -672,7 +674,10 @@
 
       detailTableBody.innerHTML = filteredDetails
         .map(
-          (detail) => `
+          (detail) => {
+            const ecart = computeEcart(detail);
+            const ecartClassName = ecart === 0 ? '' : ' cell-input--ecart-alert';
+            return `
             <tr data-detail-id="${detail.id}">
               <td><span class="field-badge">${detail.champ}</span></td>
               <td><input class="cell-input" data-field="code" value="${escapeHtml(detail.code)}" /></td>
@@ -685,13 +690,14 @@
               </td>
               <td><input class="cell-input" data-field="qtePosee" type="number" min="0" step="1" value="${detail.qtePosee}" /></td>
               <td><input class="cell-input" data-field="qteRetour" type="number" min="0" step="1" value="${detail.qteRetour}" /></td>
-              <td><input class="cell-input" type="number" value="${computeEcart(detail)}" readonly aria-label="Ecart" /></td>
+              <td><input class="cell-input${ecartClassName}" type="number" value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td><textarea class="cell-textarea" data-field="observation">${escapeHtml(detail.observation)}</textarea></td>
               <td><button class="btn-danger" type="button" data-detail-delete="${detail.id}">Supprimer</button></td>
             </tr>
-          `,
+          `;
+          },
         )
         .join('');
 


### PR DESCRIPTION
### Motivation
- Rendre immédiatement visible toute différence entre `qtePosee` et `qteRetour` sur la page 3 en colorant la cellule d'écart quand elle est différente de `0`.
- Inclure la valeur de l'écart dans l'export Excel pour disposer du même indicateur dans les fichiers exportés.

### Description
- Ajout de la colonne `Ecart` dans le HTML généré par `buildDetailExcelContent` et insertion de la valeur calculée via `computeEcart(detail)` pour chaque ligne exportée.
- Calcul de l'écart réutilisé lors du rendu du tableau (`renderTable`) et affichage de la valeur calculée dans la cellule d'écart au lieu d'appeler `computeEcart` inline.
- Application conditionnelle d'une classe CSS `cell-input--ecart-alert` quand l'écart est différent de `0` pour mettre le fond en rouge.
- Ajout du style `.cell-input--ecart-alert` dans `css/style.css` qui définit le fond et la bordure rouge clair.

### Testing
- `node --check js/app.js` a été exécuté et a réussi, confirmant l'absence d'erreurs de syntaxe dans `js/app.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c82a8bb320832ab614584e560eb815)