### PR TITLE
Ajout de l'icône cloche dans l'en-tête

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,7 +101,16 @@ button {
 
 .header-menu {
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   flex-shrink: 0;
+}
+
+.icon-cloche {
+  width: 2rem;
+  height: 2rem;
+  object-fit: contain;
 }
 
 .header-menu__trigger {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>??</button>
         <h1>Suivi Matériel</h1>
         <div class="header-menu">
+          <img src="Icon/cloche.png" alt="cloche" class="icon-cloche" />
           <button
             id="homeMenuButton"
             class="icon-button header-menu__trigger"


### PR DESCRIPTION
### Motivation
- Ajouter une icône de notification visible à côté du bouton des trois points dans l'en-tête de la page d'accueil pour préparer une future fonctionnalité de notifications.
- L'image est fournie en tant que fichier binaire et ne doit être ni lue ni modifiée, seulement référencée par son chemin (`Icon/cloche.png`).

### Description
- Inséré un élément image `<img src="Icon/cloche.png" alt="cloche" class="icon-cloche" />` dans `index.html` à côté du bouton de menu. 
- Mis à jour `css/style.css` pour que `.header-menu` utilise `display: inline-flex`, `align-items: center` et un `gap` afin d'aligner proprement l'icône et le bouton. 
- Ajouté la classe `.icon-cloche` avec des règles `width: 2rem`, `height: 2rem` et `object-fit: contain` pour dimensionner l'icône de manière cohérente avec la barre d'en-tête. 
- Aucun comportement JavaScript n'a été ajouté; l'icône est statique pour le moment.

### Testing
- Exécution de la vérification de cohérence `git diff --check`, qui a réussi sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d11b5063dc832a84e180b7ababc8ab)