### PR TITLE
Ajoute un snackbar « Annuler » après suppression (pages 1 & 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -505,11 +505,24 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
   border-radius: 999px;
   opacity: 0;
   transition: transform 0.25s ease, opacity 0.25s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: calc(100vw - 2rem);
+  z-index: 30;
 }
 
 .toast--visible {
   opacity: 1;
   transform: translate(-50%, 0);
+}
+
+.toast__action {
+  border: 0;
+  background: transparent;
+  color: #93c5fd;
+  font-weight: 700;
+  padding: 0.25rem 0.35rem;
 }
 
 @media (min-width: 768px) {

--- a/js/app.js
+++ b/js/app.js
@@ -291,8 +291,15 @@
 
       siteList.querySelectorAll('[data-site-delete]').forEach((button) => {
         button.addEventListener('click', async () => {
-          const removed = await StorageService.removeSite(button.dataset.siteDelete);
-          UiService.showToast(removed ? 'Site supprimé.' : 'Suppression impossible.');
+          const removedSnapshot = await StorageService.removeSite(button.dataset.siteDelete);
+          if (!removedSnapshot) {
+            UiService.showToast('Suppression impossible.');
+            return;
+          }
+          UiService.showUndoSnackbar('Site supprimé.', async () => {
+            const restored = await StorageService.restoreSite(removedSnapshot);
+            UiService.showToast(restored ? 'Suppression annulée.' : 'Restauration impossible.');
+          });
         });
       });
     }
@@ -510,8 +517,15 @@
 
       itemList.querySelectorAll('[data-item-delete]').forEach((button) => {
         button.addEventListener('click', async () => {
-          const removed = await StorageService.removeItem(siteId, button.dataset.itemDelete);
-          UiService.showToast(removed ? 'Élément supprimé.' : 'Suppression impossible.');
+          const removedSnapshot = await StorageService.removeItem(siteId, button.dataset.itemDelete);
+          if (!removedSnapshot) {
+            UiService.showToast('Suppression impossible.');
+            return;
+          }
+          UiService.showUndoSnackbar('Élément supprimé.', async () => {
+            const restored = await StorageService.restoreItem(removedSnapshot);
+            UiService.showToast(restored ? 'Suppression annulée.' : 'Restauration impossible.');
+          });
         });
       });
     }

