### PR TITLE
Fermer le bottom sheet avant d'afficher la confirmation de déconnexion

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -690,29 +690,42 @@ import { firebaseAuth } from './firebase-core.js';
       overlay.hidden = true;
       overlay.classList.remove('is-open');
     };
-    const closeSheet = () => {
-      if (overlay.hidden) {
-        return;
-      }
-      overlay.classList.remove('is-open');
-      overlay.__closeTransitionHandler = (event) => {
-        if (event.target !== overlay && event.target !== sheet) {
+    const closeSheet = () =>
+      new Promise((resolve) => {
+        if (overlay.hidden) {
+          resolve();
           return;
         }
-        finalizeClose();
-      };
-      overlay.addEventListener('transitionend', overlay.__closeTransitionHandler);
-      overlay.__closeTimerId = window.setTimeout(finalizeClose, closeTransitionDurationMs);
-    };
+
+        let isResolved = false;
+        const finish = () => {
+          if (isResolved) {
+            return;
+          }
+          isResolved = true;
+          finalizeClose();
+          resolve();
+        };
+
+        overlay.classList.remove('is-open');
+        overlay.__closeTransitionHandler = (event) => {
+          if (event.target !== overlay && event.target !== sheet) {
+            return;
+          }
+          finish();
+        };
+        overlay.addEventListener('transitionend', overlay.__closeTransitionHandler);
+        overlay.__closeTimerId = window.setTimeout(finish, closeTransitionDurationMs);
+      });
 
     logoutButton.onclick = async () => {
+      await closeSheet();
       const shouldLogout = await askLogoutConfirmation();
       if (!shouldLogout) {
         return;
       }
       try {
         await signOut(firebaseAuth);
-        closeSheet();
       } catch (_error) {
         message.textContent = "Impossible de se déconnecter pour l'instant.";
       }


### PR DESCRIPTION
### Motivation
- Éviter la superposition visuelle entre le bottom sheet de profil et la card/modale de confirmation de déconnexion pour un rendu propre et fluide.
- Garantir que la confirmation n'apparaisse qu'après la fermeture effective (fin de la transition) du bottom sheet.
- Ne toucher à aucun autre comportement, design ou action du bottom sheet.

### Description
- Le helper de fermeture du bottom sheet (`closeSheet`) a été refactorisé pour retourner une `Promise` qui se résout une fois la transition de fermeture terminée et les écouteurs nettoyés (fichier modifié : `js/app.js`).
- L'action `onclick` du bouton « Déconnexion » attend maintenant la résolution de `closeSheet()` avant d'appeler `askLogoutConfirmation()`, ce qui garantit la séquence : fermer le sheet puis afficher la confirmation.
- Aucun autre comportement ni design du bottom sheet n'a été modifié, et les fermetures déclenchées par clic sur le fond ou gestes tactiles conservent leur logique existante.

### Testing
- Exécution de la vérification de syntaxe avec `node --check js/app.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e509c3ec54832ab6449f23b75536b6)