### PR TITLE
Rendre la liste de la page Historiques scrollable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -436,14 +436,18 @@ body[data-page="history"] .list-grid {
 
 .page-content--history {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(216, 236, 255, 0.35));
+  overflow: hidden;
 }
 
 .history-list {
+  flex: 1;
+  min-height: 0;
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid rgba(182, 206, 232, 0.8);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
-  overflow: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .history-list__items {


### PR DESCRIPTION
### Motivation
- Rendre la liste d'historiques scrollable pour éviter que la page entière défile et conserver l'en-tête fixe lorsque le nombre d'entrées est élevé.

### Description
- Ajout de `overflow: hidden` sur `.page-content--history` et transformation de `.history-list` en conteneur scrollable avec `flex: 1`, `min-height: 0`, `overflow-y: auto` et `-webkit-overflow-scrolling: touch` dans `css/style.css`.
- Seul le fichier `css/style.css` a été modifié.

### Testing
- Commandes vérifiées automatiquement: `git diff -- css/style.css`, `nl -ba css/style.css | sed -n '430,460p'` et `git commit`, toutes exécutées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9336a2754832ab19bb25276d449bd)