### PR TITLE
Force redirect to index.html after mobile Google sign-in

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -10,6 +10,16 @@ import {
 import { firebaseAuth } from './firebase-core.js';
 
 console.log('LOGIN PAGE LOADED');
+const GOOGLE_LOGIN_STORAGE_KEY = 'googleLogin';
+
+if (sessionStorage.getItem(GOOGLE_LOGIN_STORAGE_KEY) === 'true') {
+  onAuthStateChanged(firebaseAuth, (user) => {
+    if (user) {
+      sessionStorage.removeItem(GOOGLE_LOGIN_STORAGE_KEY);
+      window.location.replace('index.html');
+    }
+  });
+}
 
 onAuthStateChanged(firebaseAuth, (user) => {
   if (user) {
@@ -28,6 +38,7 @@ onAuthStateChanged(firebaseAuth, (user) => {
 getRedirectResult(firebaseAuth)
   .then((result) => {
     if (result && result.user) {
+      sessionStorage.removeItem(GOOGLE_LOGIN_STORAGE_KEY);
       console.log('Redirect result OK');
       const authPayload = {
         uid: result.user.uid || '',
@@ -279,6 +290,7 @@ googleLoginButton.addEventListener('click', async () => {
     return;
   }
 
+  sessionStorage.setItem(GOOGLE_LOGIN_STORAGE_KEY, 'true');
   isAuthInProgress = true;
   globalError.textContent = '';
   setLoading(true, googleLoginButton);


### PR DESCRIPTION
### Motivation

- Mobile Google redirect sign-in can return to the login page before the Firebase auth state is available, which can prevent automatic navigation to the app home.

### Description

- Add a `GOOGLE_LOGIN_STORAGE_KEY` constant and set `sessionStorage.setItem('googleLogin','true')` when the Google button is clicked to mark an in-progress redirect flow.
- Add an early guarded `onAuthStateChanged` listener that checks the `googleLogin` marker and calls `window.location.replace('index.html')` once the user is restored.
- Remove the `googleLogin` marker in the `getRedirectResult` success path before redirecting to avoid stale state.
- Preserve existing popup-based desktop behavior and only augment the redirect flow for mobile.

### Testing

- Ran `node --check js/login.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45657fb08832aaa398aec3f194990)