### PR TITLE
Ajouter un loader global avec overlay et spinner pour chaque page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1489,3 +1489,37 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
 .data-table--hide-action td:last-child {
   display: none;
 }
+
+.global-loader-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.7);
+  z-index: 9999;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+
+.global-loader-overlay--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.global-loader-spinner {
+  width: 52px;
+  height: 52px;
+  border: 4px solid rgba(39, 141, 218, 0.2);
+  border-top-color: var(--primary-dark);
+  border-radius: 50%;
+  animation: global-spinner-rotate 0.9s linear infinite;
+}
+
+@keyframes global-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/js/app.js
+++ b/js/app.js
@@ -2256,5 +2256,7 @@
     }
   }
 
-  bootstrap();
+  bootstrap().finally(() => {
+    UiService.markAppReady();
+  });
 })();

--- a/js/ui.js
+++ b/js/ui.js
@@ -2,7 +2,77 @@
   const TOAST_VISIBLE_CLASS = "toast--visible";
   const DEFAULT_TOAST_DURATION = 3000;
   const DEFAULT_SNACKBAR_DURATION = 5000;
+  const GLOBAL_LOADER_ID = "globalPageLoader";
+  const GLOBAL_LOADER_HIDDEN_CLASS = "global-loader-overlay--hidden";
   let hideTimerId = null;
+  let globalLoader = null;
+  let hasWindowLoaded = document.readyState === "complete";
+  let isAppReady = false;
+
+  function ensureGlobalLoader() {
+    if (globalLoader) {
+      return globalLoader;
+    }
+
+    globalLoader = document.getElementById(GLOBAL_LOADER_ID);
+    if (globalLoader) {
+      return globalLoader;
+    }
+
+    const overlay = document.createElement("div");
+    overlay.id = GLOBAL_LOADER_ID;
+    overlay.className = "global-loader-overlay";
+    overlay.setAttribute("role", "status");
+    overlay.setAttribute("aria-live", "polite");
+    overlay.setAttribute("aria-label", "Chargement en cours");
+
+    const spinner = document.createElement("div");
+    spinner.className = "global-loader-spinner";
+    spinner.setAttribute("aria-hidden", "true");
+    overlay.appendChild(spinner);
+
+    document.body.appendChild(overlay);
+    globalLoader = overlay;
+    return globalLoader;
+  }
+
+  function showGlobalLoader() {
+    ensureGlobalLoader().classList.remove(GLOBAL_LOADER_HIDDEN_CLASS);
+  }
+
+  function hideGlobalLoader() {
+    ensureGlobalLoader().classList.add(GLOBAL_LOADER_HIDDEN_CLASS);
+  }
+
+  function waitForImagesReady() {
+    const pendingImages = Array.from(document.images).filter((image) => !image.complete);
+    if (pendingImages.length === 0) {
+      return Promise.resolve();
+    }
+
+    return Promise.all(
+      pendingImages.map(
+        (image) =>
+          new Promise((resolve) => {
+            image.addEventListener("load", resolve, { once: true });
+            image.addEventListener("error", resolve, { once: true });
+          }),
+      ),
+    ).then(() => undefined);
+  }
+
+  function maybeHideGlobalLoader() {
+    if (!hasWindowLoaded || !isAppReady) {
+      return;
+    }
+
+    waitForImagesReady().then(hideGlobalLoader);
+  }
+
+  function markAppReady() {
+    isAppReady = true;
+    maybeHideGlobalLoader();
+  }
 
   function formatDate(dateValue) {
     if (!dateValue) {
@@ -99,8 +169,20 @@
   }
 
   function navigate(url) {
-    window.location.href = url;
+    showGlobalLoader();
+    window.requestAnimationFrame(() => {
+      window.location.href = url;
+    });
   }
+
+  ensureGlobalLoader();
+  showGlobalLoader();
+
+  window.addEventListener("beforeunload", showGlobalLoader);
+  window.addEventListener("load", () => {
+    hasWindowLoaded = true;
+    maybeHideGlobalLoader();
+  });
 
   window.UiService = {
     formatDate,
@@ -110,5 +192,8 @@
     renderEmptyState,
     bindDialogCloser,
     navigate,
+    showGlobalLoader,
+    hideGlobalLoader,
+    markAppReady,
   };
 })();


### PR DESCRIPTION
### Motivation
- Fournir un feedback visuel cohérent lors du chargement initial et lors des changements de page en affichant un overlay central avec un spinner circulaire.
- Le loader doit recouvrir toute la page, être centré et ne disparaître qu'une fois tout le contenu (DOM + données + images) prêt.
- Respecter les contraintes existantes : ne pas toucher la logique métier, réutilisable via une seule classe globale, et apparaître à chaque navigation.

### Description
- Implémentation d'un loader injecté dynamiquement dans `js/ui.js` avec les fonctions `ensureGlobalLoader`, `showGlobalLoader`, `hideGlobalLoader`, `waitForImagesReady` et `markAppReady` pour piloter l'affichage/masquage du loader.
- Le loader est affiché au démarrage (`ensureGlobalLoader(); showGlobalLoader();`), avant les navigations via `UiService.navigate`, et sur `beforeunload` pour couvrir les transitions de page.
- Le masquage attend deux conditions : l'événement `window.load` et l'appel à `UiService.markAppReady()` (qui est déclenché depuis le bootstrap de l'app), puis s'assure que toutes les images non complètes sont chargées avant de cacher l'overlay.
- Ajout des styles réutilisables dans `css/style.css` : `.global-loader-overlay`, `.global-loader-overlay--hidden`, `.global-loader-spinner` et l'animation `@keyframes global-spinner-rotate`.
- Raccordement minimal dans `js/app.js` : remplacement de `bootstrap();` par `bootstrap().finally(() => { UiService.markAppReady(); });` pour signaler la fin d'initialisation sans modifier la logique métier.

### Testing
- Vérification de la validité des fichiers JavaScript avec `node --check js/ui.js && node --check js/app.js` exécutée et réussie.
- L'ajout de styles a été injecté dans `css/style.css` et n'a pas déclenché d'erreurs de build dans cet environnement basique (vérifié via les checks JS ci-dessus).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ecfa9548832aae1888ea6dc2761f)