### PR TITLE
Ajouter avatars aux entrées de la page Historiques

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -457,21 +457,70 @@ body[data-page="history"] .list-grid {
 }
 
 .history-list__item {
-  padding: 0.9rem 1rem;
+  padding: 0.85rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  transition: background-color 0.2s ease;
 }
 
 .history-list__item + .history-list__item {
   border-top: 1px solid #cdddee;
 }
 
-.history-list__title {
+.history-list__item:hover {
+  background: rgba(89, 184, 255, 0.09);
+}
+
+.history-list__avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #dbeafe;
+  color: #1d4ed8;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.history-list__avatar-image {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
+}
+
+.history-list__avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.history-list__content {
+  min-width: 0;
+}
+
+.history-list__name {
   margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.history-list__title {
+  margin: 0.22rem 0 0;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--text);
 }
 
 .history-list__date {
-  margin: 0.35rem 0 0;
+  margin: 0.18rem 0 0;
   color: var(--text-muted);
   font-size: 0.86rem;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -492,8 +492,22 @@
     });
   }
 
+  function getInitialsFromName(name) {
+    const parts = String(name || '')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (!parts.length) {
+      return '??';
+    }
+    if (parts.length === 1) {
+      return parts[0].slice(0, 2).toUpperCase();
+    }
+    return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+  }
+
   function getAvatarInitials(profile) {
-    return String(profile?.username || '??').slice(0, 2).toUpperCase();
+    return getInitialsFromName(profile?.username);
   }
 
   function renderAvatarVisual(container, profile) {
@@ -1654,6 +1668,20 @@
     }
 
     try {
+      const users = await StorageService.listUsers();
+      const usersById = users.reduce((accumulator, user) => {
+        if (user?.id) {
+          accumulator[user.id] = user;
+        }
+        return accumulator;
+      }, {});
+      const usersByName = users.reduce((accumulator, user) => {
+        const usernameKey = String(user?.username || '').trim().toLowerCase();
+        if (usernameKey && !accumulator[usernameKey]) {
+          accumulator[usernameKey] = user;
+        }
+        return accumulator;
+      }, {});
       const historiques = await StorageService.listHistoriques();
       if (!historiques.length) {
         UiService.renderEmptyState(historyList, 'Aucun historique enregistré pour le moment.');
@@ -1663,12 +1691,28 @@
       historyList.innerHTML = `
         <ul class="history-list__items">
           ${historiques
-            .map((history) => `
+            .map((history) => {
+              const normalizedName = String(history.userName || '').trim().toLowerCase();
+              const matchedUser = usersById[history.userId] || usersByName[normalizedName] || null;
+              const avatarUrl = String(matchedUser?.avatarUrl || '').trim();
+              const displayName = String(history.userName || 'Utilisateur inconnu').trim();
+              const initials = getInitialsFromName(displayName);
+              const avatarMarkup = avatarUrl
+                ? `<img class="history-list__avatar-image" src="${escapeHtml(avatarUrl)}" alt="Avatar de ${escapeHtml(displayName)}" />`
+                : `<span class="history-list__avatar-fallback" aria-hidden="true">${escapeHtml(initials)}</span>`;
+              return `
               <li class="history-list__item" aria-label="Historique">
-                <p class="history-list__title">${escapeHtml(history.userName)} ${escapeHtml(history.action)}</p>
-                <p class="history-list__date">${escapeHtml(UiService.formatDate(history.createdAt?.toDate?.() || history.createdAt))}</p>
+                <div class="history-list__avatar">
+                  ${avatarMarkup}
+                </div>
+                <div class="history-list__content">
+                  <p class="history-list__name">${escapeHtml(displayName)}</p>
+                  <p class="history-list__title">${escapeHtml(history.action)}</p>
+                  <p class="history-list__date">${escapeHtml(UiService.formatDate(history.createdAt?.toDate?.() || history.createdAt))}</p>
+                </div>
               </li>
-            `)
+            `;
+            })
             .join('')}
         </ul>
       `;

--- a/js/storage.js
+++ b/js/storage.js
@@ -263,6 +263,7 @@ async function listUsers() {
       return {
         id: snap.id,
         username: normalizeUsername(data.username),
+        avatarUrl: normalizeAvatarUrl(data.avatarUrl),
         role: normalizeRole(data.role),
       };
     })
@@ -1033,6 +1034,7 @@ async function appendHistoryEntry(actionText) {
     const profile = await getCurrentUserProfile();
     const username = normalizeUsername(profile?.username) || 'Utilisateur inconnu';
     await addDoc(historyCollection(), {
+      userId: profile?.id || state.userId || null,
       userName: username,
       action,
       createdAt: serverTimestamp(),
@@ -1059,6 +1061,7 @@ async function listHistoriques() {
     const data = snap.data() || {};
     return {
       id: snap.id,
+      userId: sanitizeText(data.userId, false),
       userName: normalizeUsername(data.userName) || 'Utilisateur inconnu',
       action: sanitizeText(data.action, false),
       createdAt: data.createdAt || null,


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité et l’identification des utilisateurs sur la page `Historiques` en affichant un avatar à gauche de chaque entrée.

### Description
- Ajout d’un rendu d’avatar dans `initHistoryPage` (fichier `js/app.js`) qui récupère les utilisateurs, construit des index par `id` et par nom, puis associe chaque historique à une image si `avatarUrl` est disponible ou affiche des initiales en fallback.
- Enrichissement du stockage (`js/storage.js`) pour renvoyer `avatarUrl` dans `listUsers`, pour enregistrer `userId` lors de la création d’un historique (`appendHistoryEntry`) et pour exposer `userId` dans `listHistoriques` afin de permettre une résolution fiable des avatars.
- Ajout de styles CSS (`css/style.css`) pour disposer chaque ligne en `flex` horizontal, créer l’espace entre avatar et texte, définir la taille et le style circulaire de l’avatar (approx. 35–45px), et ajouter un léger effet `:hover` et séparateur entre lignes.
- Amélioration des initiales de fallback via une nouvelle utilitaire qui extrait les initiales pertinentes d’un nom composé.

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check js/app.js && node --check js/storage.js` et elle a réussi.
- Le changement a été commité localement après modifications (fichiers modifiés : `js/app.js`, `js/storage.js`, `css/style.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9525407dc832a964b3e27ad608f09)