### PR TITLE
Typeahead intelligent pour le champ `Code` (Page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -484,6 +484,70 @@ button {
   box-shadow: 0 0 0 3px rgba(89, 184, 255, 0.18);
 }
 
+.typeahead {
+  position: relative;
+}
+
+.typeahead__menu {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: grid;
+  gap: 0.2rem;
+  max-height: 15rem;
+  overflow-y: auto;
+  padding: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  box-shadow: 0 16px 30px rgba(31, 42, 55, 0.14);
+}
+
+.typeahead__option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.14rem;
+  width: 100%;
+  border: 0;
+  border-radius: 0.6rem;
+  background: transparent;
+  padding: 0.5rem 0.6rem;
+  text-align: left;
+  color: var(--text);
+}
+
+.typeahead__option:hover,
+.typeahead__option:focus-visible,
+.typeahead__option.is-active {
+  background: rgba(89, 184, 255, 0.14);
+  outline: none;
+}
+
+.typeahead__code {
+  font-weight: 700;
+}
+
+.typeahead__designation {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.typeahead__empty {
+  padding: 0.5rem 0.6rem;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.typeahead mark {
+  background: #ffef94;
+  color: inherit;
+  padding: 0 0.1em;
+  border-radius: 0.2em;
+}
+
 .list-grid {
   display: grid;
   gap: 0.9rem;

--- a/js/app.js
+++ b/js/app.js
@@ -17,6 +17,10 @@
       .replace(/'/g, '&#39;');
   }
 
+  function escapeRegExp(value) {
+    return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
   function setCountText(element, count, singular, plural) {
     element.textContent = `${count} ${count === 1 ? singular : plural}`;
   }
@@ -1566,13 +1570,153 @@
     const detailTableBody = requireElement('detailTableBody');
     const detailSearchInput = requireElement('detailSearchInput');
     const exportButton = requireElement('exportDetailsButton');
+    const codeInput = requireElement('codeInput');
     const designationInput = requireElement('designationInput');
+    const codeSuggestions = requireElement('codeSuggestions');
 
     setupZoomableDetailTable();
 
     let currentSite = StorageService.getSite(siteId);
     let currentItem = StorageService.getItem(siteId, itemId);
     let currentDetails = [];
+    let codeSuggestionSource = [];
+    let visibleCodeSuggestions = [];
+    let activeSuggestionIndex = -1;
+
+    function buildCodeSuggestionSource(details) {
+      const suggestionsByCode = new Map();
+      details.forEach((detail) => {
+        const code = String(detail?.code || '').trim();
+        if (!code) {
+          return;
+        }
+        const designation = String(detail?.designation || '').trim();
+        const key = code.toLowerCase();
+        if (!suggestionsByCode.has(key)) {
+          suggestionsByCode.set(key, { code, designation });
+          return;
+        }
+        const existing = suggestionsByCode.get(key);
+        if (!existing.designation && designation) {
+          existing.designation = designation;
+        }
+      });
+
+      return Array.from(suggestionsByCode.values())
+        .sort((a, b) => a.code.localeCompare(b.code, 'fr', { sensitivity: 'base' }));
+    }
+
+    function getCodeMatches(query) {
+      const normalizedQuery = String(query || '').trim().toLowerCase();
+      if (!normalizedQuery) {
+        return [];
+      }
+
+      return codeSuggestionSource
+        .map((entry) => {
+          const codeLower = entry.code.toLowerCase();
+          const matchIndex = codeLower.indexOf(normalizedQuery);
+          return { entry, matchIndex, startsWith: codeLower.startsWith(normalizedQuery) };
+        })
+        .filter((item) => item.matchIndex !== -1)
+        .sort((a, b) => {
+          if (a.startsWith !== b.startsWith) {
+            return a.startsWith ? -1 : 1;
+          }
+          if (a.matchIndex !== b.matchIndex) {
+            return a.matchIndex - b.matchIndex;
+          }
+          return a.entry.code.localeCompare(b.entry.code, 'fr', { sensitivity: 'base' });
+        })
+        .slice(0, 8)
+        .map((item) => item.entry);
+    }
+
+    function buildHighlightedText(text, query) {
+      const safeText = String(text || '');
+      const normalizedQuery = String(query || '').trim();
+      if (!normalizedQuery) {
+        return escapeHtml(safeText);
+      }
+
+      const matcher = new RegExp(`(${escapeRegExp(normalizedQuery)})`, 'ig');
+      return escapeHtml(safeText).replace(matcher, '<mark>$1</mark>');
+    }
+
+    function setActiveSuggestion(index) {
+      activeSuggestionIndex = index;
+      if (!codeSuggestions) {
+        return;
+      }
+
+      codeSuggestions.querySelectorAll('.typeahead__option').forEach((option, optionIndex) => {
+        const isActive = optionIndex === index;
+        option.classList.toggle('is-active', isActive);
+        option.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        if (isActive) {
+          option.scrollIntoView({ block: 'nearest' });
+        }
+      });
+    }
+
+    function hideCodeSuggestions() {
+      visibleCodeSuggestions = [];
+      activeSuggestionIndex = -1;
+      if (!codeSuggestions) {
+        return;
+      }
+      codeSuggestions.hidden = true;
+      codeSuggestions.innerHTML = '';
+    }
+
+    function applyCodeSuggestion(entry) {
+      if (!entry || !codeInput || !designationInput) {
+        return;
+      }
+      codeInput.value = entry.code;
+      designationInput.value = entry.designation || '';
+      hideCodeSuggestions();
+    }
+
+    function renderCodeSuggestions(query) {
+      if (!codeSuggestions) {
+        return;
+      }
+
+      visibleCodeSuggestions = getCodeMatches(query);
+      activeSuggestionIndex = -1;
+
+      if (!visibleCodeSuggestions.length) {
+        hideCodeSuggestions();
+        return;
+      }
+
+      codeSuggestions.hidden = false;
+      codeSuggestions.innerHTML = visibleCodeSuggestions
+        .map(
+          (entry, index) => `
+            <button
+              type="button"
+              class="typeahead__option"
+              role="option"
+              data-typeahead-index="${index}"
+              aria-selected="false"
+            >
+              <span class="typeahead__code">${buildHighlightedText(entry.code, query)}</span>
+              <span class="typeahead__designation">${buildHighlightedText(entry.designation || 'Désignation indisponible', query)}</span>
+            </button>
+          `,
+        )
+        .join('');
+    }
+
+    async function refreshCodeSuggestionSource() {
+      const details = await StorageService.getAllDetails();
+      codeSuggestionSource = buildCodeSuggestionSource(details);
+      if (document.activeElement === codeInput) {
+        renderCodeSuggestions(codeInput.value);
+      }
+    }
 
     if (!permissions.canDelete) {
       document.querySelector('.data-table')?.classList.add('data-table--hide-action');
@@ -1733,8 +1877,66 @@
       }
       detailForm.reset();
       requireElement('uniteInput').value = 'm';
+      hideCodeSuggestions();
       UiService.showToast('Article ajoutée .');
     });
+
+    if (codeInput && codeSuggestions) {
+      codeInput.addEventListener('focus', () => {
+        renderCodeSuggestions(codeInput.value);
+      });
+
+      codeInput.addEventListener('input', () => {
+        renderCodeSuggestions(codeInput.value);
+      });
+
+      codeInput.addEventListener('keydown', (event) => {
+        if (!visibleCodeSuggestions.length) {
+          return;
+        }
+
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          const nextIndex = activeSuggestionIndex < visibleCodeSuggestions.length - 1 ? activeSuggestionIndex + 1 : 0;
+          setActiveSuggestion(nextIndex);
+          return;
+        }
+
+        if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          const nextIndex = activeSuggestionIndex > 0 ? activeSuggestionIndex - 1 : visibleCodeSuggestions.length - 1;
+          setActiveSuggestion(nextIndex);
+          return;
+        }
+
+        if (event.key === 'Enter' && activeSuggestionIndex >= 0) {
+          event.preventDefault();
+          applyCodeSuggestion(visibleCodeSuggestions[activeSuggestionIndex]);
+          return;
+        }
+
+        if (event.key === 'Escape') {
+          hideCodeSuggestions();
+        }
+      });
+
+      codeInput.addEventListener('blur', () => {
+        window.setTimeout(hideCodeSuggestions, 140);
+      });
+
+      codeSuggestions.addEventListener('mousedown', (event) => {
+        event.preventDefault();
+      });
+
+      codeSuggestions.addEventListener('click', (event) => {
+        const option = event.target.closest('[data-typeahead-index]');
+        if (!option) {
+          return;
+        }
+        const suggestion = visibleCodeSuggestions[Number(option.dataset.typeaheadIndex)];
+        applyCodeSuggestion(suggestion);
+      });
+    }
 
     if (detailSearchInput) {
       detailSearchInput.addEventListener('input', renderTable);
@@ -1747,6 +1949,7 @@
     StorageService.subscribeSites((sites) => {
       currentSite = sites.find((site) => site.id === siteId) || currentSite;
       renderTitle();
+      refreshCodeSuggestionSource();
     });
 
     StorageService.subscribeItems(siteId, (items) => {
@@ -1771,6 +1974,7 @@
     );
 
     renderTitle();
+    refreshCodeSuggestionSource();
   }
 
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -841,6 +841,14 @@ async function getDetailRowsBySite(siteId) {
   return clone(rowsByItem);
 }
 
+async function getAllDetails() {
+  const details = [];
+  state.detailsByItem.forEach((itemDetails) => {
+    details.push(...itemDetails);
+  });
+  return clone(details);
+}
+
 function isDuplicateSiteName(name) {
   const normalized = sanitizeText(name, true);
   if (!normalized) {
@@ -1409,6 +1417,7 @@ window.StorageService = {
   subscribeDetailDesignations,
   subscribeDetailRows,
   getDetailRowsBySite,
+  getAllDetails,
   createSite,
   removeSite,
   restoreSite,

--- a/page3.html
+++ b/page3.html
@@ -21,7 +21,10 @@
           <form id="detailForm" class="responsive-form" novalidate>
             <label class="input-group">
               <span>Code</span>
-              <input id="codeInput" name="code" type="text" maxlength="40" aria-label="Code" />
+              <div class="typeahead" id="codeTypeahead">
+                <input id="codeInput" name="code" type="text" maxlength="40" aria-label="Code" autocomplete="off" />
+                <div id="codeSuggestions" class="typeahead__menu" role="listbox" aria-label="Suggestions de code" hidden></div>
+              </div>
             </label>
             <label class="input-group input-group--wide">
               <span>Désignation</span>


### PR DESCRIPTION
### Motivation
- Améliorer l’expérience de saisie du champ `code` sur la Page 3 avec des suggestions en temps réel basées sur l’ensemble des données existantes (tous les sites et toutes les lignes OUT). 
- Permettre la recherche partielle et la navigation clavier pour gagner du temps et réduire les erreurs de saisie sans recharger la page. 
- Lors d’une sélection, auto-remplir `code` et `designation` pour accélérer la création d’articles tout en préservant le comportement existant du formulaire.

### Description
- Ajout du conteneur typeahead et du menu de suggestions pour le champ `code` dans `page3.html` (`#codeTypeahead`, `#codeSuggestions`).
- Nouveau style professionnel pour le dropdown, l’état actif et le highlight des correspondances dans `css/style.css` (`.typeahead*`, `mark`).
- Ajout de `StorageService.getAllDetails()` dans `js/storage.js` pour exposer toutes les lignes de détail (tous sites / tous OUT) comme source dédupliquée des suggestions.
- Implémentation dans `js/app.js` de la logique de suggestions : préparation des sources (`buildCodeSuggestionSource`), recherche partielle et tri (préfixe d’abord) (`getCodeMatches`), surlignage des fragments correspondants (`buildHighlightedText`), rendu, sélection (clic) et navigation clavier (`ArrowUp/Down`, `Enter`, `Escape`), et intégration avec les abonnements existants (`subscribeSites` etc.).

### Testing
- Vérification statique du code JavaScript avec `node --check js/app.js` qui a réussi.
- Vérification statique du code JavaScript avec `node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26a0fb5e4832a8618b3fd7c87de77)