### PR TITLE
Add Firestore cascade cleanup for site and OUT deletions

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -149,6 +149,30 @@ function canDelete(documentData) {
   return Boolean(documentData);
 }
 
+async function removeDetailsForItem(siteId, itemId) {
+  const detailsRef = makePageItemsCollection('page3');
+  const detailsQuery = query(detailsRef, where('siteId', '==', siteId), where('itemId', '==', itemId));
+  const detailsSnapshot = await getDocs(detailsQuery);
+  await Promise.all(detailsSnapshot.docs.map((detailDoc) => deleteDoc(detailDoc.ref)));
+}
+
+async function removeItemsForSite(siteId) {
+  const itemsRef = makePageItemsCollection('page2');
+  const itemsQuery = query(itemsRef, where('siteId', '==', siteId));
+  const itemsSnapshot = await getDocs(itemsQuery);
+
+  for (const itemDoc of itemsSnapshot.docs) {
+    await removeDetailsForItem(siteId, itemDoc.id);
+    await deleteDoc(itemDoc.ref);
+  }
+}
+
+async function removeAllPageItems(pageName) {
+  const pageRef = makePageItemsCollection(pageName);
+  const snapshot = await getDocs(pageRef);
+  await Promise.all(snapshot.docs.map((docSnap) => deleteDoc(docSnap.ref)));
+}
+
 async function init() {
   if (state.initialized) {
     return;
@@ -335,7 +359,16 @@ async function removeSite(siteId) {
   if (!snap.exists() || !canDelete(snap.data())) {
     return false;
   }
+
+  await removeItemsForSite(siteId);
   await deleteDoc(targetRef);
+
+  const sitesRef = makePageItemsCollection('page1');
+  const remainingSites = await getDocs(sitesRef);
+  if (remainingSites.empty) {
+    await Promise.all([removeAllPageItems('page2'), removeAllPageItems('page3')]);
+  }
+
   await persistFullSnapshot();
   return true;
 }
@@ -372,6 +405,9 @@ async function removeItem(_siteId, itemId) {
   if (!snap.exists() || !canDelete(snap.data())) {
     return false;
   }
+
+  const itemData = snap.data();
+  await removeDetailsForItem(itemData.siteId, itemId);
   await deleteDoc(targetRef);
   await persistFullSnapshot();
   return true;


### PR DESCRIPTION
### Motivation
- Prevent orphaned records in page2/page3 when a site (page1) or an OUT (page2) is removed, and automatically clear page2/page3 when no sites remain.

### Description
- Added helper functions `removeDetailsForItem`, `removeItemsForSite`, and `removeAllPageItems` to remove related documents in page3/page2 collections.
- Updated `removeSite(siteId)` to cascade-delete the site's page2 items and their page3 details and to clear all page2/page3 items when the last site is deleted.
- Updated `removeItem(..., itemId)` to delete associated page3 details before removing the page2 (OUT) document.
- Kept `persistFullSnapshot()` calls to ensure snapshots are updated after deletions.

### Testing
- Ran `node --check js/storage.js` to validate the file syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8356750e0832aa4bdf7951aa437bc)