### PR TITLE
Modifier la gestion des rôles : passer à « Limité » / « Standard » (compatibilité ascendante)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -324,35 +324,6 @@ import { firebaseAuth } from './firebase-core.js';
     }
   }
 
-  const HOME_MODES = {
-    LECTURE: 'lecture',
-    FULL: 'full',
-    ADMIN: 'admin',
-  };
-
-  const ADMIN_EMAIL = 'andrainaaina@gmail.com';
-
-  function resolveHomeModeFromAuthUser(user) {
-    if (!user) {
-      return HOME_MODES.LECTURE;
-    }
-    const email = String(user?.email || '').trim().toLowerCase();
-    if (email === ADMIN_EMAIL) {
-      return HOME_MODES.ADMIN;
-    }
-    return HOME_MODES.FULL;
-  }
-
-  function buildHomePermissionsByMode(mode) {
-    if (mode === HOME_MODES.ADMIN) {
-      return { canCreate: true, canEdit: true, canDelete: true, isAdmin: true };
-    }
-    if (mode === HOME_MODES.FULL) {
-      return { canCreate: true, canEdit: true, canDelete: true, isAdmin: false };
-    }
-    return { canCreate: false, canEdit: false, canDelete: false, isAdmin: false };
-  }
-
   function downloadExcelFile(fileName, title, workbook) {
     const blob = new Blob(['\ufeff', workbook], { type: 'application/vnd.ms-excel;charset=utf-8;' });
     const link = document.createElement('a');
@@ -469,13 +440,32 @@ import { firebaseAuth } from './firebase-core.js';
 
   function buildPermissions(profile) {
     const username = String(profile?.username || '');
-    const role = String(profile?.role || 'full').toLowerCase();
+    const role = String(profile?.role || 'limite').toLowerCase();
     const isAdmin = username === 'Admin' || role === 'admin';
+    const isStandard = role === 'standard';
     const isLecture = role === 'lecture';
     if (isAdmin) {
-      return { canCreate: true, canEdit: true, canDelete: true, isAdmin: true, isLecture: false };
+      return {
+        canCreate: true,
+        canEdit: true,
+        canDelete: true,
+        isAdmin: true,
+        isStandard: false,
+        canManageUsers: true,
+        canImportExport: true,
+        isLecture: false,
+      };
     }
-    return { canCreate: true, canEdit: true, canDelete: true, isAdmin: false, isLecture };
+    return {
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      isAdmin: false,
+      isStandard,
+      canManageUsers: isStandard,
+      canImportExport: isStandard,
+      isLecture,
+    };
   }
 
   function ensureMaintenanceOverlay() {
@@ -990,59 +980,34 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
-    function mettreAJourPermissionsUI(mode) {
-      currentPermissions = buildHomePermissionsByMode(mode);
+    function mettreAJourPermissionsUI(nextPermissions) {
+      currentPermissions = { ...currentPermissions, ...(nextPermissions || {}) };
 
       if (openCreateSite) {
         openCreateSite.hidden = !currentPermissions.canCreate;
       }
 
       if (importDataButton) {
-        importDataButton.hidden = mode !== HOME_MODES.ADMIN;
+        importDataButton.hidden = !currentPermissions.canImportExport;
       }
 
       if (exportDataButton) {
-        exportDataButton.hidden = mode !== HOME_MODES.ADMIN;
+        exportDataButton.hidden = !currentPermissions.canImportExport;
       }
 
       if (manageUsersButton) {
-        manageUsersButton.hidden = !currentPermissions.isAdmin;
+        manageUsersButton.hidden = !currentPermissions.canManageUsers;
       }
 
       closeHomeMenu();
       renderSites();
     }
 
-    function appliquerModeLecture() {
-      mettreAJourPermissionsUI(HOME_MODES.LECTURE);
-    }
-
-    function appliquerModeFull() {
-      mettreAJourPermissionsUI(HOME_MODES.FULL);
-    }
-
-    function appliquerModeAdmin() {
-      mettreAJourPermissionsUI(HOME_MODES.ADMIN);
-    }
-
-    function appliquerModeParUtilisateur(authUser) {
-      mettreAJourHeaderUtilisateur(authUser || null);
-      const mode = resolveHomeModeFromAuthUser(authUser);
-      if (mode === HOME_MODES.ADMIN) {
-        appliquerModeAdmin(authUser);
-        return;
-      }
-      if (mode === HOME_MODES.FULL) {
-        appliquerModeFull(authUser);
-        return;
-      }
-      appliquerModeLecture();
-    }
-
-    appliquerModeParUtilisateur(authState?.authUser || null);
+    mettreAJourHeaderUtilisateur(authState?.authUser || null);
+    mettreAJourPermissionsUI(currentPermissions);
     onAuthStateChanged(firebaseAuth, (user) => {
       renderUserAvatar(user || null);
-      appliquerModeParUtilisateur(user || null);
+      mettreAJourHeaderUtilisateur(user || null);
     });
 
     openCreateSite?.addEventListener('click', () => {
@@ -1860,7 +1825,7 @@ import { firebaseAuth } from './firebase-core.js';
 
 
   async function initUsersPage(permissions) {
-    if (!permissions.isAdmin) {
+    if (!permissions.isAdmin && !permissions.isStandard) {
       UiService.navigate('index.html');
       return;
     }
@@ -1871,7 +1836,7 @@ import { firebaseAuth } from './firebase-core.js';
     const maintenanceStatusText = requireElement('maintenanceStatusText');
     backButton?.addEventListener('click', () => UiService.navigate('index.html'));
 
-    const roleLabel = { adjoint: 'Adjoint', ecriture: 'Ecriture' };
+    const roleLabel = { standard: 'Standard', limite: 'Limité' };
 
     function cleanText(value) {
       return String(value || '').trim();
@@ -1888,7 +1853,7 @@ import { firebaseAuth } from './firebase-core.js';
 
     function resolveRole(user) {
       const role = cleanText(user?.role).toLowerCase();
-      return role === 'adjoint' || role === 'admin' ? 'adjoint' : 'ecriture';
+      return role === 'standard' || role === 'adjoint' || role === 'admin' ? 'standard' : 'limite';
     }
 
     function resolveMaintenanceAuthorized(user) {
@@ -1922,10 +1887,10 @@ import { firebaseAuth } from './firebase-core.js';
             <td>${escapeHtml(resolveDisplayName(user))}</td>
             <td class="users-email-cell">${escapeHtml(cleanText(user.email) || '-')}</td>
             <td>
-              ${cleanText(user.email).toLowerCase() === 'andrainaaina@gmail.com' ? 'Adjoint' : `
+              ${cleanText(user.email).toLowerCase() === 'andrainaaina@gmail.com' ? 'admin' : `
               <select data-user-role="${user.id}">
-                <option value="adjoint" ${resolveRole(user) === 'adjoint' ? 'selected' : ''}>${roleLabel.adjoint}</option>
-                <option value="ecriture" ${resolveRole(user) === 'ecriture' ? 'selected' : ''}>${roleLabel.ecriture}</option>
+                <option value="standard" ${resolveRole(user) === 'standard' ? 'selected' : ''}>${roleLabel.standard}</option>
+                <option value="limite" ${resolveRole(user) === 'limite' ? 'selected' : ''}>${roleLabel.limite}</option>
               </select>`}
             </td>
             <td class="maintenance-access-cell">
@@ -2103,7 +2068,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     if (!String(nextProfile.role || '').trim()) {
-      nextProfile.role = 'ecriture';
+      nextProfile.role = 'limite';
     }
     return nextProfile;
   }

--- a/js/storage.js
+++ b/js/storage.js
@@ -43,16 +43,27 @@ function normalizeRole(value) {
   if (role === 'admin') {
     return 'admin';
   }
-  if (role === 'adjoint' || role === 'full') {
-    return 'adjoint';
+  if (role === 'adjoint' || role === 'full' || role === 'standard') {
+    return 'standard';
   }
   if (role === 'lecture') {
     return 'lecture';
   }
-  if (role === 'ecriture' || role === 'écriture') {
-    return 'ecriture';
+  if (role === 'ecriture' || role === 'écriture' || role === 'limite' || role === 'limité') {
+    return 'limite';
   }
-  return 'ecriture';
+  return 'limite';
+}
+
+function serializeRole(role) {
+  const normalized = normalizeRole(role);
+  if (normalized === 'admin') {
+    return 'admin';
+  }
+  if (normalized === 'standard') {
+    return 'Standard';
+  }
+  return 'Limité';
 }
 
 function normalizeUsername(value) {
@@ -174,7 +185,7 @@ async function ensureCurrentUser() {
         photoURL: authPhotoUrl,
         avatarUrl: authPhotoUrl,
         avatar: authPhotoUrl,
-        role: 'Ecriture',
+        role: 'Limité',
         status: deleteField(),
         approved: deleteField(),
         pending: deleteField(),
@@ -191,7 +202,7 @@ async function ensureCurrentUser() {
       id: state.userId,
       username: authDisplayName,
       avatarUrl: authPhotoUrl,
-      role: 'ecriture',
+      role: 'limite',
       maintenanceAccess: false,
       maintenanceAuthorized: false,
       lastNameChange: null,
@@ -212,7 +223,7 @@ async function ensureCurrentUser() {
     updatedAt: serverTimestamp(),
   };
   if (!Object.prototype.hasOwnProperty.call(data, 'role') || !String(data.role || '').trim()) {
-    updates.role = 'Ecriture';
+    updates.role = 'Limité';
   }
   if (!Object.prototype.hasOwnProperty.call(data, 'maintenanceAuthorized')) {
     updates.maintenanceAuthorized = false;
@@ -255,7 +266,7 @@ async function getCurrentUserProfile() {
       id: null,
       username: '',
       email: '',
-      role: 'full',
+      role: 'limite',
       maintenanceAccess: false,
       lastNameChange: null,
       avatarUrl: '',
@@ -310,7 +321,7 @@ async function saveUsername(username) {
   };
 
   if (isFirstUsername) {
-    updates.role = 'full';
+    updates.role = 'Limité';
     updates.status = deleteField();
     updates.approved = deleteField();
     updates.pending = deleteField();
@@ -395,7 +406,7 @@ async function updateUserRole(userId, role) {
   await setDoc(
     userDocRef(userId),
     {
-      role: nextRole,
+      role: serializeRole(nextRole),
       updatedAt: serverTimestamp(),
     },
     { merge: true },
@@ -435,7 +446,7 @@ function subscribeCurrentUserProfile(onChange, onError) {
           onChange({
             id: state.userId,
             username: '',
-            role: isAdminEmail(state.authUser?.email) ? 'admin' : 'full',
+            role: isAdminEmail(state.authUser?.email) ? 'admin' : 'limite',
             maintenanceAccess: false,
             lastNameChange: null,
             avatarUrl: '',

--- a/users.html
+++ b/users.html
@@ -112,13 +112,13 @@
       function resolveRole(user) {
         const role = cleanString(user.role);
         const normalized = toLower(role);
-        if (normalized === 'admin' || normalized === 'adjoint') {
-          return 'Adjoint';
+        if (normalized === 'admin') {
+          return 'admin';
         }
-        if (normalized === 'ecriture') {
-          return 'Ecriture';
+        if (normalized === 'standard' || normalized === 'adjoint') {
+          return 'Standard';
         }
-        return 'Ecriture';
+        return 'Limité';
       }
 
       function resolveMaintenanceAuthorized(user) {
@@ -139,7 +139,7 @@
 
         const updates = {};
         if (!cleanString(user.role)) {
-          updates.role = 'Ecriture';
+          updates.role = 'Limité';
         }
 
         const maintenanceAuthorized = resolveMaintenanceAuthorized(user);
@@ -169,7 +169,7 @@
             const role = resolveRole(user);
             const maintenanceAuthorized = resolveMaintenanceAuthorized(user);
             const photoURL = cleanString(user.photoURL || user.avatarUrl || user.avatar);
-            const isPrimaryAdmin = toLower(role) === 'adjoint' && toLower(email) === 'andrainaaina@gmail.com';
+            const isPrimaryAdmin = toLower(email) === 'andrainaaina@gmail.com';
 
             const avatarMarkup = photoURL
               ? `<span class="users-avatar"><img src="${photoURL.replace(/"/g, '&quot;')}" alt="Avatar de ${displayName.replace(/"/g, '&quot;')}" /></span>`
@@ -181,10 +181,11 @@
                 <td>${displayName}</td>
                 <td class="users-email-cell">${email || '-'}</td>
                 <td>
-                  <select class="users-role-select" data-user-role="${user.id}" ${isPrimaryAdmin ? 'disabled' : ''}>
-                    <option value="Adjoint" ${role === 'Adjoint' ? 'selected' : ''}>Adjoint</option>
-                    <option value="Ecriture" ${role === 'Ecriture' ? 'selected' : ''}>Ecriture</option>
-                  </select>
+                  ${isPrimaryAdmin ? 'admin' : `
+                  <select class="users-role-select" data-user-role="${user.id}">
+                    <option value="Standard" ${role === 'Standard' ? 'selected' : ''}>Standard</option>
+                    <option value="Limité" ${role === 'Limité' ? 'selected' : ''}>Limité</option>
+                  </select>`}
                 </td>
                 <td class="maintenance-access-cell">
                   <input
@@ -208,7 +209,7 @@
         tableBody.querySelectorAll('[data-user-role]').forEach((select) => {
           select.addEventListener('change', async () => {
             const userId = select.getAttribute('data-user-role');
-            const selected = toLower(select.value) === 'adjoint' ? 'Adjoint' : 'Ecriture';
+            const selected = toLower(select.value) === 'standard' ? 'Standard' : 'Limité';
             try {
               await setDoc(
                 doc(firebaseDb, 'users', userId),


### PR DESCRIPTION
### Motivation
- Unifier les libellés et la logique de rôles pour remplacer `Ecriture` → `Limité` et `Adjoint` → `Standard` tout en gardant `admin` séparé.
- Faire en sorte que les nouveaux utilisateurs reçoivent par défaut le rôle `Limité` et que l’application reconnaisse les valeurs anciennes de la base.
- Donner aux utilisateurs `Standard` l’accès aux fonctions avancées (Importer / Exporter / Gestion d’utilisateurs) depuis la page d’accueil.

### Description
- Normalisation et sérialisation des rôles dans `js/storage.js` : `normalizeRole` accepte les anciennes valeurs (`ecriture`, `adjoint`, `full`) et les mappe respectivement vers `limite`/`standard`, et `serializeRole` écrit `Limité` / `Standard` (ou `admin`) en Firestore.
- Par défaut, les nouveaux documents utilisateur sont créés avec `role: 'Limité'` et les chemins de lecture utilisent désormais `normalizeRole` (mise à jour des valeurs par défaut et des points d’écriture). (`js/storage.js`)
- Logique d’autorisation et UI mises à jour dans `js/app.js` : `buildPermissions` et l’affichage du menu prennent en compte `standard` pour activer `canImportExport` / `canManageUsers`, et l’accès à la page `users` est autorisé pour `admin` ET `Standard`.
- Interface de gestion utilisateurs harmonisée : libellés du sélecteur et valeurs dans `users.html` changés en `Standard` / `Limité`, affichage explicite `admin` pour l’admin primaire, et écriture des sélections en Firestore avec les nouveaux libellés.

### Testing
- Vérification de la syntaxe des modules JS avec `node --check js/storage.js` : succès.
- Vérification de la syntaxe des modules JS avec `node --check js/app.js` : succès.
- Tests automatiques effectués : aucune suite de tests automatisés existante dans le projet, seules les vérifications de parsing JS ci‑dessus ont été exécutées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fca4bedc832a825f1c1095caa7e1)