### PR TITLE
Fix page2 export when Firestore ordered query is unavailable (sort client-side)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -451,7 +451,7 @@
         }
       }
       if (!rows.length) {
-        UiService.showToast('Aucune donée');
+        UiService.showToast('Aucune donnée');
         return;
       }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -330,9 +330,24 @@ function subscribeDetailDesignations(siteId, onChange, onError) {
   );
 }
 
+function sortDetailRowsByChamp(rowsByItem) {
+  Object.keys(rowsByItem).forEach((itemId) => {
+    rowsByItem[itemId].sort((left, right) => {
+      const leftChamp = Number(left.champ);
+      const rightChamp = Number(right.champ);
+
+      if (Number.isFinite(leftChamp) && Number.isFinite(rightChamp)) {
+        return leftChamp - rightChamp;
+      }
+
+      return String(left.champ || '').localeCompare(String(right.champ || ''), 'fr', { numeric: true });
+    });
+  });
+}
+
 function subscribeDetailRows(siteId, onChange, onError) {
   const detailsRef = makePageItemsCollection('page3');
-  const q = query(detailsRef, where('siteId', '==', siteId), orderBy('champ', 'asc'));
+  const q = query(detailsRef, where('siteId', '==', siteId));
 
   return onSnapshot(
     q,
@@ -349,6 +364,7 @@ function subscribeDetailRows(siteId, onChange, onError) {
         }
         rowsByItem[itemId].push(detail);
       });
+      sortDetailRowsByChamp(rowsByItem);
       onChange(clone(rowsByItem));
     },
     (error) => {
@@ -361,7 +377,7 @@ function subscribeDetailRows(siteId, onChange, onError) {
 
 async function getDetailRowsBySite(siteId) {
   const detailsRef = makePageItemsCollection('page3');
-  const q = query(detailsRef, where('siteId', '==', siteId), orderBy('champ', 'asc'));
+  const q = query(detailsRef, where('siteId', '==', siteId));
   const snapshot = await getDocs(q);
   const rowsByItem = {};
 
@@ -377,6 +393,7 @@ async function getDetailRowsBySite(siteId) {
     rowsByItem[itemId].push(detail);
   });
 
+  sortDetailRowsByChamp(rowsByItem);
   return clone(rowsByItem);
 }
 


### PR DESCRIPTION
### Motivation
- Exports from page2 could claim "Aucune donnée" even when OUT items had detail lines because the Firestore query used `orderBy('champ')`, which can fail if a composite index is not present. 
- The goal is to reliably fetch detail rows by `siteId` without depending on server-side ordering and preserve a consistent order for exported rows.

### Description
- Removed `orderBy('champ', 'asc')` from the Firestore queries in `subscribeDetailRows` and `getDetailRowsBySite` so rows are fetched using only `where('siteId', '==', siteId)`. 
- Added a local helper `sortDetailRowsByChamp(rowsByItem)` in `js/storage.js` to sort each OUT's detail rows by the `champ` field (numeric-aware, locale compare fallback), and invoked it before emitting or returning results. 
- Updated `js/app.js` to correct the toast message typo from `Aucune donée` to `Aucune donnée` shown when no rows are available for export. 

### Testing
- Ran syntax checks with `node --check js/storage.js` and `node --check js/app.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c903815f24832aa90103455ef32472)