### PR TITLE
Fix Google redirect flow on login page

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -80,12 +80,18 @@ function mapGoogleAuthError(error) {
   return 'Connexion Google impossible pour le moment. Réessayez.';
 }
 
-getRedirectResult(firebaseAuth).catch((error) => {
-  logAuthError(error);
-  globalError.textContent = mapGoogleAuthError(error);
-  isAuthInProgress = false;
-  setLoading(false, googleLoginButton);
-});
+getRedirectResult(firebaseAuth)
+  .then((result) => {
+    if (result?.user) {
+      redirectToHome();
+    }
+  })
+  .catch((error) => {
+    logAuthError(error);
+    globalError.textContent = mapGoogleAuthError(error);
+    isAuthInProgress = false;
+    setLoading(false, googleLoginButton);
+  });
 
 function setLoading(isLoading, sourceButton = emailLoginButton) {
   emailLoginButton.disabled = isLoading;


### PR DESCRIPTION
### Motivation

- Corriger le flux de redirection pour `signInWithRedirect` afin d’éviter que l’utilisateur mobile reste bloqué sur `login.html` après sélection d’un compte Google.
- Assurer une redirection automatique vers `index.html` tout en conservant la compatibilité desktop (popup) et la logique existante de gestion d’état.

### Description

- Ajout d’un `.then` sur `getRedirectResult(firebaseAuth)` qui appelle `redirectToHome()` si `result?.user` est présent.
- Conserve la redirection déjà en place via `onAuthStateChanged(firebaseAuth, ...)` et le stockage local du `authUser`.
- Préserve la gestion d’erreur et le reset de l’état/loading dans le `catch` de `getRedirectResult` pour ne pas casser le login existant.

### Testing

- Exécution de la vérification syntaxique `node --check js/login.js`, qui a réussi. 
- Aucun test automatisé supplémentaire n’a été ajouté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ccf1f4e0832aabc3783b0e3edc56)