### PR TITLE
Center Code and Désignation column headers in data table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -464,7 +464,10 @@ body[data-page="item-detail"] .data-table th {
 }
 
 body[data-page="item-detail"] .data-table th:nth-child(2),
-body[data-page="item-detail"] .data-table th:nth-child(3),
+body[data-page="item-detail"] .data-table th:nth-child(3) {
+  text-align: center;
+}
+
 body[data-page="item-detail"] .data-table td:nth-child(2),
 body[data-page="item-detail"] .data-table td:nth-child(3) {
   text-align: left;


### PR DESCRIPTION
### Motivation
- Aligner visuellement les titres de colonnes `Code` et `Désignation` dans le tableau des détails d'articles sans modifier l'alignement des champs de saisie.

### Description
- Mis à jour `css/style.css` pour centrer les en-têtes `th` des colonnes 2 et 3 (`Code` et `Désignation`) dans le contexte `body[data-page="item-detail"] .data-table` tout en laissant les cellules/inputs de ces colonnes alignés à gauche.

### Testing
- Exécution de `git diff --check` (sans erreurs) et vérification de l'état avec `git status --short`, les changements de feuille de style ont été committés avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa2987990832a843e2d1ce600b99f)