### PR TITLE
Corrige redirection Google Auth Android sur login

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -33,7 +33,7 @@ function logAuthError(error) {
 
 
 function redirectToHome() {
-  window.location.href = 'index.html';
+  window.location.replace('index.html');
 }
 
 onAuthStateChanged(firebaseAuth, (user) => {
@@ -41,6 +41,7 @@ onAuthStateChanged(firebaseAuth, (user) => {
     return;
   }
 
+  // utilisateur déjà connecté
   const authPayload = {
     uid: user.uid || '',
     displayName: user.displayName || '',


### PR DESCRIPTION
### Motivation
- Sur Android l'utilisation de `signInWithRedirect` recharge la page et l'utilisateur reste sur `login.html` au lieu d'être envoyé vers `index.html`.
- Il faut empêcher que le bouton "retour" ramène vers `login.html` après authentification.

### Description
- Remplacement de la navigation post-login par `window.location.replace('index.html')` via la fonction `redirectToHome()` pour bloquer le retour arrière.
- Conservation du listener `onAuthStateChanged(firebaseAuth, ...)` pour détecter immédiatement un utilisateur déjà connecté et le rediriger au chargement de `login.html`.
- Conservation du traitement `getRedirectResult(firebaseAuth)` pour gérer le résultat du `signInWithRedirect` et rediriger quand `result.user` est présent.
- Changements effectués dans `js/login.js` (1 suppression, 2 insertions mineures et un commentaire explicatif ajouté).

### Testing
- Exécution de `node --check js/login.js` pour vérifier la validité syntaxique du module JavaScript, résultat : succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d28ab104832ab428930407e7eb22)