### PR TITLE
Update page 2 date filter label and remove 'L'Année dernier' option

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -35,13 +35,12 @@
             />
           </label>
           <label class="input-group search-filter-group">
-            <span>Filtrer par date</span>
+            <span>Filtrer par : </span>
             <select id="itemDateFilter" aria-label="Filtrer les résultats par date">
               <option value="all">Tous</option>
               <option value="today">Aujourd'hui</option>
               <option value="yesterday">Hier</option>
               <option value="lastMonth">Le mois dernier</option>
-              <option value="lastYear">L'Année dernier</option>
             </select>
           </label>
         </section>


### PR DESCRIPTION
### Motivation
- Clarify the date filter UI on page 2 by making the label more generic and removing an obsolete year filter option.

### Description
- Updated `page2.html` to change the filter label from "Filtrer par date" to "Filtrer par : " and removed the `<option value="lastYear">L'Année dernier</option>` entry from the date filter dropdown.

### Testing
- No automated tests were present or executed for this static HTML text change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d10b3b79e4832ab73e0d85ea1ddd1a)