### PR TITLE
Améliore la gestion du verrouillage par mot de passe sur la page 1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -897,6 +897,11 @@ body[data-page="history"] .list-grid {
   object-fit: contain;
 }
 
+.list-card__lock-icon--with-delete {
+  top: calc(0.75rem + 2.25rem + 0.35rem);
+  bottom: auto;
+}
+
 .btn,
 .btn-danger {
   border: 0;
@@ -987,6 +992,13 @@ body[data-page="history"] .list-grid {
 
 .modal-content {
   padding: 1rem;
+}
+
+.modal-helper-text {
+  margin: -0.2rem 0 0.9rem;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
 }
 
 .modal-header {

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
       <dialog id="siteLockDialog" class="modal-card">
         <form class="modal-content" id="siteLockForm">
           <div class="modal-header">
-            <h2>Verrouiller ce site</h2>
+            <h2>Créer un mot de passe</h2>
             <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
           </div>
           <label class="input-group">
@@ -97,6 +97,30 @@
           <div class="modal-actions modal-actions--split">
             <button type="button" class="btn" data-close-dialog>Annuler</button>
             <button type="submit" class="btn btn-success">Enregistrer</button>
+          </div>
+        </form>
+      </dialog>
+
+      <dialog id="siteLockManageDialog" class="modal-card">
+        <form class="modal-content" id="siteLockManageForm">
+          <div class="modal-header">
+            <h2>Gestion de l’accès sécurisé</h2>
+            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
+          </div>
+          <p class="modal-helper-text">Ce site est actuellement protégé par un mot de passe.</p>
+          <label class="input-group">
+            <span>Mot de passe actuel</span>
+            <input id="siteLockCurrentPasswordInput" type="password" autocomplete="current-password" />
+          </label>
+          <label class="input-group">
+            <span>Nouveau mot de passe</span>
+            <input id="siteLockNewPasswordInput" type="password" autocomplete="new-password" />
+          </label>
+          <p id="siteLockManageError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split">
+            <button type="submit" class="btn btn-danger" data-lock-manage-action="unlock">Déverrouiller</button>
+            <button type="submit" class="btn btn-success" data-lock-manage-action="update">Mettre à jour le mot de passe</button>
+            <button type="button" class="btn" data-close-dialog>Annuler</button>
           </div>
         </form>
       </dialog>

--- a/js/app.js
+++ b/js/app.js
@@ -795,6 +795,11 @@ import { firebaseAuth } from './firebase-core.js';
     const siteUnlockForm = requireElement('siteUnlockForm');
     const siteUnlockPasswordInput = requireElement('siteUnlockPasswordInput');
     const siteUnlockError = requireElement('siteUnlockError');
+    const siteLockManageDialog = requireElement('siteLockManageDialog');
+    const siteLockManageForm = requireElement('siteLockManageForm');
+    const siteLockCurrentPasswordInput = requireElement('siteLockCurrentPasswordInput');
+    const siteLockNewPasswordInput = requireElement('siteLockNewPasswordInput');
+    const siteLockManageError = requireElement('siteLockManageError');
 
     let currentSites = [];
     let itemCountsBySite = {};
@@ -803,6 +808,7 @@ import { firebaseAuth } from './firebase-core.js';
     let isAuthenticated = Boolean(authState?.isAuthenticated);
     let siteIdPendingLock = null;
     let siteIdPendingUnlock = null;
+    let siteIdPendingLockManage = null;
 
     async function loadUserNames() {
       try {
@@ -930,9 +936,11 @@ import { firebaseAuth } from './firebase-core.js';
         .map((site) => {
           const createdLabel = buildCreatedLabel(site, userNamesById);
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
+          const canShowDeleteButton =
+            isAuthenticated && currentPermissions.canDelete && !isSiteLocked(site);
           return `
             <article class="list-card">
-              ${isAuthenticated && currentPermissions.canDelete ? `<button class="list-card__delete-button" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
+              ${canShowDeleteButton ? `<button class="list-card__delete-button" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
@@ -941,7 +949,7 @@ import { firebaseAuth } from './firebase-core.js';
                 </div>
               </button>
               <img
-                class="list-card__lock-icon"
+                class="list-card__lock-icon ${canShowDeleteButton ? 'list-card__lock-icon--with-delete' : ''}"
                 src="${lockIconSrc}"
                 alt="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
                 aria-label="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
@@ -988,6 +996,25 @@ import { firebaseAuth } from './firebase-core.js';
         };
 
         const openLockDialog = () => {
+          const targetSite = currentSites.find((site) => site.id === siteId);
+          if (isSiteLocked(targetSite)) {
+            if (
+              !siteLockManageDialog ||
+              !siteLockCurrentPasswordInput ||
+              !siteLockNewPasswordInput ||
+              !siteLockManageError
+            ) {
+              return;
+            }
+            siteIdPendingLockManage = siteId;
+            siteLockCurrentPasswordInput.value = '';
+            siteLockNewPasswordInput.value = '';
+            siteLockManageError.textContent = '';
+            siteLockManageDialog.showModal();
+            siteLockCurrentPasswordInput.focus();
+            return;
+          }
+
           if (!siteLockDialog || !siteLockPasswordInput || !siteLockConfirmPasswordInput || !siteLockError) {
             return;
           }
@@ -1252,6 +1279,65 @@ import { firebaseAuth } from './firebase-core.js';
       }
     });
 
+    siteLockManageForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!siteIdPendingLockManage) {
+        return;
+      }
+
+      const submittedAction = event.submitter?.dataset?.lockManageAction;
+      const currentPasswordValue = siteLockCurrentPasswordInput?.value || '';
+      const newPasswordValue = siteLockNewPasswordInput?.value || '';
+      const targetSite = currentSites.find((site) => site.id === siteIdPendingLockManage);
+      if (!isSiteLocked(targetSite)) {
+        siteLockManageDialog?.close();
+        siteIdPendingLockManage = null;
+        return;
+      }
+
+      if (!currentPasswordValue.trim()) {
+        siteLockManageError.textContent = 'Mot de passe actuel incorrect.';
+        return;
+      }
+
+      try {
+        const currentPasswordHash = await hashPassword(currentPasswordValue);
+        if (currentPasswordHash !== targetSite.passwordHash) {
+          siteLockManageError.textContent = 'Mot de passe actuel incorrect.';
+          return;
+        }
+
+        if (submittedAction === 'unlock') {
+          const result = await StorageService.clearSiteLock(siteIdPendingLockManage);
+          if (!result?.ok) {
+            siteLockManageError.textContent = 'Impossible de retirer le verrouillage.';
+            return;
+          }
+          siteLockManageDialog?.close();
+          siteIdPendingLockManage = null;
+          UiService.showToast('Le verrouillage a été retiré avec succès.');
+          return;
+        }
+
+        if (!newPasswordValue.trim()) {
+          siteLockManageError.textContent = 'Veuillez saisir un nouveau mot de passe.';
+          return;
+        }
+
+        const nextPasswordHash = await hashPassword(newPasswordValue);
+        const result = await StorageService.setSiteLock(siteIdPendingLockManage, { passwordHash: nextPasswordHash });
+        if (!result?.ok) {
+          siteLockManageError.textContent = 'Impossible de mettre à jour le mot de passe.';
+          return;
+        }
+        siteLockManageDialog?.close();
+        siteIdPendingLockManage = null;
+        UiService.showToast('Le mot de passe a été mis à jour avec succès.');
+      } catch (_error) {
+        siteLockManageError.textContent = 'Erreur pendant la gestion du mot de passe.';
+      }
+    });
+
     siteLockDialog?.addEventListener('close', () => {
       siteIdPendingLock = null;
       if (siteLockError) {
@@ -1263,6 +1349,13 @@ import { firebaseAuth } from './firebase-core.js';
       siteIdPendingUnlock = null;
       if (siteUnlockError) {
         siteUnlockError.textContent = '';
+      }
+    });
+
+    siteLockManageDialog?.addEventListener('close', () => {
+      siteIdPendingLockManage = null;
+      if (siteLockManageError) {
+        siteLockManageError.textContent = '';
       }
     });
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1053,6 +1053,41 @@ async function setSiteLock(siteId, lockPayload) {
   return { ok: true };
 }
 
+async function clearSiteLock(siteId) {
+  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
+  if (siteIndex === -1) {
+    return { ok: false, reason: 'site_not_found' };
+  }
+
+  const timestamp = nowIso();
+  const nextLockState = {
+    isLocked: false,
+    passwordHash: deleteField(),
+    lockedAt: deleteField(),
+    lockedByName: deleteField(),
+    dateModification: timestamp,
+  };
+
+  await setDoc(
+    doc(state.db, 'pages', 'page1', 'items', siteId),
+    nextLockState,
+    { merge: true },
+  );
+
+  state.sites[siteIndex] = {
+    ...state.sites[siteIndex],
+    isLocked: false,
+    passwordHash: '',
+    lockedAt: null,
+    lockedByName: '',
+    dateModification: timestamp,
+  };
+  sortState();
+  persistOfflineState();
+  emitAll();
+  return { ok: true };
+}
+
 async function removeSite(siteId) {
   const siteIndex = state.sites.findIndex((site) => site.id === siteId);
   if (siteIndex === -1) {
@@ -1566,6 +1601,7 @@ window.StorageService = {
   getAllDetails,
   createSite,
   setSiteLock,
+  clearSiteLock,
   removeSite,
   restoreSite,
   createItem,


### PR DESCRIPTION
### Motivation
- Ajouter une gestion claire et complète du verrouillage par mot de passe uniquement pour la page 1, en distinguant création (site non verrouillé) et gestion (site verrouillé) via un clic long. 
- Masquer dynamiquement le bouton `Supprimer` quand un site est verrouillé et conserver l'icône cadenas ouverte/fermée pour un rendu professionnel et cohérent. 

### Description
- Ajout d'une nouvelle modal centrée `siteLockManageDialog` dans `index.html` avec le titre `Gestion de l’accès sécurisé`, le texte d'information, les champs `Mot de passe actuel` et `Nouveau mot de passe`, et les boutons `Déverrouiller`, `Mettre à jour le mot de passe` et `Annuler`. 
- Mise à jour de `js/app.js` pour rendre le `long press` contextuel : ouvrir la modal de création (`siteLockDialog`) si le site n'est pas verrouillé, ou ouvrir la modal de gestion (`siteLockManageDialog`) si le site est verrouillé, et traitement des actions de déverrouillage / mise à jour (vérification du mot de passe actuel, validations et toasts). 
- Ajout de `clearSiteLock(siteId)` dans `js/storage.js` pour retirer proprement le verrouillage en base (`isLocked = false`, suppression de `passwordHash` et métadonnées) et propagation dans l'état local. 
- Ajustements d'UI : le bouton `Supprimer` est désormais rendu uniquement si `isLocked === false`, l'icône cadenas utilise `Icon/Cadenas_close.png` / `Icon/Cadenas_Open.png`, et CSS (`css/style.css`) contient des règles pour aligner l'icône et le texte d'aide de la modal. 

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js && node --check js/storage.js`, qui a réussi. 
- Aucun autre test automatisé disponible dans l'environnement cible, les changements ont été commités localement et la PR préparée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e523951364832a8e30514963cdf49d)