### PR TITLE
Suppression complète des utilisateurs + reset client et relance du flow de création en temps réel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -791,6 +791,32 @@ body[data-page="history"] .list-grid {
   background: rgba(15, 23, 42, 0.44);
 }
 
+.username-onboarding {
+  width: min(92vw, 30rem);
+}
+
+.username-onboarding::backdrop {
+  background: rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(4px);
+}
+
+.username-onboarding .modal-content {
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(216, 226, 236, 0.85);
+  background: linear-gradient(165deg, #ffffff 0%, #f7fbff 100%);
+  box-shadow: 0 28px 55px rgba(31, 42, 55, 0.18);
+  transform: translateY(10px);
+  opacity: 0;
+  animation: onboardingCardIn 0.28s ease forwards;
+}
+
+@keyframes onboardingCardIn {
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
 .modal-content {
   padding: 1rem;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -488,6 +488,15 @@
     overlay.hidden = true;
   }
 
+  function clearClientUserState() {
+    try {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    } catch (_error) {
+      // Ignore storage cleanup errors (private mode / restricted storage).
+    }
+  }
+
   async function initApprovalGate(profile, permissions) {
     if (permissions?.isAdmin) {
       return profile;
@@ -496,8 +505,30 @@
     const currentPage = document.body.dataset.page;
     return new Promise((resolve) => {
       let approvedShown = false;
+      let recoveringDeletedUser = false;
       const unsubscribe = StorageService.subscribeCurrentUserProfile(
         (latestProfile) => {
+          if (latestProfile?.missing) {
+            if (recoveringDeletedUser) {
+              return;
+            }
+            recoveringDeletedUser = true;
+            hideApprovalOverlay();
+            clearClientUserState();
+            if (currentPage !== 'home') {
+              UiService.navigate('index.html');
+              return;
+            }
+            window.setTimeout(async () => {
+              await StorageService.ensureCurrentUser();
+              const recreatedProfile = await StorageService.getCurrentUserProfile();
+              await promptForMissingUsername(recreatedProfile);
+              approvedShown = false;
+              recoveringDeletedUser = false;
+            }, 0);
+            return;
+          }
+
           const status = String(latestProfile?.status || 'pending');
           if (status === 'rejected') {
             showApprovalOverlay('rejected');
@@ -544,19 +575,19 @@
 
     dialog = document.createElement('dialog');
     dialog.id = 'usernameDialog';
-    dialog.className = 'modal-card';
+    dialog.className = 'modal-card username-onboarding';
     dialog.innerHTML = `
       <form class="modal-content" id="usernameForm">
         <div class="modal-header">
-          <h2>Entrer votre nom</h2>
+          <h2>Créer votre profil</h2>
         </div>
         <label class="input-group">
-          <span>Nom</span>
+          <span>Nom utilisateur</span>
           <input id="usernameInput" type="text" maxlength="20" />
         </label>
         <p id="usernameError" class="form-error" aria-live="polite"></p>
         <div class="modal-actions">
-          <button type="submit" class="btn btn-success">Enregistrer</button>
+          <button type="submit" class="btn btn-success">Valider</button>
         </div>
       </form>
     `;
@@ -1790,7 +1821,7 @@
           if (!shouldDelete) {
             return;
           }
-          await StorageService.updateUserStatus(button.dataset.deleteUser, 'rejected');
+          await StorageService.deleteUser(button.dataset.deleteUser);
           UiService.showToast('Utilisateur supprimé.');
           await renderUsers();
         });

--- a/js/storage.js
+++ b/js/storage.js
@@ -327,14 +327,31 @@ async function updateUserStatus(userId, status) {
   return true;
 }
 
+async function deleteUser(userId) {
+  const targetId = String(userId || '').trim();
+  if (!targetId) {
+    return false;
+  }
+  await deleteDoc(userDocRef(targetId));
+  return true;
+}
+
 function subscribeCurrentUserProfile(onChange, onError) {
   try {
     return onSnapshot(
       userDocRef(),
-      async (snapshot) => {
+      (snapshot) => {
         if (!snapshot.exists()) {
-          const profile = await ensureCurrentUser();
-          onChange(profile);
+          onChange({
+            id: state.userId,
+            username: '',
+            role: 'full',
+            status: 'pending',
+            lastNameChange: null,
+            avatarUrl: '',
+            createdAt: null,
+            missing: true,
+          });
           return;
         }
         const data = snapshot.data() || {};
@@ -346,6 +363,7 @@ function subscribeCurrentUserProfile(onChange, onError) {
           lastNameChange: data.lastNameChange || null,
           avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
           createdAt: data.createdAt || null,
+          missing: false,
         });
       },
       (error) => {
@@ -1348,6 +1366,7 @@ window.StorageService = {
   listUsers,
   updateUserRole,
   updateUserStatus,
+  deleteUser,
   setMaintenanceState,
   subscribeMaintenanceState,
   subscribeCurrentUserProfile,


### PR DESCRIPTION
### Motivation
- Remplacer le flag `status = 'rejected'` par une suppression complète du document `users/{userId}` pour effacer toutes les données utilisateur côté Firestore et permettre au client de revenir au flow « nouvel utilisateur ». 
- Permettre une expérience fluide en temps réel où l’administrateur voit l’utilisateur retiré immédiatement et l’utilisateur coté client retrouve l’écran de création de nom sans message d’« accès refusé ». 

### Description
- Ajout de l’API `deleteUser(userId)` dans `js/storage.js` qui appelle `deleteDoc(userDocRef(...))` et exposition via `window.StorageService`. 
- Modification de `subscribeCurrentUserProfile` pour signaler le cas `document inexistant` en émettant `missing: true` au lieu de recréer automatiquement le document. 
- Client: dans `initApprovalGate` ( `js/app.js` ) détection de `latestProfile.missing` pour vider `localStorage`/`sessionStorage`, masquer l’overlay de statut, rediriger vers `index.html` si besoin, recréer le profil via `StorageService.ensureCurrentUser()` et relancer le modal de création de nom (`promptForMissingUsername`). 
- Admin UI: le bouton « Supprimer » de la page de gestion appelle désormais `StorageService.deleteUser(...)` et l’interface se met à jour immédiatement via `renderUsers()` (plus de passage à `rejected`). 
- UI/UX: mise à jour du modal de création de nom (`Créer votre profil`, champ libellé `Nom utilisateur`, bouton `Valider`) et ajout de styles/animation (`.username-onboarding`) pour une card centrée, overlay léger et animation d’entrée. 

### Testing
- Vérification syntaxique JavaScript via `node --check js/app.js && node --check js/storage.js`, qui a réussi. 
- Vérification manuelle de l’interface d’administration via le rendu dynamique `renderUsers()` remplacant le document supprimé a été exercée localement (script-driven UI update). 
- Aucun test automatisé supplémentaire (unit/integration) n’a été exécuté dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95f4f8db8832a8afabfdee7c4e0a2)