### PR TITLE
Center values in page 3 table and Excel exports

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -447,6 +447,11 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
   background: #f7faff;
 }
 
+body[data-page="item-detail"] .data-table td {
+  text-align: center;
+  vertical-align: middle;
+}
+
 .data-table th {
   position: sticky;
   top: 0;
@@ -470,6 +475,7 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
 .cell-textarea {
   min-width: 6rem;
   padding: 0.7rem 0.8rem;
+  text-align: center;
 }
 
 .cell-input--ecart-alert {
@@ -505,6 +511,7 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
 .qte-sortie-field {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -74,6 +74,10 @@
   <head>
     <meta charset="UTF-8" />
     <title>${escapeHtml(title)}</title>
+    <style>
+      table { border-collapse: collapse; width: 100%; }
+      th, td { border: 1px solid #cfd8e3; padding: 8px; text-align: center; vertical-align: middle; }
+    </style>
   </head>
   <body>
     <table>
@@ -119,6 +123,10 @@
   <head>
     <meta charset="UTF-8" />
     <title>${escapeHtml(title)}</title>
+    <style>
+      table { border-collapse: collapse; width: 100%; }
+      th, td { border: 1px solid #cfd8e3; padding: 8px; text-align: center; vertical-align: middle; }
+    </style>
   </head>
   <body>
     <table>


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité du tableau de détails (page 3 / `item-detail`) et garantir que les cellules des fichiers Excel exportés aient un alignement centré.

### Description
- Centrage des cellules du tableau de détail en ajoutant `text-align: center; vertical-align: middle;` pour les `td` et en centrant les champs d'entrée via `css/style.css`.
- Centrage du bloc quantité/unité (`.qte-sortie-field`) avec `justify-content: center` pour aligner la quantité et l'unité au centre.
- Mise à jour des fonctions d'export (`buildDetailExcelContent` et `buildSiteExcelContent` dans `js/app.js`) pour injecter un petit style `<style>` dans le HTML exporté qui force un centrage horizontal et vertical des `th`/`td` et ajoute des bordures simples.
- Fichiers modifiés : `css/style.css`, `js/app.js`.

### Testing
- Vérification syntaxique du bundle JS avec `node --check js/app.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c921c4887c832a9eb5d6c27fa9e5ad)