### PR TITLE
Replace trash icon with 'Supprimer' text on delete buttons (pages 1-3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -276,7 +276,7 @@
                 </div>
               </button>
               <div class="list-card__actions">
-                <button class="btn-danger btn-danger--icon" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer"><i class="fa-solid fa-trash" aria-hidden="true"></i></button>
+                <button class="btn-danger" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">Supprimer</button>
               </div>
             </article>
           `,
@@ -502,7 +502,7 @@
                 </div>
               </button>
               <div class="list-card__actions">
-                <button class="btn-danger btn-danger--icon" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer"><i class="fa-solid fa-trash" aria-hidden="true"></i></button>
+                <button class="btn-danger" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer">Supprimer</button>
               </div>
             </article>
           `,
@@ -730,7 +730,7 @@
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td><input class="cell-input" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" /></td>
-              <td><button class="btn-danger btn-danger--icon" type="button" data-detail-delete="${detail.id}" aria-label="Supprimer" title="Supprimer"><i class="fa-solid fa-trash" aria-hidden="true"></i></button></td>
+              <td><button class="btn-danger" type="button" data-detail-delete="${detail.id}" aria-label="Supprimer" title="Supprimer">Supprimer</button></td>
             </tr>
           `;
           },


### PR DESCRIPTION
### Motivation
- Rendre les boutons de suppression explicites en remplaçant l'icône corbeille par le libellé `Supprimer` sur les pages 1, 2 et 3 tout en conservant le comportement existant.

### Description
- Remplacement des templates de boutons de suppression dans `js/app.js` pour afficher `<button class="btn-danger">Supprimer</button>` à la place des boutons avec l'icône `<i class="fa-solid fa-trash">` pour les sélecteurs `data-site-delete`, `data-item-delete` et `data-detail-delete`, sans modifier les attributs `data-*` ni les gestionnaires d'événements.

### Testing
- Recherches de code effectuées avec `rg` pour valider la suppression des anciens motifs et la présence des nouveaux boutons, et toutes les vérifications ont retourné les résultats attendus.
- Vérification de l'état du dépôt avec `git status` puis création du commit avec `git commit`, et la confirmation du commit a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91f92d28c832ab1e82f8b53108855)