### PR TITLE
Page 2 : remplacer « Le mois dernier » par « Il y a longtemps » et adapter le filtre date

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -74,13 +74,9 @@
     }
 
     if (filterValue === 'lastMonth') {
-      const currentMonth = today.getMonth();
-      const currentYear = today.getFullYear();
-      const previousMonthDate = new Date(currentYear, currentMonth - 1, 1);
-      return (
-        itemDate.getMonth() === previousMonthDate.getMonth()
-        && itemDate.getFullYear() === previousMonthDate.getFullYear()
-      );
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      return itemDay.getTime() < yesterday.getTime();
     }
 
     if (filterValue === 'lastYear') {
@@ -108,12 +104,8 @@
       return 'Hier';
     }
 
-    const previousMonthDate = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-    if (
-      itemDate.getMonth() === previousMonthDate.getMonth()
-      && itemDate.getFullYear() === previousMonthDate.getFullYear()
-    ) {
-      return 'Le mois dernier';
+    if (itemDay.getTime() < yesterday.getTime()) {
+      return 'Il y a longtemps';
     }
 
     return null;

--- a/page2.html
+++ b/page2.html
@@ -40,7 +40,7 @@
               <option value="all">Tous</option>
               <option value="today">Aujourd'hui</option>
               <option value="yesterday">Hier</option>
-              <option value="lastMonth">Le mois dernier</option>
+              <option value="lastMonth">Il y a longtemps</option>
             </select>
           </label>
         </section>


### PR DESCRIPTION
### Motivation
- Mettre à jour le libellé du filtre date et adapter sa logique pour que l’option affichée « Il y a longtemps » regroupe toutes les données antérieures à J-1 sans inclure Aujourd’hui ni Hier.

### Description
- Modifié `page2.html` pour remplacer le texte de l'option `value="lastMonth"` de « Le mois dernier » vers « Il y a longtemps ». 
- Modifié `js/app.js` dans `itemMatchesDateFilter` pour que la branche `lastMonth` retourne `itemDay.getTime() < yesterday.getTime()` (tous les enregistrements strictement antérieurs à J-1). 
- Modifié `resolveItemPeriodLabel` pour qu’un élément antérieur à J-1 affiche la période « Il y a longtemps ». 
- Les autres options et la valeur d'option (`lastMonth`) sont conservées et le comportement de `today` et `yesterday` reste inchangé.

### Testing
- Exécuté `node --check js/app.js` pour valider la syntaxe du fichier modifié et la commande a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f72b9374832ab7e1782e4e1b7768)