### PR TITLE
Left-align Code and Désignation columns on page3 detail table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -463,6 +463,13 @@ body[data-page="item-detail"] .data-table th {
   text-align: center;
 }
 
+body[data-page="item-detail"] .data-table th:nth-child(2),
+body[data-page="item-detail"] .data-table th:nth-child(3),
+body[data-page="item-detail"] .data-table td:nth-child(2),
+body[data-page="item-detail"] .data-table td:nth-child(3) {
+  text-align: left;
+}
+
 .field-badge {
   display: inline-flex;
   align-items: center;
@@ -480,6 +487,10 @@ body[data-page="item-detail"] .data-table th {
   min-width: 6rem;
   padding: 0.7rem 0.8rem;
   text-align: center;
+}
+
+.cell-input--left {
+  text-align: left;
 }
 
 .cell-input--ecart-alert {

--- a/js/app.js
+++ b/js/app.js
@@ -724,8 +724,8 @@
             return `
             <tr data-detail-id="${detail.id}">
               <td><span class="field-badge">${detail.champ}</span></td>
-              <td><input class="cell-input cell-input--autosize" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
-              <td><input class="cell-input cell-input--autosize cell-input--designation" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--left" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
               <td>
                 <div class="qte-sortie-field">
                   <input class="cell-input" data-field="qteSortie" type="number" min="0" step="1" value="${escapeHtml(detail.qteSortie)}" />


### PR DESCRIPTION
### Motivation
- Improve readability of the detail table on page 3 by left-aligning textual fields so `Code` and `Désignation` values are easier to scan.

### Description
- Added specific column rules to `css/style.css` to left-align the second and third columns only using `body[data-page="item-detail"] .data-table th:nth-child(2), th:nth-child(3), td:nth-child(2), td:nth-child(3)`.
- Introduced a utility class `.cell-input--left` in `css/style.css` to force left alignment for input cells.
- Applied the `.cell-input--left` class to the `code` and `designation` inputs in the detail row renderer in `js/app.js` so editable cells match the new column alignment.

### Testing
- Ran `git diff --check` which reported no problems (passed).
- Ran `node --check js/app.js` to validate the modified JS syntax which completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9f9624f4832a94f702e4509e57d1)