### PR TITLE
Fix avatar bottom-sheet freeze by cleaning overlay listeners/timers and disabling pointer events when closed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1148,6 +1148,7 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   align-items: flex-end;
   justify-content: center;
   transition: background 0.25s ease;
+  pointer-events: none;
 }
 
 .bottom-sheet {
@@ -1162,6 +1163,7 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
 
 .bottom-sheet-overlay.is-open {
   background: rgba(15, 23, 42, 0.42);
+  pointer-events: auto;
 }
 
 .bottom-sheet-overlay.is-open .bottom-sheet {

--- a/js/app.js
+++ b/js/app.js
@@ -750,13 +750,35 @@
     message.textContent = '';
     fileInput.value = '';
 
-    const closeSheet = () => {
+    const closeTransitionDurationMs = 320;
+    const clearCloseListeners = () => {
+      if (overlay.__closeTimerId) {
+        window.clearTimeout(overlay.__closeTimerId);
+        overlay.__closeTimerId = null;
+      }
+      if (overlay.__closeTransitionHandler) {
+        overlay.removeEventListener('transitionend', overlay.__closeTransitionHandler);
+        overlay.__closeTransitionHandler = null;
+      }
+    };
+    const finalizeClose = () => {
+      clearCloseListeners();
+      overlay.hidden = true;
       overlay.classList.remove('is-open');
-      const onTransitionEnd = () => {
-        overlay.hidden = true;
-        overlay.removeEventListener('transitionend', onTransitionEnd);
+    };
+    const closeSheet = () => {
+      if (overlay.hidden) {
+        return;
+      }
+      overlay.classList.remove('is-open');
+      overlay.__closeTransitionHandler = (event) => {
+        if (event.target !== overlay && event.target !== sheet) {
+          return;
+        }
+        finalizeClose();
       };
-      overlay.addEventListener('transitionend', onTransitionEnd);
+      overlay.addEventListener('transitionend', overlay.__closeTransitionHandler);
+      overlay.__closeTimerId = window.setTimeout(finalizeClose, closeTransitionDurationMs);
     };
 
     renameButton.onclick = () => {
@@ -815,6 +837,7 @@
     };
 
     overlay.hidden = false;
+    clearCloseListeners();
     window.requestAnimationFrame(() => {
       overlay.classList.add('is-open');
     });


### PR DESCRIPTION
### Motivation
- The avatar bottom-sheet could leave an invisible overlay that still intercepted interactions after close, causing the UI to freeze until a full page refresh.
- The existing close logic relied solely on the `transitionend` event and could leave stale timers/listeners active if `transitionend` was missed or races occurred.

### Description
- Prevent the overlay from intercepting input when closed by adding `pointer-events: none` to `.bottom-sheet-overlay` and `pointer-events: auto` only in `.bottom-sheet-overlay.is-open` in `css/style.css`.
- Harden the close lifecycle in `openAvatarBottomSheet` by introducing `clearCloseListeners`, `finalizeClose`, and a `closeTransitionDurationMs` fallback timer to guarantee cleanup even if `transitionend` is not fired.
- Store cleanup handles on the DOM node (`overlay.__closeTimerId` and `overlay.__closeTransitionHandler`) to safely remove previous handlers/timers before opening and avoid leaking state.
- Add a guard so `closeSheet` no-ops if the overlay is already hidden and call `clearCloseListeners()` before opening to ensure a clean state.

### Testing
- Ran `node --check js/app.js` which succeeded without syntax errors.
- Ran `node --check js/ui.js` which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbaa705bb4832a83219ca1905e27da)