### PR TITLE
Uniformiser l’affichage de la page 1 sur tous les écrans

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -677,6 +677,58 @@ body[data-page="home"] .list-grid {
   grid-template-columns: 1fr;
 }
 
+body[data-page="home"] .app-header--home {
+  justify-content: space-between;
+  position: sticky;
+  flex-wrap: nowrap;
+  gap: clamp(0.45rem, 1.2vw, 0.7rem);
+  padding: clamp(0.62rem, 1.4vw, 0.75rem) clamp(0.8rem, 2.2vw, 1rem);
+}
+
+body[data-page="home"] .app-header--home h1 {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  width: min(72vw, 24rem);
+  text-align: center;
+  font-size: clamp(1.14rem, 3.2vw, 1.6rem);
+  pointer-events: none;
+}
+
+body[data-page="home"] .avatar-button,
+body[data-page="home"] .header-login-button,
+body[data-page="home"] .header-menu {
+  position: relative;
+  z-index: 1;
+}
+
+body[data-page="home"] .avatar-button,
+body[data-page="home"] .header-login-button {
+  flex-shrink: 0;
+}
+
+body[data-page="home"] .header-menu {
+  margin-left: auto;
+}
+
+body[data-page="home"] .search-panel {
+  padding: clamp(0.82rem, 2.1vw, 1rem);
+}
+
+body[data-page="home"] .search-panel .input-group {
+  max-width: 100%;
+}
+
+body[data-page="home"] .section-heading--sticky {
+  padding: clamp(0.56rem, 1.6vw, 0.7rem) clamp(0.72rem, 2vw, 0.85rem);
+}
+
+body[data-page="home"] .list-card {
+  width: 100%;
+  max-width: 680px;
+}
+
 body[data-page="history"] .list-grid {
   grid-template-columns: 1fr;
 }
@@ -1516,6 +1568,10 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
 @media (max-width: 767px) {
   .app-header {
     flex-wrap: wrap;
+  }
+
+  body[data-page="home"] .app-header {
+    flex-wrap: nowrap;
   }
 
   body[data-page="users-management"] .app-header--detail {


### PR DESCRIPTION
### Motivation
- Rendre la page d’accueil (`data-page="home"`) visuellement identique sur desktop, tablette et mobile sans versions dédiées par breakpoint.
- Conserver strictement l’organisation des éléments du header (avatar/logo à gauche, titre centré, menu à droite) et la structure des blocs (recherche, « Sites enregistrés », cards, FAB).
- Autoriser uniquement des ajustements doux (tailles/paddings via `clamp`) pour préserver l’apparence générale.

### Description
- Ajout de règles CSS ciblées dans `css/style.css` sous le sélecteur `body[data-page="home"]` pour forcer un layout uniforme sur la page d’accueil.
- Le titre `h1` du header est centré via positionnement absolu (`left: 50%` + `transform: translateX(-50%)`) pour garantir le même rendu sur toutes les largeurs.
- Le `flex-wrap` du header home est neutralisé (`flex-wrap: nowrap`) afin d’empêcher le réagencement (wrap) sur petits écrans et maintenir la même disposition.
- Ajustements discrets de `padding`, `gap`, `font-size` et largeurs de blocs en `clamp()` pour une adaptation douce sans changement de logique JavaScript ni fonctionnalité.

### Testing
- Aucune suite de tests automatisés n’est présente dans le dépôt, donc aucun test automatisé n’a été exécuté.
- Vérifications locales basiques effectuées: `git diff -- css/style.css` et `git status --short` (diff/commit OK).
- Aucun changement fonctionnel JavaScript n’a été apporté, donc aucune validation de comportement runtime automatisée n’a été nécessaire.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67f8e7894832aa42f0fb4667b0f68)