### PR TITLE
Make page 2 header use same gradient as page 1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2410,7 +2410,7 @@ body[data-page="site-detail"] .app-header--detail {
   min-height: var(--header-height);
   height: var(--header-height);
   padding: 0.75rem clamp(0.75rem, 2.3vw, 1.2rem);
-  background: var(--primary-color);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   display: grid;
   grid-template-columns: var(--detail-side-size) minmax(0, 1fr) var(--detail-side-size);
   align-items: center;


### PR DESCRIPTION
### Motivation
- Harmonize the visual appearance of the app by making the header on page 2 use the exact same color as the header on page 1 for perfect header consistency.

### Description
- Replace the `background` value for `body[data-page="site-detail"] .app-header--detail` in `css/style.css` from `var(--primary-color)` to `linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%)`, without touching any other properties, layout, or pages.

### Testing
- Confirmed via file-diff and file-line inspection that only the single CSS property was changed in `css/style.css` and that the modification was applied successfully; no automated visual/browser rendering tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b54a5abc832a82184e9d987b28fc)