### PR TITLE
Refactor header page2 : centrage exact du titre (3 zones)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2380,19 +2380,44 @@ body[data-page="home"] .fab {
 }
 
 body[data-page="site-detail"] .app-header--detail {
-  min-height: clamp(5.6rem, 13vw, 7.2rem);
-  padding-top: clamp(0.8rem, 1.8vw, 1.1rem);
-  padding-bottom: clamp(0.8rem, 1.8vw, 1.15rem);
-  padding-inline: calc(clamp(0.75rem, 2.2vw, 1.1rem) + var(--header-side-width));
+  --detail-side-size: clamp(2.5rem, 7.8vw, 2.75rem);
+  min-height: var(--header-height);
+  height: var(--header-height);
+  padding: 0.75rem clamp(0.75rem, 2.3vw, 1.2rem);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  display: grid;
+  grid-template-columns: var(--detail-side-size) minmax(0, 1fr) var(--detail-side-size);
+  align-items: center;
+  gap: clamp(0.4rem, 1.4vw, 0.8rem);
+  position: sticky;
+  top: 0;
 }
 
-body[data-page="site-detail"] .app-header--detail .back-button {
-  left: clamp(0.7rem, 2.2vw, 1.1rem);
+body[data-page="site-detail"] .detail-header__side {
+  width: var(--detail-side-size);
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body[data-page="site-detail"] .detail-header__side .back-button {
+  position: static;
+  transform: none;
+  width: 100%;
+  height: 100%;
+}
+
+body[data-page="site-detail"] .detail-header__center {
+  min-width: 0;
+  display: flex;
+  justify-content: center;
 }
 
 body[data-page="site-detail"] .header-title {
   width: min(100%, 32rem);
-  gap: 0.24rem;
+  gap: 0.28rem;
+  flex-direction: column;
 }
 
 body[data-page="site-detail"] #siteTitle {
@@ -2542,9 +2567,11 @@ body[data-page="site-detail"] .list-separator {
     height: 1.2rem;
   }
 
-  body[data-page="site-detail"] .app-header--detail .back-button {
-    width: 2.5rem;
-    height: 2.5rem;
+  body[data-page="site-detail"] .app-header--detail {
+    --detail-side-size: 2.5rem;
+    min-height: clamp(4.5rem, 16vw, 5.2rem);
+    height: auto;
+    padding-block: 0.6rem;
   }
 
   body[data-page="site-detail"] .app-header--detail .btn-retour {

--- a/page2.html
+++ b/page2.html
@@ -9,11 +9,16 @@
   <body data-page="site-detail">
     <div class="app-shell">
       <header class="app-header app-header--detail">
-        <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
-        <div class="header-title header-title--stacked">
-          <h1 id="siteTitle">Chargement...</h1>
-          <p id="itemCount" class="site-detail-subtitle">0 OUTS</p>
+        <div class="detail-header__side detail-header__side--left">
+          <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
         </div>
+        <div class="detail-header__center">
+          <div class="header-title header-title--stacked">
+            <h1 id="siteTitle">Chargement...</h1>
+            <p id="itemCount" class="site-detail-subtitle">0 OUTS</p>
+          </div>
+        </div>
+        <div class="detail-header__side detail-header__side--right" aria-hidden="true"></div>
       </header>
 
       <main class="page-content">


### PR DESCRIPTION
### Motivation

- Corriger l’alignement du header de `page2` pour que le bouton retour reste à gauche et que le bloc texte (titre + sous-titre) soit mathématiquement et visuellement centré indépendamment de la présence du bouton.
- Obtenir un rendu mobile professionnel et identique à la page 1 en hauteur, couleur et comportement sticky tout en conservant la logique et les textes existants.

### Description

- Refactor du markup de `page2.html` pour une structure en 3 zones : gauche (`detail-header__side--left` contenant le `back-button`), centre (`detail-header__center` contenant le bloc texte) et droite (`detail-header__side--right` zone miroir vide).
- Mise à jour de `css/style.css` pour `body[data-page="site-detail"] .app-header--detail` : conversion en grid 3 colonnes avec variable `--detail-side-size`, centrage strict du contenu central et miroir latéral pour assurer un centrage exact.
- Ajustements CSS pour vertical centering du bouton retour, espacement interne amélioré et `position: sticky; top: 0;` explicite pour un comportement sticky stable sur mobile.
- Harmonisation visuelle avec la page 1 (hauteur, gradient/couleur de fond) sans modifier les textes, la logique JavaScript ni d’autres pages.

### Testing

- Contrôles statiques automatisés exécutés : `git diff --check` a renvoyé OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a9d6fd30832abd22045105947462)