### PR TITLE
Fix header avatar to share photo/fallback logic with bottom sheet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1483,11 +1483,14 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   padding: 0;
 }
 
-.avatar-image {
+.avatar-image,
+.header-avatar-img,
+.sheet-avatar-img {
   width: 100%;
   height: 100%;
-  border-radius: inherit;
   object-fit: cover;
+  border-radius: 50%;
+  display: block;
 }
 
 .avatar-initials {

--- a/js/app.js
+++ b/js/app.js
@@ -268,23 +268,28 @@ import { firebaseAuth } from './firebase-core.js';
     });
   }
 
-  function getAuthUserData(user) {
+  function normalizeAuthUserData(user) {
     const authUser = user || firebaseAuth.currentUser;
     if (!authUser) {
       return null;
     }
+    const photoUrl = String(authUser.photoURL || authUser.photo || '').trim();
+    const displayName = String(authUser.displayName || authUser.name || '').trim();
+    const email = String(authUser.email || '').trim();
     return {
       uid: authUser.uid || '',
-      name: authUser.displayName || '',
-      email: authUser.email || '',
-      photo: authUser.photoURL || '',
+      name: displayName,
+      displayName,
+      email,
+      photoURL: photoUrl,
+      photo: photoUrl,
     };
   }
 
   function renderHomeAccessControls({ authUser, onAvatarClick }) {
     const avatarButton = document.getElementById('userAvatarButton');
     const loginButton = document.getElementById('openLoginButton');
-    const userData = getAuthUserData(authUser);
+    const userData = normalizeAuthUserData(authUser);
     const isAuthenticated = Boolean(userData);
 
     setHomeAccessControlVisibility({ showAvatar: false, showLoginButton: false });
@@ -502,19 +507,35 @@ import { firebaseAuth } from './firebase-core.js';
     return getInitialsFromName(source);
   }
 
-  function getAvatarInitials(authUserData) {
-    return getAvatarFallback(authUserData);
-  }
-
-  function renderAvatarVisual(container, authUserData) {
+  function renderAvatarVisual(container, { photo, initials, imageClass, altText }) {
     if (!container) {
       return;
     }
-    const avatarUrl = String(authUserData?.photo || '').trim();
-    const initials = getAvatarInitials(authUserData);
-    container.innerHTML = avatarUrl
-      ? `<img src="${escapeHtml(avatarUrl)}" alt="Photo de profil" class="avatar-image" />`
+    container.innerHTML = photo
+      ? `<img src="${escapeHtml(photo)}" alt="${escapeHtml(altText)}" class="${imageClass}" />`
       : `<span class="avatar-initials">${escapeHtml(initials)}</span>`;
+  }
+
+  function renderUserAvatar(user) {
+    const normalizedUser = normalizeAuthUserData(user);
+    const photo = String(normalizedUser?.photoURL || '').trim();
+    const initials = getAvatarFallback(normalizedUser);
+    const headerAvatarElement = document.getElementById('userAvatarButton');
+    const bottomSheetAvatarElement = document.getElementById('avatarSheetPreview');
+
+    renderAvatarVisual(headerAvatarElement, {
+      photo,
+      initials,
+      imageClass: 'header-avatar-img',
+      altText: 'Avatar',
+    });
+
+    renderAvatarVisual(bottomSheetAvatarElement, {
+      photo,
+      initials,
+      imageClass: 'sheet-avatar-img',
+      altText: 'Avatar',
+    });
   }
 
   function renderAvatar(authUserData, onClick) {
@@ -522,7 +543,7 @@ import { firebaseAuth } from './firebase-core.js';
     if (!avatarButton) {
       return;
     }
-    renderAvatarVisual(avatarButton, authUserData);
+    renderUserAvatar(authUserData);
     avatarButton.title = authUserData?.name || authUserData?.email || '';
     setHomeAccessControlVisibility({ showAvatar: true, showLoginButton: false });
     avatarButton.onclick = onClick;
@@ -568,7 +589,7 @@ import { firebaseAuth } from './firebase-core.js';
       return;
     }
 
-    renderAvatarVisual(avatarPreview, authUserData);
+    renderUserAvatar(authUserData);
     nameLabel.textContent = String(authUserData?.name || authUserData?.email || 'Utilisateur');
     avatarPreview.title = authUserData?.name || authUserData?.email || '';
     message.textContent = '';
@@ -874,7 +895,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     const syncHomeAuthControls = (authUser) => {
-      const authUserData = getAuthUserData(authUser);
+      const authUserData = normalizeAuthUserData(authUser);
       renderHomeAccessControls({
         authUser: authUserData,
         onAvatarClick: () => openAvatarBottomSheet(authUserData),
@@ -883,6 +904,7 @@ import { firebaseAuth } from './firebase-core.js';
 
     syncHomeAuthControls(authState?.authUser || null);
     onAuthStateChanged(firebaseAuth, (user) => {
+      renderUserAvatar(user || null);
       syncHomeAuthControls(user || null);
     });
 


### PR DESCRIPTION
### Motivation
- The header avatar rendered a different user object path than the bottom sheet which could lose `photoURL` and show initials instead of the photo. The goal is to unify avatar source and fallback behavior so both places show the same photo or the same 2-letter fallback.

### Description
- Added `normalizeAuthUserData(user)` in `js/app.js` to normalize both Firebase user objects and pre-normalized objects to consistent `photoURL`, `photo`, `name`, `displayName`, and `email` fields.
- Introduced a centralized `renderUserAvatar(user)` that updates both the header (`#userAvatarButton`) and bottom-sheet (`#avatarSheetPreview`) avatars using the same logic: use `photoURL` when present, otherwise render the 2-letter fallback (name or email prefix).
- Reworked `renderAvatarVisual` to accept a parameter object (`{ photo, initials, imageClass, altText }`) and updated all avatar render sites (header, bottom sheet, auth state sync) to call the centralized renderer so there is a single source of truth.
- Updated auth sync to call `renderUserAvatar` on each `onAuthStateChanged` before other access-control rendering, preventing race/double-normalization issues.
- Added shared CSS classes in `css/style.css` (`.header-avatar-img`, `.sheet-avatar-img`) to ensure circular crop and proper cover fit (`object-fit: cover`, `border-radius: 50%`, `display: block`).

### Testing
- Ran `node --check js/app.js` to verify syntax and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ab06f504832a8199b2ef2f1159c3)