### PR TITLE
Improve global loader overlay with backdrop blur and fallback

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1590,11 +1590,19 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.7);
-  z-index: 9999;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 10000;
+  -webkit-backdrop-filter: blur(7px);
+  backdrop-filter: blur(7px);
   opacity: 1;
   visibility: visible;
   transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+
+@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .global-loader-overlay {
+    background: rgba(255, 255, 255, 0.82);
+  }
 }
 
 .global-loader-content {


### PR DESCRIPTION
### Motivation
- Prevent page content from showing through while the global loader is visible by applying a visual mask (blur or stronger semi-transparent background) to the page background.

### Description
- Update `.global-loader-overlay` in `css/style.css` to use `background: rgba(255,255,255,0.6)`, increase `z-index` to `10000`, and add `-webkit-backdrop-filter` / `backdrop-filter: blur(7px)` so the background is blurred while the loader (spinner + text) remains sharp.
- Add a CSS feature-detection fallback using `@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px)))` to apply `background: rgba(255,255,255,0.82)` when blur is not supported by the browser.
- No JavaScript logic was changed; loader show/hide behavior remains handled by the existing `js/ui.js` implementation.

### Testing
- Ran `git diff --check` with no issues reported.
- Verified repository status with `git status --short` and committed the `css/style.css` change successfully.
- Inspected the modified file lines to confirm the new rules were applied (`css/style.css` around L1587-L1606).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3089ddfc8832abb50502de5f0b6b0)