### PR TITLE
Add avatar photo editing with Cloudinary upload

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -871,6 +871,26 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   background: rgba(255, 255, 255, 0.9);
   color: var(--primary-dark);
   font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0;
+}
+
+.avatar-image {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
+}
+
+.avatar-initials {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
 }
 
 .bottom-sheet-overlay {
@@ -928,6 +948,28 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   font-size: 1.6rem;
   font-weight: 800;
   box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.7);
+  overflow: hidden;
+}
+
+.bottom-sheet__avatar-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.bottom-sheet__avatar-edit {
+  position: absolute;
+  right: -0.15rem;
+  bottom: -0.15rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  border: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  color: var(--primary-dark);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
 }
 
 .bottom-sheet__action {

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,7 @@
 (function () {
   const { StorageService, UiService } = window;
+  const CLOUDINARY_UPLOAD_URL = 'https://api.cloudinary.com/v1_1/dskw13nem/image/upload';
+  const CLOUDINARY_UPLOAD_PRESET = 'public_upload';
 
   function requireElement(id) {
     return document.getElementById(id);
@@ -490,13 +492,27 @@
     });
   }
 
+  function getAvatarInitials(profile) {
+    return String(profile?.username || '??').slice(0, 2).toUpperCase();
+  }
+
+  function renderAvatarVisual(container, profile) {
+    if (!container) {
+      return;
+    }
+    const avatarUrl = String(profile?.avatarUrl || '').trim();
+    const initials = getAvatarInitials(profile);
+    container.innerHTML = avatarUrl
+      ? `<img src="${escapeHtml(avatarUrl)}" alt="Photo de profil" class="avatar-image" />`
+      : `<span class="avatar-initials">${escapeHtml(initials)}</span>`;
+  }
+
   function renderAvatar(profile, onClick) {
     const avatarButton = document.getElementById('userAvatarButton');
     if (!avatarButton) {
       return;
     }
-    const base = String(profile.username || '??').slice(0, 2).toUpperCase();
-    avatarButton.textContent = base;
+    renderAvatarVisual(avatarButton, profile);
     avatarButton.title = profile.username || '';
     avatarButton.hidden = false;
     avatarButton.onclick = onClick;
@@ -516,8 +532,15 @@
       <div class="bottom-sheet" id="avatarBottomSheet" role="dialog" aria-modal="true" aria-label="Actions du profil">
         <div class="bottom-sheet__handle" aria-hidden="true"></div>
         <div class="bottom-sheet__content">
-          <div class="bottom-sheet__avatar" id="avatarSheetPreview">??</div>
+          <div class="bottom-sheet__avatar-wrap">
+            <div class="bottom-sheet__avatar" id="avatarSheetPreview">??</div>
+            <button type="button" class="bottom-sheet__avatar-edit" id="avatarSheetEditButton" aria-label="Modifier la photo de profil">
+              <i class="fa-solid fa-pencil" aria-hidden="true"></i>
+            </button>
+            <input id="avatarFileInput" type="file" accept="image/*" hidden />
+          </div>
           <button type="button" class="bottom-sheet__action" id="avatarSheetRename">Modifier un nom</button>
+          <p id="avatarSheetMessage" class="form-error" aria-live="polite"></p>
         </div>
       </div>
     `;
@@ -526,19 +549,23 @@
     return overlay;
   }
 
-  function openAvatarBottomSheet(profile, onRenameClick) {
+  function openAvatarBottomSheet(profile, handlers) {
     const overlay = ensureAvatarBottomSheet();
     const sheet = overlay.querySelector('#avatarBottomSheet');
     const avatarPreview = overlay.querySelector('#avatarSheetPreview');
     const renameButton = overlay.querySelector('#avatarSheetRename');
+    const editButton = overlay.querySelector('#avatarSheetEditButton');
+    const fileInput = overlay.querySelector('#avatarFileInput');
+    const message = overlay.querySelector('#avatarSheetMessage');
 
-    if (!sheet || !avatarPreview || !renameButton) {
+    if (!sheet || !avatarPreview || !renameButton || !editButton || !fileInput || !message) {
       return;
     }
 
-    const base = String(profile?.username || '??').slice(0, 2).toUpperCase();
-    avatarPreview.textContent = base;
+    renderAvatarVisual(avatarPreview, profile);
     avatarPreview.title = profile?.username || '';
+    message.textContent = '';
+    fileInput.value = '';
 
     const closeSheet = () => {
       overlay.classList.remove('is-open');
@@ -551,7 +578,36 @@
 
     renameButton.onclick = () => {
       closeSheet();
-      onRenameClick();
+      handlers.onRenameClick();
+    };
+
+    editButton.onclick = () => {
+      message.textContent = '';
+      fileInput.click();
+    };
+
+    fileInput.onchange = async () => {
+      const [selectedFile] = fileInput.files || [];
+      if (!selectedFile) {
+        return;
+      }
+      if (!selectedFile.type.startsWith('image/')) {
+        message.textContent = 'Veuillez sélectionner une image valide.';
+        return;
+      }
+      editButton.disabled = true;
+      renameButton.disabled = true;
+      message.textContent = 'Téléversement en cours...';
+      try {
+        await handlers.onUploadAvatar(selectedFile);
+        message.textContent = 'Photo de profil mise à jour.';
+        closeSheet();
+      } catch (_error) {
+        message.textContent = "Échec de l'upload. Veuillez réessayer.";
+      } finally {
+        editButton.disabled = false;
+        renameButton.disabled = false;
+      }
     };
 
     overlay.onclick = (event) => {
@@ -579,6 +635,24 @@
     window.requestAnimationFrame(() => {
       overlay.classList.add('is-open');
     });
+  }
+
+  async function uploadAvatarToCloudinary(file) {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('upload_preset', CLOUDINARY_UPLOAD_PRESET);
+    const response = await fetch(CLOUDINARY_UPLOAD_URL, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error('upload_failed');
+    }
+    const data = await response.json();
+    if (!data?.secure_url) {
+      throw new Error('missing_secure_url');
+    }
+    return String(data.secure_url);
   }
 
   function ensureRenameDialog() {
@@ -885,9 +959,23 @@
 
     const refreshAvatar = async () => {
       const latest = await StorageService.getCurrentUserProfile();
-      renderAvatar(latest, () => openAvatarBottomSheet(latest, () => openRenameDialog(latest, refreshAvatar)));
+      renderAvatar(latest, () => openAvatarBottomSheet(latest, {
+        onRenameClick: () => openRenameDialog(latest, refreshAvatar),
+        onUploadAvatar: async (file) => {
+          const avatarUrl = await uploadAvatarToCloudinary(file);
+          await StorageService.updateAvatarUrl(avatarUrl);
+          await refreshAvatar();
+        },
+      }));
     };
-    renderAvatar(userProfile, () => openAvatarBottomSheet(userProfile, () => openRenameDialog(userProfile, refreshAvatar)));
+    renderAvatar(userProfile, () => openAvatarBottomSheet(userProfile, {
+      onRenameClick: () => openRenameDialog(userProfile, refreshAvatar),
+      onUploadAvatar: async (file) => {
+        const avatarUrl = await uploadAvatarToCloudinary(file);
+        await StorageService.updateAvatarUrl(avatarUrl);
+        await refreshAvatar();
+      },
+    }));
 
 
     const openCreateSite = requireElement('openCreateSite');

--- a/js/storage.js
+++ b/js/storage.js
@@ -58,6 +58,10 @@ function normalizeUsername(value) {
   return sanitizeText(value, false);
 }
 
+function normalizeAvatarUrl(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
 const BLOCKED_USERNAMES = new Set([
   'FACEBOOK',
   'YOUTUBE',
@@ -133,6 +137,7 @@ async function ensureCurrentUser() {
       ref,
       {
         username: '',
+        avatarUrl: '',
         role: 'full',
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
@@ -140,7 +145,7 @@ async function ensureCurrentUser() {
       },
       { merge: true },
     );
-    return { id: state.userId, username: '', role: 'full', lastNameChange: null };
+    return { id: state.userId, username: '', role: 'full', lastNameChange: null, avatarUrl: '' };
   }
 
   const data = snap.data() || {};
@@ -149,6 +154,7 @@ async function ensureCurrentUser() {
     username: normalizeUsername(data.username),
     role: normalizeRole(data.role),
     lastNameChange: data.lastNameChange || null,
+    avatarUrl: normalizeAvatarUrl(data.avatarUrl),
   };
 }
 
@@ -163,6 +169,7 @@ async function getCurrentUserProfile() {
     username: normalizeUsername(data.username),
     role: normalizeRole(data.role),
     lastNameChange: data.lastNameChange || null,
+    avatarUrl: normalizeAvatarUrl(data.avatarUrl),
   };
 }
 
@@ -233,6 +240,19 @@ async function changeUsername(username) {
   );
 
   return { ok: true, username: nextName };
+}
+
+async function updateAvatarUrl(avatarUrl) {
+  const nextAvatarUrl = normalizeAvatarUrl(avatarUrl);
+  await setDoc(
+    userDocRef(),
+    {
+      avatarUrl: nextAvatarUrl,
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+  return { ok: true, avatarUrl: nextAvatarUrl };
 }
 
 async function listUsers() {
@@ -1243,6 +1263,7 @@ window.StorageService = {
   getCurrentUserProfile,
   saveUsername,
   changeUsername,
+  updateAvatarUrl,
   listUsers,
   updateUserRole,
   setMaintenanceState,


### PR DESCRIPTION
### Motivation
- Permettre à l’utilisateur de changer sa photo de profil depuis la fiche profil (bottom sheet) et d’héberger l’image sur Cloudinary pour un chargement et affichage instantané.

### Description
- Remplacement du rendu d’initiales par un rendu visuel qui affiche soit l’image (`avatarUrl`) soit les initiales, avec nouveaux styles pour `.avatar-image` et le conteneur. 
- Ajout d’un petit bouton « crayon » positionné en bas à droite de l’avatar dans le bottom sheet, d’un `input type="file" accept="image/*"` caché et d’un message d’état/erreur inline. 
- Upload automatique vers Cloudinary via `fetch` + `FormData` avec les constantes `CLOUDINARY_UPLOAD_URL` et `CLOUDINARY_UPLOAD_PRESET`, récupération de `data.secure_url` puis sauvegarde immédiate dans le profil utilisateur via `StorageService.updateAvatarUrl(...)`. 
- Extension du profil utilisateur pour inclure `avatarUrl` dans la lecture/création/normalisation côté `StorageService` et ajout de la fonction `updateAvatarUrl` pour persister l’URL dans Firestore.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` et `node --check js/storage.js`, les deux ont réussi. 
- Aucun test d’intégration navigateur automatisé n’a été exécuté dans cet environnement, l’upload Cloudinary a été implémenté selon la spécification (`upload_preset = "public_upload"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94dbc5420832abadf59377ee40d92)