### PR TITLE
Update page 2 search label wording in French

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -26,7 +26,7 @@
 
         <section class="search-panel surface-card">
           <label class="input-group">
-            <span>Recherche N° OUT et par article</span>
+            <span>Recherche par N°OUT Ou par Article</span>
             <input
               id="itemSearchInput"
               type="search"


### PR DESCRIPTION
### Motivation
- Clarify the French copy for the search field on page 2 so it explicitly indicates searching by N°OUT or by article.

### Description
- Replace the text `Recherche N° OUT et par article` with `Recherche par N°OUT Ou par Article` in `page2.html` (single-line change).

### Testing
- Ran `git diff -- page2.html` and `rg -n "Recherche par N°OUT Ou par Article" page2.html`, both commands confirmed the updated text and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab2fda510832aa9fa587fdfa3bbc8)