### PR TITLE
Masquer le bouton Supprimer pour utilisateurs non connectés (page 1)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -765,6 +765,7 @@ import { firebaseAuth } from './firebase-core.js';
     let itemCountsBySite = {};
     let userNamesById = {};
     let currentPermissions = permissions;
+    let isAuthenticated = Boolean(authState?.isAuthenticated);
 
     async function loadUserNames() {
       try {
@@ -893,7 +894,7 @@ import { firebaseAuth } from './firebase-core.js';
           const labels = buildCreatedModifiedLabels(site, userNamesById);
           return `
             <article class="list-card">
-              ${currentPermissions.canDelete ? `<button class="list-card__delete-button" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
+              ${isAuthenticated && currentPermissions.canDelete ? `<button class="list-card__delete-button" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
@@ -1006,8 +1007,10 @@ import { firebaseAuth } from './firebase-core.js';
     mettreAJourHeaderUtilisateur(authState?.authUser || null);
     mettreAJourPermissionsUI(currentPermissions);
     onAuthStateChanged(firebaseAuth, (user) => {
+      isAuthenticated = Boolean(user);
       renderUserAvatar(user || null);
       mettreAJourHeaderUtilisateur(user || null);
+      renderSites();
     });
 
     openCreateSite?.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Sur la page d’accueil (page 1), le bouton « Supprimer » des cartes de site doit rester invisible pour les utilisateurs non authentifiés sans modifier le design ni les autres comportements.

### Description
- Ajout d’un état local `isAuthenticated` dans `initHomePage` initialisé depuis `authState` pour refléter si un utilisateur est connecté.
- Mise à jour de la condition d’affichage du bouton supprimer dans `renderSites` pour utiliser `isAuthenticated && currentPermissions.canDelete` au lieu de `currentPermissions.canDelete` seul.
- Synchronisation de `isAuthenticated` dans le callback `onAuthStateChanged` et appel à `renderSites()` pour mettre à jour l’UI immédiatement lors des changements d’authentification.
- Aucune autre logique, style ou comportement des autres boutons n’a été modifié.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5011999ac832a936cfef628950cdd)