### PR TITLE
Add search and filter icons to labels on page2 and page3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -463,6 +463,19 @@ button {
   color: var(--text-muted);
 }
 
+.input-group span.label-with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.label-icon {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
 .input-group input,
 .input-group select,
 .cell-input,

--- a/page2.html
+++ b/page2.html
@@ -26,7 +26,7 @@
 
         <section class="search-panel surface-card">
           <label class="input-group">
-            <span>Recherche par N°OUT Ou par Article</span>
+            <span class="label-with-icon"><img src="Icon/chercher.png" alt="" class="label-icon" aria-hidden="true" /><span>Chercher par numéro OUT ou par Article</span></span>
             <input
               id="itemSearchInput"
               type="search"
@@ -35,7 +35,7 @@
             />
           </label>
           <label class="input-group search-filter-group">
-            <span>Filtrer par : </span>
+            <span class="label-with-icon"><img src="Icon/filtre.png" alt="" class="label-icon" aria-hidden="true" /><span>Filtrer par</span></span>
             <select id="itemDateFilter" aria-label="Filtrer les résultats par date">
               <option value="all">Tous</option>
               <option value="today">Aujourd'hui</option>

--- a/page3.html
+++ b/page3.html
@@ -58,7 +58,7 @@
           </div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">
-              <span>Recherche</span>
+              <span class="label-with-icon"><img src="Icon/chercher.png" alt="" class="label-icon" aria-hidden="true" /><span>Recherche</span></span>
               <input id="detailSearchInput" type="text" placeholder="Entrer votre Recherche..." autocomplete="off" />
             </label>
           </div>


### PR DESCRIPTION
### Motivation
- Improve visual affordance of search and filter controls by adding repository icons to their labels while keeping existing behavior unchanged.

### Description
- Inserted an inline icon to the left of the search label on `page2.html` using `Icon/chercher.png` and adjusted the label text to `Chercher par numéro OUT ou par Article`.
- Inserted an inline icon to the left of the filter label on `page2.html` using `Icon/filtre.png` and adjusted the label text to `Filtrer par`.
- Inserted an inline icon to the left of the table search label on `page3.html` using `Icon/chercher.png` and left the input logic untouched.
- Added reusable CSS rules in `css/style.css` (`.label-with-icon` and `.label-icon`) that use `inline-flex`, `align-items: center`, a small `gap` and set the icon size to `18px` to ensure vertical alignment and spacing without changing JS behavior.

### Testing
- Verified icon files exist with `test -f Icon/chercher.png && test -f Icon/filtre.png` and the check succeeded.
- Searched and validated updated markup and selectors with `rg` and confirmed the new classes and labels are present in `page2.html`, `page3.html`, and `css/style.css`.
- Confirmed diffs with `git diff` and committed the changes successfully; all automated checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e3407790832a95b3fa7c8f713645)