### PR TITLE
Remplacer les libellés 'Supprimer' par une icône trash sur les pages 1–3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -321,6 +321,20 @@ button {
   padding: 0.7rem 1rem;
 }
 
+.btn-danger--icon {
+  width: 2.6rem;
+  height: 2.6rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+
+.btn-danger--icon i {
+  pointer-events: none;
+}
+
 .fab {
   position: fixed;
   right: 1.25rem;

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body data-page="home">
     <div class="app-shell">

--- a/js/app.js
+++ b/js/app.js
@@ -276,7 +276,7 @@
                 </div>
               </button>
               <div class="list-card__actions">
-                <button class="btn-danger" type="button" data-site-delete="${site.id}">Supprimer</button>
+                <button class="btn-danger btn-danger--icon" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer"><i class="fa-solid fa-trash" aria-hidden="true"></i></button>
               </div>
             </article>
           `,
@@ -502,7 +502,7 @@
                 </div>
               </button>
               <div class="list-card__actions">
-                <button class="btn-danger" type="button" data-item-delete="${item.id}">Supprimer</button>
+                <button class="btn-danger btn-danger--icon" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer"><i class="fa-solid fa-trash" aria-hidden="true"></i></button>
               </div>
             </article>
           `,
@@ -730,7 +730,7 @@
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td><input class="cell-input" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" /></td>
-              <td><button class="btn-danger" type="button" data-detail-delete="${detail.id}">Supprimer</button></td>
+              <td><button class="btn-danger btn-danger--icon" type="button" data-detail-delete="${detail.id}" aria-label="Supprimer" title="Supprimer"><i class="fa-solid fa-trash" aria-hidden="true"></i></button></td>
             </tr>
           `;
           },

--- a/page2.html
+++ b/page2.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Détail liste - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body data-page="site-detail">
     <div class="app-shell">

--- a/page3.html
+++ b/page3.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Détail complet - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body data-page="item-detail">
     <div class="app-shell app-shell--wide">


### PR DESCRIPTION
### Motivation
- Moderniser l'interface en remplaçant le texte `Supprimer` par une icône poubelle pour les actions de suppression tout en conservant la même ergonomie et la logique existante des boutons.

### Description
- Ajout de la feuille de style Font Awesome dans `index.html`, `page2.html` et `page3.html` pour fournir l'icône `fa-trash`.
- Remplacement du texte `Supprimer` par un bouton contenant `<i class="fa-solid fa-trash">` pour les suppressions de site, d'OUT et de ligne dans `js/app.js`, en conservant les attributs `data-*` pour préserver la fonctionnalité existante et en ajoutant `aria-label` et `title` pour l'accessibilité.
- Ajout d'une variante CSS `btn-danger--icon` dans `css/style.css` pour styliser correctement les boutons d'action en mode icône seule.
- Aucune logique JavaScript métier n'a été modifiée, seule la structure HTML des boutons et le style ont été adaptés.

### Testing
- Exécution de `node --check js/app.js` qui a réussi.
- Exécution de `node --check js/ui.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91c964978832ab6c6c3720a1d47fb)