### PR TITLE
Ajout d’un mode maintenance global (Firestore) avec overlay bloquant pour non‑admins

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -239,6 +239,107 @@ button {
   padding: 1rem;
 }
 
+.details-card {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.maintenance-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.maintenance-toggle-row__label {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.maintenance-toggle-row__status {
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  width: 3.2rem;
+  height: 1.9rem;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: #c8d4e2;
+  transition: background 0.2s ease;
+}
+
+.slider::before {
+  content: "";
+  position: absolute;
+  left: 0.2rem;
+  top: 0.2rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked + .slider {
+  background: var(--success);
+}
+
+.switch input:checked + .slider::before {
+  transform: translateX(1.3rem);
+}
+
+.maintenance-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(11, 15, 24, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.maintenance-overlay[hidden] {
+  display: none;
+}
+
+.maintenance-card {
+  width: min(100%, 32rem);
+  background: #fff;
+  border-radius: var(--radius-md);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 1.4rem 1.2rem;
+  text-align: center;
+}
+
+.maintenance-card h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.3rem;
+  color: #0f172a;
+}
+
+.maintenance-card p {
+  margin: 0;
+  color: #111827;
+  font-weight: 600;
+}
+
 .section-heading {
   display: flex;
   align-items: center;

--- a/js/app.js
+++ b/js/app.js
@@ -248,8 +248,8 @@
 
   function buildPermissions(profile) {
     const username = String(profile?.username || '');
-    const role = String(profile?.role || 'full');
-    const isAdmin = username === 'Admin';
+    const role = String(profile?.role || 'full').toLowerCase();
+    const isAdmin = username === 'Admin' || role === 'admin';
     if (isAdmin) {
       return { canCreate: true, canEdit: true, canDelete: true, isAdmin: true };
     }
@@ -260,6 +260,41 @@
       return { canCreate: true, canEdit: true, canDelete: false, isAdmin: false };
     }
     return { canCreate: true, canEdit: true, canDelete: true, isAdmin: false };
+  }
+
+  function ensureMaintenanceOverlay() {
+    let overlay = document.getElementById('maintenanceOverlay');
+    if (overlay) {
+      return overlay;
+    }
+    overlay = document.createElement('div');
+    overlay.id = 'maintenanceOverlay';
+    overlay.className = 'maintenance-overlay';
+    overlay.hidden = true;
+    overlay.innerHTML = `
+      <article class="maintenance-card" role="alertdialog" aria-modal="true" aria-labelledby="maintenanceTitle">
+        <h3 id="maintenanceTitle">Information</h3>
+        <p>Page en cours de maintenance, veuillez attendre s'il vous plaît</p>
+      </article>
+    `;
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  function initMaintenanceGate(permissions) {
+    if (permissions?.isAdmin) {
+      return () => {};
+    }
+
+    const overlay = ensureMaintenanceOverlay();
+    return StorageService.subscribeMaintenanceState(
+      (maintenanceState) => {
+        overlay.hidden = !maintenanceState.enabled;
+      },
+      () => {
+        UiService.showToast('État de maintenance indisponible.');
+      },
+    );
   }
 
   function formatRetryDate(value) {
@@ -1245,9 +1280,20 @@
 
     const tableBody = requireElement('usersTableBody');
     const backButton = requireElement('usersBackButton');
+    const maintenanceToggle = requireElement('maintenanceToggle');
+    const maintenanceStatusText = requireElement('maintenanceStatusText');
     backButton?.addEventListener('click', () => UiService.navigate('index.html'));
 
     const roleLabel = { lecture: 'Lecture seule', ecriture: 'Écriture seule', full: 'Tout accès' };
+
+    function updateMaintenanceLabel(isEnabled) {
+      if (maintenanceStatusText) {
+        maintenanceStatusText.textContent = isEnabled ? 'Activé' : 'Désactivé';
+      }
+      if (maintenanceToggle) {
+        maintenanceToggle.checked = Boolean(isEnabled);
+      }
+    }
 
     async function renderUsers() {
       const users = await StorageService.listUsers();
@@ -1274,6 +1320,32 @@
         });
       });
     }
+
+    let ignoreToggleEvent = false;
+    StorageService.subscribeMaintenanceState(
+      (maintenanceState) => {
+        ignoreToggleEvent = true;
+        updateMaintenanceLabel(Boolean(maintenanceState.enabled));
+        ignoreToggleEvent = false;
+      },
+      () => {
+        UiService.showToast('Impossible de synchroniser l’état de maintenance.');
+      },
+    );
+
+    maintenanceToggle?.addEventListener('change', async () => {
+      if (ignoreToggleEvent) {
+        return;
+      }
+      const enabled = maintenanceToggle.checked;
+      updateMaintenanceLabel(enabled);
+      try {
+        await StorageService.setMaintenanceState(enabled);
+      } catch (_error) {
+        updateMaintenanceLabel(!enabled);
+        UiService.showToast('Échec de mise à jour de l’état de maintenance.');
+      }
+    });
 
     await renderUsers();
   }
