### PR TITLE
Historique : afficher en colonne unique et purger au-delà de 100 entrées

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -302,6 +302,10 @@ body[data-page="home"] .list-grid {
   grid-template-columns: 1fr;
 }
 
+body[data-page="history"] .list-grid {
+  grid-template-columns: 1fr;
+}
+
 .list-card {
   position: relative;
   padding: 1rem;
@@ -651,6 +655,10 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
 
   .list-grid {
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  body[data-page="history"] .list-grid {
+    grid-template-columns: 1fr;
   }
 
   .responsive-form {

--- a/js/storage.js
+++ b/js/storage.js
@@ -972,9 +972,20 @@ async function appendHistoryEntry(actionText) {
       action,
       createdAt: serverTimestamp(),
     });
+    await pruneHistoryEntries();
   } catch (_error) {
     // L'historique ne doit pas bloquer l'action principale.
   }
+}
+
+async function pruneHistoryEntries() {
+  const snapshot = await getDocs(query(historyCollection(), orderBy('createdAt', 'desc')));
+  if (snapshot.size <= 100) {
+    return;
+  }
+
+  const docsToDelete = snapshot.docs.slice(100);
+  await Promise.all(docsToDelete.map((historyDoc) => deleteDoc(historyDoc.ref)));
 }
 
 async function listHistoriques() {


### PR DESCRIPTION
### Motivation
- Rendre la page d'historique plus lisible en affichant chaque card de résultat sur une seule colonne quel que soit la taille d'écran.
- Empêcher la table `historiques` Firestore de croître indéfiniment en conservant seulement les 100 entrées les plus récentes.

### Description
- Ajout de règles CSS pour forcer la grille d'historique en une seule colonne via `body[data-page="history"] .list-grid` dans `css/style.css` (appliqué globalement et dans la media query). 
- Ajout de la fonction `pruneHistoryEntries()` dans `js/storage.js` qui lit les documents triés par `createdAt` décroissant et supprime les documents au-delà des 100 premiers. 
- Appel de `pruneHistoryEntries()` immédiatement après l'ajout d'une nouvelle entrée d'historique depuis `appendHistoryEntry()` pour effectuer la purge automatique après chaque création. 
- La purge utilise `getDocs(query(historyCollection(), orderBy('createdAt', 'desc')))` et `deleteDoc(...)` pour supprimer les entrées les plus anciennes tout en conservant les 100 plus récentes.

### Testing
- Vérification de la syntaxe des modules JS avec `node --check js/storage.js && node --check js/app.js && node --check js/ui.js`, qui a réussi.
- La modification CSS et la nouvelle logique de purge ont été ajoutées et les fichiers JS se chargent sans erreur lors des vérifications statiques.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d112d6e0e0832a9f5d778430fc1912)