### PR TITLE
Add per-site lock/unlock UI and storage support (password protected)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -888,6 +888,15 @@ body[data-page="history"] .list-grid {
   background: rgba(31, 42, 55, 0.16);
 }
 
+.list-card__lock-icon {
+  position: absolute;
+  right: 0.85rem;
+  bottom: 0.95rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  object-fit: contain;
+}
+
 .btn,
 .btn-danger {
   border: 0;
@@ -899,6 +908,10 @@ body[data-page="history"] .list-grid {
 .btn-success {
   color: #fff;
   background: var(--success);
+}
+
+.modal-actions--split {
+  justify-content: space-between;
 }
 
 .btn-danger {

--- a/index.html
+++ b/index.html
@@ -79,6 +79,46 @@
         </form>
       </dialog>
 
+      <dialog id="siteLockDialog" class="modal-card">
+        <form class="modal-content" id="siteLockForm">
+          <div class="modal-header">
+            <h2>Verrouiller ce site</h2>
+            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
+          </div>
+          <label class="input-group">
+            <span>Entrer un mot de passe</span>
+            <input id="siteLockPasswordInput" type="password" autocomplete="new-password" />
+          </label>
+          <label class="input-group">
+            <span>Confirmer le mot de passe</span>
+            <input id="siteLockConfirmPasswordInput" type="password" autocomplete="new-password" />
+          </label>
+          <p id="siteLockError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split">
+            <button type="button" class="btn" data-close-dialog>Annuler</button>
+            <button type="submit" class="btn btn-success">Enregistrer</button>
+          </div>
+        </form>
+      </dialog>
+
+      <dialog id="siteUnlockDialog" class="modal-card">
+        <form class="modal-content" id="siteUnlockForm">
+          <div class="modal-header">
+            <h2>Site verrouillé</h2>
+            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
+          </div>
+          <label class="input-group">
+            <span>Mot de passe</span>
+            <input id="siteUnlockPasswordInput" type="password" autocomplete="current-password" />
+          </label>
+          <p id="siteUnlockError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split">
+            <button type="button" class="btn" data-close-dialog>Annuler</button>
+            <button type="submit" class="btn btn-success">Valider</button>
+          </div>
+        </form>
+      </dialog>
+
       <div id="toast" class="toast" aria-live="polite"></div>
     </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -25,6 +25,19 @@ import { firebaseAuth } from './firebase-core.js';
     element.textContent = `${count} ${count === 1 ? singular : plural}`;
   }
 
+  function isSiteLocked(site) {
+    return Boolean(site?.isLocked) && Boolean(String(site?.passwordHash || '').trim());
+  }
+
+  async function hashPassword(value) {
+    const normalized = String(value || '');
+    const encoded = new TextEncoder().encode(normalized);
+    const digest = await crypto.subtle.digest('SHA-256', encoded);
+    return Array.from(new Uint8Array(digest))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
   function resolveActorLabel(userId, userMap, fallbackName) {
     const directName = String(fallbackName || '').trim();
     if (directName) {
@@ -773,12 +786,23 @@ import { firebaseAuth } from './firebase-core.js';
     const exportDataButton = requireElement('exportDataButton');
     const manageUsersButton = requireElement('manageUsersButton');
     const historyButton = requireElement('historyButton');
+    const siteLockDialog = requireElement('siteLockDialog');
+    const siteLockForm = requireElement('siteLockForm');
+    const siteLockPasswordInput = requireElement('siteLockPasswordInput');
+    const siteLockConfirmPasswordInput = requireElement('siteLockConfirmPasswordInput');
+    const siteLockError = requireElement('siteLockError');
+    const siteUnlockDialog = requireElement('siteUnlockDialog');
+    const siteUnlockForm = requireElement('siteUnlockForm');
+    const siteUnlockPasswordInput = requireElement('siteUnlockPasswordInput');
+    const siteUnlockError = requireElement('siteUnlockError');
 
     let currentSites = [];
     let itemCountsBySite = {};
     let userNamesById = {};
     let currentPermissions = permissions;
     let isAuthenticated = Boolean(authState?.isAuthenticated);
+    let siteIdPendingLock = null;
+    let siteIdPendingUnlock = null;
 
     async function loadUserNames() {
       try {
@@ -915,14 +939,82 @@ import { firebaseAuth } from './firebase-core.js';
                   <span>${escapeHtml(createdLabel)}</span>
                 </div>
               </button>
+              <img
+                class="list-card__lock-icon"
+                src="${isSiteLocked(site) ? 'Icon/Cadenas_close' : 'Icon/Cadenas_Open'}"
+                alt="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
+                aria-label="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
+              />
             </article>
           `;
         })
         .join('');
 
       siteList.querySelectorAll('[data-site-open]').forEach((button) => {
+        let longPressTimer = null;
+        let skipClickAfterLongPress = false;
+        const siteId = button.dataset.siteOpen;
+
+        const clearLongPressTimer = () => {
+          if (!longPressTimer) {
+            return;
+          }
+          window.clearTimeout(longPressTimer);
+          longPressTimer = null;
+        };
+
+        const openLockDialog = () => {
+          if (!siteLockDialog || !siteLockPasswordInput || !siteLockConfirmPasswordInput || !siteLockError) {
+            return;
+          }
+          siteIdPendingLock = siteId;
+          siteLockPasswordInput.value = '';
+          siteLockConfirmPasswordInput.value = '';
+          siteLockError.textContent = '';
+          siteLockDialog.showModal();
+          siteLockPasswordInput.focus();
+        };
+
+        button.addEventListener('pointerdown', (event) => {
+          if (event.button !== 0) {
+            return;
+          }
+          skipClickAfterLongPress = false;
+          clearLongPressTimer();
+          longPressTimer = window.setTimeout(() => {
+            skipClickAfterLongPress = true;
+            openLockDialog();
+          }, 650);
+        });
+
+        button.addEventListener('pointerup', clearLongPressTimer);
+        button.addEventListener('pointerleave', clearLongPressTimer);
+        button.addEventListener('pointercancel', clearLongPressTimer);
+        button.addEventListener('contextmenu', (event) => {
+          event.preventDefault();
+          clearLongPressTimer();
+          skipClickAfterLongPress = true;
+          openLockDialog();
+        });
+
         button.addEventListener('click', () => {
-          UiService.navigate(`page2.html?siteId=${encodeURIComponent(button.dataset.siteOpen)}`);
+          if (skipClickAfterLongPress) {
+            skipClickAfterLongPress = false;
+            return;
+          }
+          const targetSite = currentSites.find((site) => site.id === siteId);
+          if (!isSiteLocked(targetSite)) {
+            UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
+            return;
+          }
+          if (!siteUnlockDialog || !siteUnlockPasswordInput || !siteUnlockError) {
+            return;
+          }
+          siteIdPendingUnlock = siteId;
+          siteUnlockPasswordInput.value = '';
+          siteUnlockError.textContent = '';
+          siteUnlockDialog.showModal();
+          siteUnlockPasswordInput.focus();
         });
       });
 
@@ -1066,6 +1158,87 @@ import { firebaseAuth } from './firebase-core.js';
       } catch (error) {
         console.error('Erreur lors de la création du site :', error);
         siteFormError.textContent = "Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.";
+      }
+    });
+
+    siteLockForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!siteIdPendingLock) {
+        return;
+      }
+      const passwordValue = siteLockPasswordInput?.value || '';
+      const confirmValue = siteLockConfirmPasswordInput?.value || '';
+
+      if (!passwordValue.trim() || !confirmValue.trim()) {
+        siteLockError.textContent = 'Veuillez remplir tous les champs.';
+        return;
+      }
+
+      if (passwordValue !== confirmValue) {
+        siteLockError.textContent = 'Les mots de passe ne correspondent pas.';
+        return;
+      }
+
+      try {
+        const passwordHash = await hashPassword(passwordValue);
+        const result = await StorageService.setSiteLock(siteIdPendingLock, { passwordHash });
+        if (!result?.ok) {
+          siteLockError.textContent = 'Impossible de verrouiller ce site.';
+          return;
+        }
+        siteLockDialog?.close();
+        siteIdPendingLock = null;
+        UiService.showToast('Site verrouillé.');
+      } catch (_error) {
+        siteLockError.textContent = 'Erreur pendant le verrouillage.';
+      }
+    });
+
+    siteUnlockForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!siteIdPendingUnlock) {
+        return;
+      }
+      const passwordValue = siteUnlockPasswordInput?.value || '';
+      if (!passwordValue.trim()) {
+        siteUnlockError.textContent = 'Veuillez entrer le mot de passe.';
+        return;
+      }
+
+      const targetSite = currentSites.find((site) => site.id === siteIdPendingUnlock);
+      if (!isSiteLocked(targetSite)) {
+        siteUnlockDialog?.close();
+        UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteIdPendingUnlock)}`);
+        siteIdPendingUnlock = null;
+        return;
+      }
+
+      try {
+        const passwordHash = await hashPassword(passwordValue);
+        if (passwordHash !== targetSite.passwordHash) {
+          siteUnlockError.textContent = 'Mot de passe incorrect.';
+          return;
+        }
+        const openSiteId = siteIdPendingUnlock;
+        siteUnlockDialog?.close();
+        siteIdPendingUnlock = null;
+        UiService.navigate(`page2.html?siteId=${encodeURIComponent(openSiteId)}`);
+      } catch (_error) {
+        siteUnlockError.textContent = 'Erreur pendant la vérification.';
+      }
+    });
+
+    siteLockDialog?.addEventListener('close', () => {
+      siteIdPendingLock = null;
+      if (siteLockError) {
+        siteLockError.textContent = '';
+      }
+    });
+
+    siteUnlockDialog?.addEventListener('close', () => {
+      siteIdPendingUnlock = null;
+      if (siteUnlockError) {
+        siteUnlockError.textContent = '';
       }
     });
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1017,6 +1017,42 @@ async function createSite(name) {
   return { ok: true, id: site.id };
 }
 
+async function setSiteLock(siteId, lockPayload) {
+  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
+  if (siteIndex === -1) {
+    return { ok: false, reason: 'site_not_found' };
+  }
+
+  const timestamp = nowIso();
+  const lockerName = (await resolveCurrentUserName()) || 'Utilisateur';
+  const nextLockState = {
+    isLocked: true,
+    passwordHash: sanitizeText(lockPayload?.passwordHash, false),
+    lockedAt: timestamp,
+    lockedByName: lockerName,
+    dateModification: timestamp,
+  };
+
+  if (!nextLockState.passwordHash) {
+    return { ok: false, reason: 'invalid_password_hash' };
+  }
+
+  await setDoc(
+    doc(state.db, 'pages', 'page1', 'items', siteId),
+    nextLockState,
+    { merge: true },
+  );
+
+  state.sites[siteIndex] = {
+    ...state.sites[siteIndex],
+    ...nextLockState,
+  };
+  sortState();
+  persistOfflineState();
+  emitAll();
+  return { ok: true };
+}
+
 async function removeSite(siteId) {
   const siteIndex = state.sites.findIndex((site) => site.id === siteId);
   if (siteIndex === -1) {
@@ -1529,6 +1565,7 @@ window.StorageService = {
   getDetailRowsBySite,
   getAllDetails,
   createSite,
+  setSiteLock,
   removeSite,
   restoreSite,
   createItem,


### PR DESCRIPTION
### Motivation
- Add the ability to lock individual sites with a password so access to site details can be protected.
- Provide a user flow for setting a password via long-press/context-menu and unlocking a locked site before navigation.

### Description
- Add lock/unlock modal dialogs to `index.html` (`#siteLockDialog` and `#siteUnlockDialog`) and wire up inputs and actions. 
- Add styling (`.list-card__lock-icon` and `.modal-actions--split`) to `css/style.css` and render a lock icon per site showing locked/unlocked state.
- Implement client-side helpers in `js/app.js`: `isSiteLocked`, `hashPassword` (SHA-256), long-press/contextmenu handling to open the lock dialog, unlock dialog handling, and navigation gating when a site is locked; manage pending lock/unlock site ids and form submission flows.
- Implement `setSiteLock` in `js/storage.js` to persist lock metadata (`isLocked`, `passwordHash`, `lockedAt`, `lockedByName`, `dateModification`) to the backend and update in-memory state, and expose it on `StorageService`.

### Testing
- Ran the project automated test suite with `npm test`, and all tests passed.
- Ran lint and build checks with `npm run lint` and `npm run build`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5178edc20832ab1925ddee64424d9)