### PR TITLE
Aligner la hauteur du header de la page 3 sur `--header-height`

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1403,6 +1403,11 @@ body[data-page="item-detail"] .table-wrapper--shared {
   padding-bottom: 1.5rem;
 }
 
+body[data-page="item-detail"] .app-header--detail {
+  min-height: var(--header-height);
+  height: var(--header-height);
+}
+
 body[data-page="item-detail"] .table-container input,
 body[data-page="item-detail"] .table-container select,
 body[data-page="item-detail"] .table-container button,


### PR DESCRIPTION
### Motivation

- Assurer une hauteur strictement identique du header entre les pages 1, 2 et 3 en réutilisant la variable de hauteur partagée `--header-height`.
- Appliquer ce correctif uniquement à la page 3 (`data-page="item-detail"`) sans modifier d’autres propriétés ni la structure ou le comportement du header.

### Description

- Ajout d’une règle CSS ciblée dans `css/style.css` pour `body[data-page="item-detail"] .app-header--detail` qui définit `min-height` et `height` à `var(--header-height)`.
- Aucun autre fichier, propriété de header (couleur, texte, padding, marges, icônes, sticky, alignement) ou page n’a été modifié.

### Testing

- Vérification du diff pour confirmer que la modification se limite à l’ajout de la règle CSS ciblée et qu’aucune autre ligne n’a été changée.
- Inspection du fichier `css/style.css` pour valider la présence des lignes ajoutées (`body[data-page="item-detail"] .app-header--detail { min-height: var(--header-height); height: var(--header-height); }`).
- Aucune suite de tests automatisés n’a été exécutée pour ce changement CSS isolé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b754bc34832ab20bdfedcfc797d9)