### PR TITLE
Modernize home page UX (header, search, site cards)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 :root {
-  --bg: #f4f7fb;
+  --bg: #f5f7fa;
   --surface: #ffffff;
   --surface-muted: #eef3f8;
   --primary: #59b8ff;
@@ -13,7 +13,7 @@
   --radius-lg: 24px;
   --radius-md: 16px;
   --radius-sm: 12px;
-  --header-height: 5.75rem;
+  --header-height: 6.5rem;
   --header-side-width: 3rem;
 }
 
@@ -25,9 +25,9 @@ body {
   margin: 0;
   height: 100vh;
   overflow: hidden;
-  background: linear-gradient(180deg, #e9f6ff 0%, var(--bg) 30%, var(--bg) 100%);
+  background: var(--bg);
   color: var(--text);
-  font-family: "Roboto", sans-serif;
+  font-family: "Inter", "Segoe UI", Roboto, system-ui, -apple-system, sans-serif;
 }
 
 body[data-page="history"] {
@@ -77,9 +77,9 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  background: linear-gradient(135deg, #2f80ed 0%, #56ccf2 100%);
   color: #fff;
-  box-shadow: var(--shadow);
+  box-shadow: 0 8px 24px rgba(25, 99, 194, 0.28);
   position: sticky;
   top: 0;
   z-index: 20;
@@ -103,16 +103,18 @@ button {
 }
 
 .app-header--home {
-  justify-content: space-between;
+  justify-content: center;
   gap: 0.6rem;
+  position: relative;
+  padding-inline: 1.1rem;
 }
 
 .header-login-button {
-  border: 1px solid rgba(255, 255, 255, 0.7);
-  background: rgba(255, 255, 255, 0.22);
+  border: 1.5px solid rgba(255, 255, 255, 0.9);
+  background: transparent;
   color: #fff;
-  border-radius: 999px;
-  padding: 0.58rem 0.95rem;
+  border-radius: 20px;
+  padding: 0.62rem 1.1rem;
   font-size: 0.9rem;
   font-weight: 600;
   transition: background 0.2s ease, transform 0.2s ease;
@@ -135,8 +137,11 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.9rem;
+  font-size: 1.65rem;
   line-height: 1;
+  background: rgba(255, 255, 255, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(4px);
 }
 
 .header-menu__trigger span {
@@ -2031,8 +2036,11 @@ body[data-page="site-detail"] .list-card:active {
 body[data-page="home"] .search-panel {
   width: min(100%, 680px);
   margin: 0 auto;
-  padding: 0.6rem 0.75rem;
-  border-radius: 16px;
+  padding: 0.75rem 0.85rem;
+  border-radius: 20px;
+  box-shadow: none;
+  background: transparent;
+  border: 0;
 }
 
 body[data-page="home"] .search-panel .input-group {
@@ -2042,11 +2050,11 @@ body[data-page="home"] .search-panel .input-group {
 
 body[data-page="home"] .search-input__icon-wrap {
   position: absolute;
-  left: 14px;
+  left: 16px;
   top: 50%;
   transform: translateY(-50%);
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2064,11 +2072,125 @@ body[data-page="home"] .search-input {
   width: min(100%, 600px);
   margin: 0 auto;
   border-radius: 25px;
-  padding: 12px 16px 12px 40px;
+  padding: 0.95rem 1rem 0.95rem 3rem;
   border: 1px solid rgba(216, 226, 236, 0.95);
-  box-shadow: 0 6px 16px rgba(31, 42, 55, 0.1);
+  box-shadow: 0 8px 24px rgba(17, 24, 39, 0.1);
 }
 
 body[data-page="home"] .section-heading--sticky {
-  margin-top: -0.1rem;
+  margin-top: 0.2rem;
+  width: min(100%, 680px);
+  margin-inline: auto;
+  background: #fff;
+  border-radius: 18px;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(216, 226, 236, 0.8);
+  box-shadow: 0 8px 24px rgba(31, 42, 55, 0.08);
+}
+
+body[data-page="home"] .section-heading h2 {
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+body[data-page="home"] .site-count-badge {
+  margin: 0;
+  padding: 0.28rem 0.72rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #dbeafe 0%, #e0f2fe 100%);
+  color: #1d4ed8;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+body[data-page="home"] .page-content {
+  padding: 1.1rem 1rem 6.25rem;
+  gap: 1rem;
+}
+
+body[data-page="home"] .list-grid {
+  width: min(100%, 680px);
+  margin: 0 auto;
+  gap: 0.9rem;
+}
+
+body[data-page="home"] .list-card {
+  padding: 0;
+  background: linear-gradient(165deg, #f7fbff 0%, #edf6ff 100%);
+  color: #111827;
+  border: 1px solid #d9e8f7;
+  border-radius: 20px;
+  box-shadow: 0 12px 28px rgba(30, 64, 175, 0.14);
+}
+
+body[data-page="home"] .list-card__button {
+  padding: 1.2rem 3.25rem 1.15rem 1.2rem;
+  display: grid;
+  gap: 0.72rem;
+}
+
+body[data-page="home"] .list-card__title {
+  font-size: 1.1rem;
+  line-height: 1.22;
+  letter-spacing: 0.01em;
+}
+
+body[data-page="home"] .list-card__meta {
+  margin-top: 0;
+  gap: 0.55rem;
+}
+
+body[data-page="home"] .list-card__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.52rem;
+  color: #6b7280;
+  line-height: 1.3;
+}
+
+body[data-page="home"] .list-card__meta-item .icon {
+  width: 18px;
+  height: 18px;
+  margin-right: 0;
+  opacity: 1;
+}
+
+body[data-page="home"] .list-card__meta-item--out {
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+body[data-page="home"] .list-card__lock-icon {
+  right: 0.92rem;
+  bottom: 0.92rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(17, 24, 39, 0.18);
+  padding: 0.15rem;
+}
+
+body[data-page="home"] .list-card__lock-icon--with-delete {
+  top: calc(0.72rem + 2.25rem + 0.4rem);
+}
+
+body[data-page="home"] .header-login-button,
+body[data-page="home"] .avatar-button {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+body[data-page="home"] .avatar-button {
+  border: 1px solid rgba(255, 255, 255, 0.5);
+}
+
+body[data-page="home"] .header-menu {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
 }

--- a/index.html
+++ b/index.html
@@ -53,10 +53,8 @@
         </section>
 
         <section class="section-heading section-heading--sticky">
-          <div>
-            <h2>Sites enregistrés</h2>
-            <p id="siteCount">0 site</p>
-          </div>
+          <h2>Sites enregistrés</h2>
+          <p id="siteCount" class="site-count-badge">0 site</p>
         </section>
 
         <section id="siteList" class="list-grid" aria-live="polite"></section>

--- a/js/app.js
+++ b/js/app.js
@@ -973,7 +973,8 @@ import { firebaseAuth } from './firebase-core.js';
 
       siteList.innerHTML = sites
         .map((site) => {
-          const createdLabel = buildCreatedLabel(site, userNamesById);
+          const siteOwnerLabel = resolveActorLabel(site?.createdBy, userNamesById, site?.createdByName);
+          const createdAtLabel = buildDateAndTimeLabel(site?.dateCreation);
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
           const canShowDeleteButton =
             isAuthenticated && currentPermissions.canDelete && !isSiteLocked(site);
@@ -983,8 +984,9 @@ import { firebaseAuth } from './firebase-core.js';
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
-                  <span>${itemCountsBySite[site.id] || 0} OUT${(itemCountsBySite[site.id] || 0) > 1 ? 'S' : ''}</span>
-                  <span>${escapeHtml(createdLabel)}</span>
+                  <span class="list-card__meta-item list-card__meta-item--out"><img src="Icon/OUT.png" alt="" aria-hidden="true" class="icon" /><span>${itemCountsBySite[site.id] || 0} OUT${(itemCountsBySite[site.id] || 0) > 1 ? 'S' : ''}</span></span>
+                  <span class="list-card__meta-item"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>${escapeHtml(createdAtLabel)}</span></span>
+                  <span class="list-card__meta-item"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>${escapeHtml(siteOwnerLabel)}</span></span>
                 </div>
               </button>
               <img


### PR DESCRIPTION
### Motivation
- Modernize the page 1 UI to a professional SaaS mobile look with improved header, search bar and site cards while keeping existing behavior unchanged.
- Surface key site metadata (OUT count, created date/time, owner) visually with requested icons for faster scanning.
- Improve overall spacing, typography and color palette to make the UI cleaner and more legible on mobile.

### Description
- Updated `css/style.css` to apply global tokens and styles: background `#F5F7FA`, font stack switched to `Inter`/system UI, increased header height, header gradient `#2F80ED → #56CCF2`, shadows, pill search styling, card styles, lock badge styling and spacing/aeration for `body[data-page="home"]`.
- Modified `index.html` to simplify the section heading and add a `site-count-badge` element for the visible sites badge.
- Adjusted `js/app.js` site rendering to output the vertical meta lines per site using repository icons (`Icon/OUT.png`, `Icon/Date et Heure.png`, `Icon/Utilisateur.png`) and to use `buildDateAndTimeLabel` / `resolveActorLabel` for the displayed date and owner; no business logic was altered.
- All changes are visual/markup-focused so existing JavaScript behavior and app logic were preserved.

### Testing
- Ran `node --check js/app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6721863b0832aa8883a55227bf5b5)