### PR TITLE
Masque le typeahead du champ « Code » sur la page 3 lorsque la saisie est vide

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1658,6 +1658,7 @@
         return;
       }
       codeSuggestions.hidden = true;
+      codeSuggestions.style.display = 'none';
       codeSuggestions.innerHTML = '';
     }
 
@@ -1675,6 +1676,12 @@
         return;
       }
 
+      const normalizedQuery = String(query || '').trim();
+      if (!normalizedQuery) {
+        hideCodeSuggestions();
+        return;
+      }
+
       visibleCodeSuggestions = getCodeMatches(query);
       activeSuggestionIndex = -1;
 
@@ -1684,6 +1691,7 @@
       }
 
       codeSuggestions.hidden = false;
+      codeSuggestions.style.display = 'block';
       codeSuggestions.innerHTML = visibleCodeSuggestions
         .map(
           (entry, index) => `
@@ -1705,7 +1713,7 @@
     async function refreshCodeSuggestionSource() {
       const details = await StorageService.getAllDetails();
       codeSuggestionSource = buildCodeSuggestionSource(details);
-      if (document.activeElement === codeInput) {
+      if (document.activeElement === codeInput && String(codeInput.value || '').trim()) {
         renderCodeSuggestions(codeInput.value);
       }
     }
@@ -1887,6 +1895,10 @@
 
     if (codeInput && codeSuggestions) {
       codeInput.addEventListener('focus', () => {
+        if (!String(codeInput.value || '').trim()) {
+          hideCodeSuggestions();
+          return;
+        }
         renderCodeSuggestions(codeInput.value);
       });
 


### PR DESCRIPTION
### Motivation
- Améliorer l’expérience sur la page de détail en s’assurant que le card de suggestions (typeahead) du champ `Code` n’apparaît jamais lorsque le champ est vide ou contient uniquement des espaces, tout en conservant la logique de recherche et de suggestion existante.

### Description
- Dans `js/app.js` le rendu des suggestions vérifie maintenant `String(query || '').trim()` et quitte tôt si la valeur est vide pour éviter d’afficher le card lorsque l’utilisateur n’a rien saisi.
- Le masquage est renforcé en combinant `codeSuggestions.hidden = true` et `codeSuggestions.style.display = 'none'`, et l’affichage explicite utilise `style.display = 'block'` quand des suggestions sont présentes.
- Lors du rafraîchissement de la source (`refreshCodeSuggestionSource`) on n’appelle plus `renderCodeSuggestions` si la valeur actuelle du champ `codeInput` est vide après `trim()`; le gestionnaire `focus` du champ respecte aussi cette garde.
- La logique existante de matching, tri, navigation clavier et sélection des suggestions est conservée sans modification fonctionnelle.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` qui a réussi.
- Validation locale manuelle (lecture du diff et des handlers affectés) pour s’assurer que les chemins d’affichage/masquage sont cohérents et que la logique de suggestion n’est pas modifiée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e300996d70832ab4f7f4d0aee474c7)