### PR TITLE
Uniformiser la hauteur des headers des pages 1 à 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2555,8 +2555,8 @@ body[data-page="site-detail"] .list-separator {
   }
 
   body[data-page="home"] .app-header--home {
-    min-height: clamp(4.5rem, 16vw, 5.2rem);
-    height: auto;
+    min-height: var(--header-height);
+    height: var(--header-height);
     padding-block: 0.6rem;
   }
 
@@ -2600,8 +2600,8 @@ body[data-page="site-detail"] .list-separator {
 
   body[data-page="site-detail"] .app-header--detail {
     --detail-side-size: 2.5rem;
-    min-height: clamp(4.5rem, 16vw, 5.2rem);
-    height: auto;
+    min-height: var(--header-height);
+    height: var(--header-height);
     padding-block: 0.6rem;
   }
 


### PR DESCRIPTION
### Motivation
- Garantir que les en-têtes (headers) des pages 1 (`home`), 2 (`site-detail`) et 3 (`item-detail`) aient strictement la même hauteur sur mobile sans toucher à d’autres propriétés visuelles ou comportementales.

### Description
- Dans `css/style.css` sous le breakpoint `@media (max-width: 767px)`, les règles pour `body[data-page="home"] .app-header--home` et `body[data-page="site-detail"] .app-header--detail` ont été modifiées pour utiliser `min-height: var(--header-height)` et `height: var(--header-height)` afin d’aligner leur hauteur sur celle de la page 3, sans autre changement de propriété.

### Testing
- Aucun test automatisé n’est disponible pour ce projet ; la correction a été validée par inspection des règles CSS ciblées dans `css/style.css` (recherches et visualisation des lignes modifiées) et appliquée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ba1317c8832a92155bedc087d809)