### PR TITLE
Ajouter l'action Supprimer utilisateur et blocage immédiat des comptes rejetés

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -393,6 +393,11 @@ button {
   border-color: #ef4444;
 }
 
+.status-card--rejected h3,
+.status-card--rejected p {
+  color: #b91c1c;
+}
+
 .status-card h3 {
   margin: 0 0 0.7rem;
 }
@@ -665,6 +670,11 @@ body[data-page="history"] .list-grid {
 .status-pill--rejected {
   background: rgba(239, 68, 68, 0.16);
   color: #b91c1c;
+}
+
+.table-action-disabled {
+  color: var(--text-muted);
+  font-weight: 600;
 }
 
 .list-card {

--- a/js/app.js
+++ b/js/app.js
@@ -432,7 +432,7 @@
       return { title: 'Accès autorisé', message: 'Bienvenue.', tone: 'approved' };
     }
     if (status === 'rejected') {
-      return { title: 'Demande refusée', message: 'Votre demande a été refusée.', tone: 'rejected' };
+      return { title: 'Accès refusé', message: 'Vous n’avez pas l’autorisation d’utiliser cette page.', tone: 'rejected' };
     }
     return {
       title: 'En attente de confirmation',
@@ -499,6 +499,11 @@
       const unsubscribe = StorageService.subscribeCurrentUserProfile(
         (latestProfile) => {
           const status = String(latestProfile?.status || 'pending');
+          if (status === 'rejected') {
+            showApprovalOverlay('rejected');
+            return;
+          }
+
           if (status === 'approved') {
             if (!approvedShown) {
               approvedShown = true;
@@ -516,7 +521,7 @@
           }
 
           showApprovalOverlay(status);
-          if (currentPage !== 'home') {
+          if (status !== 'rejected' && currentPage !== 'home') {
             UiService.navigate('index.html');
           }
         },
@@ -1763,6 +1768,11 @@
                 <option value="full" ${user.role === 'full' ? 'selected' : ''}>${roleLabel.full}</option>
               </select>`}
             </td>
+            <td>
+              ${user.username === 'Admin'
+      ? '<span class="table-action-disabled">-</span>'
+      : `<button type="button" class="btn btn-danger" data-delete-user="${user.id}">Supprimer</button>`}
+            </td>
           </tr>
         `)
         .join('');
@@ -1771,6 +1781,18 @@
         select.addEventListener('change', async () => {
           await StorageService.updateUserRole(select.dataset.userRole, select.value);
           UiService.showToast('Rôle mis à jour.');
+        });
+      });
+
+      tableBody.querySelectorAll('[data-delete-user]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          const shouldDelete = window.confirm('Êtes-vous sûr de vouloir supprimer cet utilisateur ?');
+          if (!shouldDelete) {
+            return;
+          }
+          await StorageService.updateUserStatus(button.dataset.deleteUser, 'rejected');
+          UiService.showToast('Utilisateur supprimé.');
+          await renderUsers();
         });
       });
 

--- a/users.html
+++ b/users.html
@@ -38,6 +38,7 @@
                   <th>Nom</th>
                   <th>Statut</th>
                   <th>Rôle</th>
+                  <th>Actions</th>
                 </tr>
               </thead>
               <tbody id="usersTableBody"></tbody>


### PR DESCRIPTION
### Motivation
- Permettre à un administrateur de supprimer un utilisateur en marquant son compte comme `rejected` afin de lui retirer immédiatement l’accès.
- Garantir le blocage en temps réel côté utilisateur via l’écoute Firestore pour empêcher toute interaction si `status === "rejected"`.

### Description
- Ajout de la colonne `Actions` dans la table des utilisateurs dans `users.html` pour accueillir les actions d’administration.
- Ajout d’un bouton `Supprimer` (classe `btn btn-danger`) par utilisateur non-admin qui affiche une confirmation native (`window.confirm`) puis appelle `StorageService.updateUserStatus(userId, 'rejected')` pour effectuer une suppression logique.
- Mise à jour du message affiché dans l’overlay d’état utilisateur dans `js/app.js` pour `rejected` : « Vous n’avez pas l’autorisation d’utiliser cette page. » et gestion explicite du cas `rejected` dans `initApprovalGate` pour bloquer immédiatement l’utilisateur via le listener `subscribeCurrentUserProfile`.
- Ajustements CSS dans `css/style.css` pour colorer le texte de la card rejetée en rouge et ajouter un style `table-action-disabled` pour l’affichage du placeholder sur le compte Admin.

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check` sur `js/app.js`, `js/ui.js` et `js/storage.js`, et elle a réussi.
- Aucun test automatisé supplémentaire n’a été exécuté dans cet environnement (UI manuelle et intégration Firestore non couverte ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95bfadde8832a8275b66975118ce2)