### PR TITLE
Fix: visibilité exclusive avatar / bouton "Se connecter" sur la page d'accueil

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -288,21 +288,35 @@ import { firebaseAuth } from './firebase-core.js';
     const userData = getAuthUserData(authUser);
     const isAuthenticated = Boolean(userData);
 
+    setHomeAccessControlVisibility({ showAvatar: false, showLoginButton: false });
+
     if (isAuthenticated) {
-      if (loginButton) {
-        loginButton.hidden = true;
-      }
+      setHomeAccessControlVisibility({ showAvatar: true, showLoginButton: false });
       renderAvatar(userData, onAvatarClick);
       return;
     }
 
     if (avatarButton) {
-      avatarButton.hidden = true;
       avatarButton.onclick = null;
     }
     if (loginButton) {
-      loginButton.hidden = false;
+      setHomeAccessControlVisibility({ showAvatar: false, showLoginButton: true });
       loginButton.onclick = () => UiService.navigate('login.html');
+    }
+  }
+
+  function setHomeAccessControlVisibility({ showAvatar, showLoginButton }) {
+    const avatarButton = document.getElementById('userAvatarButton');
+    const loginButton = document.getElementById('openLoginButton');
+
+    if (avatarButton) {
+      avatarButton.hidden = !showAvatar;
+      avatarButton.style.display = showAvatar ? 'inline-flex' : 'none';
+    }
+
+    if (loginButton) {
+      loginButton.hidden = !showLoginButton;
+      loginButton.style.display = showLoginButton ? 'inline-flex' : 'none';
     }
   }
 
@@ -673,7 +687,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
     renderAvatarVisual(avatarButton, authUserData);
     avatarButton.title = authUserData?.name || authUserData?.email || '';
-    avatarButton.hidden = false;
+    setHomeAccessControlVisibility({ showAvatar: true, showLoginButton: false });
     avatarButton.onclick = onClick;
   }
 


### PR DESCRIPTION
### Motivation
- Le header pouvait afficher simultanément l'avatar (`#userAvatarButton`) et le bouton « Se connecter » (`#openLoginButton`), ce qui est incorrect.
- Il faut un état initial neutre au chargement pour éviter que les deux éléments soient visibles avant la résolution de l'authentification.
- Le masquage doit être réel (pas seulement changement de contenu) en utilisant `hidden` et `display: none` pour garantir l'exclusivité.

### Description
- Ajout de la fonction `setHomeAccessControlVisibility({ showAvatar, showLoginButton })` dans `js/app.js` qui applique à la fois `hidden` et `style.display` (`'none'` / `'inline-flex'`).
- `renderHomeAccessControls` initialise maintenant un état neutre (les deux masqués) puis n'affiche que l'élément attendu selon l'état d'authentification.
- `renderAvatar` utilise la même fonction helper pour réactiver l'avatar et masquer le bouton de login, empêchant d'autres chemins de code de réafficher les deux.

### Testing
- Exécution de `node --check js/app.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e46cd4c4ec832ab1f5da080ec8e1db)