### PR TITLE
Add admin approval workflow to block new users until approved

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -340,6 +340,68 @@ button {
   font-weight: 600;
 }
 
+.status-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  background: rgba(11, 15, 24, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.28s ease;
+}
+
+.status-overlay[hidden] {
+  display: none;
+}
+
+.status-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.status-card {
+  width: min(100%, 30rem);
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.28);
+  padding: 1.8rem 1.4rem;
+  text-align: center;
+  transform: scale(0.92);
+  opacity: 0;
+  transition: transform 0.25s ease, opacity 0.25s ease, border-color 0.25s ease;
+  border: 1px solid #e5e7eb;
+}
+
+.status-overlay.is-visible .status-card {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.status-card--pending {
+  border-color: #f59e0b;
+}
+
+.status-card--approved {
+  border-color: #22c55e;
+}
+
+.status-card--rejected {
+  border-color: #ef4444;
+}
+
+.status-card h3 {
+  margin: 0 0 0.7rem;
+}
+
+.status-card p {
+  margin: 0;
+  font-weight: 500;
+}
+
 .section-heading {
   display: flex;
   align-items: center;
@@ -523,6 +585,86 @@ body[data-page="history"] .list-grid {
   margin: 0.18rem 0 0;
   color: var(--text-muted);
   font-size: 0.86rem;
+}
+
+.pending-users-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.pending-user-card {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 0.85rem;
+  box-shadow: 0 10px 20px rgba(31, 42, 55, 0.08);
+}
+
+.pending-user-card__identity {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pending-user-card__avatar,
+.table-avatar {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.pending-user-card__avatar--fallback,
+.table-avatar--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+.pending-user-card__name {
+  margin: 0;
+  font-weight: 700;
+}
+
+.pending-user-card__status {
+  margin: 0.2rem 0 0;
+  color: var(--text-muted);
+}
+
+.pending-user-card__actions {
+  display: inline-flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.28rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.status-pill--pending {
+  background: rgba(245, 158, 11, 0.16);
+  color: #b45309;
+}
+
+.status-pill--approved {
+  background: rgba(34, 197, 94, 0.16);
+  color: #15803d;
+}
+
+.status-pill--rejected {
+  background: rgba(239, 68, 68, 0.16);
+  color: #b91c1c;
 }
 
 .list-card {

--- a/js/app.js
+++ b/js/app.js
@@ -427,6 +427,106 @@
     );
   }
 
+  function getStatusVisual(status) {
+    if (status === 'approved') {
+      return { title: 'Accès autorisé', message: 'Bienvenue.', tone: 'approved' };
+    }
+    if (status === 'rejected') {
+      return { title: 'Demande refusée', message: 'Votre demande a été refusée.', tone: 'rejected' };
+    }
+    return {
+      title: 'En attente de confirmation',
+      message: 'Les informations sont enregistrées. En attente de confirmation par l’administrateur.',
+      tone: 'pending',
+    };
+  }
+
+  function ensureApprovalOverlay() {
+    let overlay = document.getElementById('approvalOverlay');
+    if (overlay) {
+      return overlay;
+    }
+    overlay = document.createElement('div');
+    overlay.id = 'approvalOverlay';
+    overlay.className = 'status-overlay';
+    overlay.hidden = true;
+    overlay.innerHTML = `
+      <article class="status-card status-card--pending" role="alertdialog" aria-modal="true" aria-labelledby="approvalTitle">
+        <h3 id="approvalTitle"></h3>
+        <p id="approvalMessage"></p>
+      </article>
+    `;
+    document.body.appendChild(overlay);
+    return overlay;
+  }
+
+  function showApprovalOverlay(status) {
+    const overlay = ensureApprovalOverlay();
+    const card = overlay.querySelector('.status-card');
+    const title = overlay.querySelector('#approvalTitle');
+    const message = overlay.querySelector('#approvalMessage');
+    const visual = getStatusVisual(status);
+
+    if (!card || !title || !message) {
+      return;
+    }
+
+    title.textContent = visual.title;
+    message.textContent = visual.message;
+    card.classList.remove('status-card--pending', 'status-card--approved', 'status-card--rejected');
+    card.classList.add(`status-card--${visual.tone}`);
+    overlay.hidden = false;
+    window.requestAnimationFrame(() => overlay.classList.add('is-visible'));
+  }
+
+  function hideApprovalOverlay() {
+    const overlay = document.getElementById('approvalOverlay');
+    if (!overlay) {
+      return;
+    }
+    overlay.classList.remove('is-visible');
+    overlay.hidden = true;
+  }
+
+  async function initApprovalGate(profile, permissions) {
+    if (permissions?.isAdmin) {
+      return profile;
+    }
+
+    const currentPage = document.body.dataset.page;
+    return new Promise((resolve) => {
+      let approvedShown = false;
+      const unsubscribe = StorageService.subscribeCurrentUserProfile(
+        (latestProfile) => {
+          const status = String(latestProfile?.status || 'pending');
+          if (status === 'approved') {
+            if (!approvedShown) {
+              approvedShown = true;
+              showApprovalOverlay('approved');
+              window.setTimeout(() => {
+                hideApprovalOverlay();
+                unsubscribe?.();
+                if (currentPage !== 'home') {
+                  UiService.navigate('index.html');
+                }
+                resolve(latestProfile);
+              }, 3000);
+            }
+            return;
+          }
+
+          showApprovalOverlay(status);
+          if (currentPage !== 'home') {
+            UiService.navigate('index.html');
+          }
+        },
+        () => {
+          UiService.showToast('Impossible de vérifier votre statut utilisateur.');
+        },
+      );
+    });
+  }
+
   function formatRetryDate(value) {
     return new Intl.DateTimeFormat('fr-FR', { dateStyle: 'medium', timeStyle: 'short' }).format(value);
   }
@@ -1590,6 +1690,7 @@
     }
 
     const tableBody = requireElement('usersTableBody');
+    const pendingUsersList = requireElement('pendingUsersList');
     const backButton = requireElement('usersBackButton');
     const maintenanceToggle = requireElement('maintenanceToggle');
     const maintenanceStatusText = requireElement('maintenanceStatusText');
@@ -1606,12 +1707,54 @@
       }
     }
 
+    function statusLabel(status) {
+      if (status === 'approved') {
+        return 'Approuvé';
+      }
+      if (status === 'rejected') {
+        return 'Refusé';
+      }
+      return 'En attente';
+    }
+
     async function renderUsers() {
       const users = await StorageService.listUsers();
+      const pendingUsers = users.filter((user) => user.status === 'pending');
+
+      if (pendingUsersList) {
+        pendingUsersList.innerHTML = pendingUsers.length
+          ? pendingUsers
+            .map((user) => `
+              <article class="pending-user-card">
+                <div class="pending-user-card__identity">
+                  ${user.avatarUrl
+      ? `<img class="pending-user-card__avatar" src="${escapeHtml(user.avatarUrl)}" alt="Avatar de ${escapeHtml(user.username)}" />`
+      : `<span class="pending-user-card__avatar pending-user-card__avatar--fallback">${escapeHtml(getInitialsFromName(user.username))}</span>`}
+                  <div>
+                    <p class="pending-user-card__name">${escapeHtml(user.username)}</p>
+                    <p class="pending-user-card__status">${statusLabel(user.status)}</p>
+                  </div>
+                </div>
+                <div class="pending-user-card__actions">
+                  <button type="button" class="btn btn-success" data-approve-user="${user.id}">Accepter</button>
+                  <button type="button" class="btn btn-danger" data-reject-user="${user.id}">Refuser</button>
+                </div>
+              </article>
+            `)
+            .join('')
+          : '<p class="empty-state">Aucun utilisateur en attente.</p>';
+      }
+
       tableBody.innerHTML = users
         .map((user) => `
           <tr>
+            <td>
+              ${user.avatarUrl
+      ? `<img class="table-avatar" src="${escapeHtml(user.avatarUrl)}" alt="Avatar de ${escapeHtml(user.username)}" />`
+      : `<span class="table-avatar table-avatar--fallback">${escapeHtml(getInitialsFromName(user.username))}</span>`}
+            </td>
             <td>${escapeHtml(user.username)}</td>
+            <td><span class="status-pill status-pill--${escapeHtml(user.status)}">${statusLabel(user.status)}</span></td>
             <td>
               ${user.username === 'Admin' ? 'Admin' : `
               <select data-user-role="${user.id}">
@@ -1628,6 +1771,22 @@
         select.addEventListener('change', async () => {
           await StorageService.updateUserRole(select.dataset.userRole, select.value);
           UiService.showToast('Rôle mis à jour.');
+        });
+      });
+
+      pendingUsersList?.querySelectorAll('[data-approve-user]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          await StorageService.updateUserStatus(button.dataset.approveUser, 'approved');
+          UiService.showToast('Utilisateur accepté.');
+          await renderUsers();
+        });
+      });
+
+      pendingUsersList?.querySelectorAll('[data-reject-user]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          await StorageService.updateUserStatus(button.dataset.rejectUser, 'rejected');
+          UiService.showToast('Utilisateur refusé.');
+          await renderUsers();
         });
       });
     }
