### PR TITLE
Ajout de la colonne « Autorisé (maintenance) » dans la gestion des utilisateurs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -933,7 +933,19 @@ body[data-page="users-management"] .table-wrapper--users {
 }
 
 body[data-page="users-management"] .table-wrapper--users .data-table {
-  min-width: 44rem;
+  min-width: 52rem;
+}
+
+body[data-page="users-management"] .maintenance-access-cell {
+  text-align: center;
+  vertical-align: middle;
+}
+
+body[data-page="users-management"] .maintenance-access-checkbox {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--primary);
+  cursor: pointer;
 }
 
 body[data-page="item-detail"] .table-wrapper {

--- a/js/app.js
+++ b/js/app.js
@@ -1809,8 +1809,7 @@
       return 'En attente';
     }
 
-    async function renderUsers() {
-      const users = await StorageService.listUsers();
+    function renderUsers(users) {
       const pendingUsers = users.filter((user) => user.status === 'pending');
 
       if (pendingUsersList) {
@@ -1855,6 +1854,15 @@
                 <option value="full" ${user.role === 'full' ? 'selected' : ''}>${roleLabel.full}</option>
               </select>`}
             </td>
+            <td class="maintenance-access-cell">
+              <input
+                type="checkbox"
+                class="maintenance-access-checkbox"
+                data-user-maintenance-access="${user.id}"
+                ${user.maintenanceAccess ? 'checked' : ''}
+                aria-label="Autoriser ${escapeHtml(user.username)} pendant la maintenance"
+              />
+            </td>
             <td>
               ${user.username === 'Admin'
       ? '<span class="table-action-disabled">-</span>'
@@ -1871,6 +1879,19 @@
         });
       });
 
+      tableBody.querySelectorAll('[data-user-maintenance-access]').forEach((checkbox) => {
+        checkbox.addEventListener('change', async () => {
+          const isAllowed = checkbox.checked;
+          try {
+            await StorageService.updateUserMaintenanceAccess(checkbox.dataset.userMaintenanceAccess, isAllowed);
+            UiService.showToast('Accès maintenance mis à jour.');
+          } catch (_error) {
+            checkbox.checked = !isAllowed;
+            UiService.showToast('Impossible de mettre à jour l’accès maintenance.');
+          }
+        });
+      });
+
       tableBody.querySelectorAll('[data-delete-user]').forEach((button) => {
         button.addEventListener('click', async () => {
           const shouldDelete = window.confirm('Êtes-vous sûr de vouloir supprimer cet utilisateur ?');
@@ -1879,7 +1900,6 @@
           }
           await StorageService.deleteUser(button.dataset.deleteUser);
           UiService.showToast('Utilisateur supprimé.');
-          await renderUsers();
         });
       });
 
@@ -1887,7 +1907,6 @@
         button.addEventListener('click', async () => {
           await StorageService.updateUserStatus(button.dataset.approveUser, 'approved');
           UiService.showToast('Utilisateur accepté.');
-          await renderUsers();
         });
       });
 
@@ -1895,7 +1914,6 @@
         button.addEventListener('click', async () => {
           await StorageService.updateUserStatus(button.dataset.rejectUser, 'rejected');
           UiService.showToast('Utilisateur refusé.');
-          await renderUsers();
         });
       });
     }
@@ -1926,7 +1944,21 @@
       }
     });
 
-    await renderUsers();
+    try {
+      const initialUsers = await StorageService.listUsers();
+      renderUsers(initialUsers);
+    } catch (_error) {
+      UiService.showToast('Impossible de charger les utilisateurs.');
+    }
+
+    StorageService.subscribeUsers(
+      (users) => {
+        renderUsers(users);
+      },
+      () => {
+        UiService.showToast('Synchronisation des utilisateurs indisponible.');
+      },
+    );
   }
 
   async function initHistoryPage() {

--- a/js/storage.js
+++ b/js/storage.js
@@ -70,6 +70,10 @@ function normalizeStatus(value) {
   return 'pending';
 }
 
+function normalizeMaintenanceAccess(value) {
+  return Boolean(value);
+}
+
 const BLOCKED_USERNAMES = new Set([
   'FACEBOOK',
   'YOUTUBE',
@@ -150,6 +154,7 @@ async function ensureCurrentUser() {
         avatar: '',
         role: 'full',
         status: 'pending',
+        maintenanceAccess: false,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
         lastNameChange: null,
@@ -162,6 +167,7 @@ async function ensureCurrentUser() {
       avatarUrl: '',
       role: 'full',
       status: 'pending',
+      maintenanceAccess: false,
       lastNameChange: null,
       createdAt: null,
     };
@@ -173,6 +179,7 @@ async function ensureCurrentUser() {
     username: normalizeUsername(data.username || data.name),
     role: normalizeRole(data.role),
     status: normalizeStatus(data.status),
+    maintenanceAccess: normalizeMaintenanceAccess(data.maintenanceAccess),
     lastNameChange: data.lastNameChange || null,
     avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
     createdAt: data.createdAt || null,
@@ -190,6 +197,7 @@ async function getCurrentUserProfile() {
     username: normalizeUsername(data.username || data.name),
     role: normalizeRole(data.role),
     status: normalizeStatus(data.status),
+    maintenanceAccess: normalizeMaintenanceAccess(data.maintenanceAccess),
     lastNameChange: data.lastNameChange || null,
     avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
     createdAt: data.createdAt || null,
@@ -293,6 +301,7 @@ async function listUsers() {
         avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
         role: normalizeRole(data.role),
         status: normalizeStatus(data.status),
+        maintenanceAccess: normalizeMaintenanceAccess(data.maintenanceAccess),
         createdAt: data.createdAt || null,
       };
     })
@@ -327,6 +336,19 @@ async function updateUserStatus(userId, status) {
   return true;
 }
 
+async function updateUserMaintenanceAccess(userId, maintenanceAccess) {
+  await setDoc(
+    userDocRef(userId),
+    {
+      maintenanceAccess: Boolean(maintenanceAccess),
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+
+  return true;
+}
+
 async function deleteUser(userId) {
   const targetId = String(userId || '').trim();
   if (!targetId) {
@@ -347,6 +369,7 @@ function subscribeCurrentUserProfile(onChange, onError) {
             username: '',
             role: 'full',
             status: 'pending',
+            maintenanceAccess: false,
             lastNameChange: null,
             avatarUrl: '',
             createdAt: null,
@@ -360,11 +383,47 @@ function subscribeCurrentUserProfile(onChange, onError) {
           username: normalizeUsername(data.username || data.name),
           role: normalizeRole(data.role),
           status: normalizeStatus(data.status),
+          maintenanceAccess: normalizeMaintenanceAccess(data.maintenanceAccess),
           lastNameChange: data.lastNameChange || null,
           avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
           createdAt: data.createdAt || null,
           missing: false,
         });
+      },
+      (error) => {
+        if (typeof onError === 'function') {
+          onError(error);
+        }
+      },
+    );
+  } catch (error) {
+    if (typeof onError === 'function') {
+      onError(error);
+    }
+    return () => {};
+  }
+}
+
+function subscribeUsers(onChange, onError) {
+  try {
+    return onSnapshot(
+      usersCollection(),
+      (snapshot) => {
+        const users = snapshot.docs
+          .map((snap) => {
+            const data = snap.data() || {};
+            return {
+              id: snap.id,
+              username: normalizeUsername(data.username || data.name),
+              avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
+              role: normalizeRole(data.role),
+              status: normalizeStatus(data.status),
+              maintenanceAccess: normalizeMaintenanceAccess(data.maintenanceAccess),
+              createdAt: data.createdAt || null,
+            };
+          })
+          .filter((user) => user.username);
+        onChange(users);
       },
       (error) => {
         if (typeof onError === 'function') {
@@ -1364,8 +1423,10 @@ window.StorageService = {
   changeUsername,
   updateAvatarUrl,
   listUsers,
+  subscribeUsers,
   updateUserRole,
   updateUserStatus,
+  updateUserMaintenanceAccess,
   deleteUser,
   setMaintenanceState,
   subscribeMaintenanceState,

--- a/users.html
+++ b/users.html
@@ -38,6 +38,7 @@
                   <th>Nom</th>
                   <th>Statut</th>
                   <th>Rôle</th>
+                  <th>Autorisé (maintenance)</th>
                   <th>Actions</th>
                 </tr>
               </thead>


### PR DESCRIPTION
### Motivation
- Permettre aux administrateurs d’autoriser ou bloquer des utilisateurs individuellement pendant une maintenance via le tableau "Tous les utilisateurs" et de stocker cet état dans Firestore.
- Assurer une mise à jour en temps réel de l’interface quand l’état change pour rester synchronisé entre clients.

### Description
- Ajout d’une colonne d’en-tête "Autorisé (maintenance)" dans `users.html` et rendu d’une checkbox par utilisateur avec un `aria-label` pour l’accessibilité.`
- UI : `js/app.js` affiche la checkbox (`maintenanceAccess`) pour chaque utilisateur, gère l’événement `change` pour appeler `StorageService.updateUserMaintenanceAccess(...)` et effectue un rollback visuel + toast en cas d’échec.
- Stockage : `js/storage.js` ajoute la normalisation `normalizeMaintenanceAccess`, inclut `maintenanceAccess` dans les lectures/retours de profil et liste, initialise la valeur par défaut `false` pour les nouveaux profils, expose `updateUserMaintenanceAccess(...)` et ajoute `subscribeUsers(...)` pour la synchro temps réel.
- Synchronisation : remplacement du rafraîchissement manuel par une souscription Firestore côté UI (`StorageService.subscribeUsers(...)`) pour refléter immédiatement les changements depuis la base.
- Styles : `css/style.css` ajuste la largeur minimale du tableau et ajoute des règles de centrage/tailles pour la nouvelle cellule et la checkbox afin de rester cohérent avec le design existant.

### Testing
- Vérifications syntaxiques JavaScript effectuées localement : `node --check js/app.js && node --check js/ui.js` (succès).
- Vérification syntaxique JavaScript effectuée localement : `node --check js/storage.js` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbae1aebc0832a99cf97885f9a3726)