### PR TITLE
Rendre le tableau utilisateurs scrollable verticalement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -917,6 +917,25 @@ body[data-page="history"] .list-grid {
   will-change: transform;
 }
 
+body[data-page="users-management"] .table-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+body[data-page="users-management"] .table-wrapper--users {
+  width: 100%;
+  min-width: 0;
+  max-height: clamp(18rem, 48vh, 34rem);
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+body[data-page="users-management"] .table-wrapper--users .data-table {
+  min-width: 44rem;
+}
+
 body[data-page="item-detail"] .table-wrapper {
   padding-bottom: 1.5rem;
 }

--- a/users.html
+++ b/users.html
@@ -30,7 +30,7 @@
         </section>
         <section class="surface-card table-card">
           <h2 class="section-title">Tous les utilisateurs</h2>
-          <div class="table-wrapper">
+          <div class="table-wrapper table-wrapper--users">
             <table class="data-table">
               <thead>
                 <tr>


### PR DESCRIPTION
### Motivation
- Permettre au tableau "Tous les utilisateurs" de défiler verticalement à l'intérieur de la zone principale afin qu'il utilise l'espace disponible sans casser la mise en page globale.

### Description
- Ajout de la classe `table-wrapper--users` dans `users.html` et ajout de règles CSS dans `css/style.css` pour rendre `.table-card` en flex et appliquer `max-height: clamp(18rem, 48vh, 34rem)`, `overflow: auto`, une bordure et `min-width: 44rem` au conteneur du tableau.

### Testing
- Exécution de `git status --short`, inspection des fichiers modifiés avec `nl -ba users.html` et `nl -ba css/style.css`, et création du commit via `git commit -m "Rendre le tableau utilisateurs scrollable verticalement"`, toutes les commandes se sont exécutées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96472d8c8832aad69c0e7341ee955)