### PR TITLE
Fix Android Google login redirect by handling auth state immediately

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -9,6 +9,40 @@ import {
 } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
 import { firebaseAuth } from './firebase-core.js';
 
+console.log('LOGIN PAGE LOADED');
+
+onAuthStateChanged(firebaseAuth, (user) => {
+  if (user) {
+    console.log('Utilisateur détecté après redirect');
+    const authPayload = {
+      uid: user.uid || '',
+      displayName: user.displayName || '',
+      email: user.email || '',
+      photoURL: user.photoURL || '',
+    };
+    localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
+    window.location.replace('index.html');
+  }
+});
+
+getRedirectResult(firebaseAuth)
+  .then((result) => {
+    if (result && result.user) {
+      console.log('Redirect result OK');
+      const authPayload = {
+        uid: result.user.uid || '',
+        displayName: result.user.displayName || '',
+        email: result.user.email || '',
+        photoURL: result.user.photoURL || '',
+      };
+      localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
+      window.location.replace('index.html');
+    }
+  })
+  .catch((error) => {
+    console.log('Erreur redirect:', error);
+  });
+
 const STORAGE_KEY = 'suiviMateriel.loginMemo.v1';
 
 const form = document.getElementById('loginForm');
@@ -35,22 +69,6 @@ function logAuthError(error) {
 function redirectToHome() {
   window.location.replace('index.html');
 }
-
-onAuthStateChanged(firebaseAuth, (user) => {
-  if (!user) {
-    return;
-  }
-
-  // utilisateur déjà connecté
-  const authPayload = {
-    uid: user.uid || '',
-    displayName: user.displayName || '',
-    email: user.email || '',
-    photoURL: user.photoURL || '',
-  };
-  localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
-  redirectToHome();
-});
 
 function mapGoogleAuthError(error) {
   const code = String(error?.code || '');
@@ -80,19 +98,6 @@ function mapGoogleAuthError(error) {
 
   return 'Connexion Google impossible pour le moment. Réessayez.';
 }
-
-getRedirectResult(firebaseAuth)
-  .then((result) => {
-    if (result?.user) {
-      redirectToHome();
-    }
-  })
-  .catch((error) => {
-    logAuthError(error);
-    globalError.textContent = mapGoogleAuthError(error);
-    isAuthInProgress = false;
-    setLoading(false, googleLoginButton);
-  });
 
 function setLoading(isLoading, sourceButton = emailLoginButton) {
   emailLoginButton.disabled = isLoading;


### PR DESCRIPTION
### Motivation

- On Android, after selecting a Google account the app returned to `login.html` but did not redirect to `index.html`, leaving the user stuck.  
- The redirect recovery must run before any UI listeners or button initialization to avoid being blocked or delayed by other code.  
- A lightweight startup check and fallback are required to reliably detect the signed-in user and persist the auth payload before redirecting.

### Description

- Add an immediate startup log `console.log('LOGIN PAGE LOADED')` at the top of `js/login.js` to verify the script is executed after the Google redirect.  
- Register `onAuthStateChanged(firebaseAuth, ...)` at module load to detect an existing user, persist `suiviMateriel.authUser.v1` to `localStorage`, log detection, and call `window.location.replace('index.html')`.  
- Call `getRedirectResult(firebaseAuth)` as a startup fallback to detect redirect sign-in results, persist the same `authUser` payload, log success or error, and redirect to `index.html`.  
- Remove the later duplicate `onAuthStateChanged`/`getRedirectResult` handlers to prevent delayed or competing flows after redirect.

### Testing

- Ran `git diff --check` to ensure no trivial whitespace or diff issues and it succeeded.  
- Verified repository status with `git status --short` to confirm only the intended `js/login.js` change was staged and present.  
- Confirmed `login.html` loads the module via `<script type="module" src="js/login.js"></script>` so the new startup handlers will execute on page load.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d5d4832c832abbc2fdddf472381b)