### PR TITLE
Historiques : afficher le détail en liste avec séparateur et style dédié

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,10 @@ body {
   font-family: "Roboto", sans-serif;
 }
 
+body[data-page="history"] {
+  background: linear-gradient(180deg, #d8ecff 0%, #eef6ff 45%, #f6f9ff 100%);
+}
+
 button,
 input,
 select,
@@ -304,6 +308,44 @@ body[data-page="home"] .list-grid {
 
 body[data-page="history"] .list-grid {
   grid-template-columns: 1fr;
+}
+
+.page-content--history {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(216, 236, 255, 0.35));
+}
+
+.history-list {
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(182, 206, 232, 0.8);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.history-list__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.history-list__item {
+  padding: 0.9rem 1rem;
+}
+
+.history-list__item + .history-list__item {
+  border-top: 1px solid #cdddee;
+}
+
+.history-list__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.history-list__date {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.86rem;
 }
 
 .list-card {

--- a/historiques.html
+++ b/historiques.html
@@ -13,8 +13,8 @@
         <div><h1>Historiques</h1></div>
       </header>
 
-      <main class="page-content">
-        <section id="historyList" class="list-grid" aria-live="polite"></section>
+      <main class="page-content page-content--history">
+        <section id="historyList" class="history-list" aria-live="polite"></section>
       </main>
 
       <div id="toast" class="toast" aria-live="polite"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -1291,18 +1291,18 @@
         return;
       }
 
-      historyList.innerHTML = historiques
-        .map((history) => `
-          <article class="list-card">
-            <div class="list-card__button" aria-label="Historique">
-              <h3 class="list-card__title">${escapeHtml(history.userName)} ${escapeHtml(history.action)}</h3>
-              <div class="list-card__meta">
-                <span>${escapeHtml(UiService.formatDate(history.createdAt?.toDate?.() || history.createdAt))}</span>
-              </div>
-            </div>
-          </article>
-        `)
-        .join('');
+      historyList.innerHTML = `
+        <ul class="history-list__items">
+          ${historiques
+            .map((history) => `
+              <li class="history-list__item" aria-label="Historique">
+                <p class="history-list__title">${escapeHtml(history.userName)} ${escapeHtml(history.action)}</p>
+                <p class="history-list__date">${escapeHtml(UiService.formatDate(history.createdAt?.toDate?.() || history.createdAt))}</p>
+              </li>
+            `)
+            .join('')}
+        </ul>
+      `;
     } catch (_error) {
       UiService.renderEmptyState(historyList, "Impossible de charger l'historique.");
     }


### PR DESCRIPTION
### Motivation
- Rendre la page `historiques.html` conforme à la demande UX en affichant les entrées d'historique sous forme de liste simple (sans card), avec un séparateur entre chaque élément et un fond/UI spécifique à la page historique.

### Description
- Remplace le rendu en cartes par une structure `ul/li` dans la fonction `initHistoryPage` (`js/app.js`) pour afficher `userName`, `action` et la date de l'événement.
- Met à jour le markup de la page pour ajouter la classe de conteneur `page-content--history` et remplacer `class="list-grid"` par `class="history-list"` dans `historiques.html`.
- Ajoute des règles CSS dédiées dans `css/style.css` pour le fond de la page historique (`body[data-page="history"]`), le conteneur `.history-list`, le style des items `.history-list__item` et le séparateur visuel via `.history-list__item + .history-list__item`.
- Ajuste le style des titres et dates d'entrée (`.history-list__title`, `.history-list__date`) pour une meilleure lisibilité.

### Testing
- Exécuté `git -C /workspace/Album diff --check` et la vérification a réussi.
- Aucun test unitaires automatisé présent pour cette UI, les modifications ont été vérifiées localement via inspection du diff et des fichiers modifiés (`historiques.html`, `js/app.js`, `css/style.css`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d115272594832ab9af0db6680d8568)