### PR TITLE
Rendre visible le bouton 'X' de fermeture sur les modales de création

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -372,6 +372,24 @@ button {
   margin-bottom: 1rem;
 }
 
+.modal-header .icon-button {
+  width: 2.25rem;
+  height: 2.25rem;
+  background: rgba(31, 42, 55, 0.08);
+  color: var(--text);
+  font-size: 1.4rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.modal-header .icon-button:hover,
+.modal-header .icon-button:focus-visible {
+  background: rgba(31, 42, 55, 0.16);
+}
+
 .modal-actions,
 .form-footer {
   display: flex;


### PR DESCRIPTION
### Motivation
- Améliorer la visibilité et l'interaction du bouton de fermeture `X` dans l'en-tête des modales de création (site et OUT) afin de faciliter la fermeture via la souris et le clavier.

### Description
- Ajout de règles CSS dans `css/style.css` ciblant `.modal-header .icon-button` pour définir la taille, la couleur, l'alignement et un état `:hover`/`:focus-visible` afin de rendre le bouton clairement visible sur fond clair.

### Testing
- Exécution de `rg -n "modal-header \.icon-button" css/style.css` a trouvé le sélecteur ajouté et a réussi.
- Inspection du diff via `git diff -- css/style.css` a confirmé l'insertion des nouvelles règles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab77d4524832aa38b36f838d92e92)