### PR TITLE
Améliorer la gestion des utilisateurs dans users.html

### DIFF
--- a/users.html
+++ b/users.html
@@ -5,6 +5,41 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Gestion des utilisateurs - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
+    <style>
+      .users-avatar {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        background: #e8edf5;
+        color: #234;
+        font-weight: 700;
+        font-size: 0.8rem;
+      }
+
+      .users-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .users-role-select {
+        min-width: 120px;
+      }
+
+      .users-email-cell {
+        max-width: 260px;
+        word-break: break-word;
+      }
+
+      .maintenance-access-cell {
+        text-align: center;
+      }
+    </style>
   </head>
   <body data-page="users-management">
     <div class="app-shell app-shell--wide">
@@ -26,12 +61,13 @@
         </section>
         <section class="surface-card table-card">
           <h2 class="section-title">Tous les utilisateurs</h2>
-           <div class="table-wrapper table-wrapper--users">
+          <div class="table-wrapper table-wrapper--users">
             <table class="data-table">
               <thead>
                 <tr>
                   <th>Photo</th>
                   <th>Nom</th>
+                  <th>Email</th>
                   <th>Rôle</th>
                   <th>Autorisé (maintenance)</th>
                   <th>Actions</th>
@@ -47,5 +83,211 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
+    <script type="module">
+      import { collection, onSnapshot, doc, setDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+      import { firebaseDb } from './js/firebase-core.js';
+
+      const ADMIN_EMAIL = 'andrainaaina@gmail.com';
+
+      function cleanString(value) {
+        return String(value || '').trim();
+      }
+
+      function toLower(value) {
+        return cleanString(value).toLowerCase();
+      }
+
+      function resolveDisplayName(user) {
+        const displayName = cleanString(user.displayName || user.username || user.name);
+        if (displayName) {
+          return displayName;
+        }
+        const emailPrefix = cleanString(user.email).split('@')[0];
+        return emailPrefix || 'Utilisateur';
+      }
+
+      function getInitials(name) {
+        const normalized = cleanString(name).replace(/\s+/g, ' ').replace(/[^\p{L}\p{N} ]/gu, '');
+        return (normalized.slice(0, 2) || 'US').toUpperCase();
+      }
+
+      function resolveRole(user) {
+        if (toLower(user.email) === ADMIN_EMAIL) {
+          return 'admin';
+        }
+        const role = toLower(user.role);
+        if (role === 'admin') {
+          return 'admin';
+        }
+        if (role === 'adjoint' || role === 'ecriture') {
+          return role;
+        }
+        if (role === 'full') {
+          return 'adjoint';
+        }
+        return 'ecriture';
+      }
+
+      function resolveMaintenanceAuthorized(user) {
+        if (typeof user.maintenanceAuthorized === 'boolean') {
+          return user.maintenanceAuthorized;
+        }
+        if (typeof user.maintenanceAccess === 'boolean') {
+          return user.maintenanceAccess;
+        }
+        return false;
+      }
+
+      function syncDefaults(user) {
+        const email = cleanString(user.email);
+        if (!user.id || !email) {
+          return;
+        }
+
+        const updates = {};
+        const role = resolveRole(user);
+        if (!cleanString(user.role)) {
+          updates.role = role === 'admin' ? 'admin' : role;
+        } else if (toLower(user.role) === 'full') {
+          updates.role = 'adjoint';
+        }
+
+        const maintenanceAuthorized = resolveMaintenanceAuthorized(user);
+        if (!Object.prototype.hasOwnProperty.call(user, 'maintenanceAuthorized')) {
+          updates.maintenanceAuthorized = maintenanceAuthorized;
+        }
+        if (!Object.prototype.hasOwnProperty.call(user, 'maintenanceAccess')) {
+          updates.maintenanceAccess = maintenanceAuthorized;
+        }
+
+        if (Object.keys(updates).length) {
+          updates.updatedAt = serverTimestamp();
+          setDoc(doc(firebaseDb, 'users', user.id), updates, { merge: true }).catch(() => {});
+        }
+      }
+
+      function renderUsers(users) {
+        const tableBody = document.getElementById('usersTableBody');
+        if (!tableBody) {
+          return;
+        }
+
+        const rows = users
+          .map((user) => {
+            const displayName = resolveDisplayName(user);
+            const email = cleanString(user.email);
+            const role = resolveRole(user);
+            const maintenanceAuthorized = resolveMaintenanceAuthorized(user);
+            const photoURL = cleanString(user.photoURL || user.avatarUrl || user.avatar);
+            const isPrimaryAdmin = toLower(email) === ADMIN_EMAIL;
+
+            const avatarMarkup = photoURL
+              ? `<span class="users-avatar"><img src="${photoURL.replace(/"/g, '&quot;')}" alt="Avatar de ${displayName.replace(/"/g, '&quot;')}" /></span>`
+              : `<span class="users-avatar" aria-hidden="true">${getInitials(displayName)}</span>`;
+
+            return `
+              <tr data-user-id="${user.id}">
+                <td>${avatarMarkup}</td>
+                <td>${displayName}</td>
+                <td class="users-email-cell">${email || '-'}</td>
+                <td>
+                  <select class="users-role-select" data-user-role="${user.id}" ${isPrimaryAdmin ? 'disabled' : ''}>
+                    <option value="adjoint" ${role === 'adjoint' || role === 'admin' ? 'selected' : ''}>Adjoint</option>
+                    <option value="ecriture" ${role === 'ecriture' ? 'selected' : ''}>Ecriture</option>
+                  </select>
+                </td>
+                <td class="maintenance-access-cell">
+                  <input
+                    type="checkbox"
+                    class="maintenance-access-checkbox"
+                    data-user-maintenance-access="${user.id}"
+                    ${maintenanceAuthorized ? 'checked' : ''}
+                    aria-label="Autoriser ${displayName.replace(/"/g, '&quot;')} pendant la maintenance"
+                  />
+                </td>
+                <td>
+                  <button type="button" class="btn-delete" data-delete-user="${user.id}" ${isPrimaryAdmin ? 'disabled' : ''}>Supprimer</button>
+                </td>
+              </tr>
+            `;
+          })
+          .join('');
+
+        tableBody.innerHTML = rows;
+
+        tableBody.querySelectorAll('[data-user-role]').forEach((select) => {
+          select.addEventListener('change', async () => {
+            const userId = select.getAttribute('data-user-role');
+            const selected = toLower(select.value) === 'adjoint' ? 'admin' : 'ecriture';
+            try {
+              await setDoc(
+                doc(firebaseDb, 'users', userId),
+                {
+                  role: selected,
+                  updatedAt: serverTimestamp(),
+                },
+                { merge: true },
+              );
+              window.UiService?.showToast('Rôle mis à jour.');
+            } catch (_error) {
+              window.UiService?.showToast('Impossible de mettre à jour le rôle.');
+            }
+          });
+        });
+
+        tableBody.querySelectorAll('[data-user-maintenance-access]').forEach((checkbox) => {
+          checkbox.addEventListener('change', async () => {
+            const userId = checkbox.getAttribute('data-user-maintenance-access');
+            const checked = checkbox.checked;
+            try {
+              await setDoc(
+                doc(firebaseDb, 'users', userId),
+                {
+                  maintenanceAuthorized: checked,
+                  maintenanceAccess: checked,
+                  updatedAt: serverTimestamp(),
+                },
+                { merge: true },
+              );
+              window.UiService?.showToast('Accès maintenance mis à jour.');
+            } catch (_error) {
+              checkbox.checked = !checked;
+              window.UiService?.showToast('Impossible de mettre à jour l’accès maintenance.');
+            }
+          });
+        });
+
+        tableBody.querySelectorAll('[data-delete-user]').forEach((button) => {
+          button.addEventListener('click', async () => {
+            const userId = button.getAttribute('data-delete-user');
+            if (!userId || !window.StorageService?.deleteUser) {
+              return;
+            }
+            button.disabled = true;
+            try {
+              await window.StorageService.deleteUser(userId);
+              window.UiService?.showToast('Utilisateur supprimé.');
+            } catch (_error) {
+              window.UiService?.showToast('Impossible de supprimer cet utilisateur.');
+            } finally {
+              button.disabled = false;
+            }
+          });
+        });
+      }
+
+      const usersRef = collection(firebaseDb, 'users');
+      onSnapshot(
+        usersRef,
+        (snapshot) => {
+          const users = snapshot.docs.map((entry) => ({ id: entry.id, ...(entry.data() || {}) }));
+          users.forEach(syncDefaults);
+          renderUsers(users);
+        },
+        () => {
+          window.UiService?.showToast('Impossible de charger la liste des utilisateurs.');
+        },
+      );
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Rendre la section « Tous les utilisateurs » complète et conforme aux besoins (photo, nom, email, rôle, autorisé maintenance, actions) tout en conservant le style et la logique admin existante.
- Supporter les anciens enregistrements sans champ `role` ou `maintenanceAuthorized` en appliquant des valeurs par défaut propres et en synchronisant les champs compatibles (`maintenanceAccess`).

### Description
- Seul le fichier `users.html` a été modifié pour ajouter la colonne **Email**, des styles locaux d’avatars/colonnes et un script module embarqué qui gère l’affichage et la persistance côté Firestore en temps réel via `onSnapshot`.
- Le rendu dynamique affiche pour chaque utilisateur : avatar (photoURL ou fallback 2 lettres), `displayName` (ou préfixe d’email), `email`, un `select` rôle limité à `Adjoint` / `Ecriture`, une checkbox `Autorisé (maintenance)` et les actions existantes (suppression) avec le compte admin principal (`andrainaaina@gmail.com`) protégé/locké côté UI.
- Logique des rôles et maintenance : `Adjoint` est mappé/traité comme admin pour l’interface, `Ecriture` est le défaut quand le rôle est absent; la checkbox écrit `maintenanceAuthorized` et synchronise `maintenanceAccess` pour compatibilité avec la logique existante; les anciens documents sont normalisés automatiquement (`syncDefaults`).
- Aucune autre page ou fichier JS existant n’a été touché; les changements restent encapsulés dans `users.html` et persistent les modifications via `setDoc`/`serverTimestamp` sur Firestore.

### Testing
- Vérifications d’intégrité et d’application réalisées via commandes shell automatisées et commits, toutes réussies: `git -C /workspace/Album status --short`, `git -C /workspace/Album diff -- users.html`, `nl -ba /workspace/Album/users.html`, et `git -C /workspace/Album commit -m "Update users table UI with email, role defaults and maintenance authorization"`.
- Inspection du contenu du fichier avec `sed`/`rg` pour confirmer l’insertion du script et des styles locaux a été effectuée et a réussi.
- Aucun test unitaire automatisé supplémentaire n’était présent pour cette page; les modifications ont été déployées par commit unique et ciblé sur `users.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4beefb874832ab53d61aace14ce3f)