### PR TITLE
Supprimer la colonne « Champ » de l'export Excel (page 2)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -102,7 +102,6 @@
         (row) => `
           <tr>
             <td>${escapeHtml(row.out)}</td>
-            <td>${escapeHtml(row.champ)}</td>
             <td>${escapeHtml(row.code)}</td>
             <td>${escapeHtml(row.designation)}</td>
             <td>${escapeHtml(row.qteSortie)}</td>
@@ -126,7 +125,6 @@
       <thead>
         <tr>
           <th>OUT</th>
-          <th>Champ</th>
           <th>Code</th>
           <th>Désignation</th>
           <th>Qté Sortie</th>


### PR DESCRIPTION
### Motivation
- L'export depuis la page 2 (`détail liste`) ne doit plus inclure la colonne `Champ` dans le fichier Excel pour correspondre aux besoins d'export.

### Description
- Supprime l'en-tête `Champ` et la cellule correspondante dans la fonction `buildSiteExcelContent` de `js/app.js` afin de retirer la colonne du fichier généré.

### Testing
- Vérification syntaxique exécutée avec `node --check js/app.js`, résultat : réussite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90613ea80832ab642c8d225844e7a)