### PR TITLE
Harmonize Page 3 table UI with users page and add scroll for pending users

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -899,6 +899,30 @@ body[data-page="history"] .list-grid {
   padding-inline: 0;
 }
 
+.section-heading--table {
+  margin-bottom: 0.75rem;
+}
+
+.table-container--card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: #fff;
+}
+
+.table-wrapper--shared {
+  width: 100%;
+  min-width: 0;
+  max-height: clamp(18rem, 48vh, 34rem);
+  overflow: auto;
+}
+
+body[data-page="users-management"] .pending-users-list--scroll {
+  max-height: clamp(13rem, 38vh, 20rem);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+
 .table-container {
   overflow-x: auto;
   overflow-y: hidden;
@@ -924,10 +948,6 @@ body[data-page="users-management"] .table-card {
 }
 
 body[data-page="users-management"] .table-wrapper--users {
-  width: 100%;
-  min-width: 0;
-  max-height: clamp(18rem, 48vh, 34rem);
-  overflow: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
 }
@@ -948,7 +968,9 @@ body[data-page="users-management"] .maintenance-access-checkbox {
   cursor: pointer;
 }
 
-body[data-page="item-detail"] .table-wrapper {
+body[data-page="item-detail"] .table-wrapper--shared {
+  width: max-content;
+  min-width: 100%;
   padding-bottom: 1.5rem;
 }
 

--- a/page3.html
+++ b/page3.html
@@ -46,9 +46,9 @@
         </section>
 
         <section class="surface-card table-card">
-          <div class="section-heading">
+          <div class="section-heading section-heading--table">
             <div>
-              <h2>Tableau des données</h2>
+              <h2 class="section-title">Tableau des données</h2>
               <p id="detailCount">0 ligne</p>
             </div>
             <button type="button" id="exportDetailsButton" class="btn btn-success">Exporter</button>
@@ -59,8 +59,8 @@
               <input id="detailSearchInput" type="text" placeholder="Rechercher..." autocomplete="off" />
             </label>
           </div>
-          <div class="table-container" id="detailTableContainer">
-            <div class="table-wrapper" id="detailTableWrapper">
+          <div class="table-container table-container--card" id="detailTableContainer">
+            <div class="table-wrapper table-wrapper--shared" id="detailTableWrapper">
               <table class="data-table" id="detailDataTable">
               <thead>
                 <tr>

--- a/users.html
+++ b/users.html
@@ -26,11 +26,11 @@
         </section>
         <section class="surface-card table-card">
           <h2 class="section-title">Utilisateurs en attente</h2>
-          <div id="pendingUsersList" class="pending-users-list"></div>
+          <div id="pendingUsersList" class="pending-users-list pending-users-list--scroll"></div>
         </section>
         <section class="surface-card table-card">
           <h2 class="section-title">Tous les utilisateurs</h2>
-          <div class="table-wrapper table-wrapper--users">
+          <div class="table-wrapper table-wrapper--users table-wrapper--shared">
             <table class="data-table">
               <thead>
                 <tr>


### PR DESCRIPTION
### Motivation
- Uniformiser l’apparence des tableaux entre la Page 3 (Détail) et la page « Gestion des utilisateurs » et améliorer l’UX de la liste des utilisateurs en attente sans toucher à la logique existante.

### Description
- Modifié `page3.html` pour réutiliser la même structure de card/heading et des wrappers partagés en ajoutant `section-heading--table`, `section-title`, `table-container--card` et `table-wrapper--shared` tout en conservant les IDs existants (`detailDataTable`, `detailTableBody`, etc.).
- Modifié `users.html` pour rendre la zone `#pendingUsersList` scrollable en ajoutant la classe `pending-users-list--scroll` et pour réutiliser `table-wrapper--shared` pour la table des utilisateurs.
- Ajouté des règles CSS dans `css/style.css` pour `.section-heading--table`, `.table-container--card`, `.table-wrapper--shared` et `.pending-users-list--scroll`, et adapté quelques sélecteurs existants pour éviter la duplication tout en maintenant le comportement précédent.
- Aucun identifiant ou sélecteur utilisé par le JavaScript n’a été renommé afin de préserver les events et l’intégration Firebase.

### Testing
- Exécuté la vérification `git diff --check` qui n’a renvoyé aucune erreur.
- Vérifié l’état du dépôt avec `git status --short` (aucune modification non enregistrée restante).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb29939e4832a9354aafd8ea6dff5)