### PR TITLE
Ajuster l’affichage du tableau sur la page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,9 +415,10 @@ button {
 }
 
 .data-table {
-  width: 100%;
-  min-width: 1100px;
+  width: max-content;
+  min-width: 100%;
   border-collapse: collapse;
+  table-layout: auto;
 }
 
 .data-table th,
@@ -453,7 +454,7 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
 
 .cell-input,
 .cell-textarea {
-  min-width: 8rem;
+  min-width: 6rem;
   padding: 0.7rem 0.8rem;
 }
 
@@ -467,17 +468,30 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
   resize: vertical;
 }
 
-.cell-textarea--designation {
-  min-width: 12rem;
-  min-height: 4.25rem;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+.cell-input--autosize {
+  width: auto;
+  min-width: fit-content;
+}
+
+.cell-input--designation {
+  min-width: 20ch;
 }
 
 .meta-value {
   display: inline-block;
   min-width: 6rem;
   padding: 0.75rem 0.2rem;
+}
+
+.meta-value--inline {
+  min-width: auto;
+  padding: 0;
+}
+
+.qte-sortie-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .toast {

--- a/js/app.js
+++ b/js/app.js
@@ -702,12 +702,12 @@
             return `
             <tr data-detail-id="${detail.id}">
               <td><span class="field-badge">${detail.champ}</span></td>
-              <td><input class="cell-input" data-field="code" value="${escapeHtml(detail.code)}" /></td>
-              <td><textarea class="cell-textarea cell-textarea--designation" data-field="designation">${escapeHtml(detail.designation)}</textarea></td>
+              <td><input class="cell-input cell-input--autosize" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--designation" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
               <td>
-                <div>
+                <div class="qte-sortie-field">
                   <input class="cell-input" data-field="qteSortie" type="number" min="0" step="1" value="${escapeHtml(detail.qteSortie)}" />
-                  <small class="meta-value">${escapeHtml(detail.unite)}</small>
+                  <span class="meta-value meta-value--inline">${escapeHtml(detail.unite)}</span>
                 </div>
               </td>
               <td><input class="cell-input" data-field="qtePosee" type="number" min="0" step="1" value="${detail.qtePosee}" /></td>


### PR DESCRIPTION
### Motivation
- Rendre la page de détail (page 3) plus lisible en évitant que le texte des colonnes soit tronqué, convertir la désignation en champ simple plutôt qu'en textarea multiligne, et afficher l’unité de `Qté Sortie` à côté de la valeur pour une lecture plus claire.

### Description
- `js/app.js`: remplace le `textarea` de la colonne `Désignation` par un `input` simple et ajoute un dimensionnement via l’attribut `size` pour `code` et `designation`, et regroupe `Qté Sortie` et son unité dans un conteneur inline `qte-sortie-field` avec la classe `meta-value--inline`.
- `css/style.css`: ajuste la table pour s’adapter au contenu (`width: max-content`, `min-width: 100%`, `table-layout: auto`), réduit certaines tailles minimales et ajoute les classes `.cell-input--autosize`, `.cell-input--designation`, `.meta-value--inline` et `.qte-sortie-field` pour l’alignement et l’affichage inline.
- Comportement visuel: champ `Désignation` devient un champ normal (non multiligne), les codes/labels s’auto-dimensionnent mieux et l’unité s’affiche sur la même ligne que la quantité.

### Testing
- Exécuté `node --check js/app.js` pour vérifier la validité syntaxique du fichier modifié et la commande a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c911a34b90832aa5c3e2d2624c8636)