### PR TITLE
Fallback fetch for page 2 export when detail cache isn't ready

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -434,13 +434,21 @@
       );
     }
 
-    function exportItems() {
+    async function exportItems() {
       if (!currentSite) {
         UiService.navigate('index.html');
         return;
       }
 
-      const rows = buildSiteExportRows();
+      let rows = buildSiteExportRows();
+      if (!rows.length) {
+        try {
+          detailRowsByItem = await StorageService.getDetailRowsBySite(siteId);
+          rows = buildSiteExportRows();
+        } catch (_error) {
+          // On conserve le comportement actuel: un toast utilisateur si aucune donnée exploitable.
+        }
+      }
       if (!rows.length) {
         UiService.showToast('Aucun sous-élément avec des données à exporter.');
         return;

--- a/js/storage.js
+++ b/js/storage.js
@@ -359,6 +359,27 @@ function subscribeDetailRows(siteId, onChange, onError) {
   );
 }
 
+async function getDetailRowsBySite(siteId) {
+  const detailsRef = makePageItemsCollection('page3');
+  const q = query(detailsRef, where('siteId', '==', siteId), orderBy('champ', 'asc'));
+  const snapshot = await getDocs(q);
+  const rowsByItem = {};
+
+  snapshot.docs.forEach((docSnap) => {
+    const detail = normalizeDocData(docSnap);
+    const itemId = String(detail.itemId || '');
+    if (!itemId) {
+      return;
+    }
+    if (!rowsByItem[itemId]) {
+      rowsByItem[itemId] = [];
+    }
+    rowsByItem[itemId].push(detail);
+  });
+
+  return clone(rowsByItem);
+}
+
 async function createSite(name) {
   const siteName = sanitizeText(name, true);
   if (!siteName) {
@@ -706,6 +727,7 @@ window.StorageService = {
   subscribeDetailCounts,
   subscribeDetailDesignations,
   subscribeDetailRows,
+  getDetailRowsBySite,
   createSite,
   removeSite,
   createItem,


### PR DESCRIPTION
### Motivation
- Users could click the "Exporter" button on page 2 before the realtime subscription finished hydrating `detailRowsByItem`, producing a false toast `"Aucun sous-élément avec des données à exporter."` even when OUT cards show lines. 
- Provide a fallback that loads detail rows directly from Firestore so exports succeed when the local cache is not yet available.

### Description
- Added `async function getDetailRowsBySite(siteId)` in `js/storage.js` to fetch and return detail rows grouped by `itemId` from `page3/items` and exposed it on `window.StorageService` as `getDetailRowsBySite`.
- Made the page 2 `exportItems` handler in `js/app.js` asynchronous and added a fallback where, if `buildSiteExportRows()` yields no rows, it calls `StorageService.getDetailRowsBySite(siteId)`, rebuilds the rows, and proceeds with the export if data is present.
- Preserved existing user-facing behavior and error handling by showing the same toast only when no exportable rows are available after the fallback attempt.

### Testing
- Ran `node --check js/app.js` which completed successfully.
- Ran `node --check js/storage.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8f9cdca80832a9fd2247628a91c71)