### PR TITLE
Revamp home UI: updated search panel, list-card layout, and site rendering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2087,8 +2087,11 @@ body[data-page="site-detail"] .list-card:active {
 body[data-page="home"] .search-panel {
   width: min(100%, 680px);
   margin: 0 auto;
-  padding: 0.6rem 0.75rem;
-  border-radius: 16px;
+  padding: clamp(0.9rem, 2.5vw, 1.05rem);
+  border-radius: 20px;
+  background: #ffffff;
+  border: 1px solid rgba(216, 226, 236, 0.75);
+  box-shadow: 0 14px 28px rgba(31, 42, 55, 0.09);
 }
 
 body[data-page="home"] .search-panel .input-group {
@@ -2119,14 +2122,15 @@ body[data-page="home"] .search-input__icon {
 body[data-page="home"] .search-input {
   width: min(100%, 600px);
   margin: 0 auto;
-  border-radius: 25px;
-  padding: 12px 16px 12px 40px;
-  border: 1px solid rgba(216, 226, 236, 0.95);
-  box-shadow: 0 6px 16px rgba(31, 42, 55, 0.1);
+  border-radius: 999px;
+  padding: 13px 16px 13px 42px;
+  border: 1px solid rgba(202, 216, 230, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55);
+  background: #fdfefe;
 }
 
 body[data-page="home"] .section-heading--sticky {
-  margin-top: -0.1rem;
+  margin-top: 0.1rem;
 }
 
 html,
@@ -2186,11 +2190,13 @@ body[data-page="home"] .app-header--home > h1 {
 
 body[data-page="home"] .page-content {
   padding-inline: clamp(0.75rem, 2.5vw, 1.35rem);
+  padding-top: clamp(1rem, 2.8vw, 1.3rem);
+  padding-bottom: calc(6.6rem + env(safe-area-inset-bottom, 0px));
+  gap: 0.9rem;
 }
 
 body[data-page="home"] .search-panel {
   width: min(100%, 1120px);
-  padding: clamp(0.55rem, 1.2vw, 0.8rem) clamp(0.6rem, 1.4vw, 0.85rem);
 }
 
 body[data-page="home"] .search-input {
@@ -2201,6 +2207,11 @@ body[data-page="home"] .search-input {
 body[data-page="home"] .section-heading--sticky {
   width: min(100%, 1120px);
   margin-inline: auto;
+  padding: 0.72rem 0.9rem;
+  border-radius: 16px;
+  border: 1px solid rgba(206, 226, 211, 0.7);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 20px rgba(32, 96, 68, 0.08);
 }
 
 body[data-page="home"] .list-grid {
@@ -2211,11 +2222,29 @@ body[data-page="home"] .list-grid {
 body[data-page="home"] .list-card {
   width: 100%;
   max-width: 100%;
-  padding: clamp(0.8rem, 2.2vw, 1rem) clamp(0.8rem, 2.5vw, 1rem);
+  background: #ffffff;
+  color: var(--text);
+  border-radius: 20px;
+  border: 1px solid rgba(216, 226, 236, 0.9);
+  box-shadow: 0 16px 28px rgba(31, 42, 55, 0.11);
+  padding: 0;
+  margin-bottom: 0;
+  overflow: hidden;
+}
+
+body[data-page="home"] .list-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+  background: linear-gradient(180deg, #59b8ff 0%, #2b90dc 100%);
 }
 
 body[data-page="home"] .list-card__button {
-  padding-right: clamp(2.3rem, 8vw, 3rem);
+  display: grid;
+  gap: 0.52rem;
+  padding: 1rem 0.95rem 0.9rem 1.18rem;
+  padding-right: clamp(3rem, 9vw, 3.4rem);
 }
 
 body[data-page="home"] .list-card__title {
@@ -2225,12 +2254,129 @@ body[data-page="home"] .list-card__title {
 }
 
 body[data-page="home"] .list-card__meta {
+  margin-top: 0.3rem;
   grid-template-columns: minmax(0, 1fr);
-  gap: 0.35rem;
+  gap: 0.55rem;
 }
 
 body[data-page="home"] .list-card__meta > span {
   overflow-wrap: anywhere;
+}
+
+body[data-page="home"] .list-card__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.48rem;
+  color: #4b5563;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+body[data-page="home"] .list-card__meta-item .icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 0;
+  opacity: 0.92;
+}
+
+body[data-page="home"] .list-card__meta-item--outs {
+  color: #15803d;
+  font-weight: 700;
+  margin-top: 0.2rem;
+}
+
+body[data-page="home"] .list-card__title {
+  font-size: 1.02rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+body[data-page="home"] .list-card__divider {
+  display: block;
+  height: 1px;
+  background: rgba(216, 226, 236, 0.9);
+  margin-top: 0.2rem;
+}
+
+body[data-page="home"] .list-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+body[data-page="home"] .list-card__status-icon {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}
+
+body[data-page="home"] .list-card__status--unlocked {
+  color: #16a34a;
+}
+
+body[data-page="home"] .list-card__status--locked {
+  color: #dc2626;
+}
+
+body[data-page="home"] .list-card__delete-button {
+  top: 0.7rem;
+  right: 0.72rem;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.2);
+  color: #1f2937;
+  opacity: 1;
+  z-index: 2;
+}
+
+body[data-page="home"] .list-card__delete-button:hover,
+body[data-page="home"] .list-card__delete-button:focus-visible {
+  background: rgba(148, 163, 184, 0.32);
+}
+
+body[data-page="home"] .list-card__lock-icon {
+  display: none;
+}
+
+body[data-page="home"] .section-heading--saved {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+body[data-page="home"] .saved-sites-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+body[data-page="home"] .saved-sites-label__icon {
+  width: 19px;
+  height: 19px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+body[data-page="home"] .site-count-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(22, 163, 74, 0.14);
+  color: #166534;
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+body[data-page="home"] .fab {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  box-shadow: 0 18px 28px rgba(39, 141, 218, 0.35);
 }
 
 body[data-page="site-detail"] .app-header--detail {

--- a/index.html
+++ b/index.html
@@ -48,15 +48,16 @@
             <span class="search-input__icon-wrap" aria-hidden="true">
               <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
             </span>
-            <input id="searchInput" class="search-input" type="search" placeholder="Rechercher..." autocomplete="off" />
+            <input id="searchInput" class="search-input" type="search" placeholder="Rechercher un site..." autocomplete="off" />
           </label>
         </section>
 
-        <section class="section-heading section-heading--sticky">
-          <div>
-            <h2>Sites enregistrés</h2>
-            <p id="siteCount">0 site</p>
+        <section class="section-heading section-heading--sticky section-heading--saved">
+          <div class="saved-sites-label">
+            <img src="Icon/Site.png" alt="" aria-hidden="true" class="saved-sites-label__icon" />
+            <h2>Site enregistré</h2>
           </div>
+          <span id="siteCount" class="site-count-pill" aria-label="Nombre de sites enregistrés">0</span>
         </section>
 
         <section id="siteList" class="list-grid" aria-live="polite"></section>

--- a/js/app.js
+++ b/js/app.js
@@ -47,11 +47,6 @@ import { firebaseAuth } from './firebase-core.js';
     return username || 'Utilisateur';
   }
 
-  function buildCreatedLabel(item, userMap) {
-    const createdBy = resolveActorLabel(item?.createdBy, userMap, item?.createdByName);
-    return `Créé par ${createdBy} le ${UiService.formatDate(item?.dateCreation)}`;
-  }
-
   function buildDateAndTimeLabel(dateValue) {
     if (!dateValue) {
       return '--';
@@ -961,7 +956,7 @@ import { firebaseAuth } from './firebase-core.js';
     function renderSites() {
       const query = searchInput.value.trim().toUpperCase();
       const sites = currentSites.filter((site) => String(site.nom || '').toUpperCase().includes(query));
-      setCountText(siteCount, sites.length, 'site', 'sites');
+      siteCount.textContent = String(sites.length);
 
       if (!sites.length) {
         UiService.renderEmptyState(
@@ -973,8 +968,11 @@ import { firebaseAuth } from './firebase-core.js';
 
       siteList.innerHTML = sites
         .map((site) => {
-          const createdLabel = buildCreatedLabel(site, userNamesById);
+          const outCount = itemCountsBySite[site.id] || 0;
+          const createdDateTime = buildDateAndTimeLabel(site?.dateCreation);
+          const createdBy = resolveActorLabel(site?.createdBy, userNamesById, site?.createdByName);
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
+          const lockLabel = isSiteLocked(site) ? 'Verrouillé' : 'Déverrouillé';
           const canShowDeleteButton =
             isAuthenticated && currentPermissions.canDelete && !isSiteLocked(site);
           return `
@@ -983,43 +981,29 @@ import { firebaseAuth } from './firebase-core.js';
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
-                  <span>${itemCountsBySite[site.id] || 0} OUT${(itemCountsBySite[site.id] || 0) > 1 ? 'S' : ''}</span>
-                  <span>${escapeHtml(createdLabel)}</span>
+                  <span class="list-card__meta-item list-card__meta-item--outs">
+                    <img src="Icon/OUT.png" alt="" aria-hidden="true" class="icon" />
+                    <span>${outCount} OUT${outCount > 1 ? 'S' : ''}</span>
+                  </span>
+                  <span class="list-card__meta-item">
+                    <img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" />
+                    <span>Créé le ${escapeHtml(createdDateTime)}</span>
+                  </span>
+                  <span class="list-card__meta-item">
+                    <img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" />
+                    <span>${escapeHtml(createdBy)}</span>
+                  </span>
                 </div>
+                <span class="list-card__divider" aria-hidden="true"></span>
+                <span class="list-card__status ${isSiteLocked(site) ? 'list-card__status--locked' : 'list-card__status--unlocked'}">
+                  <img src="${lockIconSrc}" alt="" aria-hidden="true" class="list-card__status-icon" />
+                  <span>${lockLabel}</span>
+                </span>
               </button>
-              <img
-                class="list-card__lock-icon ${canShowDeleteButton ? 'list-card__lock-icon--with-delete' : ''}"
-                src="${lockIconSrc}"
-                alt="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
-                aria-label="${isSiteLocked(site) ? 'Site verrouillé' : 'Site non verrouillé'}"
-              />
             </article>
           `;
         })
         .join('');
-
-      siteList.querySelectorAll('.list-card__lock-icon').forEach((icon) => {
-        const iconSrc = icon.getAttribute('src');
-        console.debug('[page1][lock-icon] src utilisé :', iconSrc);
-
-        icon.addEventListener(
-          'error',
-          () => {
-            const fallbackSrc = 'Icon/Cadenas_close.png';
-            console.warn('[page1][lock-icon] erreur de chargement, fallback appliqué :', iconSrc, '->', fallbackSrc);
-            icon.src = fallbackSrc;
-
-            icon.addEventListener(
-              'error',
-              () => {
-                icon.style.display = 'none';
-              },
-              { once: true },
-            );
-          },
-          { once: true },
-        );
-      });
 
       siteList.querySelectorAll('[data-site-open]').forEach((button) => {
         let longPressTimer = null;


### PR DESCRIPTION
### Motivation
- Modernize the home page presentation by updating the search panel, saved-sites header, and list-card visuals to improve readability and information density.
- Surface key site metadata (OUT count, creation date/time, creator) and clear lock status on each site card.

### Description
- Restyled the home page by updating `css/style.css` with new paddings, rounded corners, backgrounds, borders, shadows, and many new utility classes for `.list-card`, `.list-card__meta-item`, `.list-card__status`, `.saved-sites-label`, `.site-count-pill`, and more.
- Added a left accent bar on cards via `.list-card::before`, adjusted FAB styling, and changed multiple sizing values to use `clamp()` and responsive units.
- Modified `index.html` search input placeholder text and restructured the saved sites header into a `section-heading--saved` block including an icon and a site count pill element.
- Updated `js/app.js` rendering: removed `buildCreatedLabel`, replaced aggregated label with discrete meta items showing OUT count, formatted creation date/time via `buildDateAndTimeLabel`, creator via `resolveActorLabel`, and explicit lock status with icon and label; simplified `siteCount` update to show just the number; removed the old lock-icon image + error-handling code.

### Testing
- Ran project static checks and build tasks with `npm run lint` and `npm run build`, both of which completed successfully.
- Executed automated test suite via `npm test` and all tests passed (no regressions detected in unit/integration tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68eed5c14832ab7e9dea1f11cee3e)