### PR TITLE
Page d'accueil : affichage exclusif avatar/bouton et mode écriture pour utilisateurs non-admin

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2095,6 +2095,23 @@ import { firebaseAuth } from './firebase-core.js';
       UiService.renderEmptyState(historyList, "Impossible de charger l'historique.");
     }
   }
+  function resolveConnectedProfile(profile, isAuthenticated) {
+    const nextProfile = { ...(profile || {}) };
+    const email = String(nextProfile?.email || '').trim().toLowerCase();
+
+    if (!isAuthenticated) {
+      return { role: 'lecture' };
+    }
+
+    if (email === 'andrainaaina@gmail.com') {
+      nextProfile.role = 'admin';
+      return nextProfile;
+    }
+
+    nextProfile.role = 'ecriture';
+    return nextProfile;
+  }
+
   async function bootstrap() {
     UiService.bindDialogCloser();
     setupBackButtons();
@@ -2110,11 +2127,9 @@ import { firebaseAuth } from './firebase-core.js';
       profile = await StorageService.getCurrentUserProfile();
     }
 
-    if (isAuthenticated && String(profile?.email || '').trim().toLowerCase() === 'andrainaaina@gmail.com') {
-      profile.role = 'admin';
-    }
+    profile = resolveConnectedProfile(profile, isAuthenticated);
 
-    const permissions = buildPermissions(isAuthenticated ? profile : { role: 'lecture' });
+    const permissions = buildPermissions(profile);
 
     if (isAuthenticated) {
       profile = await initApprovalGate(profile, permissions);


### PR DESCRIPTION
### Motivation
- Assurer que sur la page 1 il n’y ait jamais à la fois l’avatar et le bouton « Se connecter », et préserver le comportement existant du clic sur l’avatar.
- Garantir que tout utilisateur connecté dont l’email n’est pas `Andrainaaina@gmail.com` obtienne le mode écriture au lieu d’un accès en lecture seule.
- Conserver intacte la logique Admin existante pour l’adresse `Andrainaaina@gmail.com`.

### Description
- Ajout de la fonction `resolveConnectedProfile(profile, isAuthenticated)` dans `js/app.js` pour centraliser la résolution du rôle selon l’état Firebase Auth.
- La fonction retourne `role: 'lecture'` si non connecté, force `role: 'admin'` si l’email est `andrainaaina@gmail.com`, et assigne `role: 'ecriture'` pour tout autre utilisateur connecté.
- Intégration de `resolveConnectedProfile` dans le `bootstrap` avant l’appel à `buildPermissions`, de sorte que les permissions et comportements de la page (y compris la page home) utilisent le rôle calculé.
- Aucune modification de la logique d’affichage côté UI n’a été faite au-delà de conserver l’affichage exclusif : utilisateur connecté → avatar visible et bouton « Se connecter » masqué ; non connecté → avatar masqué et bouton « Se connecter » visible qui navigue vers `login.html`.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` (succès).
- Aucun test automatisé supplémentaire disponible dans l’environnement courant; les modifications sont limitées à `js/app.js` et conservent les flux existants (`initApprovalGate`, `initHomePage`, etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e46a3838e8832a958d8ead59f6e4c4)