--- a/js/storage.js
+++ b/js/storage.js
@@ -153,7 +153,9 @@ async function removeDetailsForItem(siteId, itemId) {
   const detailsRef = makePageItemsCollection('page3');
   const detailsQuery = query(detailsRef, where('siteId', '==', siteId), where('itemId', '==', itemId));
   const detailsSnapshot = await getDocs(detailsQuery);
+  const removedDetails = detailsSnapshot.docs.map(normalizeDocData);
   await Promise.all(detailsSnapshot.docs.map((detailDoc) => deleteDoc(detailDoc.ref)));
+  return removedDetails;
 }
 
 async function removeItemsForSite(siteId) {
@@ -424,8 +426,19 @@ async function removeSite(siteId) {
   const targetRef = doc(state.db, 'pages', 'page1', 'items', siteId);
   const snap = await getDoc(targetRef);
   if (!snap.exists() || !canDelete(snap.data())) {
-    return false;
+    return null;
   }
+
+  const siteData = normalizeDocData(snap);
+  const itemsRef = makePageItemsCollection('page2');
+  const itemsQuery = query(itemsRef, where('siteId', '==', siteId));
+  const itemsSnapshot = await getDocs(itemsQuery);
+  const removedItems = itemsSnapshot.docs.map(normalizeDocData);
+
+  const detailsRef = makePageItemsCollection('page3');
+  const detailsQuery = query(detailsRef, where('siteId', '==', siteId));
+  const detailsSnapshot = await getDocs(detailsQuery);
+  const removedDetails = detailsSnapshot.docs.map(normalizeDocData);
 
   await removeItemsForSite(siteId);
   await deleteDoc(targetRef);
@@ -437,7 +450,11 @@ async function removeSite(siteId) {
   }
 
   await persistFullSnapshot();
-  return true;
+  return {
+    site: siteData,
+    items: removedItems,
+    details: removedDetails,
+  };
 }
 
 async function createItem(siteId, numberValue) {
@@ -470,12 +487,96 @@ async function removeItem(_siteId, itemId) {
   const targetRef = doc(state.db, 'pages', 'page2', 'items', itemId);
   const snap = await getDoc(targetRef);
   if (!snap.exists() || !canDelete(snap.data())) {
+    return null;
+  }
+
+  const itemData = normalizeDocData(snap);
+  const removedDetails = await removeDetailsForItem(itemData.siteId, itemId);
+  await deleteDoc(targetRef);
+  await persistFullSnapshot();
+  return {
+    item: itemData,
+    details: removedDetails,
+  };
+}
+
+function withoutId(payload) {
+  const copy = { ...payload };
+  delete copy.id;
+  return copy;
+}
+
+async function restoreSite(snapshot) {
+  const site = snapshot?.site;
+  if (!site?.id) {
     return false;
   }
 
-  const itemData = snap.data();
-  await removeDetailsForItem(itemData.siteId, itemId);
-  await deleteDoc(targetRef);
+  const timestamp = nowIso();
+  const siteRef = doc(state.db, 'pages', 'page1', 'items', site.id);
+  await setDoc(siteRef, {
+    ...withoutId(site),
+    dateModification: timestamp,
+    updatedAt: serverTimestamp(),
+  });
+
+  const items = Array.isArray(snapshot.items) ? snapshot.items : [];
+  for (const item of items) {
+    if (!item?.id) {
+      continue;
+    }
+    const itemRef = doc(state.db, 'pages', 'page2', 'items', item.id);
+    await setDoc(itemRef, {
+      ...withoutId(item),
+      dateModification: timestamp,
+      updatedAt: serverTimestamp(),
+    });
+  }
+
+  const details = Array.isArray(snapshot.details) ? snapshot.details : [];
+  for (const detail of details) {
+    if (!detail?.id) {
+      continue;
+    }
+    const detailRef = doc(state.db, 'pages', 'page3', 'items', detail.id);
+    await setDoc(detailRef, {
+      ...withoutId(detail),
+      dateModification: timestamp,
+      updatedAt: serverTimestamp(),
+    });
+  }
+
+  await persistFullSnapshot();
+  return true;
+}
+
+async function restoreItem(snapshot) {
+  const item = snapshot?.item;
+  if (!item?.id) {
+    return false;
+  }
+
+  const timestamp = nowIso();
+  const itemRef = doc(state.db, 'pages', 'page2', 'items', item.id);
+  await setDoc(itemRef, {
+    ...withoutId(item),
+    dateModification: timestamp,
+    updatedAt: serverTimestamp(),
+  });
+
+  const details = Array.isArray(snapshot.details) ? snapshot.details : [];
+  for (const detail of details) {
+    if (!detail?.id) {
+      continue;
+    }
+    const detailRef = doc(state.db, 'pages', 'page3', 'items', detail.id);
+    await setDoc(detailRef, {
+      ...withoutId(detail),
+      dateModification: timestamp,
+      updatedAt: serverTimestamp(),
+    });
+  }
+
   await persistFullSnapshot();
   return true;
 }
@@ -747,8 +848,10 @@ window.StorageService = {
   getDetailRowsBySite,
   createSite,
   removeSite,
+  restoreSite,
   createItem,
   removeItem,
+  restoreItem,
   createDetail,
   updateDetail,
   removeDetail,

--- a/js/ui.js
+++ b/js/ui.js
@@ -18,12 +18,42 @@
     if (!toast) {
       return;
     }
+    toast.innerHTML = "";
     toast.textContent = message;
     toast.classList.add("toast--visible");
     window.clearTimeout(showToast.timeoutId);
     showToast.timeoutId = window.setTimeout(() => {
       toast.classList.remove("toast--visible");
     }, 2200);
+  }
+
+  function showUndoSnackbar(message, onUndo, actionLabel = "Annuler") {
+    const toast = document.getElementById("toast");
+    if (!toast) {
+      return;
+    }
+
+    toast.innerHTML = "";
+    const text = document.createElement("span");
+    text.textContent = message;
+    const actionButton = document.createElement("button");
+    actionButton.type = "button";
+    actionButton.className = "toast__action";
+    actionButton.textContent = actionLabel;
+    actionButton.addEventListener("click", async () => {
+      toast.classList.remove("toast--visible");
+      window.clearTimeout(showToast.timeoutId);
+      if (typeof onUndo === "function") {
+        await onUndo();
+      }
+    });
+
+    toast.append(text, actionButton);
+    toast.classList.add("toast--visible");
+    window.clearTimeout(showToast.timeoutId);
+    showToast.timeoutId = window.setTimeout(() => {
+      toast.classList.remove("toast--visible");
+    }, 5000);
   }
 
   function renderEmptyState(container, message) {
@@ -46,6 +76,7 @@
     formatDate,
     getQueryParams,
     showToast,
+    showUndoSnackbar,
     renderEmptyState,
     bindDialogCloser,
     navigate,


### PR DESCRIPTION
### Motivation
- Permettre à l'utilisateur d'annuler rapidement une suppression sur la liste des sites (page 1) et la liste des éléments (page 2) en affichant un snackbar avec un bouton `Annuler` après la suppression.

### Description
- Ajout de `UiService.showUndoSnackbar(message, onUndo, actionLabel)` pour afficher un snackbar actionnable tout en conservant `UiService.showToast` pour les messages simples.
- `StorageService.removeSite` et `StorageService.removeItem` renvoient désormais un snapshot des données supprimées (site/item + leurs items/details) et `removeDetailsForItem` retourne les détails supprimés pour permettre une restauration complète.
- Ajout des fonctions de restauration `restoreSite(snapshot)` et `restoreItem(snapshot)` qui recréent les documents avec leurs IDs d'origine et mettent à jour les timestamps (`dateModification`, `updatedAt`) puis appellent `persistFullSnapshot()`.
- Mise à jour de l'UI (`js/app.js`) pour utiliser le snackbar après suppression et appeler les méthodes de restauration si l'utilisateur clique sur `Annuler`, et adaptation du style (`css/style.css`) pour supporter un bouton d'action dans le toast.

### Testing
- Vérification de syntaxe JavaScript avec `node --check js/app.js`, `node --check js/storage.js` et `node --check js/ui.js`, toutes les vérifications sont passées avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c914f95fa8832a96ce99e985674eea)