### PR TITLE
Center table header alignment in page 3 detail view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -459,6 +459,10 @@ body[data-page="item-detail"] .data-table td {
   z-index: 1;
 }
 
+body[data-page="item-detail"] .data-table th {
+  text-align: center;
+}
+
 .field-badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Make the column headers of the item detail table visually consistent with the centered cell values on the detail page by aligning headers to the center.

### Description
- Added a single CSS rule in `css/style.css` to set the header alignment for the item detail table: `body[data-page="item-detail"] .data-table th { text-align: center; }`.

### Testing
- No automated tests were added or run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c92a2d3be8832a8abc96755e8db350)