### PR TITLE
Ajouter zoom et déplacement ciblés pour le tableau de la Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -672,12 +672,33 @@ body[data-page="history"] .list-grid {
   padding-inline: 0;
 }
 
-.table-wrapper {
+.table-container {
   overflow-x: auto;
+  overflow-y: hidden;
+  cursor: grab;
+  user-select: none;
+}
+
+.table-container.is-grabbing {
+  cursor: grabbing;
+}
+
+.table-wrapper {
+  width: max-content;
+  min-width: 100%;
+  transform-origin: 0 0;
+  will-change: transform;
 }
 
 body[data-page="item-detail"] .table-wrapper {
   padding-bottom: 1.5rem;
+}
+
+body[data-page="item-detail"] .table-container input,
+body[data-page="item-detail"] .table-container select,
+body[data-page="item-detail"] .table-container button,
+body[data-page="item-detail"] .table-container textarea {
+  user-select: text;
 }
 
 .data-table {

--- a/js/app.js
+++ b/js/app.js
@@ -124,6 +124,134 @@
     return qteSortie - (qtePosee + qteRetour);
   }
 
+  function setupZoomableDetailTable() {
+    const tableContainer = requireElement('detailTableContainer');
+    const tableWrapper = requireElement('detailTableWrapper');
+    if (!tableContainer || !tableWrapper) {
+      return;
+    }
+
+    const minScale = 0.7;
+    const maxScale = 2;
+    let scale = 1;
+    let translateX = 0;
+    let translateY = 0;
+    let dragState = null;
+    let pinchState = null;
+
+    function clampScale(value) {
+      return Math.min(maxScale, Math.max(minScale, value));
+    }
+
+    function applyTransform() {
+      tableWrapper.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`;
+    }
+
+    function zoomAtPoint(nextScale, clientX, clientY) {
+      const clampedScale = clampScale(nextScale);
+      if (clampedScale === scale) {
+        return;
+      }
+
+      const rect = tableContainer.getBoundingClientRect();
+      const localX = clientX - rect.left;
+      const localY = clientY - rect.top;
+      const nextTranslateX = localX - ((localX - translateX) / scale) * clampedScale;
+      const nextTranslateY = localY - ((localY - translateY) / scale) * clampedScale;
+
+      scale = clampedScale;
+      translateX = nextTranslateX;
+      translateY = nextTranslateY;
+      applyTransform();
+    }
+
+    function isInteractiveTarget(target) {
+      return Boolean(target.closest('input, select, textarea, button, a, label'));
+    }
+
+    tableContainer.addEventListener('wheel', (event) => {
+      if (!event.ctrlKey) {
+        return;
+      }
+      event.preventDefault();
+      const direction = event.deltaY > 0 ? -1 : 1;
+      const zoomStep = 0.08;
+      zoomAtPoint(scale + direction * zoomStep, event.clientX, event.clientY);
+    }, { passive: false });
+
+    tableContainer.addEventListener('mousedown', (event) => {
+      if (event.button !== 0 || isInteractiveTarget(event.target)) {
+        return;
+      }
+      dragState = {
+        startX: event.clientX,
+        startY: event.clientY,
+        startTranslateX: translateX,
+        startTranslateY: translateY,
+      };
+      tableContainer.classList.add('is-grabbing');
+      event.preventDefault();
+    });
+
+    window.addEventListener('mousemove', (event) => {
+      if (!dragState) {
+        return;
+      }
+      translateX = dragState.startTranslateX + (event.clientX - dragState.startX);
+      translateY = dragState.startTranslateY + (event.clientY - dragState.startY);
+      applyTransform();
+    });
+
+    window.addEventListener('mouseup', () => {
+      dragState = null;
+      tableContainer.classList.remove('is-grabbing');
+    });
+
+    tableContainer.addEventListener('touchstart', (event) => {
+      if (event.touches.length === 2) {
+        const [touchA, touchB] = event.touches;
+        const dx = touchB.clientX - touchA.clientX;
+        const dy = touchB.clientY - touchA.clientY;
+        pinchState = {
+          distance: Math.hypot(dx, dy),
+          scale,
+        };
+      }
+    }, { passive: true });
+
+    tableContainer.addEventListener('touchmove', (event) => {
+      if (event.touches.length !== 2 || !pinchState) {
+        return;
+      }
+
+      const [touchA, touchB] = event.touches;
+      const dx = touchB.clientX - touchA.clientX;
+      const dy = touchB.clientY - touchA.clientY;
+      const currentDistance = Math.hypot(dx, dy);
+      if (!currentDistance || !pinchState.distance) {
+        return;
+      }
+
+      const midpointX = (touchA.clientX + touchB.clientX) / 2;
+      const midpointY = (touchA.clientY + touchB.clientY) / 2;
+      const scaleFactor = currentDistance / pinchState.distance;
+      zoomAtPoint(pinchState.scale * scaleFactor, midpointX, midpointY);
+      event.preventDefault();
+    }, { passive: false });
+
+    tableContainer.addEventListener('touchend', (event) => {
+      if (event.touches.length < 2) {
+        pinchState = null;
+      }
+    });
+
+    tableContainer.addEventListener('touchcancel', () => {
+      pinchState = null;
+    });
+
+    applyTransform();
+  }
+
   function setupBackButtons() {
     document.querySelectorAll('[data-back]').forEach((button) => {
       button.addEventListener('click', () => {
@@ -1066,6 +1194,8 @@
     const detailSearchInput = requireElement('detailSearchInput');
     const exportButton = requireElement('exportDetailsButton');
     const designationInput = requireElement('designationInput');
+
+    setupZoomableDetailTable();
 
     let currentSite = StorageService.getSite(siteId);
     let currentItem = StorageService.getItem(siteId, itemId);

--- a/page3.html
+++ b/page3.html
@@ -59,8 +59,9 @@
               <input id="detailSearchInput" type="text" placeholder="Rechercher..." autocomplete="off" />
             </label>
           </div>
-          <div class="table-wrapper">
-            <table class="data-table">
+          <div class="table-container" id="detailTableContainer">
+            <div class="table-wrapper" id="detailTableWrapper">
+              <table class="data-table" id="detailDataTable">
               <thead>
                 <tr>
                   <th>#   </th>
@@ -76,8 +77,9 @@
                   <th>Action</th>
                 </tr>
               </thead>
-              <tbody id="detailTableBody"></tbody>
-            </table>
+                <tbody id="detailTableBody"></tbody>
+              </table>
+            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
### Motivation
- Permettre un zoom et un déplacement fluides et limités seulement sur le tableau de données de la Page 3 sans affecter le reste de la page. 
- Offrir une expérience tactile (pinch) sur mobile et un contrôle par molette + Ctrl sur ordinateur tout en gardant l'accès horizontal aux colonnes via un défilement. 

### Description
- HTML : encapsulation du tableau dans `<div class="table-container" id="detailTableContainer">` et un wrapper interne `<div class="table-wrapper" id="detailTableWrapper">` pour isoler les interactions (`page3.html`).
- CSS : ajout de règles pour `.table-container` et `.table-wrapper` pour `overflow-x: auto`, curseurs `grab`/`grabbing`, `transform-origin` et `will-change` et pour préserver la sélection des champs interactifs (`css/style.css`).
- JS : implémentation de `setupZoomableDetailTable()` dans `js/app.js` qui gère le zoom (Ctrl + molette), le pinch-to-zoom à deux doigts, le drag-pan souris, applique la transformation via `transform: translate(...) scale(...)` et borne le zoom entre `0.7` et `2` ; l'initialisation est appelée depuis `initItemDetailPage()`.
- Comportement : le zoom s'applique uniquement au contenu du wrapper du tableau et le tableau reste accessible sans zoom grâce à `overflow-x: auto`.

### Testing
- Exécution de la vérification de syntaxe JS avec `node --check js/app.js` et le contrôle a réussi. 
- Aucune suite e2e automatisée n'a été exécutée dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9356d2100832a9864fa20fb1378bb)