### PR TITLE
Improve responsive layout for home and site-detail pages (CSS only)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2072,3 +2072,298 @@ body[data-page="home"] .search-input {
 body[data-page="home"] .section-heading--sticky {
   margin-top: -0.1rem;
 }
+
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+.app-shell,
+.page-content,
+.list-grid,
+.search-panel,
+.list-card,
+.list-card__button,
+.list-card__meta,
+.list-card__meta-item,
+.section-heading,
+.header-title {
+  min-width: 0;
+}
+
+body[data-page="home"] .app-header--home {
+  position: relative;
+  justify-content: center;
+  padding-inline: clamp(0.75rem, 2.3vw, 1.2rem);
+  gap: 0;
+}
+
+body[data-page="home"] #userAvatarButton,
+body[data-page="home"] #openLoginButton {
+  position: absolute;
+  left: clamp(0.7rem, 2.3vw, 1.1rem);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+body[data-page="home"] #openLoginButton {
+  max-width: min(42vw, 11.5rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+body[data-page="home"] .header-menu {
+  position: absolute;
+  right: clamp(0.7rem, 2.3vw, 1.1rem);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+body[data-page="home"] .app-header--home > h1 {
+  width: min(100%, 22rem);
+  padding-inline: clamp(2.7rem, 10vw, 6.4rem);
+  margin: 0 auto;
+}
+
+body[data-page="home"] .page-content {
+  padding-inline: clamp(0.75rem, 2.5vw, 1.35rem);
+}
+
+body[data-page="home"] .search-panel {
+  width: min(100%, 760px);
+  padding: clamp(0.55rem, 1.2vw, 0.8rem) clamp(0.6rem, 1.4vw, 0.85rem);
+}
+
+body[data-page="home"] .search-input {
+  width: 100%;
+  max-width: 100%;
+}
+
+body[data-page="home"] .section-heading--sticky {
+  width: min(100%, 760px);
+  margin-inline: auto;
+}
+
+body[data-page="home"] .list-grid {
+  width: min(100%, 760px);
+  margin-inline: auto;
+}
+
+body[data-page="home"] .list-card {
+  width: 100%;
+  max-width: 100%;
+  padding: clamp(0.8rem, 2.2vw, 1rem) clamp(0.8rem, 2.5vw, 1rem);
+}
+
+body[data-page="home"] .list-card__button {
+  padding-right: clamp(2.3rem, 8vw, 3rem);
+}
+
+body[data-page="home"] .list-card__title {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.3;
+}
+
+body[data-page="home"] .list-card__meta {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.35rem;
+}
+
+body[data-page="home"] .list-card__meta > span {
+  overflow-wrap: anywhere;
+}
+
+body[data-page="site-detail"] .app-header--detail {
+  min-height: clamp(5.6rem, 13vw, 7.2rem);
+  padding-top: clamp(0.8rem, 1.8vw, 1.1rem);
+  padding-bottom: clamp(0.8rem, 1.8vw, 1.15rem);
+  padding-inline: calc(clamp(0.75rem, 2.2vw, 1.1rem) + var(--header-side-width));
+}
+
+body[data-page="site-detail"] .app-header--detail .back-button {
+  left: clamp(0.7rem, 2.2vw, 1.1rem);
+}
+
+body[data-page="site-detail"] .header-title {
+  width: min(100%, 32rem);
+  gap: 0.24rem;
+}
+
+body[data-page="site-detail"] #siteTitle {
+  width: 100%;
+  font-size: clamp(1.05rem, 4vw, 1.55rem);
+}
+
+body[data-page="site-detail"] .site-detail-subtitle {
+  text-align: center;
+  padding-inline: 0.35rem;
+  overflow-wrap: anywhere;
+}
+
+body[data-page="site-detail"] .page-content {
+  padding-inline: clamp(0.75rem, 2.4vw, 1.25rem);
+  padding-bottom: calc(8.8rem + env(safe-area-inset-bottom, 0px));
+}
+
+body[data-page="site-detail"] .search-panel--site {
+  width: min(100%, 860px);
+  margin-inline: auto;
+}
+
+body[data-page="site-detail"] #itemSearchInput {
+  padding-right: 0.9rem;
+}
+
+body[data-page="site-detail"] .filter-chip-group {
+  width: 100%;
+}
+
+body[data-page="site-detail"] .filter-chip {
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+body[data-page="site-detail"] .list-grid {
+  width: min(100%, 860px);
+  margin-inline: auto;
+}
+
+body[data-page="site-detail"] .list-card {
+  width: 100%;
+  max-width: 100%;
+}
+
+body[data-page="site-detail"] .list-card__button {
+  grid-template-columns: minmax(0, 1fr);
+  padding: clamp(0.82rem, 2.2vw, 1rem) clamp(2.3rem, 6vw, 2.9rem) clamp(0.82rem, 2.2vw, 1rem) clamp(0.9rem, 2.2vw, 1.05rem);
+}
+
+body[data-page="site-detail"] .list-card__title {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.32;
+}
+
+body[data-page="site-detail"] .list-card__meta {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+body[data-page="site-detail"] .list-card__meta-item {
+  min-width: 0;
+  align-items: flex-start;
+}
+
+body[data-page="site-detail"] .list-card__meta-item span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  line-height: 1.32;
+}
+
+body[data-page="site-detail"] .list-separator {
+  width: min(100%, 860px);
+  margin-inline: auto;
+}
+
+@media (max-width: 900px) {
+  body[data-page="site-detail"] .filter-chip-group {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    padding-bottom: 0.2rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .app-header {
+    padding-inline: 0.7rem;
+  }
+
+  body[data-page="home"] .app-header--home {
+    min-height: clamp(4.5rem, 16vw, 5.2rem);
+    height: auto;
+    padding-block: 0.6rem;
+  }
+
+  body[data-page="home"] .app-header--home > h1 {
+    font-size: clamp(1.05rem, 5.1vw, 1.3rem);
+    padding-inline: clamp(2.3rem, 13vw, 4.8rem);
+  }
+
+  body[data-page="home"] #openLoginButton {
+    font-size: 0.8rem;
+    padding: 0.46rem 0.7rem;
+    max-width: min(43vw, 9.3rem);
+  }
+
+  body[data-page="home"] #userAvatarButton,
+  body[data-page="home"] .header-menu__trigger {
+    width: 2.45rem;
+    height: 2.45rem;
+  }
+
+  body[data-page="home"] .header-menu__trigger {
+    font-size: 1.65rem;
+  }
+
+  body[data-page="home"] .page-content {
+    padding: 0.8rem 0.72rem 6.1rem;
+    gap: 0.65rem;
+  }
+
+  body[data-page="home"] .section-heading--sticky {
+    padding: 0.5rem 0.68rem;
+  }
+
+  body[data-page="home"] .list-card__lock-icon {
+    right: 0.7rem;
+    bottom: 0.75rem;
+    width: 1.2rem;
+    height: 1.2rem;
+  }
+
+  body[data-page="site-detail"] .app-header--detail .back-button {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  body[data-page="site-detail"] .app-header--detail .btn-retour {
+    width: 1.8rem;
+    height: 1.8rem;
+  }
+
+  body[data-page="site-detail"] .filter-chip {
+    padding: 0.42rem 0.74rem;
+    font-size: 0.8rem;
+  }
+
+  body[data-page="site-detail"] .list-separator__label {
+    font-size: 0.76rem;
+  }
+
+  body[data-page="site-detail"] .fab--export {
+    right: 0.72rem;
+    bottom: calc(0.7rem + env(safe-area-inset-bottom, 0px));
+    min-width: 7.8rem;
+    height: 2.8rem;
+    padding-inline: 0.8rem;
+    font-size: 0.88rem;
+    gap: 0.4rem;
+  }
+
+  body[data-page="site-detail"] .fab--export img {
+    width: 16px;
+    height: 16px;
+  }
+
+  body[data-page="site-detail"] .fab-add,
+  body[data-page="site-detail"] #openCreateItem {
+    right: 0.72rem;
+    bottom: calc(4.1rem + env(safe-area-inset-bottom, 0px));
+    width: 50px;
+    height: 50px;
+    font-size: 1.6rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix layout issues on page 1 (`home`) and page 2 (`site-detail`) so content adapts cleanly to mobile, tablet and desktop without changing any app logic or JS behavior.
- Prevent horizontal overflow and clipped text/icons/buttons while preserving the existing visual design and interactions.

### Description
- Updated `css/style.css` with global overflow protection and `min-width: 0` guards on key containers to avoid horizontal scrolling and clipping (e.g. `html, body { overflow-x: hidden }` and several `min-width: 0` rules). 
- Reworked page 1 header alignment so the title stays visually centered while avatar/login and menu are absolutely positioned left and right respectively, and added responsive paddings and font sizing for small screens. 
- Made the page 1 search panel, section widths and site `list-card` sizing fluid by using `min()`, `clamp()`, percent widths and constrained `max-width` to keep cards nearly full-width on mobile and balanced on larger screens. 
- Hardened page 2 (`site-detail`) header, search input, filter chips and OUT cards: adjusted header height/paddings, ensured meta items wrap safely, and added a horizontal-scroll fallback for filter chips on narrow screens. 
- Tuned floating buttons (`fab--export` and `fab-add`) sizes and positions on mobile to keep them visible and non-overlapping. 
- All changes are CSS-only and limited to `css/style.css`; no JavaScript, Firebase code, data models or event handlers were modified.

### Testing
- Ran `git diff --check` to validate the patch formatting and it completed successfully. 
- Ran `git status --short` to confirm the working tree state and it reported the expected changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6797a2dbc832ab690ad136b40772a)