### PR TITLE
Left-align code and designation fields in item-detail table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -463,6 +463,11 @@ body[data-page="item-detail"] .data-table th {
   text-align: center;
 }
 
+body[data-page="item-detail"] .data-table td:nth-child(2),
+body[data-page="item-detail"] .data-table td:nth-child(3) {
+  text-align: left;
+}
+
 .field-badge {
   display: inline-flex;
   align-items: center;
@@ -480,6 +485,10 @@ body[data-page="item-detail"] .data-table th {
   min-width: 6rem;
   padding: 0.7rem 0.8rem;
   text-align: center;
+}
+
+.cell-input--left {
+  text-align: left;
 }
 
 .cell-input--ecart-alert {

--- a/js/app.js
+++ b/js/app.js
@@ -724,8 +724,8 @@
             return `
             <tr data-detail-id="${detail.id}">
               <td><span class="field-badge">${detail.champ}</span></td>
-              <td><input class="cell-input cell-input--autosize" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
-              <td><input class="cell-input cell-input--autosize cell-input--designation" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--left" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
               <td>
                 <div class="qte-sortie-field">
                   <input class="cell-input" data-field="qteSortie" type="number" min="0" step="1" value="${escapeHtml(detail.qteSortie)}" />


### PR DESCRIPTION
### Motivation

- Improve readability of the item detail table by left-aligning the `code` and `designation` columns and their input fields.
- Provide a reusable input modifier class for left-aligned cell inputs.

### Description

- Add CSS rules to left-align the 2nd and 3rd table columns in `body[data-page="item-detail"] .data-table` and introduce `.cell-input--left` styling in `css/style.css`.
- Add the `cell-input--left` class to the `code` and `designation` input elements in `js/app.js` `renderTable` so those fields render left-aligned.
- No changes to data handling or application logic; this is a presentational update only.

### Testing

- Ran lint via `npm run lint` and it passed.
- Ran unit tests via `npm test` and they passed.
- Built the frontend via `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9f9624f4832a94f702e4509e57d1)