### PR TITLE
Restreindre l'édition du tableau (page 3) aux utilisateurs authentifiés

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1397,6 +1397,8 @@ import { firebaseAuth } from './firebase-core.js';
     const codeInput = requireElement('codeInput');
     const designationInput = requireElement('designationInput');
     const codeSuggestions = requireElement('codeSuggestions');
+    const isAuthenticatedUser = Boolean(firebaseAuth.currentUser);
+    const canEditDetails = permissions.canEdit && isAuthenticatedUser;
 
     setupZoomableDetailTable();
 
@@ -1659,10 +1661,10 @@ import { firebaseAuth } from './firebase-core.js';
         .join('');
 
       detailTableBody.querySelectorAll('[data-field]').forEach((field) => {
-        if (!permissions.canEdit) {
+        if (!canEditDetails) {
           field.disabled = true;
         }
-        if (!permissions.canEdit) {
+        if (!canEditDetails) {
           return;
         }
 


### PR DESCRIPTION
### Motivation
- Empêcher les utilisateurs non connectés de modifier ou d’enregistrer des données depuis la page 3 (tableau des données / `item-detail`).

### Description
- Ajout de `isAuthenticatedUser = Boolean(firebaseAuth.currentUser)` et de `canEditDetails = permissions.canEdit && isAuthenticatedUser` dans `initItemDetailPage`, puis utilisation de `canEditDetails` pour désactiver tous les champs `[data-field]` et éviter d’attacher les écouteurs de modification lorsque l’utilisateur n’est pas authentifié (fichier modifié : `js/app.js`).

### Testing
- Aucun test automatisé disponible pour ce dépôt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5034eb318832a9d2ab6379f001335)