### PR TITLE
Réorganiser la colonne Observation dans le tableau détail

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -735,9 +735,9 @@
               <td><input class="cell-input" data-field="qtePosee" type="number" min="0" step="1" value="${detail.qtePosee}" /></td>
               <td><input class="cell-input" data-field="qteRetour" type="number" min="0" step="1" value="${detail.qteRetour}" /></td>
               <td><input class="cell-input${ecartClassName}" type="number" value="${ecart}" readonly aria-label="Ecart" /></td>
+              <td><input class="cell-input cell-input--autosize" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" size="${Math.max(String(detail.observation || '').length + 1, 14)}" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
-              <td><input class="cell-input" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" /></td>
               <td><button class="btn-danger" type="button" data-detail-delete="${detail.id}" aria-label="Supprimer" title="Supprimer">Supprimer</button></td>
             </tr>
           `;

--- a/page3.html
+++ b/page3.html
@@ -70,9 +70,9 @@
                   <th>Qté posée</th>
                   <th>Qté Retour</th>
                   <th>Ecart</th>
+                  <th>Observation</th>
                   <th>Date création</th>
                   <th>Date modification</th>
-                  <th>Observation</th>
                   <th>Action</th>
                 </tr>
               </thead>


### PR DESCRIPTION
### Motivation
- Repositionner la colonne `Observation` dans le tableau de détail pour qu’elle apparaisse entre `Ecart` et `Date création` et améliorer l’édition en ligne pour que le champ s’ajuste mieux au texte.

### Description
- Déplace la colonne d’entête `Observation` dans `page3.html` entre `Ecart` et `Date création`.
- Met à jour la génération des lignes dans `js/app.js` pour rendre la cellule `observation` éditable avec la classe `cell-input--autosize` et un attribut `size` dynamique (`size="${Math.max(String(detail.observation || '').length + 1, 14)}"`).

### Testing
- Exécuté `node --check js/app.js` pour la vérification statique du fichier modifié, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9252aedc4832ab37323c164858020)