### PR TITLE
Hide 'Créer' buttons for unauthenticated users on Home and Site pages

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -985,7 +985,7 @@ import { firebaseAuth } from './firebase-core.js';
       currentPermissions = { ...currentPermissions, ...(nextPermissions || {}) };
 
       if (openCreateSite) {
-        openCreateSite.hidden = !currentPermissions.canCreate;
+        openCreateSite.hidden = !currentPermissions.canCreate || !isAuthenticated;
       }
 
       if (importDataButton) {
@@ -1255,7 +1255,8 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     const openCreateItem = requireElement('openCreateItem');
-    if (!permissions.canCreate && openCreateItem) {
+    const isAuthenticated = Boolean(firebaseAuth.currentUser);
+    if ((!permissions.canCreate || !isAuthenticated) && openCreateItem) {
       openCreateItem.hidden = true;
     }
 


### PR DESCRIPTION
### Motivation
- Enforcer l'affichage conditionnel demandé pour utilisateurs non connectés afin que les boutons de création ne soient visibles que pour des utilisateurs authentifiés, sans modifier le design ni d'autres fonctionnalités.

### Description
- Updated `js/app.js` to hide the home FAB `openCreateSite` when `!isAuthenticated` by adding the condition in `mettreAJourPermissionsUI`.
- Updated `js/app.js` to hide the site-detail FAB `openCreateItem` when there is no authenticated user by adding `const isAuthenticated = Boolean(firebaseAuth.currentUser)` and combining it with the existing `permissions.canCreate` check in `initSiteDetailPage`.
- Only `js/app.js` was modified; no visual or unrelated behavior changes were introduced.

### Testing
- Searched the codebase for the target button IDs with `rg` and confirmed the relevant buttons are in `index.html` and `page2.html` as expected.
- Inspected the updated `js/app.js` to verify the new `isAuthenticated` checks are present in `mettreAJourPermissionsUI` and `initSiteDetailPage` and that no other logic was altered.
- Verified the change scope: the diff contains modifications only to `js/app.js` and no other files were touched. All checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e504eff8fc832aa5e41cd795226113)