### PR TITLE
Optimiser la lecture Firestore avec cache local TTL de 3 minutes

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -27,6 +27,7 @@ const FIREBASE_CONFIG = {
 };
 
 const OFFLINE_CACHE_KEY = 'suiviMateriel.offlineCache.v1';
+const OFFLINE_CACHE_TTL_MS = 180 * 1000;
 
 const state = {
   initialized: false,
@@ -544,20 +545,26 @@ function persistOfflineState() {
   localStorage.setItem(OFFLINE_CACHE_KEY, JSON.stringify(payload));
 }
 
-function loadOfflineState() {
+function parseOfflineState() {
   try {
     const raw = localStorage.getItem(OFFLINE_CACHE_KEY);
     if (!raw) {
-      return false;
+      return null;
     }
     const parsed = JSON.parse(raw);
     const page1 = Array.isArray(parsed?.pages?.page1) ? parsed.pages.page1 : [];
     const page2 = Array.isArray(parsed?.pages?.page2) ? parsed.pages.page2 : [];
     const page3 = Array.isArray(parsed?.pages?.page3) ? parsed.pages.page3 : [];
-    applySnapshot({ page1, page2, page3 });
-    return true;
+    const savedAt = typeof parsed?.savedAt === 'string' ? parsed.savedAt : null;
+    const savedAtTime = savedAt ? new Date(savedAt).getTime() : NaN;
+    const isFresh = Number.isFinite(savedAtTime) && Date.now() - savedAtTime < OFFLINE_CACHE_TTL_MS;
+    return {
+      snapshot: { page1, page2, page3 },
+      savedAt,
+      isFresh,
+    };
   } catch (_error) {
-    return false;
+    return null;
   }
 }
 
@@ -678,14 +685,28 @@ async function init() {
   const app = initializeApp(FIREBASE_CONFIG);
   state.db = getFirestore(app);
 
-  const hasOfflineData = loadOfflineState();
+  const offlineState = parseOfflineState();
+  if (offlineState?.snapshot) {
+    applySnapshot(offlineState.snapshot);
+  }
 
-  try {
-    const remote = await loadRemoteSnapshot();
-    applySnapshot(remote);
-    persistOfflineState();
-  } catch (_error) {
-    if (!hasOfflineData) {
+  if (!offlineState?.isFresh) {
+    try {
+      const remote = await loadRemoteSnapshot();
+      applySnapshot(remote);
+      persistOfflineState();
+    } catch (_error) {
+      if (!offlineState?.snapshot) {
+        applySnapshot({ page1: [], page2: [], page3: [] });
+      }
+    }
+  } else if (!offlineState.snapshot) {
+    // Defensive fallback, should never happen.
+    try {
+      const remote = await loadRemoteSnapshot();
+      applySnapshot(remote);
+      persistOfflineState();
+    } catch (_error) {
       applySnapshot({ page1: [], page2: [], page3: [] });
     }
   }


### PR DESCRIPTION
### Motivation

- Réduire les lectures Firestore pendant une session en lisant les données une seule fois au chargement de la page et en affichant un cache local tant qu’il est valide.
- Faire expirer le cache après 3 minutes (180 secondes) et obliger l’utilisateur à rafraîchir manuellement la page pour récupérer des données distantes.
- Ne pas impacter le comportement des écritures qui doivent rester immédiates et indépendantes du cache.

### Description

- Ajout de la constante `OFFLINE_CACHE_TTL_MS = 180 * 1000` pour définir la durée de validité du cache. (`js/storage.js`)
- Remplacement de l’ancien `loadOfflineState` par `parseOfflineState()` qui retourne le `snapshot`, le champ `savedAt` et un flag `isFresh` calculé à partir de `savedAt` et du TTL. (`js/storage.js`)
- Mise à jour de `init()` pour appliquer d’abord le snapshot local s’il existe, puis n’effectuer une seule lecture distante (`loadRemoteSnapshot`) que si le cache est absent ou expiré, et sauvegarder le cache après cette lecture; aucun rechargement automatique n’est effectué pendant la session. (`js/storage.js`)
- Aucune modification du flux d’écriture n’a été apportée : les fonctions d’ajout/modification/suppression continuent d’envoyer les opérations immédiatement à Firestore et de persister l’état local. (`js/storage.js`)

### Testing

- Exécution de la vérification syntaxique avec `node --check js/storage.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e270a8659c832aa13aac0ab73ba3a1)