### PR TITLE
Update page 3 Ecart calculation and zero-handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -19,9 +19,15 @@
   }
 
   function computeEcart(detail) {
+    const qteSortie = Number(detail?.qteSortie) || 0;
     const qtePosee = Number(detail?.qtePosee) || 0;
     const qteRetour = Number(detail?.qteRetour) || 0;
-    return qtePosee - qteRetour;
+
+    if (qtePosee === 0 && qteRetour === 0) {
+      return '';
+    }
+
+    return qteSortie - (qtePosee + qteRetour);
   }
 
   function setupBackButtons() {
@@ -676,7 +682,7 @@
         .map(
           (detail) => {
             const ecart = computeEcart(detail);
-            const ecartClassName = ecart === 0 ? '' : ' cell-input--ecart-alert';
+            const ecartClassName = typeof ecart === 'number' && ecart !== 0 ? ' cell-input--ecart-alert' : '';
             return `
             <tr data-detail-id="${detail.id}">
               <td><span class="field-badge">${detail.champ}</span></td>


### PR DESCRIPTION
### Motivation
- Align the DANS page 3 `Ecart` computation with the requested formula so the column reflects `Qté sortie - (Qté posée + Qté Retour)` for all non-empty rows.
- Respect the requested exception to leave `Ecart` blank after creation or modification when both `Qté posée` and `Qté Retour` are `0` to avoid misleading zero values.

### Description
- Replaced the old `computeEcart` implementation in `js/app.js` to compute `qteSortie - (qtePosee + qteRetour)` and coerce inputs to numbers via `Number(...)`.
- Added a guard that returns an empty string when both `qtePosee === 0` and `qteRetour === 0`, so `Ecart` is not displayed in that case.
- Adjusted the row rendering logic so the ecart alert class is applied only when `ecart` is a numeric non-zero value (`typeof ecart === 'number' && ecart !== 0`).

### Testing
- Ran JavaScript syntax check with `node --check js/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c831635430832aabf96855e3f5b5b5)