### PR TITLE
Enregistrer et afficher le nom du créateur (createdByName)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -25,13 +25,17 @@ import { firebaseAuth } from './firebase-core.js';
     element.textContent = `${count} ${count === 1 ? singular : plural}`;
   }
 
-  function resolveActorLabel(userId, userMap) {
+  function resolveActorLabel(userId, userMap, fallbackName) {
+    const directName = String(fallbackName || '').trim();
+    if (directName) {
+      return directName;
+    }
     const username = userMap?.[String(userId || '')];
-    return username || 'N/A';
+    return username || 'Utilisateur';
   }
 
   function buildCreatedModifiedLabels(item, userMap) {
-    const createdBy = resolveActorLabel(item?.createdBy, userMap);
+    const createdBy = resolveActorLabel(item?.createdBy, userMap, item?.createdByName);
     const modifiedBy = resolveActorLabel(item?.modifiedBy || item?.updatedBy || item?.createdBy, userMap);
     return {
       createdLabel: `Créé par ${createdBy} le ${UiService.formatDate(item?.dateCreation)}`,
@@ -785,7 +789,7 @@ import { firebaseAuth } from './firebase-core.js';
         const users = await StorageService.listUsers();
         userNamesById = users.reduce((accumulator, user) => {
           if (user?.id) {
-            accumulator[user.id] = user.username || 'N/A';
+            accumulator[user.id] = user.username || 'Utilisateur';
           }
           return accumulator;
         }, {});
@@ -1130,7 +1134,7 @@ import { firebaseAuth } from './firebase-core.js';
         const users = await StorageService.listUsers();
         userNamesById = users.reduce((accumulator, user) => {
           if (user?.id) {
-            accumulator[user.id] = user.username || 'N/A';
+            accumulator[user.id] = user.username || 'Utilisateur';
           }
           return accumulator;
         }, {});

--- a/js/storage.js
+++ b/js/storage.js
@@ -591,6 +591,12 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+async function resolveCurrentUserName() {
+  const profile = await getCurrentUserProfile();
+  const rawName = profile?.username || state.authUser?.displayName || '';
+  return sanitizeText(rawName, false) || 'Utilisateur';
+}
+
 function uid() {
   return `local_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
 }
@@ -992,10 +998,12 @@ async function createSite(name) {
   }
 
   const timestamp = nowIso();
+  const creatorName = await resolveCurrentUserName();
   const sitePayload = {
     nom: siteName,
     ownerId: state.userId,
     createdBy: state.userId,
+    createdByName: creatorName,
     dateCreation: timestamp,
     dateModification: timestamp,
   };
@@ -1046,11 +1054,13 @@ async function createItem(siteId, numberValue) {
   }
 
   const timestamp = nowIso();
+  const creatorName = await resolveCurrentUserName();
   const itemPayload = {
     siteId,
     numero,
     ownerId: state.userId,
     createdBy: state.userId,
+    createdByName: creatorName,
     dateCreation: timestamp,
     dateModification: timestamp,
   };


### PR DESCRIPTION
### Motivation
- Garder le libellé existant « Créé par [Nom] le [date] » tout en affichant le nom lisible de l’utilisateur connecté au moment de la création.
- Permettre un fallback lisible pour les anciens enregistrements ou comptes sans nom (remplacer `N/A` par `Utilisateur`).
- Ne pas modifier le design ni altérer les autres données existantes, tout en restant compatible avec les documents Firestore existants.

### Description
- Ajout d'un helper `resolveCurrentUserName()` dans `js/storage.js` pour récupérer le nom courant (profil ou displayName) et normaliser le fallback sur `Utilisateur`.
- Lors de la création d'un site (`createSite`) et d'un OUT (`createItem`), on enregistre désormais `createdByName` dans le payload envoyé à Firestore sans toucher aux autres champs existants.
- Mise à jour de `js/app.js` : `resolveActorLabel()` accepte un `fallbackName` direct et retourne `Utilisateur` si aucun nom n'est disponible, et `buildCreatedModifiedLabels()` privilégie `item.createdByName` pour le libellé « Créé par ».
- Remplacement des fallbacks `N/A` par `Utilisateur` lors du chargement des maps de noms utilisateurs pour conserver un affichage cohérent.

### Testing
- Vérification de syntaxe JavaScript exécutée avec `node --check js/app.js && node --check js/storage.js`, qui a réussi.
- Aucune erreur d'exécution statique détectée sur les fichiers modifiés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50e4729a4832a9b8c2c80718109bf)