### PR TITLE
Fix Google sign-in flow and Firebase error feedback on login page

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -44,8 +44,39 @@ onAuthStateChanged(firebaseAuth, (user) => {
   redirectToHome();
 });
 
-getRedirectResult(firebaseAuth).catch(() => {
-  globalError.textContent = 'Connexion Google indisponible.';
+function mapGoogleAuthError(error) {
+  const code = String(error?.code || '');
+  const message = String(error?.message || '');
+
+  console.log('CODE :', code || 'unknown');
+  console.log('MESSAGE :', message || 'Aucun message Firebase');
+
+  if (code.includes('auth/popup-blocked')) {
+    return 'La popup Google a été bloquée par le navigateur. Autorisez les popups puis réessayez.';
+  }
+  if (code.includes('auth/unauthorized-domain')) {
+    return `Domaine non autorisé dans Firebase : "${window.location.hostname}". Ajoutez ce domaine dans Authentication > Settings > Authorized domains.`;
+  }
+  if (code.includes('auth/operation-not-allowed')) {
+    return 'Google Auth n’est pas activé dans Firebase (Authentication > Sign-in method > Google).';
+  }
+  if (code.includes('auth/popup-closed-by-user')) {
+    return 'Connexion Google annulée : la popup a été fermée avant la validation.';
+  }
+  if (code.includes('auth/cancelled-popup-request')) {
+    return 'Une autre tentative de connexion popup est déjà en cours.';
+  }
+  if (code.includes('auth/network-request-failed')) {
+    return 'Connexion réseau impossible. Vérifiez Internet puis réessayez.';
+  }
+
+  return 'Connexion Google impossible pour le moment. Réessayez.';
+}
+
+getRedirectResult(firebaseAuth).catch((error) => {
+  globalError.textContent = mapGoogleAuthError(error);
+  isAuthInProgress = false;
+  setLoading(false, googleLoginButton);
 });
 
 function setLoading(isLoading, sourceButton = emailLoginButton) {
@@ -233,8 +264,8 @@ googleLoginButton.addEventListener('click', async () => {
     if (flow === 'redirect') {
       return;
     }
-  } catch (_error) {
-    globalError.textContent = 'Connexion Google indisponible.';
+  } catch (error) {
+    globalError.textContent = mapGoogleAuthError(error);
     isAuthInProgress = false;
     setLoading(false, googleLoginButton);
     return;


### PR DESCRIPTION
### Motivation
- Replace the generic "Connexion Google indisponible" message with actionable error feedback so users can diagnose Firebase setup issues.
- Surface Firebase `error.code` and `error.message` in logs to aid debugging.
- Ensure UI state (loader and disabled button) is properly reset when redirect-based sign-in fails.
- Keep using the official Firebase Google provider and the existing popup/redirect flow behavior.

### Description
- Add `mapGoogleAuthError(error)` to log `error.code`/`error.message` and map common Firebase auth errors to user-friendly strings for `auth/popup-blocked`, `auth/unauthorized-domain`, `auth/operation-not-allowed`, `auth/popup-closed-by-user`, `auth/cancelled-popup-request`, and `auth/network-request-failed`.
- Replace the generic error handling in `getRedirectResult(firebaseAuth).catch(...)` to use `mapGoogleAuthError` and reset `isAuthInProgress` and loading state via `setLoading(false, googleLoginButton)`.
- Replace the generic catch in the Google button click handler to use `mapGoogleAuthError` so popup and fallback-to-redirect errors produce specific messages.
- Preserve the existing `GoogleAuthProvider` usage and the popup vs redirect decision based on device detection in `startGoogleSignIn()`.

### Testing
- `node --check js/login.js` was run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b69a013c832a87d8f41a7696cec7)