### PR TITLE
Corrige clé Firebase et fiabilise l'initialisation Auth

### DIFF
--- a/js/firebase-core.js
+++ b/js/firebase-core.js
@@ -1,9 +1,10 @@
 import { getApp, getApps, initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-app.js';
+import { getAnalytics, isSupported } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-analytics.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 
 const FIREBASE_CONFIG = {
-  apiKey: 'AIzaSyD6krHqIlaD7Jo-ERhNxEFuuenwjwHrho',
+  apiKey: 'AIzaSyD6krHqIlaD7Jo-ERhNxEFuuenwjwHrhro',
   authDomain: 'base-737bf.firebaseapp.com',
   projectId: 'base-737bf',
   storageBucket: 'base-737bf.firebasestorage.app',
@@ -15,5 +16,6 @@ const FIREBASE_CONFIG = {
 const firebaseApp = getApps().length ? getApp() : initializeApp(FIREBASE_CONFIG);
 const firebaseAuth = getAuth(firebaseApp);
 const firebaseDb = getFirestore(firebaseApp);
+const firebaseAnalyticsPromise = isSupported().then((supported) => (supported ? getAnalytics(firebaseApp) : null)).catch(() => null);
 
-export { firebaseApp, firebaseAuth, firebaseDb };
+export { firebaseApp, firebaseAuth, firebaseDb, firebaseAnalyticsPromise };

--- a/js/login.js
+++ b/js/login.js
@@ -25,6 +25,13 @@ const googleLoginButton = document.getElementById('googleLoginButton');
 let lastEmailCheckId = 0;
 let isAuthInProgress = false;
 
+function logAuthError(error) {
+  console.log('CODE:', error?.code || 'unknown');
+  console.log('MESSAGE:', error?.message || 'Aucun message Firebase');
+  alert(error?.code || 'auth/unknown');
+}
+
+
 function redirectToHome() {
   window.location.href = 'index.html';
 }
@@ -48,8 +55,8 @@ function mapGoogleAuthError(error) {
   const code = String(error?.code || '');
   const message = String(error?.message || '');
 
-  console.log('CODE :', code || 'unknown');
-  console.log('MESSAGE :', message || 'Aucun message Firebase');
+  console.log('CODE:', code || 'unknown');
+  console.log('MESSAGE:', message || 'Aucun message Firebase');
 
   if (code.includes('auth/popup-blocked')) {
     return 'La popup Google a été bloquée par le navigateur. Autorisez les popups puis réessayez.';
@@ -74,6 +81,7 @@ function mapGoogleAuthError(error) {
 }
 
 getRedirectResult(firebaseAuth).catch((error) => {
+  logAuthError(error);
   globalError.textContent = mapGoogleAuthError(error);
   isAuthInProgress = false;
   setLoading(false, googleLoginButton);
@@ -113,6 +121,7 @@ async function startGoogleSignIn() {
     await signInWithPopup(firebaseAuth, provider);
     return 'popup';
   } catch (error) {
+    logAuthError(error);
     const code = String(error?.code || '');
     if (code.includes('popup-blocked') || code.includes('popup-closed-by-user') || code.includes('cancelled-popup-request')) {
       await signInWithRedirect(firebaseAuth, provider);
@@ -181,7 +190,8 @@ async function validateEmailRealtime() {
       emailError.textContent = 'Email inexistant.';
       return false;
     }
-  } catch (_error) {
+  } catch (error) {
+    logAuthError(error);
     emailError.textContent = 'Vérification email indisponible.';
     return false;
   }
@@ -238,6 +248,7 @@ form.addEventListener('submit', async (event) => {
     await signInWithEmailAndPassword(firebaseAuth, emailInput.value.trim(), passwordInput.value);
     saveCredentials(emailInput.value.trim(), passwordInput.value);
   } catch (error) {
+    logAuthError(error);
     const code = String(error?.code || '');
     if (code.includes('wrong-password') || code.includes('invalid-credential')) {
       passwordError.textContent = 'Mot de passe incorrect.';
@@ -265,9 +276,8 @@ googleLoginButton.addEventListener('click', async () => {
       return;
     }
   } catch (error) {
-    console.log('🔥 Firebase Error Code :', error?.code);
-    console.log('🔥 Firebase Error Message :', error?.message);
-    alert('Erreur : ' + error?.code);
+    logAuthError(error);
+    globalError.textContent = mapGoogleAuthError(error);
     isAuthInProgress = false;
     setLoading(false, googleLoginButton);
     return;


### PR DESCRIPTION
### Motivation
- Corriger l'erreur `auth/api-key-not-valid` en s'assurant que la clé `apiKey` utilisée correspond exactement à la configuration fournie.
- Éviter les problèmes liés à une double initialisation Firebase en garantissant un point d'initialisation unique pour l'app.
- Améliorer le diagnostic des erreurs Auth/Google pour faciliter le debug des cas restants (domaines non autorisés, popups, etc.).

### Description
- Remplacement de la valeur `apiKey` dans `js/firebase-core.js` pour qu'elle corresponde exactement à la config fournie (`...wHrhro`).
- Import sécurisé de Firebase Analytics (`getAnalytics`, `isSupported`) et création de `firebaseAnalyticsPromise` initialisé conditionnellement, puis exporté avec les autres exports existants (`firebaseApp`, `firebaseAuth`, `firebaseDb`).
- Maintien d'une initialisation unique via `getApps().length ? getApp() : initializeApp(FIREBASE_CONFIG)` et conservation de `getAuth(firebaseApp)` et `getFirestore(firebaseApp)`.
- Ajout d'une fonction réutilisable `logAuthError(error)` dans `js/login.js` pour centraliser le logging (`error.code`, `error.message`) et afficher le code d'erreur (`alert`) dans les `catch` critiques, et remplacement des logs ponctuels par cette fonction.

### Testing
- Vérification qu'il n'existe qu'une seule configuration/initialisation avec `rg` (recherche `apiKey`, `initializeApp`, `getApps`) qui a montré un seul fichier `js/firebase-core.js` contenant la config, réussir.
- Vérification de la syntaxe JS des fichiers modifiés avec `node --check js/firebase-core.js && node --check js/login.js`, qui a réussi.
- Validation minimaliste par contrôle de statut (`git status --short`) et commit des fichiers modifiés, opération réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c0d7f2ec832aa9132dc0d47c484a)