### PR TITLE
Rendre la colonne «Observation» en champ texte sur une seule ligne (page 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -729,7 +729,7 @@
               <td><input class="cell-input${ecartClassName}" type="number" value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
-              <td><textarea class="cell-textarea" data-field="observation">${escapeHtml(detail.observation)}</textarea></td>
+              <td><input class="cell-input" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" /></td>
               <td><button class="btn-danger" type="button" data-detail-delete="${detail.id}">Supprimer</button></td>
             </tr>
           `;


### PR DESCRIPTION
### Motivation
- Le tableau de la page de détail (page 3) utilisait un champ multiligne pour la colonne `Observation`, la demande était de le remplacer par un champ normal sur une seule ligne.

### Description
- Remplacement du `<textarea class="cell-textarea" data-field="observation">` par `<input class="cell-input" data-field="observation" type="text" />` dans le template de rendu des lignes de `js/app.js` afin d’afficher la colonne `Observation` en champ texte simple.

### Testing
- Aucune suite de tests automatisés n’est présente dans ce dépôt, aucun test automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91b43bd20832a936b5b57626433a0)