### PR TITLE
Fix Google auth redirect flow on Android login

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -1,8 +1,10 @@
 import {
   GoogleAuthProvider,
+  browserLocalPersistence,
   fetchSignInMethodsForEmail,
   getRedirectResult,
   onAuthStateChanged,
+  setPersistence,
   signInWithEmailAndPassword,
   signInWithPopup,
   signInWithRedirect,
@@ -10,48 +12,43 @@ import {
 import { firebaseAuth } from './firebase-core.js';
 
 console.log('LOGIN PAGE LOADED');
-const GOOGLE_LOGIN_STORAGE_KEY = 'googleLogin';
+console.log('Auth initialized');
 
-if (sessionStorage.getItem(GOOGLE_LOGIN_STORAGE_KEY) === 'true') {
-  onAuthStateChanged(firebaseAuth, (user) => {
-    if (user) {
-      sessionStorage.removeItem(GOOGLE_LOGIN_STORAGE_KEY);
-      window.location.replace('index.html');
-    }
-  });
-}
+const authReadyPromise = setPersistence(firebaseAuth, browserLocalPersistence)
+  .then(() => {
+    onAuthStateChanged(firebaseAuth, (user) => {
+      console.log('Auth state changed:', user ? user.email : 'no user');
+      if (user) {
+        const authPayload = {
+          uid: user.uid || '',
+          displayName: user.displayName || '',
+          email: user.email || '',
+          photoURL: user.photoURL || '',
+        };
+        localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
+        window.location.replace('index.html');
+      }
+    });
 
-onAuthStateChanged(firebaseAuth, (user) => {
-  if (user) {
-    console.log('Utilisateur détecté après redirect');
-    const authPayload = {
-      uid: user.uid || '',
-      displayName: user.displayName || '',
-      email: user.email || '',
-      photoURL: user.photoURL || '',
-    };
-    localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
-    window.location.replace('index.html');
-  }
-});
-
-getRedirectResult(firebaseAuth)
-  .then((result) => {
-    if (result && result.user) {
-      sessionStorage.removeItem(GOOGLE_LOGIN_STORAGE_KEY);
-      console.log('Redirect result OK');
-      const authPayload = {
-        uid: result.user.uid || '',
-        displayName: result.user.displayName || '',
-        email: result.user.email || '',
-        photoURL: result.user.photoURL || '',
-      };
-      localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
-      window.location.replace('index.html');
-    }
+    getRedirectResult(firebaseAuth)
+      .then((result) => {
+        if (result && result.user) {
+          const authPayload = {
+            uid: result.user.uid || '',
+            displayName: result.user.displayName || '',
+            email: result.user.email || '',
+            photoURL: result.user.photoURL || '',
+          };
+          localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
+          window.location.replace('index.html');
+        }
+      })
+      .catch((error) => {
+        console.log('Redirect error:', error.code, error.message);
+      });
   })
   .catch((error) => {
-    console.log('Erreur redirect:', error);
+    console.log('Persistence error:', error.code, error.message);
   });
 
 const STORAGE_KEY = 'suiviMateriel.loginMemo.v1';
@@ -132,6 +129,7 @@ function isMobileDevice() {
 }
 
 async function startGoogleSignIn() {
+  await authReadyPromise;
   const provider = new GoogleAuthProvider();
   provider.setCustomParameters({ prompt: 'select_account' });
 
@@ -268,6 +266,7 @@ form.addEventListener('submit', async (event) => {
 
   setLoading(true, emailLoginButton);
   try {
+    await authReadyPromise;
     await signInWithEmailAndPassword(firebaseAuth, emailInput.value.trim(), passwordInput.value);
     saveCredentials(emailInput.value.trim(), passwordInput.value);
   } catch (error) {
@@ -290,7 +289,6 @@ googleLoginButton.addEventListener('click', async () => {
     return;
   }
 
-  sessionStorage.setItem(GOOGLE_LOGIN_STORAGE_KEY, 'true');
   isAuthInProgress = true;
   globalError.textContent = '';
   setLoading(true, googleLoginButton);


### PR DESCRIPTION
### Motivation
- Corriger la perte d’état après `signInWithRedirect` sur mobile en supprimant la dépendance à `sessionStorage` qui empêchait la redirection automatique vers `index.html` sur Android.
- Rendre la persistance d’authentification fiable en forçant `browserLocalPersistence` avant toute tentative de connexion pour conserver l’état entre redirections.

### Description
- Supprimé le flag et la logique conditionnée par `sessionStorage` dans `js/login.js` afin d’éliminer la dépendance non fiable sur mobile.
- Ajouté l’appel à `setPersistence(firebaseAuth, browserLocalPersistence)` et exposé un `authReadyPromise` pour garantir que la persistance est initialisée avant toute tentative de login.
- Initialisé de manière non conditionnelle `onAuthStateChanged(...)` et exécuté `getRedirectResult(...)` immédiatement après l’initialisation de la persistance, avec logs de debug (`LOGIN PAGE LOADED`, `Auth initialized`, `Auth state changed: ...`, et `Redirect error: ...`).
- Attendu `authReadyPromise` avant `signInWithEmailAndPassword(...)` et avant le démarrage du flux Google (`startGoogleSignIn`) et retiré l’écriture du flag `sessionStorage` au clic sur le bouton Google, en conservant `signInWithRedirect` sur mobile et `signInWithPopup` sur desktop.

### Testing
- Vérification par recherche de motifs que `sessionStorage`/`googleLogin` ont été retirés et que `setPersistence` / `Auth state changed` logs sont présents via `rg -n ...` (succès).
- Application du patch avec l’outil de modification (`apply_patch`) qui a retourné `Success` (succès).
- Contrôle d’état git via `git status --short` et commit via `git commit` pour valider l’édition du fichier `js/login.js` (succès).
- Aucun test automatisé d’intégration ou E2E sur CI n’a été exécuté durant cette PR; les validations ci‑dessus sont des vérifications automatisées locales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45931aab4832ab73b255032f75d78)