### PR TITLE
Detect in-app browsers and show Chrome warning on login page

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -29,6 +29,20 @@ function isMobileDevice() {
   return isMobileUserAgent || (touchDevice && smallViewport);
 }
 
+function isInAppBrowser() {
+  return /FBAN|FBAV|Instagram|Messenger|WhatsApp/i.test(navigator.userAgent);
+}
+
+function showInAppBrowserWarning() {
+  if (!isInAppBrowser()) {
+    return;
+  }
+
+  alert('Veuillez ouvrir ce site dans Google Chrome pour vous connecter avec Google.');
+}
+
+showInAppBrowserWarning();
+
 function debugStep(message, { withAlert = false } = {}) {
   const details = `[${new Date().toISOString()}] ${message} | device=${isMobileDevice() ? 'mobile' : 'desktop'}`;
   console.log(details);


### PR DESCRIPTION
### Motivation
- Prevent Google authentication failures caused by embedded in-app browsers (Facebook, Instagram, Messenger, WhatsApp) on mobile by proactively warning users to open the site in Chrome.

### Description
- Added `isInAppBrowser()` in `js/login.js` that checks `navigator.userAgent` for `FBAN|FBAV|Instagram|Messenger|WhatsApp` signatures.
- Added `showInAppBrowserWarning()` which displays an alert prompting users to open the site in Google Chrome when an in-app browser is detected.
- Invoked `showInAppBrowserWarning()` on page load so affected users see guidance before attempting Google sign-in.
- Modified file: `js/login.js` (added ~14 lines).

### Testing
- Inspected the modified file with `git diff -- js/login.js` and reviewed the relevant lines with `nl -ba js/login.js | sed -n '20,70p'` which showed the new functions and the call on load (success).
- Verified repository status with `git status --short` and committed the change (success).
- No automated test suite is configured for this UI behavior, so no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e46099a9c8832aa9508ef7929589ea)