### PR TITLE
Définir les nouveaux utilisateurs en lecture seule par défaut

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -188,7 +188,7 @@ async function saveUsername(username) {
   };
 
   if (isFirstUsername) {
-    updates.role = 'ecriture';
+    updates.role = 'lecture';
   }
 
   await setDoc(


### PR DESCRIPTION
### Motivation
- Lors de l'enregistrement initial du nom d'un nouvel utilisateur, placer le compte en `lecture` (mode lecture seule) par défaut tout en n'affectant pas le comportement des utilisateurs existants.

### Description
- Modifier `js/storage.js` dans `saveUsername` pour que, si `isFirstUsername` est vrai, on applique `updates.role = 'lecture'` au lieu de `'ecriture'`.

### Testing
- Exécution de `node --check js/storage.js` qui a réussi sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01abd5718832aa5546f068dd6dad7)