### PR TITLE
Fix avatar fallback and remove "??" placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <body data-page="home">
     <div class="app-shell">
       <header class="app-header app-header--home">
-        <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>??</button>
+        <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>U</button>
         <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
         <h1>Suivi Matériel</h1>
         <div class="header-menu">

--- a/js/app.js
+++ b/js/app.js
@@ -652,21 +652,22 @@ import { firebaseAuth } from './firebase-core.js';
   }
 
   function getInitialsFromName(name) {
-    const parts = String(name || '')
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean);
-    if (!parts.length) {
-      return '??';
-    }
-    if (parts.length === 1) {
-      return parts[0].slice(0, 2).toUpperCase();
-    }
-    return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+    const sanitizedName = String(name || '')
+      .replace(/[^a-zA-Z0-9 ]/g, '')
+      .trim();
+    const initials = sanitizedName.substring(0, 2).toUpperCase();
+    return initials || 'U';
+  }
+
+  function getAvatarFallback(user) {
+    const displayName = String(user?.displayName || user?.name || '').trim();
+    const emailName = String(user?.email || '').split('@')[0].trim();
+    const source = displayName || emailName || 'U';
+    return getInitialsFromName(source);
   }
 
   function getAvatarInitials(authUserData) {
-    return getInitialsFromName(authUserData?.name);
+    return getAvatarFallback(authUserData);
   }
 
   function renderAvatarVisual(container, authUserData) {
@@ -706,7 +707,7 @@ import { firebaseAuth } from './firebase-core.js';
         <div class="bottom-sheet__handle" aria-hidden="true"></div>
         <div class="bottom-sheet__content">
           <div class="bottom-sheet__avatar-wrap">
-            <div class="bottom-sheet__avatar" id="avatarSheetPreview">??</div>
+            <div class="bottom-sheet__avatar" id="avatarSheetPreview">U</div>
           </div>
           <p class="bottom-sheet__name" id="avatarSheetName">Utilisateur</p>
           <button type="button" class="bottom-sheet__action" id="avatarSheetLogout">Déconnexion</button>


### PR DESCRIPTION
### Motivation
- The home page avatar showed `??` after Firebase login instead of the Google `photoURL` or meaningful initials.
- The intended behavior is to prefer the profile photo when `photoURL` exists and otherwise show two uppercase initials derived from `displayName` or the email local-part.
- The change ensures a safe default of `U` and prevents the `??` placeholder from being displayed.

### Description
- Added `getAvatarFallback(user)` to derive initials with priority for `displayName`, then the email local-part, and fallback to `U` when no data is available. 
- Replaced old initials logic with `getInitialsFromName(name)` that sanitizes input, takes the first two significant characters, and returns `'U'` when empty. 
- Updated `getAvatarInitials` and `renderAvatarVisual` to use the new fallback while preserving the `photoURL` image preference (`<img>` when `photo` is present). 
- Replaced hardcoded `??` placeholders in the home avatar button (`index.html`) and bottom-sheet preview with `U` so they never show `??` by default.

### Testing
- Ran `git diff --check` to validate diffs and formatting and it completed without reported issues. 
- Searched the codebase with `rg` to verify no remaining `??` placeholders exist in the page 1 avatar flow and confirmed updated symbols are present. 
- Verified the avatar rendering functions (`getAvatarFallback`, `getInitialsFromName`, `renderAvatarVisual`) are used in the home rendering path and bottom sheet rendering via static analysis of `js/app.js` and `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e46f5b4cd4832ab965f846309f39a1)