### PR TITLE
Refonte UI/UX mobile-first de la page détail site

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1721,3 +1721,235 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
     transform: rotate(360deg);
   }
 }
+
+/* Site detail page modern UI overrides */
+body[data-page="site-detail"] {
+  background: #f3f6fa;
+}
+
+body[data-page="site-detail"] .app-header--detail {
+  min-height: 7.2rem;
+  height: auto;
+  align-items: flex-start;
+  padding-top: 1.1rem;
+  padding-bottom: 1.15rem;
+  background: linear-gradient(140deg, #4f9cf8 0%, #2e6ce5 62%, #2f5fce 100%);
+}
+
+body[data-page="site-detail"] .header-title {
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+body[data-page="site-detail"] .site-detail-subtitle {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+body[data-page="site-detail"] .page-content {
+  padding-bottom: 7.2rem;
+  gap: 0.9rem;
+}
+
+body[data-page="site-detail"] .search-panel--site {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+body[data-page="site-detail"] .search-panel--site .input-group {
+  max-width: 100%;
+  position: relative;
+}
+
+body[data-page="site-detail"] .site-search-icon-wrap {
+  position: absolute;
+  left: 0.95rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+}
+
+body[data-page="site-detail"] .site-search-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  object-fit: contain;
+}
+
+.visually-hidden-control {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+body[data-page="site-detail"] #itemSearchInput {
+  width: 100%;
+  min-height: 3rem;
+  border-radius: 999px;
+  border: 1px solid #d8e2ef;
+  background: #fff;
+  padding-left: 2.6rem;
+  box-shadow: 0 7px 18px rgba(15, 23, 42, 0.06);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+body[data-page="site-detail"] #itemSearchInput:focus {
+  border-color: #2e6ce5;
+  box-shadow: 0 0 0 4px rgba(46, 108, 229, 0.12);
+}
+
+body[data-page="site-detail"] .filter-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+body[data-page="site-detail"] .filter-chip {
+  border: 1px solid #d5deea;
+  background: #fff;
+  color: #334155;
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.86rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+body[data-page="site-detail"] .filter-chip:hover {
+  border-color: #aac2ea;
+}
+
+body[data-page="site-detail"] .filter-chip:active {
+  transform: scale(0.98);
+}
+
+body[data-page="site-detail"] .filter-chip.is-active {
+  background: #2e6ce5;
+  border-color: #2e6ce5;
+  color: #fff;
+}
+
+body[data-page="site-detail"] .list-separator {
+  margin: 0.55rem 0 0.25rem;
+}
+
+body[data-page="site-detail"] .list-separator__label {
+  background: transparent;
+  color: #64748b;
+  padding-inline: 0.2rem;
+}
+
+body[data-page="site-detail"] .list-card {
+  padding: 0;
+  background: #fff;
+  color: var(--text);
+  border: 1px solid #dbe3ef;
+  border-radius: 18px;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.07);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body[data-page="site-detail"] .list-card::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: linear-gradient(180deg, #4f9cf8 0%, #2e6ce5 100%);
+}
+
+body[data-page="site-detail"] .list-card:hover {
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.11);
+}
+
+body[data-page="site-detail"] .list-card__button {
+  padding: 1rem 2.9rem 1rem 1.05rem;
+  display: grid;
+  gap: 0.62rem;
+}
+
+body[data-page="site-detail"] .list-card__button:active {
+  transform: scale(0.98);
+  transition: transform 0.2s ease;
+}
+
+body[data-page="site-detail"] .list-card__title {
+  color: #111827;
+  letter-spacing: 0.02em;
+}
+
+body[data-page="site-detail"] .list-card__meta {
+  margin-top: 0;
+  gap: 0.45rem;
+  font-size: 0.89rem;
+}
+
+body[data-page="site-detail"] .list-card__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #4b5563;
+}
+
+body[data-page="site-detail"] .list-card__meta-item img {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+body[data-page="site-detail"] .list-card__meta-item--article {
+  color: #15803d;
+  font-weight: 600;
+}
+
+body[data-page="site-detail"] .fab--export {
+  right: 1rem;
+  bottom: 1.2rem;
+  width: auto;
+  min-width: 8.8rem;
+  height: 3.1rem;
+  border-radius: 999px;
+  background: #18a85f;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding-inline: 1rem;
+  box-shadow: 0 14px 28px rgba(8, 112, 62, 0.3);
+  z-index: 40;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+body[data-page="site-detail"] .fab--export img {
+  width: 1rem;
+  height: 1rem;
+}
+
+body[data-page="site-detail"] .fab--export:hover {
+  background: #159154;
+  box-shadow: 0 16px 30px rgba(8, 112, 62, 0.35);
+}
+
+body[data-page="site-detail"] .fab--export:active {
+  transform: scale(0.98);
+}
+
+body[data-page="site-detail"] #openCreateItem {
+  left: 1rem;
+  right: auto;
+  bottom: 1.2rem;
+  width: 3.2rem;
+  height: 3.2rem;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -52,6 +52,19 @@ import { firebaseAuth } from './firebase-core.js';
     return `Créé par ${createdBy} le ${UiService.formatDate(item?.dateCreation)}`;
   }
 
+  function buildDateAndTimeLabel(dateValue) {
+    if (!dateValue) {
+      return '--';
+    }
+    const parsedDate = new Date(dateValue);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return '--';
+    }
+    const dateLabel = new Intl.DateTimeFormat('fr-FR', { dateStyle: 'short' }).format(parsedDate);
+    const timeLabel = new Intl.DateTimeFormat('fr-FR', { hour: '2-digit', minute: '2-digit' }).format(parsedDate);
+    return `${dateLabel} · ${timeLabel}`;
+  }
+
   function startOfDay(date) {
     const value = new Date(date);
     value.setHours(0, 0, 0, 0);
@@ -1432,6 +1445,7 @@ import { firebaseAuth } from './firebase-core.js';
     let userNamesById = {};
     const dateFilterStorageKey = `site-detail:item-date-filter:${siteId}`;
     const searchStorageKey = `site-detail:item-search:${siteId}`;
+    const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
 
@@ -1519,7 +1533,7 @@ import { firebaseAuth } from './firebase-core.js';
         return itemDesignations.some((designation) => String(designation || '').toUpperCase().includes(query));
       });
 
-      setCountText(itemCount, filteredItems.length, 'élément', 'éléments');
+      itemCount.textContent = `${filteredItems.length} OUT${filteredItems.length > 1 ? 'S' : ''}`;
 
       if (!filteredItems.length) {
         UiService.renderEmptyState(
@@ -1541,15 +1555,17 @@ import { firebaseAuth } from './firebase-core.js';
           `);
         }
         previousLabel = currentLabel;
-        const createdLabel = buildCreatedLabel(item, userNamesById);
+        const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
+        const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
         htmlParts.push(`
             <article class="list-card">
               ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__delete-button" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
-                  <span>${detailCountsByItem[item.id] || 0} Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span>
-                  <span>${escapeHtml(createdLabel)}</span>
+                  <span class="list-card__meta-item list-card__meta-item--article"><img src="Icon/Article.png" alt="" aria-hidden="true" /><span>${detailCountsByItem[item.id] || 0} Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span></span>
+                  <span class="list-card__meta-item"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" /><span>Créé le ${escapeHtml(createdLabel)}</span></span>
+                  <span class="list-card__meta-item"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" /><span>${escapeHtml(createdBy)}</span></span>
                 </div>
               </button>
             </article>
@@ -1612,9 +1628,29 @@ import { firebaseAuth } from './firebase-core.js';
         selectedDateFilter = 'all';
       }
       itemDateFilter.value = selectedDateFilter;
+      const updateFilterChipsState = () => {
+        filterChipButtons.forEach((chip) => {
+          chip.classList.toggle('is-active', chip.dataset.filterChip === selectedDateFilter);
+        });
+      };
+      updateFilterChipsState();
+      filterChipButtons.forEach((chip) => {
+        chip.addEventListener('click', () => {
+          const nextFilter = chip.dataset.filterChip || 'all';
+          if (nextFilter === selectedDateFilter) {
+            return;
+          }
+          selectedDateFilter = nextFilter;
+          itemDateFilter.value = selectedDateFilter;
+          window.localStorage.setItem(dateFilterStorageKey, selectedDateFilter);
+          updateFilterChipsState();
+          renderItems();
+        });
+      });
       itemDateFilter.addEventListener('change', () => {
         selectedDateFilter = itemDateFilter.value || 'all';
         window.localStorage.setItem(dateFilterStorageKey, selectedDateFilter);
+        updateFilterChipsState();
         renderItems();
       });
     }

--- a/page2.html
+++ b/page2.html
@@ -5,49 +5,51 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Détail liste - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body data-page="site-detail">
     <div class="app-shell">
       <header class="app-header app-header--detail">
         <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
-        <div class="header-title">
+        <div class="header-title header-title--stacked">
           <h1 id="siteTitle">Chargement...</h1>
+          <p id="itemCount" class="site-detail-subtitle">0 OUTS</p>
         </div>
       </header>
 
       <main class="page-content">
-        <section class="section-heading section-heading--meta surface-card">
-          <p id="itemCount">0 Nombre de OUT</p>
-          <button type="button" id="openExportItems" class="btn btn-success">
-            Exporter
-          </button>
-        </section>
-
-        <section class="search-panel surface-card">
+        <section class="search-panel search-panel--site surface-card">
           <label class="input-group">
-            <span class="label-with-icon"><img src="Icon/chercher.png" alt="" class="label-icon" aria-hidden="true" /><span>Chercher par numéro OUT ou par Article</span></span>
+            <span class="sr-only">Rechercher (OUT ou article)</span>
+            <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
             <input
               id="itemSearchInput"
               type="search"
-              placeholder="Rechercher..."
+              placeholder="Rechercher (OUT ou article)"
               autocomplete="off"
             />
           </label>
-          <label class="input-group search-filter-group">
-            <span class="label-with-icon"><img src="Icon/filtre.png" alt="" class="label-icon" aria-hidden="true" /><span>Filtrer par</span></span>
-            <select id="itemDateFilter" aria-label="Filtrer les résultats par date">
-              <option value="all">Tous</option>
-              <option value="today">Aujourd'hui</option>
-              <option value="yesterday">Hier</option>
-              <option value="lastMonth">Il y a longtemps</option>
-            </select>
-          </label>
+          <div class="filter-chip-group" role="group" aria-label="Filtrer les résultats par date">
+            <button class="filter-chip" type="button" data-filter-chip="all">Tous</button>
+            <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
+            <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>
+            <button class="filter-chip" type="button" data-filter-chip="lastMonth">Plus ancien</button>
+          </div>
+          <label class="sr-only" for="itemDateFilter">Filtrer les résultats par date</label>
+          <select id="itemDateFilter" class="visually-hidden-control" aria-label="Filtrer les résultats par date">
+            <option value="all">Tous</option>
+            <option value="today">Aujourd'hui</option>
+            <option value="yesterday">Hier</option>
+            <option value="lastMonth">Il y a longtemps</option>
+          </select>
         </section>
 
         <section id="itemList" class="list-grid" aria-live="polite"></section>
       </main>
 
+      <button type="button" id="openExportItems" class="fab fab--export" aria-label="Exporter">
+        <img src="Icon/Exporter.png" alt="" aria-hidden="true" />
+        <span>Exporter</span>
+      </button>
       <button id="openCreateItem" class="fab" type="button" aria-label="Ajouter un numéro OUT">+</button>
 
       <dialog id="itemDialog" class="modal-card">


### PR DESCRIPTION
### Motivation
- Moderniser l’interface de la page détail site pour un rendu SaaS (mobile-first, hiérarchie visuelle, lisibilité) tout en conservant la logique métier existante (Firestore, recherche, filtre, export). 
- Remplacer les éléments visuels vieillissants (cartes bleues, search inline, select visible, export haut) par des composants modernes sans casser les IDs ni le JS existant.

### Description
- HTML: refonte de `page2.html` — header empilé avec sous-titre dynamique `#itemCount`, barre de recherche unique utilisant `Icon/Recherche.png`, chips de filtre (`data-filter-chip`) et maintien du `select#itemDateFilter` caché pour compatibilité, ajout d’un FAB export flottant (`#openExportItems`) utilisant `Icon/Exporter.png` et conservation des IDs critiques (`siteTitle`, `itemSearchInput`, `itemDateFilter`, `openExportItems`, `itemList`, `openCreateItem`).
- CSS: ajouts d’overrides ciblés `body[data-page="site-detail"]` pour gradient header, recherches arrondies, chips actives/inactives, cartes blanches avec barre verticale bleue, FAB pill verte, micro-interactions (card press scale, focus search, chip active) et padding-bottom pour éviter que le FAB masque le contenu (mobile-first). 
- JS: ajout d’un utilitaire d’affichage date/heure (`dd/mm/yyyy · hh:mm`), adaptation du rendu des cartes pour inclure les icônes `Icon/Article.png`, `Icon/Date et Heure.png`, `Icon/Utilisateur.png`, mise à jour du compteur affiché dans le header, et synchronisation visuelle des chips avec le `select#itemDateFilter` existant sans modifier la logique métier (filtre, recherche et export conservés). 
- Fichiers modifiés: `page2.html`, `css/style.css`, `js/app.js`.

### Testing
- Exécution syntaxique JS: `node --check js/app.js && node --check js/ui.js && node --check js/storage.js` — réussi. 
- Vérification rapide des éléments clefs et IDs (automated checks via code inspection) — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65abe4e74832aa506ad4d66d6a913)