### PR TITLE
Corrige l’affichage des utilisateurs Firestore (fallbacks, rendu et logs)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1871,7 +1871,35 @@ import { firebaseAuth } from './firebase-core.js';
     const maintenanceStatusText = requireElement('maintenanceStatusText');
     backButton?.addEventListener('click', () => UiService.navigate('index.html'));
 
-    const roleLabel = { lecture: 'Lecture seule', ecriture: 'Écriture seule', full: 'Tout accès' };
+    const roleLabel = { adjoint: 'Adjoint', ecriture: 'Ecriture' };
+
+    function cleanText(value) {
+      return String(value || '').trim();
+    }
+
+    function resolveDisplayName(user) {
+      const displayName = cleanText(user?.username || user?.displayName || user?.name);
+      if (displayName) {
+        return displayName;
+      }
+      const emailPrefix = cleanText(user?.email).split('@')[0];
+      return emailPrefix || 'Utilisateur';
+    }
+
+    function resolveRole(user) {
+      const role = cleanText(user?.role).toLowerCase();
+      return role === 'adjoint' || role === 'admin' ? 'adjoint' : 'ecriture';
+    }
+
+    function resolveMaintenanceAuthorized(user) {
+      if (typeof user?.maintenanceAuthorized === 'boolean') {
+        return user.maintenanceAuthorized;
+      }
+      if (typeof user?.maintenanceAccess === 'boolean') {
+        return user.maintenanceAccess;
+      }
+      return false;
+    }
 
     function updateMaintenanceLabel(isEnabled) {
       if (maintenanceStatusText) {
@@ -1887,17 +1915,17 @@ import { firebaseAuth } from './firebase-core.js';
         .map((user) => `
           <tr>
             <td>
-              ${user.avatarUrl
-      ? `<img class="table-avatar" src="${escapeHtml(user.avatarUrl)}" alt="Avatar de ${escapeHtml(user.username)}" />`
-      : `<span class="table-avatar table-avatar--fallback">${escapeHtml(getInitialsFromName(user.username))}</span>`}
+              ${cleanText(user.avatarUrl)
+      ? `<img class="table-avatar" src="${escapeHtml(user.avatarUrl)}" alt="Avatar de ${escapeHtml(resolveDisplayName(user))}" />`
+      : `<span class="table-avatar table-avatar--fallback">${escapeHtml(getInitialsFromName(resolveDisplayName(user)).slice(0, 2))}</span>`}
             </td>
-            <td>${escapeHtml(user.username)}</td>
+            <td>${escapeHtml(resolveDisplayName(user))}</td>
+            <td class="users-email-cell">${escapeHtml(cleanText(user.email) || '-')}</td>
             <td>
-              ${user.username === 'Admin' ? 'Admin' : `
+              ${cleanText(user.email).toLowerCase() === 'andrainaaina@gmail.com' ? 'Adjoint' : `
               <select data-user-role="${user.id}">
-                <option value="lecture" ${user.role === 'lecture' ? 'selected' : ''}>${roleLabel.lecture}</option>
-                <option value="ecriture" ${user.role === 'ecriture' ? 'selected' : ''}>${roleLabel.ecriture}</option>
-                <option value="full" ${user.role === 'full' ? 'selected' : ''}>${roleLabel.full}</option>
+                <option value="adjoint" ${resolveRole(user) === 'adjoint' ? 'selected' : ''}>${roleLabel.adjoint}</option>
+                <option value="ecriture" ${resolveRole(user) === 'ecriture' ? 'selected' : ''}>${roleLabel.ecriture}</option>
               </select>`}
             </td>
             <td class="maintenance-access-cell">
@@ -1905,12 +1933,12 @@ import { firebaseAuth } from './firebase-core.js';
                 type="checkbox"
                 class="maintenance-access-checkbox"
                 data-user-maintenance-access="${user.id}"
-                ${user.maintenanceAccess ? 'checked' : ''}
-                aria-label="Autoriser ${escapeHtml(user.username)} pendant la maintenance"
+                ${resolveMaintenanceAuthorized(user) ? 'checked' : ''}
+                aria-label="Autoriser ${escapeHtml(resolveDisplayName(user))} pendant la maintenance"
               />
             </td>
             <td>
-              ${user.username === 'Admin'
+              ${cleanText(user.email).toLowerCase() === 'andrainaaina@gmail.com'
       ? '<span class="table-action-disabled">-</span>'
       : `<button type="button" class="table-delete-icon-button" data-delete-user="${user.id}" aria-label="Supprimer" title="Supprimer"><img src="Icon/poubelle.png" alt="" aria-hidden="true" class="table-delete-icon-button__icon" /></button>`}
             </td>
@@ -1985,6 +2013,15 @@ import { firebaseAuth } from './firebase-core.js';
 
     StorageService.subscribeUsers(
       (users) => {
+        console.log('[users] documents récupérés :', users.length);
+        users.forEach((user) => {
+          console.log('[users] doc:', user.id, {
+            displayName: resolveDisplayName(user),
+            email: cleanText(user.email),
+            role: resolveRole(user),
+            maintenanceAuthorized: resolveMaintenanceAuthorized(user),
+          });
+        });
         renderUsers(users);
       },
       () => {

--- a/js/storage.js
+++ b/js/storage.js
@@ -39,9 +39,18 @@ const state = {
 };
 
 function normalizeRole(value) {
-  const role = String(value || '').toLowerCase();
-  if (role === 'lecture' || role === 'ecriture' || role === 'full' || role === 'admin') {
-    return role;
+  const role = String(value || '').trim().toLowerCase();
+  if (role === 'admin') {
+    return 'admin';
+  }
+  if (role === 'adjoint' || role === 'full') {
+    return 'adjoint';
+  }
+  if (role === 'lecture') {
+    return 'lecture';
+  }
+  if (role === 'ecriture' || role === 'écriture') {
+    return 'ecriture';
   }
   return 'ecriture';
 }
@@ -366,16 +375,19 @@ async function listUsers() {
   return snapshot.docs
     .map((snap) => {
       const data = snap.data() || {};
+      const email = String(data.email || '').trim();
+      const fallbackName = email ? email.split('@')[0] : '';
       return {
         id: snap.id,
-        username: normalizeUsername(data.username || data.name),
-        avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
+        username: normalizeUsername(data.username || data.displayName || data.name || fallbackName),
+        email,
+        avatarUrl: normalizeAvatarUrl(data.photoURL || data.avatarUrl || data.avatar),
         role: normalizeRole(data.role),
-        maintenanceAccess: normalizeMaintenanceAccess(data.maintenanceAccess),
+        maintenanceAccess: normalizeMaintenanceAuthorized(data),
+        maintenanceAuthorized: normalizeMaintenanceAuthorized(data),
         createdAt: data.createdAt || null,
       };
-    })
-    .filter((user) => user.username);
+    });
 }
 
 async function updateUserRole(userId, role) {
@@ -463,19 +475,26 @@ function subscribeUsers(onChange, onError) {
     return onSnapshot(
       usersCollection(),
       (snapshot) => {
+        console.log('[users] snapshot size:', snapshot.size);
+        snapshot.docs.forEach((snap) => {
+          console.log('[users] doc id:', snap.id, snap.data());
+        });
         const users = snapshot.docs
           .map((snap) => {
             const data = snap.data() || {};
+            const email = String(data.email || '').trim();
+            const fallbackName = email ? email.split('@')[0] : '';
             return {
               id: snap.id,
-              username: normalizeUsername(data.username || data.name),
-              avatarUrl: normalizeAvatarUrl(data.avatarUrl || data.avatar),
+              username: normalizeUsername(data.username || data.displayName || data.name || fallbackName),
+              email,
+              avatarUrl: normalizeAvatarUrl(data.photoURL || data.avatarUrl || data.avatar),
               role: normalizeRole(data.role),
-              maintenanceAccess: normalizeMaintenanceAccess(data.maintenanceAccess),
+              maintenanceAccess: normalizeMaintenanceAuthorized(data),
+              maintenanceAuthorized: normalizeMaintenanceAuthorized(data),
               createdAt: data.createdAt || null,
             };
-          })
-          .filter((user) => user.username);
+          });
         onChange(users);
       },
       (error) => {


### PR DESCRIPTION
### Motivation

- Les utilisateurs n’étaient pas affichés car la lecture filtravait implicitement les docs sans `username` alors que les documents actuels utilisent `displayName`/`email`/`photoURL`. 
- Il fallait afficher systématiquement les colonnes attendues (Photo, Nom, Email, Rôle, Autorisé (maintenance), Actions) avec des fallbacks sûrs sans casser le reste de l’app.
- Des logs temporaires côté lecture Firestore étaient demandés pour diagnostiquer le flux de documents en temps réel.

### Description

- Ajustement de la lecture Firestore dans `js/storage.js` pour que `listUsers()` et `subscribeUsers()` prennent en compte `displayName`, `name` puis le préfixe d'`email`, conservent `email` et `photoURL`, et ne filtrent plus les utilisateurs sans `username`.
- Normalisation des rôles dans `js/storage.js` via `normalizeRole()` pour supporter `admin`, `adjoint`/`full`, `lecture`, `ecriture` et leurs variantes accentuées.
- Ajout de logs diagnostics temporaires dans `js/storage.js` (`snapshot.size`, chaque `doc.id` et `doc.data()`) et logs synthétiques côté UI dans `js/app.js` pour vérifier le nombre et le résumé des utilisateurs reçus.
- Mise à jour de `initUsersPage` dans `js/app.js` pour : calculer le nom affiché (`resolveDisplayName`), afficher la colonne `Email`, gérer l’avatar (image ronde ou initiales 2 lettres), appliquer `resolveRole` et `resolveMaintenanceAuthorized` en fallback, et rendre les lignes utilisateur conformément à la structure demandée.

### Testing

- Exécution de la vérification de syntaxe JavaScript : `node --check js/storage.js` a réussi.
- Exécution de la vérification de syntaxe JavaScript : `node --check js/app.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c784a354832aa014b72aace7ec8b)