### PR TITLE
Corrige affichage icône cadenas sur la page 1

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -929,6 +929,7 @@ import { firebaseAuth } from './firebase-core.js';
       siteList.innerHTML = sites
         .map((site) => {
           const createdLabel = buildCreatedLabel(site, userNamesById);
+          const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
           return `
             <article class="list-card">
               ${isAuthenticated && currentPermissions.canDelete ? `<button class="list-card__delete-button" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
@@ -941,7 +942,7 @@ import { firebaseAuth } from './firebase-core.js';
               </button>
               <img
                 class="list-card__lock-icon"
-                src="${isSiteLocked(site) ? 'Icon/Cadenas_close' : 'Icon/Cadenas_Open'}"
+                src="${lockIconSrc}"
                 alt="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
                 aria-label="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
               />
@@ -949,6 +950,29 @@ import { firebaseAuth } from './firebase-core.js';
           `;
         })
         .join('');
+
+      siteList.querySelectorAll('.list-card__lock-icon').forEach((icon) => {
+        const iconSrc = icon.getAttribute('src');
+        console.debug('[page1][lock-icon] src utilisé :', iconSrc);
+
+        icon.addEventListener(
+          'error',
+          () => {
+            const fallbackSrc = 'Icon/Cadenas_close.png';
+            console.warn('[page1][lock-icon] erreur de chargement, fallback appliqué :', iconSrc, '->', fallbackSrc);
+            icon.src = fallbackSrc;
+
+            icon.addEventListener(
+              'error',
+              () => {
+                icon.style.display = 'none';
+              },
+              { once: true },
+            );
+          },
+          { once: true },
+        );
+      });
 
       siteList.querySelectorAll('[data-site-open]').forEach((button) => {
         let longPressTimer = null;


### PR DESCRIPTION
### Motivation
- Assurer que l’icône « cadenas » se charge correctement sur la page 1 en utilisant les chemins sensibles à la casse et l’extension `.png` attendus par GitHub Pages, et fournir un mécanisme de diagnostic et de repli si l’image ne charge pas.

### Description
- Modifié `renderSites` dans `js/app.js` pour construire et utiliser `lockIconSrc` avec les chemins exacts `Icon/Cadenas_close.png` et `Icon/Cadenas_Open.png`.
- Ajouté un `console.debug` pour afficher le `src` réellement utilisé pour chaque icône cadenas au rendu.
- Ajouté un gestionnaire `error` pour appliquer en premier recours `Icon/Cadenas_close.png` en fallback et masquer l’icône si le fallback échoue.

### Testing
- Exécuté `rg -n "Cadenas_close|Cadenas_Open|lock-icon" js/app.js` pour vérifier la présence des changements dans le fichier ciblé, et la recherche a retourné les lignes attendues (succès).
- Exécuté `git add js/app.js && git commit -m "Fix page 1 lock icon path and add image fallback logging"` pour enregistrer la modification et la commande a réussi (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51e87b400832ab4642cad57711791)