### PR TITLE
Unify back button styles between detail pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2435,8 +2435,6 @@ body[data-page="site-detail"] .detail-header__side {
 body[data-page="site-detail"] .detail-header__side .back-button {
   position: static;
   transform: none;
-  width: 100%;
-  height: 100%;
 }
 
 body[data-page="site-detail"] .detail-header__center {
@@ -2603,11 +2601,6 @@ body[data-page="site-detail"] .list-separator {
     min-height: var(--header-height);
     height: var(--header-height);
     padding-block: 0.6rem;
-  }
-
-  body[data-page="site-detail"] .app-header--detail .btn-retour {
-    width: 1.8rem;
-    height: 1.8rem;
   }
 
   body[data-page="site-detail"] .filter-chip {


### PR DESCRIPTION
### Motivation
- Rendre le bouton « retour » visuellement identique entre la page de liste et la page de détail en supprimant les overrides CSS qui créaient des différences de forme/taille/icône centrage.
- Respecter la contrainte de ne modifier que le bouton retour sans toucher au header, au layout ni aux autres boutons.

### Description
- Supprimé l’override `width: 100%` et `height: 100%` appliqué à `body[data-page="site-detail"] .detail-header__side .back-button` pour empêcher le bouton de s’étirer à son conteneur.
- Supprimé la règle mobile spécifique qui réduisait la taille de `.btn-retour` dans le contexte `site-detail`, afin d’utiliser la même base de styles que l’autre page.
- Conservé le positionnement (`position: static` et `transform: none`) pour ne pas impacter le layout global; la modification touche uniquement l’apparence du bouton retour (forme, dimension d’origine, centrage de l’icône).
- Fichier modifié: `css/style.css`.

### Testing
- Cherché et vérifié les sélecteurs et occurrences liés au bouton avec `rg` pour confirmer l’unification des règles; recherche OK.
- Exécuté `git -C /workspace/Album diff --check` pour détecter des problèmes de whitespace ou erreurs de diff; résultat OK (aucune erreur signalée).
- Inspecté l’état des modifications avec `git -C /workspace/Album status --short` pour confirmer le fichier modifié; résultat OK.
- Note: aucun test visuel automatisé (capture d’écran navigateur) n’a été exécuté dans cet environnement, la vérification visuelle finale est recommandée en environnement navigateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bc96a878832a9e89ea889a3061ba)