### PR TITLE
Supprimer l’icône cloche du header de la page d'accueil

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -115,12 +115,6 @@ button {
   flex-shrink: 0;
 }
 
-.icon-cloche {
-  width: 2rem;
-  height: 2rem;
-  object-fit: contain;
-}
-
 .header-menu__trigger {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
         <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>??</button>
         <h1>Suivi Matériel</h1>
         <div class="header-menu">
-          <img src="Icon/cloche.png" alt="cloche" class="icon-cloche" />
           <button
             id="homeMenuButton"
             class="icon-button header-menu__trigger"


### PR DESCRIPTION
### Motivation
- Nettoyer l'interface en retirant uniquement l'icône de notification (« cloche ») de la page 1 sans impacter le header, la navbar ou l'alignement des autres éléments.

### Description
- Suppression de l'élément `<img src="Icon/cloche.png" class="icon-cloche">` dans `index.html` et suppression de la règle CSS `.icon-cloche` dans `css/style.css`, en conservant toutes les autres règles de layout et le comportement du menu.

### Testing
- Exécution de `rg -n "cloche|icon-cloche" index.html css/style.css js/*.js` pour vérifier qu'il ne reste plus de références, la commande n'a retourné aucun résultat (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30b377fd4832ab08f133648f42b54)