### PR TITLE
Show Firebase Google auth error code and message during login debug

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -265,7 +265,9 @@ googleLoginButton.addEventListener('click', async () => {
       return;
     }
   } catch (error) {
-    globalError.textContent = mapGoogleAuthError(error);
+    console.log('🔥 Firebase Error Code :', error?.code);
+    console.log('🔥 Firebase Error Message :', error?.message);
+    alert('Erreur : ' + error?.code);
     isAuthInProgress = false;
     setLoading(false, googleLoginButton);
     return;


### PR DESCRIPTION
### Motivation
- Pendant le debug du login Google il fallait afficher l’erreur Firebase exacte au lieu d’un message générique pour diagnostiquer des problèmes comme `auth/popup-blocked` ou `auth/unauthorized-domain`.

### Description
- Remplacement dans `js/login.js` du `catch` du bouton Google pour écrire `console.log('🔥 Firebase Error Code :', error?.code)`, `console.log('🔥 Firebase Error Message :', error?.message)` et afficher une popup `alert('Erreur : ' + error?.code)` au lieu de `globalError.textContent = mapGoogleAuthError(error)`.

### Testing
- Aucune suite de tests automatisés n'a été exécutée pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b8bb1848832a98854a0488dfb6fd)