### PR TITLE
Prioritize non-recent date filters on page2 and auto-select best period

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -90,6 +90,41 @@
     return true;
   }
 
+  function countItemsMatchingDateFilter(items, filterValue) {
+    if (!Array.isArray(items) || !items.length) {
+      return 0;
+    }
+    return items.reduce((count, item) => count + (itemMatchesDateFilter(item, filterValue) ? 1 : 0), 0);
+  }
+
+  function pickBestDateFilter(items, availableFilterValues, currentFilterValue) {
+    const filters = Array.isArray(availableFilterValues) ? availableFilterValues : [];
+    if (!filters.length) {
+      return currentFilterValue || 'all';
+    }
+
+    const hasCurrentFilter = filters.includes(currentFilterValue);
+    const isCurrentPrioritizedPeriod = hasCurrentFilter && !['all', 'today', 'yesterday'].includes(currentFilterValue);
+    if (isCurrentPrioritizedPeriod && countItemsMatchingDateFilter(items, currentFilterValue) > 0) {
+      return currentFilterValue;
+    }
+
+    const nonRecentFilters = filters.filter((value) => !['all', 'today', 'yesterday'].includes(value));
+    for (const filterValue of nonRecentFilters) {
+      if (countItemsMatchingDateFilter(items, filterValue) > 0) {
+        return filterValue;
+      }
+    }
+
+    for (const filterValue of ['today', 'yesterday']) {
+      if (filters.includes(filterValue) && countItemsMatchingDateFilter(items, filterValue) > 0) {
+        return filterValue;
+      }
+    }
+
+    return filters.includes('all') ? 'all' : filters[0];
+  }
+
   function resolveItemPeriodLabel(item) {
     const itemDate = parseDateValue(item?.dateCreation || item?.dateModification);
     if (!itemDate) {
@@ -1303,6 +1338,29 @@
       renderItems();
     }
 
+    function getAvailableItemDateFilters() {
+      if (!itemDateFilter) {
+        return ['all'];
+      }
+      return Array.from(itemDateFilter.options)
+        .map((option) => option?.value)
+        .filter((value) => Boolean(value));
+    }
+
+    function syncDateFilterWithData() {
+      if (!itemDateFilter) {
+        return;
+      }
+      const availableFilters = getAvailableItemDateFilters();
+      const nextFilter = pickBestDateFilter(currentItems, availableFilters, selectedDateFilter);
+      if (nextFilter === selectedDateFilter) {
+        return;
+      }
+      selectedDateFilter = nextFilter;
+      itemDateFilter.value = selectedDateFilter;
+      window.localStorage.setItem(dateFilterStorageKey, selectedDateFilter);
+    }
+
     function formatSiteExportUnit(unit) {
       const normalizedUnit = String(unit || '').trim().toLowerCase();
       if (normalizedUnit === 'pcs') {
@@ -1354,6 +1412,7 @@
     }
 
     function renderItems() {
+      syncDateFilterWithData();
       const query = itemSearchInput.value.trim().toUpperCase();
       const filteredItems = currentItems.filter((item) => {
         if (!itemMatchesDateFilter(item, selectedDateFilter)) {


### PR DESCRIPTION
### Motivation
- The page 2 date filter should not default to "Aujourd'hui" or "Hier" when data belongs to other periods; the UI must automatically select the most relevant period (e.g. "Le mois dernier").
- Ensure the selected filter reflects actual item dates and persist the resolved choice in `localStorage`.

### Description
- Added `countItemsMatchingDateFilter` and `pickBestDateFilter` helpers in `js/app.js` to evaluate which filter has matching items and to prefer non-recent periods over `today`/`yesterday` when possible.
- Added `getAvailableItemDateFilters` and `syncDateFilterWithData` to read available options from the DOM, pick the best filter for `currentItems`, update `itemDateFilter.value` and persist to `localStorage` via the existing `dateFilterStorageKey`.
- Integrated the sync into the page render flow by calling `syncDateFilterWithData()` at the start of `renderItems()` so the filter is kept in sync with incoming data.

### Testing
- Ran `node --check js/app.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e276efbfec832a8c6fc89f4cc400c1)