@@ -1316,6 +1388,8 @@
     let profile = await StorageService.getCurrentUserProfile();
     profile = await promptForMissingUsername(profile);
     const permissions = buildPermissions(profile);
+
+    initMaintenanceGate(permissions);
 
     const page = document.body.dataset.page;
     if (page === 'home') {

--- a/js/storage.js
+++ b/js/storage.js
@@ -7,6 +7,7 @@ import {
   getDoc,
   getDocs,
   getFirestore,
+  onSnapshot,
   orderBy,
   query,
   serverTimestamp,
@@ -106,6 +107,10 @@ function usersCollection() {
 
 function userDocRef(userId = state.userId) {
   return doc(state.db, 'users', userId);
+}
+
+function maintenanceDocRef() {
+  return doc(state.db, 'appSettings', 'maintenance');
 }
 
 async function isUsernameDuplicate(username, excludedUserId) {
@@ -256,6 +261,46 @@ async function updateUserRole(userId, role) {
   );
 
   return true;
+}
+
+function normalizeMaintenanceState(value) {
+  return {
+    enabled: Boolean(value?.enabled),
+  };
+}
+
+async function setMaintenanceState(enabled) {
+  await setDoc(
+    maintenanceDocRef(),
+    {
+      enabled: Boolean(enabled),
+      updatedAt: serverTimestamp(),
+      updatedBy: state.userId || null,
+    },
+    { merge: true },
+  );
+  return true;
+}
+
+function subscribeMaintenanceState(onChange, onError) {
+  try {
+    return onSnapshot(
+      maintenanceDocRef(),
+      (snapshot) => {
+        onChange(normalizeMaintenanceState(snapshot.exists() ? snapshot.data() : { enabled: false }));
+      },
+      (error) => {
+        if (typeof onError === 'function') {
+          onError(error);
+        }
+      },
+    );
+  } catch (error) {
+    if (typeof onError === 'function') {
+      onError(error);
+    }
+    return () => {};
+  }
 }
 
 function clone(value) {
@@ -1200,6 +1245,8 @@ window.StorageService = {
   changeUsername,
   listUsers,
   updateUserRole,
+  setMaintenanceState,
+  subscribeMaintenanceState,
   computeNextNameChangeDate,
   listHistoriques,
 };

--- a/users.html
+++ b/users.html
@@ -13,6 +13,17 @@
         <div><h1>Gestion des utilisateurs</h1></div>
       </header>
       <main class="page-content page-content--wide">
+        <section class="surface-card details-card">
+          <h2 class="section-title">Détails</h2>
+          <div class="maintenance-toggle-row">
+            <span class="maintenance-toggle-row__label">Etat de la page</span>
+            <label class="switch" for="maintenanceToggle">
+              <input id="maintenanceToggle" type="checkbox" role="switch" aria-label="Activer ou désactiver la maintenance" />
+              <span class="slider"></span>
+            </label>
+            <span id="maintenanceStatusText" class="maintenance-toggle-row__status">Désactivé</span>
+          </div>
+        </section>
         <section class="surface-card table-card">
           <div class="table-wrapper">
             <table class="data-table">


### PR DESCRIPTION
### Motivation
- Permettre à un administrateur d’activer/désactiver un mode maintenance centralisé visible par tous les utilisateurs.
- Bloquer l’interaction des utilisateurs ordinaires avec une carte persistante et non dismissible lors de la maintenance.
- Sauvegarder l’état de la maintenance en base (Firestore) et le propager en temps réel aux clients.

### Description
- Ajout d’un bloc « Détails » dans `users.html` contenant le libellé `Etat de la page`, un switch et le texte dynamique `Activé / Désactivé`.
- Ajout des styles pour le switch, l’overlay et la carte dans `css/style.css` (overlay centré, fond semi‑transparent, carte moderne avec ombre/arrondi/contraste élevé).
- Extension de `js/storage.js` avec `maintenanceDocRef()`, `setMaintenanceState(enabled)` et `subscribeMaintenanceState(onChange, onError)` utilisant `onSnapshot` vers `appSettings/maintenance` dans Firestore, et exposition de ces fonctions via `window.StorageService`.
- Ajout de la logique côté client dans `js/app.js` : création d’un overlay bloquant (`ensureMaintenanceOverlay`), initialisation globale `initMaintenanceGate(permissions)` (les admins sont explicitement exclus), et synchronisation du switch admin avec l’état Firestore (lecture en temps réel + écriture lors du toggle avec rollback visuel en cas d’erreur).

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check js/app.js` et retournant succès.
- L’intégration utilise `onSnapshot` pour la mise à jour temps réel et `setDoc` pour la persistance (tests d’intégration end‑to‑end nécessitent un environnement Firebase actif et n’ont pas été automatisés ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92e310f7c832a843f7162885feb40)