### PR TITLE
Style premium mobile-first pour le bottom sheet de profil

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1509,18 +1509,18 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  transition: background 0.25s ease;
+  transition: background 0.3s ease;
   pointer-events: none;
 }
 
 .bottom-sheet {
   width: min(100%, 32rem);
-  background: var(--surface);
-  border-radius: 1.25rem 1.25rem 0 0;
-  box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.16);
+  background: #ffffff;
+  border-radius: 20px 20px 0 0;
+  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.1);
   transform: translateY(100%);
-  transition: transform 0.28s ease;
-  padding: 0.75rem 1.25rem calc(1.25rem + env(safe-area-inset-bottom));
+  transition: transform 0.3s ease;
+  padding: 1.25rem 1.25rem calc(1.25rem + env(safe-area-inset-bottom));
 }
 
 .bottom-sheet-overlay.is-open {
@@ -1533,22 +1533,24 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
 }
 
 .bottom-sheet__handle {
-  width: 3rem;
-  height: 0.3rem;
-  border-radius: 999px;
-  background: #d5dce6;
-  margin: 0.1rem auto 1rem;
+  width: 40px;
+  height: 4px;
+  border-radius: 10px;
+  background: #ccc;
+  margin: 0 auto 15px;
 }
 
 .bottom-sheet__content {
   display: grid;
   justify-items: center;
-  gap: 1rem;
+  align-items: center;
+  text-align: center;
+  gap: 0.65rem;
 }
 
 .bottom-sheet__avatar {
-  width: 5.5rem;
-  height: 5.5rem;
+  width: clamp(5rem, 22vw, 5.625rem);
+  height: clamp(5rem, 22vw, 5.625rem);
   border-radius: 50%;
   background: linear-gradient(135deg, #c7ebff, #8ad0ff);
   color: #0f3e66;
@@ -1557,8 +1559,10 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   justify-content: center;
   font-size: 1.6rem;
   font-weight: 800;
-  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.7);
+  border: 3px solid #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   overflow: hidden;
+  margin-bottom: 10px;
 }
 
 .bottom-sheet__avatar-wrap {
@@ -1568,9 +1572,11 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
 
 .bottom-sheet__name {
   margin: 0;
-  font-size: 1rem;
+  margin-bottom: 10px;
+  font-size: clamp(1.125rem, 4.5vw, 1.25rem);
   font-weight: 700;
-  color: var(--primary-dark);
+  letter-spacing: 0.5px;
+  color: #1a73e8;
   text-align: center;
 }
 
@@ -1592,12 +1598,21 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
 
 .bottom-sheet__action {
   border: 0;
-  background: transparent;
-  color: var(--primary-dark);
+  background: #f1f3f4;
+  color: #d93025;
   font-size: 1rem;
-  font-weight: 700;
+  font-weight: 600;
   text-align: center;
-  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  padding: 0.625rem 1.25rem;
+  margin-top: 10px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.bottom-sheet__action:hover,
+.bottom-sheet__action:focus-visible {
+  background: #ffeaea;
+  transform: scale(1.05);
 }
 
 .data-table--hide-action th:last-child,


### PR DESCRIPTION
### Motivation

- Moderniser l'apparence du bottom sheet utilisateur pour un rendu mobile-first, élégant et centré utilisateur sans toucher à la logique métier ni à Firebase.
- Conserver le comportement existant tout en apportant une esthétique proche des apps mobiles premium (Google / iOS).

### Description

- Remaniement CSS dans `css/style.css` uniquement pour appliquer un fond blanc doux (`#ffffff`), coins arrondis `20px`, ombre douce `0 -10px 30px rgba(0,0,0,0.1)` et transition d'ouverture `0.3s`.
- Révision de la poignée en haut (`.bottom-sheet__handle`) pour passer à `40px × 4px`, couleur `#ccc`, bord-radius `10px` et espacement centré.
- Amélioration de l'avatar (`.bottom-sheet__avatar`) en responsive (~80–90px via `clamp()`), bordure blanche `3px`, ombre légère `0 4px 12px rgba(0,0,0,0.15)` et marge inférieure `10px`.
- Stylisation du nom (`.bottom-sheet__name`) avec couleur `#1a73e8`, graisse `700`, taille responsive via `clamp()`, et `letter-spacing: 0.5px`.
- Transformation du bouton déconnexion (`.bottom-sheet__action`) en vrai bouton moderne avec fond `#f1f3f4`, texte `#d93025`, border-radius `12px`, padding ajusté, `margin-top: 10px` et effet `hover`/`focus` (`#ffeaea` + `scale(1.05)`).

### Testing

- Aucune suite de tests automatisés spécifique à l'UI n'a été exécutée; j'ai vérifié les modifications via `git diff -- css/style.css` et `git status --short` et la mise en commit a réussi.
- Les changements sont limités à `css/style.css` et n'altèrent pas le JavaScript ou les intégrations Firebase, ce qui réduit le risque fonctionnel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4adbf3478832a902175d8f22f69c7)