### PR TITLE
Corriger l’en-tête sticky du tableau sur la page 3

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -46,7 +46,7 @@
         </section>
 
         <section class="surface-card table-card">
-          <div class="section-heading section-heading--sticky">
+          <div class="section-heading">
             <div>
               <h2>Tableau des données</h2>
               <p id="detailCount">0 ligne</p>


### PR DESCRIPTION
### Motivation
- Le conteneur affichant `Tableau des données`, le compteur (`Nombre d'article`) et le bouton `Exporter` ne devait pas rester fixe lors du défilement; il doit défiler avec le contenu de la page.

### Description
- Retrait de la classe `section-heading--sticky` du bloc d’en-tête du tableau dans `page3.html` afin que l’en-tête défile normalement avec le reste du contenu.

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caac88cb44832ab574c38fdeb920a3)