### PR TITLE
Retire l'affichage "Modifié par" des listes (pages 1 & 2)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -34,13 +34,9 @@ import { firebaseAuth } from './firebase-core.js';
     return username || 'Utilisateur';
   }
 
-  function buildCreatedModifiedLabels(item, userMap) {
+  function buildCreatedLabel(item, userMap) {
     const createdBy = resolveActorLabel(item?.createdBy, userMap, item?.createdByName);
-    const modifiedBy = resolveActorLabel(item?.modifiedBy || item?.updatedBy || item?.createdBy, userMap);
-    return {
-      createdLabel: `Créé par ${createdBy} le ${UiService.formatDate(item?.dateCreation)}`,
-      modifiedLabel: `Modifié par ${modifiedBy} le ${UiService.formatDate(item?.dateModification)}`,
-    };
+    return `Créé par ${createdBy} le ${UiService.formatDate(item?.dateCreation)}`;
   }
 
   function startOfDay(date) {
@@ -908,7 +904,7 @@ import { firebaseAuth } from './firebase-core.js';
 
       siteList.innerHTML = sites
         .map((site) => {
-          const labels = buildCreatedModifiedLabels(site, userNamesById);
+          const createdLabel = buildCreatedLabel(site, userNamesById);
           return `
             <article class="list-card">
               ${isAuthenticated && currentPermissions.canDelete ? `<button class="list-card__delete-button" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
@@ -916,8 +912,7 @@ import { firebaseAuth } from './firebase-core.js';
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
                   <span>${itemCountsBySite[site.id] || 0} OUT${(itemCountsBySite[site.id] || 0) > 1 ? 'S' : ''}</span>
-                  <span>${escapeHtml(labels.createdLabel)}</span>
-                  <small>${escapeHtml(labels.modifiedLabel)}</small>
+                  <span>${escapeHtml(createdLabel)}</span>
                 </div>
               </button>
             </article>
@@ -1233,7 +1228,7 @@ import { firebaseAuth } from './firebase-core.js';
           `);
         }
         previousLabel = currentLabel;
-        const labels = buildCreatedModifiedLabels(item, userNamesById);
+        const createdLabel = buildCreatedLabel(item, userNamesById);
         htmlParts.push(`
             <article class="list-card">
               ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__delete-button" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
@@ -1241,8 +1236,7 @@ import { firebaseAuth } from './firebase-core.js';
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
                   <span>${detailCountsByItem[item.id] || 0} Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span>
-                  <span>${escapeHtml(labels.createdLabel)}</span>
-                  <small>${escapeHtml(labels.modifiedLabel)}</small>
+                  <span>${escapeHtml(createdLabel)}</span>
                 </div>
               </button>
             </article>


### PR DESCRIPTION
### Motivation
- Supprimer l'affichage `Modifié par ...` dans la liste des sites (page 1) et dans la liste des OUT (page 2) sans toucher au design ni aux autres fonctionnalités.
- Éliminer le code d'affichage spécifique à cette étiquette pour garder le code plus simple et éviter d'exposer des champs Firestore uniquement utilisés pour l'affichage.
- Appliquer une suppression ciblée côté UI sans modifier les données stockées ni la compatibilité.

### Description
- Remplace la fonction `buildCreatedModifiedLabels` par `buildCreatedLabel` dans `js/app.js`, qui ne retourne plus que la chaîne `Créé par ...` (suppression de la logique `modifiedBy`/`updatedBy` côté affichage). 
- Met à jour les rendus des listes dans `renderSites` et `renderItems` pour utiliser `buildCreatedLabel` et supprimer le `<small>` contenant `Modifié par ...` dans les cartes de liste. 
- Aucun autre fichier n'a été modifié et aucune donnée Firestore n'est supprimée ou altérée par cette PR.

### Testing
- `node --check js/app.js` a été exécuté et a réussi sans erreur de syntaxe. 
- Recherche par motif avec `rg -n "Modifié par|buildCreatedModifiedLabels|modifiedBy|updatedBy" js/app.js` a été exécutée et n'a retourné aucune occurrence dans le fichier modifié, confirmant la suppression côté UI. 
- Le commit contenant la modification a été créé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e511a37e28832aa46cf17ce65bf988)