### PR TITLE
Remplacer les boutons "Supprimer" par l’icône `Icon/poubelle.png` dans les tableaux

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1137,6 +1137,32 @@ body[data-page="users-management"] .table-wrapper--users .data-table td:nth-chil
 
 body[data-page="users-management"] .table-wrapper--users .data-table td:last-child {
   white-space: nowrap;
+  text-align: center;
+}
+
+.table-delete-icon-button {
+  border: 0;
+  background: transparent;
+  padding: 0.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: opacity 0.2s ease, background-color 0.2s ease;
+}
+
+.table-delete-icon-button__icon {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  display: block;
+}
+
+.table-delete-icon-button:hover,
+.table-delete-icon-button:focus-visible {
+  opacity: 0.8;
+  background-color: rgba(229, 72, 77, 0.12);
 }
 
 body[data-page="users-management"] .maintenance-access-cell {

--- a/js/app.js
+++ b/js/app.js
@@ -1807,7 +1807,11 @@
               <td><input class="cell-input cell-input--autosize" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" size="${Math.max(String(detail.observation || '').length + 1, 14)}" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
-              <td>${permissions.canDelete ? `<button class="btn-danger" type="button" data-detail-delete="${detail.id}" aria-label="Supprimer" title="Supprimer">Supprimer</button>` : ""}</td>
+              <td>
+                ${permissions.canDelete
+      ? `<button class="table-delete-icon-button" type="button" data-detail-delete="${detail.id}" aria-label="Supprimer" title="Supprimer"><img src="Icon/poubelle.png" alt="" aria-hidden="true" class="table-delete-icon-button__icon" /></button>`
+      : ""}
+              </td>
             </tr>
           `;
           },
@@ -2070,7 +2074,7 @@
             <td>
               ${user.username === 'Admin'
       ? '<span class="table-action-disabled">-</span>'
-      : `<button type="button" class="btn btn-danger" data-delete-user="${user.id}">Supprimer</button>`}
+      : `<button type="button" class="table-delete-icon-button" data-delete-user="${user.id}" aria-label="Supprimer" title="Supprimer"><img src="Icon/poubelle.png" alt="" aria-hidden="true" class="table-delete-icon-button__icon" /></button>`}
             </td>
           </tr>
         `)


### PR DESCRIPTION
### Motivation
- Remplacer les boutons texte « Supprimer » par l’icône `Icon/poubelle.png` pour homogénéiser l’UI sans changer la logique métier existante.
- Conserver les attributs et événements de suppression actuels (`data-detail-delete`, `data-delete-user`) afin de ne pas casser le comportement JavaScript.
- Améliorer l’accessibilité et l’ergonomie en ajoutant un `title`/`aria-label`, un curseur `pointer` et un effet visuel au survol.

### Description
- Remplacé dans `js/app.js` le rendu des boutons texte de la colonne Action de la page détail (page 3) par un bouton contenant `<img src="Icon/poubelle.png" />` tout en gardant `data-detail-delete` et les labels `aria-label`/`title`.
- Remplacé dans `js/app.js` les boutons texte « Supprimer » du tableau utilisateurs par le même bouton-icône en conservant `data-delete-user` et la confirmation existante avant suppression.
- Ajouté dans `css/style.css` les classes `.table-delete-icon-button` et `.table-delete-icon-button__icon` pour centrer l’icône, forcer une taille d’environ `20px`, définir le `cursor: pointer`, et ajouter un effet `hover/focus` (opacité + fond rouge léger).
- Aucune modification de la logique JavaScript de suppression ou des gestionnaires d’événements n’a été effectuée.

### Testing
- Exécuté `node --check js/app.js` pour vérifier la syntaxe JavaScript et la vérification a réussi.
- Recherches automatisées (`rg -n "data-detail-delete|data-delete-user|poubelle.png|Supprimer"`) ont confirmé la présence des nouveaux boutons-icônes et la conservation des attributs de suppression; la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f2f9d630832a8ff6c7d9ae167c29)