### PR TITLE
Ajouter la page Historiques et journaliser les actions dans Firestore

### DIFF
--- a/historiques.html
+++ b/historiques.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Historiques - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body data-page="history">
+    <div class="app-shell">
+      <header class="app-header app-header--detail">
+        <button class="back-button" type="button" data-back="index.html" aria-label="Retour">←</button>
+        <div><h1>Historiques</h1></div>
+      </header>
+
+      <main class="page-content">
+        <section id="historyList" class="list-grid" aria-live="polite"></section>
+      </main>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script type="module" src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script type="module" src="js/app.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
             <span aria-hidden="true">⋯</span>
           </button>
           <div id="homeMenuPanel" class="header-menu__panel" role="menu" hidden>
+            <button id="historyButton" class="header-menu__option" type="button" role="menuitem">
+              Historiques
+            </button>
             <button id="importDataButton" class="header-menu__option" type="button" role="menuitem">
               Importer les données
             </button>

--- a/js/app.js
+++ b/js/app.js
@@ -426,6 +426,7 @@
     const importDataButton = requireElement('importDataButton');
     const exportDataButton = requireElement('exportDataButton');
     const manageUsersButton = requireElement('manageUsersButton');
+    const historyButton = requireElement('historyButton');
 
     let currentSites = [];
     let itemCountsBySite = {};
@@ -630,6 +631,13 @@
       manageUsersButton.addEventListener('click', () => {
         closeHomeMenu();
         UiService.navigate('users.html');
+      });
+    }
+
+    if (historyButton) {
+      historyButton.addEventListener('click', () => {
+        closeHomeMenu();
+        UiService.navigate('historiques.html');
       });
     }
 
@@ -1269,6 +1277,36 @@
 
     await renderUsers();
   }
