### PR TITLE
Add bottom spacing under item detail table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -428,6 +428,10 @@ button {
   overflow-x: auto;
 }
 
+body[data-page="item-detail"] .table-wrapper {
+  padding-bottom: 1.5rem;
+}
+
 .data-table {
   width: max-content;
   min-width: 100%;


### PR DESCRIPTION
### Motivation
- Improve readability on the item detail page by preventing the last row of the data table from appearing pressed against the bottom edge of the viewport.

### Description
- Add a page-scoped CSS rule in `css/style.css` for `body[data-page="item-detail"] .table-wrapper` that applies `padding-bottom: 1.5rem;` so the table has extra space at the end and the change only affects the item detail view.

### Testing
- Verified the change is limited to `css/style.css` via `git diff -- css/style.css` and the working tree is clean via `git status --short`, and committed the update; no automated test suite applies to this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caaa8ddc24832aadef70860f0978bc)