### PR TITLE
Polish UI consistency for FABs, icons, spacing, and labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -554,6 +554,30 @@ button {
   flex-shrink: 0;
 }
 
+.icon {
+  width: 18px;
+  height: 18px;
+  margin-right: 6px;
+  opacity: 0.8;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.section {
+  margin: 16px 0;
+}
+
+.card {
+  margin-bottom: 18px;
+  padding: 16px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filters {
+  margin-top: 12px;
+  margin-bottom: 16px;
+}
+
 .input-group input,
 .input-group select,
 .cell-input,
@@ -837,6 +861,8 @@ body[data-page="history"] .list-grid {
   padding: 1rem;
   background: linear-gradient(160deg, #59b8ff 0%, #2b90dc 100%);
   color: #fff;
+  margin-bottom: 18px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .list-card__button {
@@ -869,23 +895,25 @@ body[data-page="history"] .list-grid {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 18px;
+  height: 18px;
   border: 0;
-  border-radius: 50%;
-  background: rgba(31, 42, 55, 0.08);
+  border-radius: 999px;
+  background: transparent;
   color: var(--text);
-  font-size: 1.4rem;
+  font-size: 1rem;
   line-height: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  opacity: 0.4;
 }
 
 .list-card__delete-button:hover,
 .list-card__delete-button:focus-visible {
-  background: rgba(31, 42, 55, 0.16);
+  opacity: 0.75;
+  background: rgba(31, 42, 55, 0.08);
 }
 
 .list-card__lock-icon {
@@ -947,10 +975,15 @@ body[data-page="history"] .list-grid {
   height: 4rem;
   border: 0;
   border-radius: 50%;
-  background: #fff;
-  color: var(--primary-dark);
+  background: #3b82f6;
+  color: #fff;
   font-size: 2rem;
-  box-shadow: 0 12px 25px rgba(39, 141, 218, 0.28);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fab:active {
+  transform: scale(0.95);
 }
 
 .modal-card {
@@ -1777,8 +1810,8 @@ body[data-page="site-detail"] .site-search-icon-wrap {
 }
 
 body[data-page="site-detail"] .site-search-icon {
-  width: 1.05rem;
-  height: 1.05rem;
+  width: 18px;
+  height: 18px;
   object-fit: contain;
 }
 
@@ -1802,7 +1835,8 @@ body[data-page="site-detail"] #itemSearchInput {
 }
 
 body[data-page="site-detail"] #itemSearchInput:focus {
-  border-color: #2e6ce5;
+  outline: none;
+  border: 2px solid #3b82f6;
   box-shadow: 0 0 0 4px rgba(46, 108, 229, 0.12);
 }
 
@@ -1934,8 +1968,9 @@ body[data-page="site-detail"] .fab--export {
 }
 
 body[data-page="site-detail"] .fab--export img {
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
+  margin-right: 0;
 }
 
 body[data-page="site-detail"] .fab--export:hover {
@@ -1950,21 +1985,22 @@ body[data-page="site-detail"] .fab--export:active {
 body[data-page="site-detail"] .fab-add,
 body[data-page="site-detail"] #openCreateItem {
   position: fixed;
-  right: 1rem;
+  right: 20px;
   left: auto;
-  bottom: calc(5.25rem + env(safe-area-inset-bottom, 0px));
-  width: 3.5rem;
-  height: 3.5rem;
+  bottom: calc(110px + env(safe-area-inset-bottom, 0px));
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #ffffff;
-  color: #2e6ce5;
-  border: 1px solid #dbe3ef;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+  background: #3b82f6;
+  color: #fff;
+  border: 0;
+  font-size: 28px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
   z-index: 40;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: all 0.2s ease;
 }
 
 body[data-page="site-detail"] .fab-add:active,
@@ -1974,4 +2010,9 @@ body[data-page="site-detail"] #openCreateItem:active {
 
 body[data-page="site-detail"] .list-card:active {
   transform: scale(0.98);
+}
+
+.search-input:focus {
+  outline: none;
+  border: 2px solid #3b82f6;
 }

--- a/index.html
+++ b/index.html
@@ -42,10 +42,10 @@
       </header>
 
       <main class="page-content">
-        <section class="search-panel surface-card">
+        <section class="search-panel surface-card section">
           <label class="input-group">
             <span class="sr-only">Recherche</span>
-            <input id="searchInput" type="search" placeholder="Recherche..." autocomplete="off" />
+            <input id="searchInput" class="search-input" type="search" placeholder="Recherche..." autocomplete="off" />
           </label>
         </section>
 

--- a/js/app.js
+++ b/js/app.js
@@ -131,7 +131,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     if (itemDay.getTime() < yesterday.getTime()) {
-      return 'Il y a longtemps';
+      return 'Plus ancien';
     }
 
     return null;
@@ -1563,9 +1563,9 @@ import { firebaseAuth } from './firebase-core.js';
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
-                  <span class="list-card__meta-item list-card__meta-item--article"><img src="Icon/Article.png" alt="" aria-hidden="true" /><span>${detailCountsByItem[item.id] || 0} Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span></span>
-                  <span class="list-card__meta-item"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" /><span>Créé le ${escapeHtml(createdLabel)}</span></span>
-                  <span class="list-card__meta-item"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" /><span>${escapeHtml(createdBy)}</span></span>
+                  <span class="list-card__meta-item list-card__meta-item--article"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>${detailCountsByItem[item.id] || 0} Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span></span>
+                  <span class="list-card__meta-item"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Créé le ${escapeHtml(createdLabel)}</span></span>
+                  <span class="list-card__meta-item"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>${escapeHtml(createdBy)}</span></span>
                 </div>
               </button>
             </article>

--- a/page2.html
+++ b/page2.html
@@ -17,18 +17,19 @@
       </header>
 
       <main class="page-content">
-        <section class="search-panel search-panel--site surface-card">
+        <section class="search-panel search-panel--site surface-card section">
           <label class="input-group">
             <span class="sr-only">Rechercher (OUT ou article)</span>
             <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
             <input
               id="itemSearchInput"
+              class="search-input"
               type="search"
               placeholder="Rechercher (OUT ou article)"
               autocomplete="off"
             />
           </label>
-          <div class="filter-chip-group" role="group" aria-label="Filtrer les résultats par date">
+          <div class="filter-chip-group filters" role="group" aria-label="Filtrer les résultats par date">
             <button class="filter-chip" type="button" data-filter-chip="all">Tous</button>
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>
@@ -47,7 +48,7 @@
       </main>
 
       <button type="button" id="openExportItems" class="fab fab--export" aria-label="Exporter">
-        <img src="Icon/Exporter.png" alt="" aria-hidden="true" />
+        <img src="Icon/Exporter.png" alt="" aria-hidden="true" class="icon" />
         <span>Exporter</span>
       </button>
       <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>

--- a/page3.html
+++ b/page3.html
@@ -17,7 +17,7 @@
       </header>
 
       <main class="page-content page-content--wide">
-        <section id="detailFormSection" class="surface-card form-card">
+        <section id="detailFormSection" class="surface-card form-card section">
           <form id="detailForm" class="responsive-form" novalidate>
             <label class="input-group">
               <span>Code</span>
@@ -48,7 +48,7 @@
           </form>
         </section>
 
-        <section class="surface-card table-card">
+        <section class="surface-card table-card section">
           <div class="section-heading section-heading--table">
             <div>
               <h2 class="section-title">Tableau des données</h2>
@@ -58,8 +58,8 @@
           </div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">
-              <span class="label-with-icon"><img src="Icon/chercher.png" alt="" class="label-icon" aria-hidden="true" /><span>Recherche</span></span>
-              <input id="detailSearchInput" type="text" placeholder="Entrer votre Recherche..." autocomplete="off" />
+              <span class="label-with-icon"><img src="Icon/Recherche.png" alt="" class="label-icon icon" aria-hidden="true" /><span>Recherche</span></span>
+              <input id="detailSearchInput" class="search-input" type="text" placeholder="Entrer votre Recherche..." autocomplete="off" />
             </label>
           </div>
           <div class="table-container table-container--card" id="detailTableContainer">


### PR DESCRIPTION
### Motivation
- Finaliser l’UI au niveau PRO+ sans toucher à la logique métier existante (Firestore, filtres, recherche, export, création OUT) et en respectant les IDs et l’approche mobile-first.
- Corriger les dernières incohérences visuelles : FAB « + », icônes, spacing, libellés et micro-interactions pour un rendu cohérent et professionnel.

### Description
- Ajout d’utilitaires visuels et d’espace via `css/style.css`: nouvelles classes ` .icon`, `.section`, `.card`, `.filters` et réglages de spacing/transition pour cartes et sections.
- Harmonisation des FABs et micro-interactions dans `css/style.css`: `fab` et `fab-add` passent à fond bleu `#3b82f6`, taille/position du FAB `+` ajustée à `56px` et espacement vertical augmenté pour ne pas chevaucher le bouton `Exporter`.
- Discrétion du bouton supprimer en cards via `css/style.css`: réduction de taille, fond transparent et opacité diminuée (`list-card__delete-button`), et styles hover moins intrusifs.
- Standardisation des icônes et focus recherche: ajout de la classe `icon` aux images d’icônes (Article, Date, Utilisateur, Recherche, Export) et `search-input` + style `:focus` pour champ recherche; HTML mis à jour dans `index.html`, `page2.html` et `page3.html` pour appliquer ces classes.
- Correction de libellé dans `js/app.js`: remplacement de `Il y a longtemps` par `Plus ancien` (affichage des séparateurs de période), sans modifier la logique de filtrage.

### Testing
- Exécution des vérifications de syntaxe JavaScript avec `node --check js/app.js`, `node --check js/ui.js` et `node --check js/storage.js`, toutes réussies.
- Changements commités et PR préparée; aucune modification des chemins métier ni des IDs utilisées par le code d’origine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6658f89d0832a82cd6e883e574c1b)