+
+  async function initHistoryPage() {
+    const historyList = requireElement('historyList');
+    if (!historyList) {
+      return;
+    }
+
+    try {
+      const historiques = await StorageService.listHistoriques();
+      if (!historiques.length) {
+        UiService.renderEmptyState(historyList, 'Aucun historique enregistré pour le moment.');
+        return;
+      }
+
+      historyList.innerHTML = historiques
+        .map((history) => `
+          <article class="list-card">
+            <div class="list-card__button" aria-label="Historique">
+              <h3 class="list-card__title">${escapeHtml(history.userName)} ${escapeHtml(history.action)}</h3>
+              <div class="list-card__meta">
+                <span>${escapeHtml(UiService.formatDate(history.createdAt?.toDate?.() || history.createdAt))}</span>
+              </div>
+            </div>
+          </article>
+        `)
+        .join('');
+    } catch (_error) {
+      UiService.renderEmptyState(historyList, "Impossible de charger l'historique.");
+    }
+  }
   async function bootstrap() {
     UiService.bindDialogCloser();
     setupBackButtons();
@@ -1291,6 +1329,9 @@
     }
     if (page === 'users-management') {
       await initUsersPage(permissions);
+    }
+    if (page === 'history') {
+      await initHistoryPage();
     }
   }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -7,12 +7,12 @@ import {
   getDoc,
   getDocs,
   getFirestore,
+  orderBy,
   query,
   serverTimestamp,
   setDoc,
   Timestamp,
   updateDoc,
-  where,
 } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 
 const FIREBASE_CONFIG = {
@@ -293,6 +293,10 @@ function uid() {
 
 function makePageItemsCollection(pageName) {
   return collection(state.db, 'pages', pageName, 'items');
+}
+
+function historyCollection() {
+  return collection(state.db, 'historiques');
 }
 
 function normalizeDocData(docSnapshot) {
@@ -667,6 +671,7 @@ async function createSite(name) {
   const site = { id: created.id, ...sitePayload };
 
   state.sites.unshift(site);
+  await appendHistoryEntry(`a créé le site ${site.nom}`);
   persistOfflineState();
   emitAll();
   return { ok: true, id: site.id };
@@ -691,6 +696,7 @@ async function removeSite(siteId) {
     }
   });
 
+  await appendHistoryEntry(`a supprimé le site ${site.nom}`);
   persistOfflineState();
   emitAll();
 
@@ -724,6 +730,7 @@ async function createItem(siteId, numberValue) {
   }
   state.itemsBySite.get(siteId).unshift(item);
 
+  await appendHistoryEntry(`a créé ${item.numero}`);
   persistOfflineState();
   emitAll();
   return { ok: true, id: item.id };
@@ -743,6 +750,7 @@ async function removeItem(siteId, itemId) {
   const details = clone(state.detailsByItem.get(detailsKey) || []);
   state.detailsByItem.delete(detailsKey);
 
+  await appendHistoryEntry(`a supprimé ${item.numero}`);
   persistOfflineState();
   emitAll();
   return { item: clone(item), details };
@@ -877,6 +885,8 @@ async function createDetail(siteId, itemId, payload) {
   }
   state.detailsByItem.get(detailsKey).push(detail);
 
+  const item = getItem(siteId, itemId);
+  await appendHistoryEntry(`a ajouté des articles dans ${item?.numero || 'OUT inconnu'}`);
   persistOfflineState();
   emitAll();
   return { ok: true, id: detail.id };
@@ -925,6 +935,8 @@ async function updateDetail(siteId, itemId, detailId, changes) {
 
   await updateDoc(doc(state.db, 'pages', 'page3', 'items', detailId), syncedChanges);
   Object.assign(target, nextValues);
+  const item = getItem(siteId, itemId);
+  await appendHistoryEntry(`a modifié un article dans ${item?.numero || 'OUT inconnu'}`);
   persistOfflineState();
   emitAll();
   return true;
@@ -940,9 +952,42 @@ async function removeDetail(siteId, itemId, detailId) {
 
   await deleteDoc(doc(state.db, 'pages', 'page3', 'items', detailId));
   details.splice(detailIndex, 1);
+  const item = getItem(siteId, itemId);
+  await appendHistoryEntry(`a supprimé un article dans ${item?.numero || 'OUT inconnu'}`);
   persistOfflineState();
   emitAll();
   return true;
+}
+
+async function appendHistoryEntry(actionText) {
+  const action = sanitizeText(actionText, false);
+  if (!action) {
+    return;
+  }
+  try {
+    const profile = await getCurrentUserProfile();
+    const username = normalizeUsername(profile?.username) || 'Utilisateur inconnu';
+    await addDoc(historyCollection(), {
+      userName: username,
+      action,
+      createdAt: serverTimestamp(),
+    });
+  } catch (_error) {
+    // L'historique ne doit pas bloquer l'action principale.
+  }
+}
+
+async function listHistoriques() {
+  const snapshot = await getDocs(query(historyCollection(), orderBy('createdAt', 'desc')));
+  return snapshot.docs.map((snap) => {
+    const data = snap.data() || {};
+    return {
+      id: snap.id,
+      userName: normalizeUsername(data.userName) || 'Utilisateur inconnu',
+      action: sanitizeText(data.action, false),
+      createdAt: data.createdAt || null,
+    };
+  });
 }
 
 function exportData() {
@@ -1145,4 +1190,5 @@ window.StorageService = {
   listUsers,
   updateUserRole,
   computeNextNameChangeDate,
+  listHistoriques,
 };


### PR DESCRIPTION
### Motivation
- Fournir un écran simple affichant l'historique des actions utilisateurs et enregistrer ces actions dans Firestore pour audit et traçabilité.
- Le chargement doit être non temps réel (pas d'`onSnapshot`) et effectué uniquement au rafraîchissement de la page.

### Description
- Ajout d'une entrée de menu `Historiques` dans la page d'accueil (`index.html`) qui ouvre `historiques.html`.
- Nouvelle page `historiques.html` qui contient un conteneur `#historyList` et réutilise les scripts existants (`js/storage.js`, `js/app.js`).
- Ajout dans `js/storage.js` de la collection helper `historyCollection()`, de `appendHistoryEntry(actionText)` pour écrire en Firestore et de `listHistoriques()` qui récupère les documents triés par `createdAt` descendant (sans `onSnapshot`).
- Journalisation automatique (via `appendHistoryEntry`) lors des opérations importantes : `createSite`, `removeSite`, `createItem`, `removeItem`, `createDetail`, `updateDetail`, `removeDetail` ; les entrées enregistrent `userName`, `action` et `createdAt`.
- Intégration côté UI dans `js/app.js` : navigation vers `historiques.html`, initialisation de la page d'historique (`initHistoryPage`) et rendu d'une liste simple (plus récent → plus ancien) avec gestion des états vide/erreur.
- Exportation de l'API `listHistoriques` via `window.StorageService`.

### Testing
- Exécution de la vérification de syntaxe des modules : `node --check js/app.js` — succès.
- Exécution de la vérification de syntaxe des modules : `node --check js/ui.js` — succès.
- Exécution de la vérification de syntaxe des modules : `node --check js/storage.js` — succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d10e9f1114832aaae78b3b49c408eb)