### PR TITLE
Style snackbar with 80% width and auto height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -508,6 +508,8 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
+  width: 80%;
+  height: auto;
   max-width: calc(100vw - 2rem);
   z-index: 30;
 }


### PR DESCRIPTION
### Motivation
- Constrain the snackbar layout so its width is limited and its height remains content-driven by setting `width: 80%` and `height: auto` for the `.toast` component.

### Description
- Added `width: 80%` and `height: auto` to the `.toast` rule in `css/style.css` to adjust the snackbar sizing.

### Testing
- No automated tests were run (CSS-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c917fbd778832ab6cb14bd075b14e5)