@@ -1728,7 +1887,9 @@
     await StorageService.ensureCurrentUser();
     let profile = await StorageService.getCurrentUserProfile();
     profile = await promptForMissingUsername(profile);
+    profile = await StorageService.getCurrentUserProfile();
     const permissions = buildPermissions(profile);
+    profile = await initApprovalGate(profile, permissions);
 
     initMaintenanceGate(permissions);
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -62,6 +62,14 @@ function normalizeAvatarUrl(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function normalizeStatus(value) {
+  const status = String(value || '').toLowerCase();
+  if (status === 'approved' || status === 'rejected') {
+    return status;
+  }
+  return 'pending';
+}
+
 const BLOCKED_USERNAMES = new Set([
   'FACEBOOK',
   'YOUTUBE',
@@ -137,24 +145,37 @@ async function ensureCurrentUser() {
       ref,
       {
         username: '',
+        name: '',
         avatarUrl: '',
+        avatar: '',
         role: 'full',
+        status: 'pending',
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
         lastNameChange: null,
       },
       { merge: true },
     );
-    return { id: state.userId, username: '', role: 'full', lastNameChange: null, avatarUrl: '' };
+    return {
+      id: state.userId,
+      username: '',
+      avatarUrl: '',
+      role: 'full',
+      status: 'pending',
+      lastNameChange: null,
+      createdAt: null,
+    };
   }
 
   const data = snap.data() || {};
   return {
     id: snap.id,
-    username: normalizeUsername(data.username),
+    username: normalizeUsername(data.username || data.name),
     role: normalizeRole(data.role),
+    status: normalizeStatus(data.status),
     lastNameChange: data.lastNameChange || null,
-    avatarUrl: normalizeAvatarUrl(data.avatarUrl),
+    avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
+    createdAt: data.createdAt || null,
   };
 }
 
@@ -166,10 +187,12 @@ async function getCurrentUserProfile() {
   const data = snap.data() || {};
   return {
     id: snap.id,
-    username: normalizeUsername(data.username),
+    username: normalizeUsername(data.username || data.name),
     role: normalizeRole(data.role),
+    status: normalizeStatus(data.status),
     lastNameChange: data.lastNameChange || null,
-    avatarUrl: normalizeAvatarUrl(data.avatarUrl),
+    avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
+    createdAt: data.createdAt || null,
   };
 }
 
@@ -196,11 +219,13 @@ async function saveUsername(username) {
   const isFirstUsername = !profile.username;
   const updates = {
     username: nextName,
+    name: nextName,
     updatedAt: serverTimestamp(),
   };
 
   if (isFirstUsername) {
     updates.role = 'lecture';
+    updates.status = 'pending';
   }
 
   await setDoc(
@@ -233,6 +258,7 @@ async function changeUsername(username) {
     userDocRef(),
     {
       username: nextName,
+      name: nextName,
       lastNameChange: Timestamp.fromDate(new Date()),
       updatedAt: serverTimestamp(),
     },
@@ -248,6 +274,7 @@ async function updateAvatarUrl(avatarUrl) {
     userDocRef(),
     {
       avatarUrl: nextAvatarUrl,
+      avatar: nextAvatarUrl,
       updatedAt: serverTimestamp(),
     },
     { merge: true },
@@ -262,9 +289,11 @@ async function listUsers() {
       const data = snap.data() || {};
       return {
         id: snap.id,
-        username: normalizeUsername(data.username),
-        avatarUrl: normalizeAvatarUrl(data.avatarUrl),
+        username: normalizeUsername(data.username || data.name),
+        avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
         role: normalizeRole(data.role),
+        status: normalizeStatus(data.status),
+        createdAt: data.createdAt || null,
       };
     })
     .filter((user) => user.username);
@@ -282,6 +311,55 @@ async function updateUserRole(userId, role) {
   );
 
   return true;
+}
+
+async function updateUserStatus(userId, status) {
+  const nextStatus = normalizeStatus(status);
+  await setDoc(
+    userDocRef(userId),
+    {
+      status: nextStatus,
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+
+  return true;
+}
+
+function subscribeCurrentUserProfile(onChange, onError) {
+  try {
+    return onSnapshot(
+      userDocRef(),
+      async (snapshot) => {
+        if (!snapshot.exists()) {
+          const profile = await ensureCurrentUser();
+          onChange(profile);
+          return;
+        }
+        const data = snapshot.data() || {};
+        onChange({
+          id: snapshot.id,
+          username: normalizeUsername(data.username || data.name),
+          role: normalizeRole(data.role),
+          status: normalizeStatus(data.status),
+          lastNameChange: data.lastNameChange || null,
+          avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
+          createdAt: data.createdAt || null,
+        });
+      },
+      (error) => {
+        if (typeof onError === 'function') {
+          onError(error);
+        }
+      },
+    );
+  } catch (error) {
+    if (typeof onError === 'function') {
+      onError(error);
+    }
+    return () => {};
+  }
 }
 
 function normalizeMaintenanceState(value) {
@@ -1269,8 +1347,10 @@ window.StorageService = {
   updateAvatarUrl,
   listUsers,
   updateUserRole,
+  updateUserStatus,
   setMaintenanceState,
   subscribeMaintenanceState,
+  subscribeCurrentUserProfile,
   computeNextNameChangeDate,
   listHistoriques,
 };

--- a/users.html
+++ b/users.html
@@ -25,11 +25,18 @@
           </div>
         </section>
         <section class="surface-card table-card">
+          <h2 class="section-title">Utilisateurs en attente</h2>
+          <div id="pendingUsersList" class="pending-users-list"></div>
+        </section>
+        <section class="surface-card table-card">
+          <h2 class="section-title">Tous les utilisateurs</h2>
           <div class="table-wrapper">
             <table class="data-table">
               <thead>
                 <tr>
+                  <th>Avatar</th>
                   <th>Nom</th>
+                  <th>Statut</th>
                   <th>Rôle</th>
                 </tr>
               </thead>


### PR DESCRIPTION
### Motivation

- Prevent newly created users from accessing the main app until an administrator validates their profile.  
- Present immediate visual feedback to end users after name creation (pending / rejected / approved).  
- Provide admins a simple UI to review and change user status in real time.

### Description

- Add a `status` state machine (`pending` | `approved` | `rejected`) and normalize legacy `name` / `avatar` fields in `StorageService`, set new users to `status: 'pending'`, and write helpers `normalizeStatus`, `updateUserStatus` and `subscribeCurrentUserProfile` in `js/storage.js`.  
- Implement a client-side approval gate in `js/app.js` that subscribes to the current user's profile and shows a full-screen overlay card for `pending`/`rejected`, shows a 3s welcome card for `approved`, and redirects non-approved users to `index.html`.  
- Extend the admin users page (`users.html` + `js/app.js`) with a new “Utilisateurs en attente” section listing pending users (avatar/name/status) and buttons `Accepter` / `Refuser` that update `status` in Firestore, and add a `Statut` column + avatar to the full users table.  
- Add styles and animations for status overlays, cards and pending-user admin cards in `css/style.css` (fade/scale, dark overlay, rounded cards and color-coded states).

### Testing

- Checked JavaScript syntax with `node --check js/storage.js` which succeeded.  
- Checked JavaScript syntax with `node --check js/app.js` which succeeded.  
- Checked JavaScript syntax with `node --check js/ui.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9587d574c832a87f6c3426f616bc2)