### PR TITLE
Improve Google account picker login UX on login page

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -1,9 +1,11 @@
 import {
   GoogleAuthProvider,
   fetchSignInMethodsForEmail,
+  getRedirectResult,
   onAuthStateChanged,
   signInWithEmailAndPassword,
   signInWithPopup,
+  signInWithRedirect,
 } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
 import { firebaseAuth } from './firebase-core.js';
 
@@ -41,10 +43,42 @@ onAuthStateChanged(firebaseAuth, (user) => {
   redirectToHome();
 });
 
+getRedirectResult(firebaseAuth).catch(() => {
+  globalError.textContent = 'Connexion Google indisponible.';
+});
+
 function setLoading(isLoading, sourceButton = emailLoginButton) {
   emailLoginButton.disabled = isLoading;
   googleLoginButton.disabled = isLoading;
   sourceButton?.classList.toggle('is-loading', isLoading);
+}
+
+function shouldUseRedirect() {
+  const touchDevice = window.matchMedia('(pointer: coarse)').matches;
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isMobileUserAgent = /android|iphone|ipad|ipod|mobile/.test(userAgent);
+  return touchDevice || isMobileUserAgent;
+}
+
+async function startGoogleSignIn() {
+  const provider = new GoogleAuthProvider();
+  provider.setCustomParameters({ prompt: 'select_account' });
+
+  if (shouldUseRedirect()) {
+    await signInWithRedirect(firebaseAuth, provider);
+    return;
+  }
+
+  try {
+    await signInWithPopup(firebaseAuth, provider);
+  } catch (error) {
+    const code = String(error?.code || '');
+    if (code.includes('popup-blocked') || code.includes('popup-closed-by-user') || code.includes('cancelled-popup-request')) {
+      await signInWithRedirect(firebaseAuth, provider);
+      return;
+    }
+    throw error;
+  }
 }
 
 function encodeMemo(email, password) {
@@ -177,8 +211,7 @@ googleLoginButton.addEventListener('click', async () => {
   globalError.textContent = '';
   setLoading(true, googleLoginButton);
   try {
-    const provider = new GoogleAuthProvider();
-    await signInWithPopup(firebaseAuth, provider);
+    await startGoogleSignIn();
   } catch (_error) {
     globalError.textContent = 'Connexion Google indisponible.';
   } finally {

--- a/login.html
+++ b/login.html
@@ -41,7 +41,8 @@
 
           <button id="googleLoginButton" class="btn btn-google" type="button">
             <img src="Icon/btn_google.png" alt="Google" />
-            <span>Se connecter avec compte Google</span>
+            <span class="btn__label">Se connecter avec compte Google</span>
+            <span class="btn__loader" aria-hidden="true"></span>
           </button>
 
           <p id="globalError" class="global-error" aria-live="polite"></p>


### PR DESCRIPTION
### Motivation
- Ensure the Google account picker is used for sign-in and that the app connects users with Firebase Auth (Google provider) and stores `uid`, `displayName`, `email`, and `photoURL` correctly. 
- Provide a reliable UX on both desktop and mobile by choosing the proper Firebase sign-in method and showing operation feedback to users. 

### Description
- Added a loading spinner markup to the Google button in `login.html` and unified button label/loader markup to match the email button. 
- Extended `js/login.js` to import `getRedirectResult` and `signInWithRedirect` and to call `getRedirectResult(...)` to surface redirect errors to the user. 
- Implemented `shouldUseRedirect()` to detect touch/mobile clients and `startGoogleSignIn()` which sets `prompt: 'select_account'`, uses `signInWithPopup` on desktop, falls back to `signInWithRedirect` for mobile or popup failures, and preserves existing `onAuthStateChanged` handling that stores user `uid`, `displayName`, `email`, and `photoURL`. 
- Kept the button disabling/loading behavior via `setLoading(...)` while authentication is in progress. 

### Testing
- Ran `node --check js/login.js` to verify the modified module has no syntax errors, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3abc0c120832aaa76b2d24e85d886)