### PR TITLE
Add Firebase login page (Email + Google) and guest read-only flow

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -1,0 +1,102 @@
+:root {
+  --bg-1: #0ea5e9;
+  --bg-2: #1d4ed8;
+  --card-bg: rgba(255, 255, 255, 0.18);
+  --text: #0f172a;
+  --muted: #475569;
+  --danger: #dc2626;
+  --primary: #2563eb;
+  --ring: rgba(37, 99, 235, 0.25);
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Roboto, Arial, sans-serif;
+  background: radial-gradient(circle at top left, #38bdf8 0%, var(--bg-1) 35%, var(--bg-2) 100%);
+  color: var(--text);
+}
+.login-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+.login-card {
+  width: min(100%, 28rem);
+  background: var(--card-bg);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: 1.25rem;
+  box-shadow: 0 20px 50px rgba(2, 6, 23, 0.3);
+  padding: 1.2rem;
+  animation: riseIn .45s ease both;
+}
+@keyframes riseIn { from { opacity: 0; transform: translateY(14px);} to { opacity: 1; transform: translateY(0);} }
+.login-card__header h1 { margin: 0; font-size: 1.5rem; color: #fff; }
+.login-card__header p { margin: .4rem 0 1rem; color: rgba(255,255,255,.88); }
+.login-form { display: grid; gap: .8rem; }
+.field-group { display: grid; gap: .4rem; color: #f8fafc; }
+.field-group input {
+  width: 100%;
+  border: 1px solid rgba(255,255,255,.55);
+  border-radius: .85rem;
+  background: rgba(255,255,255,.95);
+  color: #0f172a;
+  padding: .8rem .9rem;
+  transition: box-shadow .2s ease, border-color .2s ease, transform .2s ease;
+}
+.field-group input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px var(--ring);
+  transform: translateY(-1px);
+}
+.password-wrap { position: relative; }
+.password-wrap input { padding-right: 3rem; }
+.password-toggle {
+  position: absolute;
+  top: 50%;
+  right: .45rem;
+  transform: translateY(-50%);
+  width: 2.2rem;
+  height: 2.2rem;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.08);
+}
+.password-toggle img { width: 1.2rem; height: 1.2rem; object-fit: contain; }
+.field-error { min-height: 1.1rem; color: #ffe4e6; font-size: .8rem; }
+.btn {
+  border: 0;
+  border-radius: .85rem;
+  padding: .82rem 1rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  transition: transform .2s ease, box-shadow .2s ease, opacity .2s ease;
+}
+.btn:hover { transform: translateY(-1px); }
+.btn:disabled { opacity: .65; cursor: not-allowed; }
+.btn-primary { background: #fff; color: var(--primary); box-shadow: 0 10px 24px rgba(15,23,42,.18); }
+.btn-google { background: rgba(255,255,255,.92); color: #111827; }
+.btn-google img { width: 1.2rem; height: 1.2rem; }
+.login-separator { text-align: center; margin: .1rem 0; color: #e2e8f0; }
+.global-error { min-height: 1.2rem; color: #fecaca; text-align: center; margin: 0; font-size: .9rem; }
+.btn__loader {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 2px solid rgba(37,99,235,.3);
+  border-top-color: var(--primary);
+  animation: spin .8s linear infinite;
+  display: none;
+}
+.btn.is-loading .btn__loader { display: inline-block; }
+.btn.is-loading .btn__label { opacity: .7; }
+@keyframes spin { to { transform: rotate(360deg);} }
+@media (max-width: 480px) {
+  .login-card { padding: 1rem; border-radius: 1rem; }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -104,7 +104,23 @@ button {
 
 .app-header--home {
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.6rem;
+}
+
+.header-login-button {
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.58rem 0.95rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.header-login-button:hover {
+  background: rgba(255, 255, 255, 0.34);
+  transform: translateY(-1px);
 }
 
 .header-menu {

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div class="app-shell">
       <header class="app-header app-header--home">
         <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>??</button>
+        <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
         <h1>Suivi Matériel</h1>
         <div class="header-menu">
           <button

--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,6 @@
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
+import { firebaseAuth } from './firebase-core.js';
+
 (function () {
   const { StorageService, UiService } = window;
   const CLOUDINARY_UPLOAD_URL = 'https://api.cloudinary.com/v1_1/dskw13nem/image/upload';
@@ -257,6 +260,37 @@
         UiService.navigate(button.dataset.back);
       });
     });
+  }
+
+  function waitForAuthState() {
+    return new Promise((resolve) => {
+      const unsubscribe = onAuthStateChanged(firebaseAuth, (user) => {
+        unsubscribe();
+        resolve(user || null);
+      }, () => resolve(null));
+    });
+  }
+
+  function renderHomeAccessControls({ isAuthenticated, profile, onAvatarClick }) {
+    const avatarButton = document.getElementById('userAvatarButton');
+    const loginButton = document.getElementById('openLoginButton');
+
+    if (isAuthenticated) {
+      if (loginButton) {
+        loginButton.hidden = true;
+      }
+      renderAvatar(profile, onAvatarClick);
+      return;
+    }
+
+    if (avatarButton) {
+      avatarButton.hidden = true;
+      avatarButton.onclick = null;
+    }
+    if (loginButton) {
+      loginButton.hidden = false;
+      loginButton.onclick = () => UiService.navigate('login.html');
+    }
   }
 
   function downloadExcelFile(fileName, title, workbook) {
@@ -931,7 +965,7 @@
     dialog.addEventListener('close', () => form.removeEventListener('submit', submitHandler), { once: true });
     dialog.showModal();
   }
-  function initHomePage(userProfile, permissions) {
+  function initHomePage(userProfile, permissions, authState) {
     const searchInput = requireElement('searchInput');
     const siteList = requireElement('siteList');
     const siteCount = requireElement('siteCount');
@@ -1161,24 +1195,32 @@
 
     const refreshAvatar = async () => {
       const latest = await StorageService.getCurrentUserProfile();
-      renderAvatar(latest, () => openAvatarBottomSheet(latest, {
-        onRenameClick: () => openRenameDialog(latest, refreshAvatar),
+      renderHomeAccessControls({
+        isAuthenticated: Boolean(authState?.isAuthenticated),
+        profile: latest,
+        onAvatarClick: () => openAvatarBottomSheet(latest, {
+          onRenameClick: () => openRenameDialog(latest, refreshAvatar),
+          onUploadAvatar: async (file) => {
+            const avatarUrl = await uploadAvatarToCloudinary(file);
+            await StorageService.updateAvatarUrl(avatarUrl);
+            await refreshAvatar();
+          },
+        }),
+      });
+    };
+
+    renderHomeAccessControls({
+      isAuthenticated: Boolean(authState?.isAuthenticated),
+      profile: userProfile,
+      onAvatarClick: () => openAvatarBottomSheet(userProfile, {
+        onRenameClick: () => openRenameDialog(userProfile, refreshAvatar),
         onUploadAvatar: async (file) => {
           const avatarUrl = await uploadAvatarToCloudinary(file);
           await StorageService.updateAvatarUrl(avatarUrl);
           await refreshAvatar();
         },
-      }));
-    };
-    renderAvatar(userProfile, () => openAvatarBottomSheet(userProfile, {
-      onRenameClick: () => openRenameDialog(userProfile, refreshAvatar),
-      onUploadAvatar: async (file) => {
-        const avatarUrl = await uploadAvatarToCloudinary(file);
-        await StorageService.updateAvatarUrl(avatarUrl);
-        await refreshAvatar();
-      },
-    }));
-
+      }),
+    });
 
     const openCreateSite = requireElement('openCreateSite');
     if (!permissions.canCreate && openCreateSite) {
@@ -2243,20 +2285,35 @@
   async function bootstrap() {
     UiService.bindDialogCloser();
     setupBackButtons();
+
+    const authUser = await waitForAuthState();
     await StorageService.init();
 
-    await StorageService.ensureCurrentUser();
+    const isAuthenticated = Boolean(authUser);
     let profile = await StorageService.getCurrentUserProfile();
-    profile = await promptForMissingUsername(profile);
-    profile = await StorageService.getCurrentUserProfile();
-    const permissions = buildPermissions(profile);
-    profile = await initApprovalGate(profile, permissions);
+
+    if (isAuthenticated) {
+      await StorageService.ensureCurrentUser();
+      profile = await StorageService.getCurrentUserProfile();
+      profile = await promptForMissingUsername(profile);
+      profile = await StorageService.getCurrentUserProfile();
+    }
+
+    if (isAuthenticated && String(profile?.email || '').trim().toLowerCase() === 'andrainaaina@gmail.com') {
+      profile.role = 'admin';
+    }
+
+    const permissions = buildPermissions(isAuthenticated ? profile : { role: 'lecture' });
+
+    if (isAuthenticated) {
+      profile = await initApprovalGate(profile, permissions);
+    }
 
     initMaintenanceGate(permissions);
 
     const page = document.body.dataset.page;
     if (page === 'home') {
-      initHomePage(profile, permissions);
+      initHomePage(profile, permissions, { isAuthenticated, authUser });
     }
     if (page === 'site-detail') {
       initSiteDetailPage(permissions);
@@ -2271,6 +2328,7 @@
       await initHistoryPage();
     }
   }
+
 
   bootstrap().finally(() => {
     UiService.markAppReady();

--- a/js/firebase-core.js
+++ b/js/firebase-core.js
@@ -1,0 +1,19 @@
+import { getApp, getApps, initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-app.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+
+const FIREBASE_CONFIG = {
+  apiKey: 'AIzaSyD6krHqIlaD7Jo-ERhNxEFuuenwjwHrho',
+  authDomain: 'base-737bf.firebaseapp.com',
+  projectId: 'base-737bf',
+  storageBucket: 'base-737bf.firebasestorage.app',
+  messagingSenderId: '560283994192',
+  appId: '1:560283994192:web:ede7aa7a3714c439542955',
+  measurementId: 'G-LMQC9RVF2E',
+};
+
+const firebaseApp = getApps().length ? getApp() : initializeApp(FIREBASE_CONFIG);
+const firebaseAuth = getAuth(firebaseApp);
+const firebaseDb = getFirestore(firebaseApp);
+
+export { firebaseApp, firebaseAuth, firebaseDb };

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,187 @@
+import {
+  GoogleAuthProvider,
+  fetchSignInMethodsForEmail,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+} from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
+import { firebaseAuth } from './firebase-core.js';
+
+const STORAGE_KEY = 'suiviMateriel.loginMemo.v1';
+
+const form = document.getElementById('loginForm');
+const emailInput = document.getElementById('loginEmail');
+const passwordInput = document.getElementById('loginPassword');
+const togglePasswordButton = document.getElementById('togglePasswordButton');
+const togglePasswordIcon = document.getElementById('togglePasswordIcon');
+const emailError = document.getElementById('emailError');
+const passwordError = document.getElementById('passwordError');
+const globalError = document.getElementById('globalError');
+const emailLoginButton = document.getElementById('emailLoginButton');
+const googleLoginButton = document.getElementById('googleLoginButton');
+
+let lastEmailCheckId = 0;
+
+function redirectToHome() {
+  window.location.href = 'index.html';
+}
+
+onAuthStateChanged(firebaseAuth, (user) => {
+  if (!user) {
+    return;
+  }
+
+  const authPayload = {
+    uid: user.uid || '',
+    displayName: user.displayName || '',
+    email: user.email || '',
+    photoURL: user.photoURL || '',
+  };
+  localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
+  redirectToHome();
+});
+
+function setLoading(isLoading, sourceButton = emailLoginButton) {
+  emailLoginButton.disabled = isLoading;
+  googleLoginButton.disabled = isLoading;
+  sourceButton?.classList.toggle('is-loading', isLoading);
+}
+
+function encodeMemo(email, password) {
+  return btoa(unescape(encodeURIComponent(JSON.stringify({ email, password }))));
+}
+
+function decodeMemo(raw) {
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(decodeURIComponent(escape(atob(raw))));
+  } catch (_error) {
+    return null;
+  }
+}
+
+function saveCredentials(email, password) {
+  localStorage.setItem(STORAGE_KEY, encodeMemo(email, password));
+}
+
+function applyMemoIfAny() {
+  const memo = decodeMemo(localStorage.getItem(STORAGE_KEY));
+  if (!memo) {
+    return;
+  }
+  if (!emailInput.value) {
+    emailInput.value = memo.email || '';
+  }
+  if (!passwordInput.value) {
+    passwordInput.value = memo.password || '';
+  }
+}
+
+function isEmailFormatValid(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+async function validateEmailRealtime() {
+  const email = emailInput.value.trim();
+  emailError.textContent = '';
+
+  if (!email) {
+    emailError.textContent = 'Email vide.';
+    return false;
+  }
+  if (!isEmailFormatValid(email)) {
+    emailError.textContent = 'Format email invalide.';
+    return false;
+  }
+
+  const requestId = ++lastEmailCheckId;
+  try {
+    const methods = await fetchSignInMethodsForEmail(firebaseAuth, email);
+    if (requestId !== lastEmailCheckId) {
+      return false;
+    }
+    if (!methods.length) {
+      emailError.textContent = 'Email inexistant.';
+      return false;
+    }
+  } catch (_error) {
+    emailError.textContent = 'Vérification email indisponible.';
+    return false;
+  }
+  return true;
+}
+
+function validatePasswordRealtime() {
+  const password = passwordInput.value;
+  passwordError.textContent = '';
+  if (!password) {
+    passwordError.textContent = 'Mot de passe requis.';
+    return false;
+  }
+  if (password.length < 6) {
+    passwordError.textContent = 'Mot de passe trop court (minimum 6 caractères).';
+    return false;
+  }
+  return true;
+}
+
+emailInput.addEventListener('focus', applyMemoIfAny);
+passwordInput.addEventListener('focus', applyMemoIfAny);
+emailInput.addEventListener('input', () => {
+  globalError.textContent = '';
+  validateEmailRealtime();
+});
+passwordInput.addEventListener('input', () => {
+  globalError.textContent = '';
+  validatePasswordRealtime();
+});
+
+togglePasswordButton.addEventListener('click', () => {
+  const nextIsVisible = passwordInput.type === 'password';
+  passwordInput.type = nextIsVisible ? 'text' : 'password';
+  togglePasswordIcon.src = nextIsVisible ? 'Icon/Eye_ON.png' : 'Icon/Eye_OFF.png';
+  togglePasswordButton.setAttribute('aria-label', nextIsVisible ? 'Cacher le mot de passe' : 'Afficher le mot de passe');
+});
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  globalError.textContent = '';
+
+  const isEmailValid = await validateEmailRealtime();
+  const isPasswordValid = validatePasswordRealtime();
+  if (!isEmailValid || !isPasswordValid) {
+    return;
+  }
+
+  setLoading(true, emailLoginButton);
+  try {
+    await signInWithEmailAndPassword(firebaseAuth, emailInput.value.trim(), passwordInput.value);
+    saveCredentials(emailInput.value.trim(), passwordInput.value);
+  } catch (error) {
+    const code = String(error?.code || '');
+    if (code.includes('wrong-password') || code.includes('invalid-credential')) {
+      passwordError.textContent = 'Mot de passe incorrect.';
+    } else if (code.includes('user-not-found')) {
+      emailError.textContent = 'Email inexistant.';
+    } else {
+      globalError.textContent = 'Connexion impossible. Veuillez réessayer.';
+    }
+  } finally {
+    setLoading(false, emailLoginButton);
+  }
+});
+
+googleLoginButton.addEventListener('click', async () => {
+  globalError.textContent = '';
+  setLoading(true, googleLoginButton);
+  try {
+    const provider = new GoogleAuthProvider();
+    await signInWithPopup(firebaseAuth, provider);
+  } catch (_error) {
+    globalError.textContent = 'Connexion Google indisponible.';
+  } finally {
+    setLoading(false, googleLoginButton);
+  }
+});

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,4 +1,3 @@
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-app.js';
 import {
   addDoc,
   collection,
@@ -6,7 +5,6 @@ import {
   doc,
   getDoc,
   getDocs,
-  getFirestore,
   onSnapshot,
   orderBy,
   query,
@@ -15,16 +13,7 @@ import {
   Timestamp,
   updateDoc,
 } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
-
-const FIREBASE_CONFIG = {
-  apiKey: 'AIzaSyD6krHqIlaD7Jo-ERhNxEFuuenwjwHrho',
-  authDomain: 'base-737bf.firebaseapp.com',
-  projectId: 'base-737bf',
-  storageBucket: 'base-737bf.firebasestorage.app',
-  messagingSenderId: '560283994192',
-  appId: '1:560283994192:web:ede7aa7a3714c439542955',
-  measurementId: 'G-LMQC9RVF2E',
-};
+import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
 const OFFLINE_CACHE_KEY = 'suiviMateriel.offlineCache.v1';
 const OFFLINE_CACHE_TTL_MS = 180 * 1000;
@@ -33,6 +22,7 @@ const state = {
   initialized: false,
   db: null,
   userId: null,
+  authUser: null,
   sites: [],
   itemsBySite: new Map(),
   detailsByItem: new Map(),
@@ -49,7 +39,7 @@ const state = {
 
 function normalizeRole(value) {
   const role = String(value || '').toLowerCase();
-  if (role === 'lecture' || role === 'ecriture' || role === 'full') {
+  if (role === 'lecture' || role === 'ecriture' || role === 'full' || role === 'admin') {
     return role;
   }
   return 'full';
@@ -110,15 +100,21 @@ function isValidUsername(username) {
   return true;
 }
 
-async function resolveUserId() {
-  const source = [navigator.userAgent || '', navigator.language || '', navigator.platform || ''].join('|');
-  const encoded = new TextEncoder().encode(source);
-  const digest = await crypto.subtle.digest('SHA-256', encoded);
-  const hash = Array.from(new Uint8Array(digest))
-    .slice(0, 16)
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
-  return `user_${hash}`;
+function getCurrentAuthUser() {
+  const authUser = firebaseAuth.currentUser;
+  if (!authUser) {
+    return null;
+  }
+  return {
+    uid: authUser.uid,
+    email: authUser.email || '',
+    displayName: authUser.displayName || '',
+    photoURL: authUser.photoURL || '',
+  };
+}
+
+function isAdminEmail(email) {
+  return String(email || '').trim().toLowerCase() === 'andrainaaina@gmail.com';
 }
 
 function usersCollection() {
@@ -126,6 +122,9 @@ function usersCollection() {
 }
 
 function userDocRef(userId = state.userId) {
+  if (!userId) {
+    return null;
+  }
   return doc(state.db, 'users', userId);
 }
 
@@ -146,6 +145,9 @@ async function isUsernameDuplicate(username, excludedUserId) {
 }
 
 async function ensureCurrentUser() {
+  if (!state.userId) {
+    return null;
+  }
   const ref = userDocRef();
   const snap = await getDoc(ref);
   if (!snap.exists()) {
@@ -153,10 +155,11 @@ async function ensureCurrentUser() {
       ref,
       {
         username: '',
+        email: state.authUser?.email || '',
         name: '',
         avatarUrl: '',
         avatar: '',
-        role: 'full',
+        role: isAdminEmail(state.authUser?.email) ? 'admin' : 'full',
         status: 'pending',
         maintenanceAccess: false,
         createdAt: serverTimestamp(),
@@ -169,7 +172,7 @@ async function ensureCurrentUser() {
       id: state.userId,
       username: '',
       avatarUrl: '',
-      role: 'full',
+      role: isAdminEmail(state.authUser?.email) ? 'admin' : 'full',
       status: 'pending',
       maintenanceAccess: false,
       lastNameChange: null,
@@ -179,6 +182,7 @@ async function ensureCurrentUser() {
 
   const data = snap.data() || {};
   return {
+    email: String(data.email || state.authUser?.email || ''),
     id: snap.id,
     username: normalizeUsername(data.username || data.name),
     role: normalizeRole(data.role),
@@ -191,12 +195,28 @@ async function ensureCurrentUser() {
 }
 
 async function getCurrentUserProfile() {
-  const snap = await getDoc(userDocRef());
+  if (!state.userId) {
+    return {
+      id: null,
+      username: '',
+      email: '',
+      role: 'lecture',
+      status: 'approved',
+      maintenanceAccess: false,
+      lastNameChange: null,
+      avatarUrl: '',
+      createdAt: null,
+      guest: true,
+    };
+  }
+  const ref = userDocRef();
+  const snap = await getDoc(ref);
   if (!snap.exists()) {
     return ensureCurrentUser();
   }
   const data = snap.data() || {};
   return {
+    email: String(data.email || state.authUser?.email || ''),
     id: snap.id,
     username: normalizeUsername(data.username || data.name),
     role: normalizeRole(data.role),
@@ -371,7 +391,7 @@ function subscribeCurrentUserProfile(onChange, onError) {
           onChange({
             id: state.userId,
             username: '',
-            role: 'full',
+            role: isAdminEmail(state.authUser?.email) ? 'admin' : 'full',
             status: 'pending',
             maintenanceAccess: false,
             lastNameChange: null,
@@ -681,9 +701,9 @@ async function init() {
   }
 
   state.initialized = true;
-  state.userId = await resolveUserId();
-  const app = initializeApp(FIREBASE_CONFIG);
-  state.db = getFirestore(app);
+  state.authUser = getCurrentAuthUser();
+  state.userId = state.authUser?.uid || null;
+  state.db = firebaseDb;
 
   const offlineState = parseOfflineState();
   if (offlineState?.snapshot) {
@@ -1219,7 +1239,7 @@ async function appendHistoryEntry(actionText) {
   }
   try {
     const profile = await getCurrentUserProfile();
-    const username = normalizeUsername(profile?.username) || 'Utilisateur inconnu';
+    const username = normalizeUsername(profile?.username) || normalizeUsername(state.authUser?.displayName) || 'Utilisateur inconnu';
     await addDoc(historyCollection(), {
       userId: profile?.id || state.userId || null,
       userName: username,
@@ -1466,4 +1486,5 @@ window.StorageService = {
   subscribeCurrentUserProfile,
   computeNextNameChangeDate,
   listHistoriques,
+  getAuthUser: () => clone(state.authUser),
 };

--- a/login.html
+++ b/login.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Connexion | Suivi Matériel</title>
+    <link rel="stylesheet" href="css/login.css" />
+  </head>
+  <body>
+    <main class="login-page">
+      <section class="login-card" aria-label="Connexion">
+        <header class="login-card__header">
+          <h1>Connexion</h1>
+          <p>Accédez à votre espace sécurisé.</p>
+        </header>
+
+        <form id="loginForm" class="login-form" novalidate>
+          <label class="field-group" for="loginEmail">
+            <span>Entrer votre mail</span>
+            <input id="loginEmail" type="email" autocomplete="email" required />
+            <small id="emailError" class="field-error" aria-live="polite"></small>
+          </label>
+
+          <label class="field-group" for="loginPassword">
+            <span>Mot de passe</span>
+            <div class="password-wrap">
+              <input id="loginPassword" type="password" autocomplete="current-password" required minlength="6" />
+              <button id="togglePasswordButton" class="password-toggle" type="button" aria-label="Afficher le mot de passe">
+                <img id="togglePasswordIcon" src="Icon/Eye_OFF.png" alt="Afficher/Cacher" />
+              </button>
+            </div>
+            <small id="passwordError" class="field-error" aria-live="polite"></small>
+          </label>
+
+          <button id="emailLoginButton" class="btn btn-primary" type="submit">
+            <span class="btn__label">Se connecter</span>
+            <span class="btn__loader" aria-hidden="true"></span>
+          </button>
+
+          <p class="login-separator">Ou</p>
+
+          <button id="googleLoginButton" class="btn btn-google" type="button">
+            <img src="Icon/btn_google.png" alt="Google" />
+            <span>Se connecter avec compte Google</span>
+          </button>
+
+          <p id="globalError" class="global-error" aria-live="polite"></p>
+        </form>
+      </section>
+    </main>
+
+    <script type="module" src="js/login.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a modern, responsive login page and Firebase Authentication (Email/Password + Google) for the app.  
- Integrate authentication without breaking existing Firestore-backed features and preserve current avatar/permissions behavior.  
- Support a lightweight guest (lecture) mode and automatically assign ADMIN role when email equals `Andrainaaina@gmail.com`.

### Description
- Added a dedicated login UI and assets with `login.html`, `css/login.css`, `js/login.js`, and a small `js/firebase-core.js` that centralizes Firebase App/Auth/Firestore exports.  
- Implemented Auth logic using `onAuthStateChanged`, `signInWithEmailAndPassword`, `signInWithPopup`, and `fetchSignInMethodsForEmail` with realtime field validation, password visibility toggle (`Icon/Eye_ON.png` / `Icon/Eye_OFF.png`), Google button (`Icon/btn_google.png`), loading state, and localStorage-based credential memo (auto-fill).  
- Integrated auth into the app by updating `js/app.js` to wait for auth state, expose a header `Se connecter` button when not authenticated, and route authenticated state into existing avatar rendering without changing existing avatar click behavior.  
- Adapted `js/storage.js` to consume the Firebase-authenticated user (`uid` as `state.userId` / `state.authUser`), include `email` in profiles, create a guest profile when not signed in (read-only permissions), and set `role: 'admin'` when the auth email matches `Andrainaaina@gmail.com`; updated `index.html` and `css/style.css` to surface the login button in the header.

### Testing
- Performed JavaScript syntax checks with `node --check js/app.js`, `node --check js/storage.js`, `node --check js/login.js`, and `node --check js/firebase-core.js`, and all checks passed.  
- Verified that new files `login.html`, `css/login.css`, `js/login.js`, and `js/firebase-core.js` are present and that existing pages still load (no runtime syntax errors detected by the static checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3a63ff084832a9b64622979b85996)