### PR TITLE
Fix page2 export to include all OUT sub-items in a single Excel file

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -406,6 +406,7 @@
     let currentItems = [];
     let detailCountsByItem = {};
     let detailDesignationsByItem = {};
+    let detailRowsByItem = {};
 
     siteTitle.textContent = currentSite ? currentSite.nom : 'Chargement...';
 
@@ -419,7 +420,7 @@
 
     function buildSiteExportRows() {
       return currentItems.flatMap((item) =>
-        (item.details || []).map((detail) => ({
+        (detailRowsByItem[item.id] || []).map((detail) => ({
           out: item.numero,
           champ: detail.champ,
           code: detail.code,
@@ -445,7 +446,7 @@
         return;
       }
 
-      const title = `${currentSite.nom}.SUIVI MATERIEL`;
+      const title = `SUIVI MATERIEL . ${currentSite.nom}`;
       const workbook = buildSiteExcelContent(title, rows);
       downloadExcelFile(`${title}.xls`, 'Export Excel', workbook);
     }
@@ -589,6 +590,14 @@
       (designationsByItem) => {
         detailDesignationsByItem = designationsByItem;
         renderItems();
+      },
+      () => {},
+    );
+
+    StorageService.subscribeDetailRows(
+      siteId,
+      (rowsByItem) => {
+        detailRowsByItem = rowsByItem;
       },
       () => {},
     );

--- a/js/storage.js
+++ b/js/storage.js
@@ -330,6 +330,35 @@ function subscribeDetailDesignations(siteId, onChange, onError) {
   );
 }
 
+function subscribeDetailRows(siteId, onChange, onError) {
+  const detailsRef = makePageItemsCollection('page3');
+  const q = query(detailsRef, where('siteId', '==', siteId), orderBy('champ', 'asc'));
+
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      const rowsByItem = {};
+      snapshot.docs.forEach((docSnap) => {
+        const detail = normalizeDocData(docSnap);
+        const itemId = String(detail.itemId || '');
+        if (!itemId) {
+          return;
+        }
+        if (!rowsByItem[itemId]) {
+          rowsByItem[itemId] = [];
+        }
+        rowsByItem[itemId].push(detail);
+      });
+      onChange(clone(rowsByItem));
+    },
+    (error) => {
+      if (typeof onError === 'function') {
+        onError(error);
+      }
+    },
+  );
+}
+
 async function createSite(name) {
   const siteName = sanitizeText(name, true);
   if (!siteName) {
@@ -676,6 +705,7 @@ window.StorageService = {
   subscribeDetails,
   subscribeDetailCounts,
   subscribeDetailDesignations,
+  subscribeDetailRows,
   createSite,
   removeSite,
   createItem,


### PR DESCRIPTION
### Motivation
- The page2 Export button relied on `item.details` which is not populated by the page2 item subscription, resulting in missing or empty exports for a site.
- The goal is to combine every sub-element (page3 rows) from all OUTs of a site into a single Excel export and use the requested filename format.

### Description
- Added `subscribeDetailRows(siteId, onChange, onError)` in `js/storage.js` to stream all page3 rows for a site and group them by `itemId`.
- Exposed `subscribeDetailRows` through `window.StorageService` so other pages can consume grouped detail rows.
- In `js/app.js` updated page2 logic to track `detailRowsByItem` and replaced use of `item.details` with `detailRowsByItem[item.id]` when building export rows.
- Changed the page2 export filename/title to the requested format `SUIVI MATERIEL . <SITE>` (e.g. `SUIVI MATERIEL . ANDRANOMENA.xls`).

### Testing
- Ran `node --check js/app.js` which succeeded.
- Ran `node --check js/storage.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8b873d1a0832a923ecb04d1608f0c)