### PR TITLE
Ajoute un Bottom Sheet déclenché au clic sur l'avatar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -873,6 +873,73 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   font-weight: 700;
 }
 
+.bottom-sheet-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(15, 23, 42, 0);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  transition: background 0.25s ease;
+}
+
+.bottom-sheet {
+  width: min(100%, 32rem);
+  background: var(--surface);
+  border-radius: 1.25rem 1.25rem 0 0;
+  box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.16);
+  transform: translateY(100%);
+  transition: transform 0.28s ease;
+  padding: 0.75rem 1.25rem calc(1.25rem + env(safe-area-inset-bottom));
+}
+
+.bottom-sheet-overlay.is-open {
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.bottom-sheet-overlay.is-open .bottom-sheet {
+  transform: translateY(0);
+}
+
+.bottom-sheet__handle {
+  width: 3rem;
+  height: 0.3rem;
+  border-radius: 999px;
+  background: #d5dce6;
+  margin: 0.1rem auto 1rem;
+}
+
+.bottom-sheet__content {
+  display: grid;
+  justify-items: center;
+  gap: 1rem;
+}
+
+.bottom-sheet__avatar {
+  width: 5.5rem;
+  height: 5.5rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #c7ebff, #8ad0ff);
+  color: #0f3e66;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  font-weight: 800;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.7);
+}
+
+.bottom-sheet__action {
+  border: 0;
+  background: transparent;
+  color: var(--primary-dark);
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: center;
+  padding: 0.5rem 1rem;
+}
+
 .data-table--hide-action th:last-child,
 .data-table--hide-action td:last-child {
   display: none;

--- a/js/app.js
+++ b/js/app.js
@@ -502,6 +502,85 @@
     avatarButton.onclick = onClick;
   }
 
+  function ensureAvatarBottomSheet() {
+    let overlay = document.getElementById('avatarSheetOverlay');
+    if (overlay) {
+      return overlay;
+    }
+
+    overlay = document.createElement('div');
+    overlay.id = 'avatarSheetOverlay';
+    overlay.className = 'bottom-sheet-overlay';
+    overlay.hidden = true;
+    overlay.innerHTML = `
+      <div class="bottom-sheet" id="avatarBottomSheet" role="dialog" aria-modal="true" aria-label="Actions du profil">
+        <div class="bottom-sheet__handle" aria-hidden="true"></div>
+        <div class="bottom-sheet__content">
+          <div class="bottom-sheet__avatar" id="avatarSheetPreview">??</div>
+          <button type="button" class="bottom-sheet__action" id="avatarSheetRename">Modifier un nom</button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  function openAvatarBottomSheet(profile, onRenameClick) {
+    const overlay = ensureAvatarBottomSheet();
+    const sheet = overlay.querySelector('#avatarBottomSheet');
+    const avatarPreview = overlay.querySelector('#avatarSheetPreview');
+    const renameButton = overlay.querySelector('#avatarSheetRename');
+
+    if (!sheet || !avatarPreview || !renameButton) {
+      return;
+    }
+
+    const base = String(profile?.username || '??').slice(0, 2).toUpperCase();
+    avatarPreview.textContent = base;
+    avatarPreview.title = profile?.username || '';
+
+    const closeSheet = () => {
+      overlay.classList.remove('is-open');
+      const onTransitionEnd = () => {
+        overlay.hidden = true;
+        overlay.removeEventListener('transitionend', onTransitionEnd);
+      };
+      overlay.addEventListener('transitionend', onTransitionEnd);
+    };
+
+    renameButton.onclick = () => {
+      closeSheet();
+      onRenameClick();
+    };
+
+    overlay.onclick = (event) => {
+      if (event.target === overlay) {
+        closeSheet();
+      }
+    };
+
+    let touchStartY = null;
+    sheet.ontouchstart = (event) => {
+      touchStartY = event.touches[0]?.clientY ?? null;
+    };
+    sheet.ontouchend = (event) => {
+      if (touchStartY === null) {
+        return;
+      }
+      const touchEndY = event.changedTouches[0]?.clientY ?? touchStartY;
+      if (touchEndY - touchStartY > 60) {
+        closeSheet();
+      }
+      touchStartY = null;
+    };
+
+    overlay.hidden = false;
+    window.requestAnimationFrame(() => {
+      overlay.classList.add('is-open');
+    });
+  }
+
   function ensureRenameDialog() {
     let dialog = document.getElementById('renameDialog');
     if (dialog) {
@@ -806,9 +885,9 @@
 
     const refreshAvatar = async () => {
       const latest = await StorageService.getCurrentUserProfile();
-      renderAvatar(latest, () => openRenameDialog(latest, refreshAvatar));
+      renderAvatar(latest, () => openAvatarBottomSheet(latest, () => openRenameDialog(latest, refreshAvatar)));
     };
-    renderAvatar(userProfile, () => openRenameDialog(userProfile, refreshAvatar));
+    renderAvatar(userProfile, () => openAvatarBottomSheet(userProfile, () => openRenameDialog(userProfile, refreshAvatar)));
 
 
     const openCreateSite = requireElement('openCreateSite');


### PR DESCRIPTION
### Motivation
- Remplacer l’ouverture directe du dialogue de renommage par une interface mobile plus moderne pour présenter des actions de profil au clic sur l’avatar.

### Description
- Ajout de `ensureAvatarBottomSheet` et `openAvatarBottomSheet` dans `js/app.js` pour construire et afficher dynamiquement un Bottom Sheet contenant un avatar agrandi et un bouton `Modifier un nom`.
- Le bouton `Modifier un nom` réutilise la logique existante et appelle `openRenameDialog(...)` sans modifier la logique métier actuelle.
- Remplacement du point d’entrée d’origine en `renderAvatar(...)` pour ouvrir le Bottom Sheet au lieu d’ouvrir directement la boîte de dialogue de renommage.
- Ajout des styles CSS (`.bottom-sheet-overlay`, `.bottom-sheet`, `.bottom-sheet__avatar`, etc.) dans `css/style.css` pour l’overlay assombri, l’animation `transform: translateY()`, les coins arrondis et l’ombre, ainsi que la gestion de la fermeture par clic hors panneau et swipe vers le bas.

### Testing
- Vérification syntaxique JavaScript avec `node --check js/app.js` qui a réussi.
- Vérification syntaxique JavaScript avec `node --check js/ui.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9490b92b8832ab6c50810799ca362)