### PR TITLE
Ajuste le responsive desktop du header et élargit le conteneur principal (page d'accueil)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2122,9 +2122,10 @@ body[data-page="home"] .header-menu {
 }
 
 body[data-page="home"] .app-header--home > h1 {
-  width: min(100%, 22rem);
-  padding-inline: clamp(2.7rem, 10vw, 6.4rem);
+  width: min(100%, 32rem);
+  padding-inline: clamp(3rem, 8vw, 6rem);
   margin: 0 auto;
+  white-space: nowrap;
 }
 
 body[data-page="home"] .page-content {
@@ -2132,7 +2133,7 @@ body[data-page="home"] .page-content {
 }
 
 body[data-page="home"] .search-panel {
-  width: min(100%, 760px);
+  width: min(100%, 1120px);
   padding: clamp(0.55rem, 1.2vw, 0.8rem) clamp(0.6rem, 1.4vw, 0.85rem);
 }
 
@@ -2142,12 +2143,12 @@ body[data-page="home"] .search-input {
 }
 
 body[data-page="home"] .section-heading--sticky {
-  width: min(100%, 760px);
+  width: min(100%, 1120px);
   margin-inline: auto;
 }
 
 body[data-page="home"] .list-grid {
-  width: min(100%, 760px);
+  width: min(100%, 1120px);
   margin-inline: auto;
 }
 
@@ -2267,6 +2268,20 @@ body[data-page="site-detail"] .list-separator {
   margin-inline: auto;
 }
 
+@media (min-width: 1024px) {
+  body[data-page="home"] .page-content {
+    width: min(100%, 1360px);
+    margin-inline: auto;
+    padding-inline: clamp(1.25rem, 2.5vw, 2.5rem);
+  }
+
+  body[data-page="home"] .search-panel,
+  body[data-page="home"] .section-heading--sticky,
+  body[data-page="home"] .list-grid {
+    width: min(100%, 1240px);
+  }
+}
+
 @media (max-width: 900px) {
   body[data-page="site-detail"] .filter-chip-group {
     flex-wrap: nowrap;
@@ -2290,6 +2305,7 @@ body[data-page="site-detail"] .list-separator {
   body[data-page="home"] .app-header--home > h1 {
     font-size: clamp(1.05rem, 5.1vw, 1.3rem);
     padding-inline: clamp(2.3rem, 13vw, 4.8rem);
+    white-space: normal;
   }
 
   body[data-page="home"] #openLoginButton {


### PR DESCRIPTION
### Motivation
- Le titre du header `Suivi Matériel` se cassait en 2 lignes sur desktop et la zone centrale de la page d’accueil était trop étroite avec de larges marges latérales.
- L’objectif est d’élargir la zone centrale sur grand écran et d’empêcher qu’une règle mobile/tablette n’implique un rendu cassé en desktop, sans toucher au JavaScript.

### Description
- Modifications CSS dans `css/style.css` pour empêcher le wrapping du titre header en desktop via `white-space: nowrap` et rétablir `white-space: normal` sur petits écrans.
- Augmentation des largeurs desktop des blocs centraux `search-panel`, `section-heading--sticky` et `list-grid` (passage de ~760px à des valeurs jusqu’à `1120px` / `1240px` selon breakpoint) et ajustement de `padding-inline` pour réduire les vides latéraux.
- Ajout d’un `@media (min-width: 1024px)` qui rend le `page-content` fluide avec `width: min(100%, 1360px)` et met à l’échelle les blocs centraux pour les écrans PC.
- Aucun changement fonctionnel ou JavaScript, uniquement des règles CSS/ responsive (`white-space`, `width`, `max-width`, `padding-inline` et media queries). Fichier impacté : `css/style.css`.

### Testing
- Application des modifications avec l’outil de patch interne (`apply_patch`) et mise à jour de `css/style.css` réussie.
- Vérification du diff avec `git diff -- css/style.css` et état du dépôt via `git status --short`, les commandes ont retourné les changements attendus.
- Aucun test unitaires automatisés présents dans le projet, recommandation : validation visuelle sur desktop/tablette/mobile après déploiement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67c3f5ba8832abaaef3367b5464c2)