### PR TITLE
Positionne le bouton + au-dessus du bouton Exporter (UI mobile, sans toucher la logique)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1750,7 +1750,7 @@ body[data-page="site-detail"] .site-detail-subtitle {
 }
 
 body[data-page="site-detail"] .page-content {
-  padding-bottom: 7.2rem;
+  padding-bottom: 9.2rem;
   gap: 0.9rem;
 }
 
@@ -1914,8 +1914,9 @@ body[data-page="site-detail"] .list-card__meta-item--article {
 }
 
 body[data-page="site-detail"] .fab--export {
+  position: fixed;
   right: 1rem;
-  bottom: 1.2rem;
+  bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   width: auto;
   min-width: 8.8rem;
   height: 3.1rem;
@@ -1943,13 +1944,34 @@ body[data-page="site-detail"] .fab--export:hover {
 }
 
 body[data-page="site-detail"] .fab--export:active {
-  transform: scale(0.98);
+  transform: scale(0.95);
 }
 
+body[data-page="site-detail"] .fab-add,
 body[data-page="site-detail"] #openCreateItem {
-  left: 1rem;
-  right: auto;
-  bottom: 1.2rem;
-  width: 3.2rem;
-  height: 3.2rem;
+  position: fixed;
+  right: 1rem;
+  left: auto;
+  bottom: calc(5.25rem + env(safe-area-inset-bottom, 0px));
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  color: #2e6ce5;
+  border: 1px solid #dbe3ef;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+  z-index: 40;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body[data-page="site-detail"] .fab-add:active,
+body[data-page="site-detail"] #openCreateItem:active {
+  transform: scale(0.95);
+}
+
+body[data-page="site-detail"] .list-card:active {
+  transform: scale(0.98);
 }

--- a/page2.html
+++ b/page2.html
@@ -50,7 +50,7 @@
         <img src="Icon/Exporter.png" alt="" aria-hidden="true" />
         <span>Exporter</span>
       </button>
-      <button id="openCreateItem" class="fab" type="button" aria-label="Ajouter un numéro OUT">+</button>
+      <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>
 
       <dialog id="itemDialog" class="modal-card">
         <form method="dialog" class="modal-content" id="itemForm">


### PR DESCRIPTION
### Motivation

- Améliorer l’UX mobile et la cohérence visuelle en alignant les actions flottantes et en évitant qu’elles masquent le contenu. 
- Respecter la contrainte « mobile first » et ne pas modifier la logique métier ni les IDs existants pour éviter toute régression JS.

### Description

- Ajout de la classe `fab-add` et attribution à `#openCreateItem` dans `page2.html` pour permettre un style dédié sans changer l’`id` ni le comportement JS. 
- Mise à jour de `css/style.css` pour fixer `body[data-page="site-detail"] .fab--export` en bas à droite avec `env(safe-area-inset-bottom)` et augmenter le `padding-bottom` de la page (`9.2rem`) afin d’empêcher les boutons de masquer le dernier OUT. 
- Nouveau style pour `.fab-add` / `#openCreateItem` (position `fixed`, aligné à droite, placé juste au‑dessus du bouton Exporter, taille ronde, ombre douce, transition + effet au clic) et harmonisation des micro-interactions (`.fab--export:active`, `.fab-add:active`, `.list-card:active`).

### Testing

- Exécuté `git diff -- page2.html css/style.css` pour valider les changements présentiels (succès). 
- Exécuté `git status --short` et réalisé le commit (`Refine site detail floating actions and mobile UI polish`) (succès). 
- Vérification manuelle du diff pour confirmer qu’aucun fichier JavaScript ni logique métier n’a été modifié (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e660a12068832a96586eec4e1381b9)