### PR TITLE
Ajuster l'export de la page 2 pour ignorer les N° OUT sans lignes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -419,7 +419,8 @@
     }
 
     function buildSiteExportRows() {
-      return currentItems.flatMap((item) =>
+      const itemsWithLines = currentItems.filter((item) => Number(detailCountsByItem[item.id] || 0) > 0);
+      return itemsWithLines.flatMap((item) =>
         (detailRowsByItem[item.id] || []).map((detail) => ({
           out: item.numero,
           champ: detail.champ,
@@ -450,7 +451,7 @@
         }
       }
       if (!rows.length) {
-        UiService.showToast('Aucun sous-élément avec des données à exporter.');
+        UiService.showToast('Aucune donée');
         return;
       }
 


### PR DESCRIPTION
### Motivation
- Limiter l'export depuis la page 2 aux seuls N° OUT qui possèdent au moins une ligne de détail afin de ne pas générer de lignes vides dans le fichier d'export.
- Informer l'utilisateur lorsqu'il n'y a aucune donnée exportable en affichant un toast et en annulant l'export.

### Description
- Filtrage des items dans `buildSiteExportRows` pour ne conserver que les `currentItems` dont `detailCountsByItem[item.id] > 0` afin de n'exporter que les OUT avec des lignes (modification dans `js/app.js`).
- Mise à jour du message utilisateur dans `exportItems` pour afficher `Aucune donée` et annuler l'export lorsque aucune ligne exportable n'est trouvée (modification dans `js/app.js`).
- Les changements ont été appliqués dans le fichier `js/app.js` et commités.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js`, qui a réussi.
- Aucune suite de tests automatisés supplémentaire n'a été exécutée pendant cette modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c901805bc8832ab5ebbd9eec041ac6)