### PR TITLE
Mise à jour des en-têtes du fichier Excel exporté en page 2

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -112,6 +112,7 @@
             <td>${escapeHtml(row.unite)}</td>
             <td>${escapeHtml(row.qtePosee)}</td>
             <td>${escapeHtml(row.qteRetour)}</td>
+            <td>${escapeHtml(computeEcart(row))}</td>
             <td>${escapeHtml(row.observation)}</td>
           </tr>
         `,
@@ -134,12 +135,13 @@
         <tr>
           <th>OUT</th>
           <th>Code</th>
-          <th>Désignation</th>
+          <th>Designation</th>
           <th>Qté Sortie</th>
           <th>Unité</th>
           <th>Qté posée</th>
           <th>Qté Retour</th>
-          <th>Observation</th>
+          <th>Ecart</th>
+          <th>Remarque</th>
         </tr>
       </thead>
       <tbody>${bodyRows}</tbody>


### PR DESCRIPTION
### Motivation
- Aligner l'export Excel de la page 2 sur le libellé métier demandé: `OUT,Code,Designation,Qté Sortie,Unité,Qté posée,Qté Retour,Ecart,Remarque`.

### Description
- Dans `js/app.js` la fonction `buildSiteExcelContent` a été modifiée pour insérer la colonne `Ecart` dans les lignes exportées en utilisant `computeEcart(row)` et pour renommer/réordonner les en-têtes afin d'obtenir `OUT, Code, Designation, Qté Sortie, Unité, Qté posée, Qté Retour, Ecart, Remarque`.
- Le libellé `Désignation` a été normalisé en `Designation` et la colonne `Observation` a été déplacée/renommée en `Remarque` pour correspondre au format attendu.

### Testing
- Vérification du code modifié avec `rg -n "<th>|computeEcart\(row\)" js/app.js`; la recherche a trouvé les nouvelles occurrences avec succès.
- Contrôle d'état Git via `git status --short` et commit effectué avec `git commit -m "Mise à jour des en-têtes export Excel de la page 2"`, les opérations se sont terminées sans erreur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa727c124832abecd73c01c4d6724)