### PR TITLE
Ajuster le mode lecture : masquer suppression sur page 2 et formulaire/colonne Action sur page 3

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -471,10 +471,11 @@ import { firebaseAuth } from './firebase-core.js';
     const username = String(profile?.username || '');
     const role = String(profile?.role || 'full').toLowerCase();
     const isAdmin = username === 'Admin' || role === 'admin';
+    const isLecture = role === 'lecture';
     if (isAdmin) {
-      return { canCreate: true, canEdit: true, canDelete: true, isAdmin: true };
+      return { canCreate: true, canEdit: true, canDelete: true, isAdmin: true, isLecture: false };
     }
-    return { canCreate: true, canEdit: true, canDelete: true, isAdmin: false };
+    return { canCreate: true, canEdit: true, canDelete: true, isAdmin: false, isLecture };
   }
 
   function ensureMaintenanceOverlay() {
@@ -1245,7 +1246,7 @@ import { firebaseAuth } from './firebase-core.js';
         const labels = buildCreatedModifiedLabels(item, userNamesById);
         htmlParts.push(`
             <article class="list-card">
-              ${permissions.canDelete ? `<button class="list-card__delete-button" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
+              ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__delete-button" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
@@ -1576,11 +1577,11 @@ import { firebaseAuth } from './firebase-core.js';
       }
     }
 
-    if (!permissions.canDelete) {
+    if (!permissions.canDelete || permissions.isLecture) {
       document.querySelector('.data-table')?.classList.add('data-table--hide-action');
     }
 
-    if (!permissions.canCreate) {
+    if (!permissions.canCreate || permissions.isLecture) {
       detailFormSection.hidden = true;
     }
 
@@ -1674,7 +1675,7 @@ import { firebaseAuth } from './firebase-core.js';
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td>
-                ${permissions.canDelete
+                ${permissions.canDelete && !permissions.isLecture
       ? `<button class="table-delete-icon-button" type="button" data-detail-delete="${detail.id}" aria-label="Supprimer" title="Supprimer"><img src="Icon/poubelle.png" alt="" aria-hidden="true" class="table-delete-icon-button__icon" /></button>`
       : ""}
               </td>


### PR DESCRIPTION
### Motivation
- Appliquer des restrictions supplémentaires uniquement pour le mode `lecture` afin que l’utilisateur puisse seulement consulter et rechercher sur les pages 2 et 3 sans pouvoir supprimer ni modifier d’éléments, tout en conservant les modes `full` et `admin` inchangés.

### Description
- Ajout de l’indicateur `isLecture` dans la valeur retournée par `buildPermissions(profile)` pour pouvoir détecter le mode lecture à l’usage de l’UI.
- En `site-detail` (page 2) : le bouton de suppression des éléments n’est rendu que si `permissions.canDelete && !permissions.isLecture` afin de masquer l’icône supprimer pour le mode `lecture`.
- En `item-detail` (page 3) : la section de formulaire (`detailFormSection`) est masquée lorsque `permissions.isLecture`, la classe `data-table--hide-action` est appliquée pour cacher la colonne Action quand approprié, et les boutons de suppression de ligne ne sont affichés que si `permissions.canDelete && !permissions.isLecture`.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b905194c832ab501f4756194206f)