### PR TITLE
Ajuster l’UI des modals de mot de passe sur la page d’accueil

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1035,6 +1035,20 @@ body[data-page="history"] .list-grid {
   gap: 0.75rem;
 }
 
+.modal-actions--password {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.modal-actions--password .btn {
+  flex: 0 1 auto;
+  min-width: fit-content;
+}
+
+.modal-actions--password-manage {
+  justify-content: space-between;
+}
+
 .form-footer {
   grid-column: 1 / -1;
   justify-content: space-between;

--- a/index.html
+++ b/index.html
@@ -83,7 +83,6 @@
         <form class="modal-content" id="siteLockForm">
           <div class="modal-header">
             <h2>Créer un mot de passe</h2>
-            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
           </div>
           <label class="input-group">
             <span>Entrer un mot de passe</span>
@@ -94,7 +93,7 @@
             <input id="siteLockConfirmPasswordInput" type="password" autocomplete="new-password" />
           </label>
           <p id="siteLockError" class="form-error" aria-live="polite"></p>
-          <div class="modal-actions modal-actions--split">
+          <div class="modal-actions modal-actions--password">
             <button type="button" class="btn" data-close-dialog>Annuler</button>
             <button type="submit" class="btn btn-success">Enregistrer</button>
           </div>
@@ -105,7 +104,6 @@
         <form class="modal-content" id="siteLockManageForm">
           <div class="modal-header">
             <h2>Gestion de l’accès sécurisé</h2>
-            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
           </div>
           <p class="modal-helper-text">Ce site est actuellement protégé par un mot de passe.</p>
           <label class="input-group">
@@ -117,7 +115,7 @@
             <input id="siteLockNewPasswordInput" type="password" autocomplete="new-password" />
           </label>
           <p id="siteLockManageError" class="form-error" aria-live="polite"></p>
-          <div class="modal-actions modal-actions--split">
+          <div class="modal-actions modal-actions--password modal-actions--password-manage">
             <button type="submit" class="btn btn-danger" data-lock-manage-action="unlock">Déverrouiller</button>
             <button type="submit" class="btn btn-success" data-lock-manage-action="update">Mettre à jour le mot de passe</button>
             <button type="button" class="btn" data-close-dialog>Annuler</button>


### PR DESCRIPTION
### Motivation
- Rendre l’interface des modals de création et de gestion du mot de passe plus propre en mettant les actions sur une seule ligne et en supprimant le bouton de fermeture « X » en haut. 
- Conserver la logique JS existante inchangée tout en assurant un rendu responsive et professionnel quel que soit l’espace d’écran.

### Description
- Supprime le bouton de fermeture en haut (`button.icon-button` « × ») dans `siteLockDialog` (création) et `siteLockManageDialog` (gestion). 
- Remplace la classe d’action existante par `modal-actions modal-actions--password` dans la modal de création et ajoute `modal-actions--password modal-actions--password-manage` dans la modal de gestion pour piloter l’affichage des boutons. 
- Ajoute des règles CSS dédiées (`.modal-actions--password` et `.modal-actions--password-manage`) pour forcer l’affichage horizontal des boutons avec `flex-wrap` en cas d’espace réduit et pour préserver l’alignement et l’ordre : `Déverrouiller`, `Mettre à jour le mot de passe`, `Annuler`. 
- Fichiers modifiés : `index.html`, `css/style.css`.

### Testing
- Exécution de vérifications de diff et d’affichage de fichiers (`git diff -- index.html css/style.css`, `nl -ba index.html | sed -n '72,140p'`, `nl -ba css/style.css | sed -n '1026,1068p'`) et inspection par `rg`/`sed`, toutes les commandes ont réussi. 
- Le commit des modifications (`git commit`) a réussi sans erreur. 
- Aucun test automatisé unitaire n’a été exécuté dans cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e526f4d958832a8e1d1da73bf475eb)