### PR TITLE
Page 3: déplacer le formulaire de détail dans un modal ouvert par bouton flottant '+'

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1460,6 +1460,86 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   text-align: left;
 }
 
+body[data-page="item-detail"] {
+  --detail-primary: var(--primary-dark);
+  --detail-primary-focus: rgba(39, 141, 218, 0.22);
+  --detail-primary-shadow: rgba(39, 141, 218, 0.32);
+}
+
+body[data-page="item-detail"].item-detail-modal-open {
+  overflow: hidden;
+}
+
+body[data-page="item-detail"] .fab-add--item-detail {
+  position: fixed;
+  right: 20px;
+  bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  border: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  color: #fff;
+  font-size: 32px;
+  line-height: 1;
+  box-shadow: 0 10px 22px var(--detail-primary-shadow);
+  z-index: 45;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+body[data-page="item-detail"] .fab-add--item-detail:hover {
+  background: linear-gradient(135deg, #66beff 0%, var(--detail-primary) 100%);
+  box-shadow: 0 14px 28px var(--detail-primary-shadow);
+}
+
+body[data-page="item-detail"] .fab-add--item-detail:active {
+  transform: scale(0.95);
+}
+
+body[data-page="item-detail"] .fab-add--item-detail:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--detail-primary-focus);
+}
+
+body[data-page="item-detail"] .detail-form-modal {
+  width: min(92vw, 32rem);
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
+body[data-page="item-detail"] .detail-form-modal::backdrop {
+  background: rgba(15, 23, 42, 0.52);
+}
+
+body[data-page="item-detail"] .detail-form-modal__content {
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(216, 226, 236, 0.85);
+  background: linear-gradient(165deg, #ffffff 0%, #f7fbff 100%);
+  box-shadow: 0 28px 55px rgba(31, 42, 55, 0.18);
+  transform: translateY(10px) scale(0.98);
+  opacity: 0;
+  animation: detailModalIn 0.24s ease forwards;
+}
+
+body[data-page="item-detail"] .detail-form-modal__section {
+  margin-bottom: 0;
+  box-shadow: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
+@keyframes detailModalIn {
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
 .field-badge {
   display: inline-flex;
   align-items: center;

--- a/js/app.js
+++ b/js/app.js
@@ -1735,6 +1735,9 @@ import { firebaseAuth } from './firebase-core.js';
     const detailForm = requireElement('detailForm');
     const detailFormSection = requireElement('detailFormSection');
     const detailFormError = requireElement('detailFormError');
+    const detailFormModal = requireElement('detailFormModal');
+    const openDetailFormButton = requireElement('openDetailFormButton');
+    const cancelDetailFormButton = requireElement('cancelDetailFormButton');
     const detailCount = requireElement('detailCount');
     const detailTableBody = requireElement('detailTableBody');
     const detailSearchInput = requireElement('detailSearchInput');
@@ -1753,6 +1756,32 @@ import { firebaseAuth } from './firebase-core.js';
     let codeSuggestionSource = [];
     let visibleCodeSuggestions = [];
     let activeSuggestionIndex = -1;
+
+    function setDetailModalOpenState(isOpen) {
+      document.body.classList.toggle('item-detail-modal-open', isOpen);
+    }
+
+    function closeDetailModal() {
+      if (!detailFormModal?.open) {
+        setDetailModalOpenState(false);
+        return;
+      }
+      detailFormModal.close();
+      setDetailModalOpenState(false);
+      hideCodeSuggestions();
+      detailFormError.textContent = '';
+    }
+
+    function openDetailModal() {
+      if (!detailFormModal || !permissions.canCreate || permissions.isLecture) {
+        return;
+      }
+      detailFormModal.showModal();
+      setDetailModalOpenState(true);
+      window.setTimeout(() => {
+        codeInput?.focus();
+      }, 60);
+    }
 
     function buildCodeSuggestionSource(details) {
       const suggestionsByCode = new Map();
@@ -1903,6 +1932,11 @@ import { firebaseAuth } from './firebase-core.js';
 
     if (!permissions.canCreate || permissions.isLecture) {
       detailFormSection.hidden = true;
+      if (openDetailFormButton) {
+        openDetailFormButton.hidden = true;
+      }
+    } else if (detailFormSection) {
+      detailFormSection.hidden = false;
     }
 
     function renderTitle() {
@@ -2069,8 +2103,34 @@ import { firebaseAuth } from './firebase-core.js';
       detailForm.reset();
       requireElement('uniteInput').value = 'm';
       hideCodeSuggestions();
+      closeDetailModal();
       UiService.showToast('Article ajoutée .');
     });
+
+    if (openDetailFormButton) {
+      openDetailFormButton.addEventListener('click', openDetailModal);
+    }
+
+    if (cancelDetailFormButton) {
+      cancelDetailFormButton.addEventListener('click', closeDetailModal);
+    }
+
+    if (detailFormModal) {
+      detailFormModal.addEventListener('cancel', (event) => {
+        event.preventDefault();
+        closeDetailModal();
+      });
+
+      detailFormModal.addEventListener('click', (event) => {
+        if (event.target === detailFormModal) {
+          closeDetailModal();
+        }
+      });
+
+      detailFormModal.addEventListener('close', () => {
+        setDetailModalOpenState(false);
+      });
+    }
 
     if (codeInput && codeSuggestions) {
       codeInput.addEventListener('focus', () => {

--- a/page3.html
+++ b/page3.html
@@ -17,37 +17,6 @@
       </header>
 
       <main class="page-content page-content--wide">
-        <section id="detailFormSection" class="surface-card form-card section">
-          <form id="detailForm" class="responsive-form" novalidate>
-            <label class="input-group">
-              <span>Code</span>
-              <div class="typeahead" id="codeTypeahead">
-                <input id="codeInput" name="code" type="text" maxlength="40" aria-label="Code" autocomplete="off" />
-                <div id="codeSuggestions" class="typeahead__menu" role="listbox" aria-label="Suggestions de code" hidden></div>
-              </div>
-            </label>
-            <label class="input-group input-group--wide">
-              <span>Désignation</span>
-              <input id="designationInput" name="designation" type="text" maxlength="120" required />
-            </label>
-            <label class="input-group">
-              <span>Qté Sortie</span>
-              <input id="qteSortieInput" name="qteSortie" type="number" min="0" step="1" />
-            </label>
-            <label class="input-group">
-              <span>Unité</span>
-              <select id="uniteInput" name="unite">
-                <option value="m">m</option>
-                <option value="Pcs">Pcs</option>
-              </select>
-            </label>
-            <div class="form-footer">
-              <p id="detailFormError" class="form-error" aria-live="polite"></p>
-              <button type="submit" class="btn btn-success">Enregistrer</button>
-            </div>
-          </form>
-        </section>
-
         <section class="surface-card table-card section">
           <div class="section-heading section-heading--table">
             <div>
@@ -86,6 +55,47 @@
           </div>
         </section>
       </main>
+
+      <button type="button" id="openDetailFormButton" class="fab-add fab-add--item-detail" aria-label="Ajouter une donnée">+</button>
+
+      <dialog id="detailFormModal" class="modal-card detail-form-modal">
+        <div class="modal-content detail-form-modal__content">
+          <div class="modal-header">
+            <h2>Ajouter une donnée</h2>
+          </div>
+          <section id="detailFormSection" class="surface-card form-card section detail-form-modal__section">
+            <form id="detailForm" class="responsive-form" novalidate>
+              <label class="input-group">
+                <span>Code</span>
+                <div class="typeahead" id="codeTypeahead">
+                  <input id="codeInput" name="code" type="text" maxlength="40" aria-label="Code" autocomplete="off" />
+                  <div id="codeSuggestions" class="typeahead__menu" role="listbox" aria-label="Suggestions de code" hidden></div>
+                </div>
+              </label>
+              <label class="input-group input-group--wide">
+                <span>Désignation</span>
+                <input id="designationInput" name="designation" type="text" maxlength="120" required />
+              </label>
+              <label class="input-group">
+                <span>Qté Sortie</span>
+                <input id="qteSortieInput" name="qteSortie" type="number" min="0" step="1" />
+              </label>
+              <label class="input-group">
+                <span>Unité</span>
+                <select id="uniteInput" name="unite">
+                  <option value="m">m</option>
+                  <option value="Pcs">Pcs</option>
+                </select>
+              </label>
+              <div class="form-footer">
+                <p id="detailFormError" class="form-error" aria-live="polite"></p>
+                <button type="button" class="btn" id="cancelDetailFormButton">Annuler</button>
+                <button type="submit" class="btn btn-success">Enregistrer</button>
+              </div>
+            </form>
+          </section>
+        </div>
+      </dialog>
 
       <div id="toast" class="toast" aria-live="polite"></div>
     </div>


### PR DESCRIPTION
### Motivation
- Sur la page item-detail (page 3) l’objectif est d’afficher le formulaire de création dans un modal déclenché par un bouton flottant, sans modifier la structure/validation interne du formulaire ni la logique métier existante.

### Description
- Le formulaire existant a été extrait du flux de page et encapsulé dans un `<dialog id="detailFormModal">` et conservé avec les mêmes IDs/classes (`detailForm`, `codeInput`, `designationInput`, `qteSortieInput`, `uniteInput`, `detailFormError`, `Enregistrer`) afin de ne rien changer à la structure ou aux validations internes (fichiers modifiés : `page3.html`).
- Ajout d’un bouton flottant circulaire `+` (`id="openDetailFormButton"`, classe `fab-add--item-detail`) positionné en bas à droite et stylisé pour réutiliser la palette visuelle existante; styles et animation modal ajoutés dans `css/style.css` (scopés à `body[data-page="item-detail"]`).
- Comportement modal implémenté dans `js/app.js` : ouverture par `openDetailFormButton`, fermeture par clic sur l’overlay, par le bouton `Annuler` (`id="cancelDetailFormButton"`) ou automatiquement après sauvegarde réussie, focus du premier champ à l’ouverture, gestion des suggestions de code et verrouillage du scroll de fond via la classe `item-detail-modal-open` appliquée au `body`.
- Respect strict des contraintes : aucune modification de la logique Firestore/CRUD, du tableau, du compteur “Article”, du bouton Exporter ou du header.

### Testing
- Syntax check JavaScript : `node --check js/app.js` — réussi.
- Syntax check JavaScript : `node --check js/ui.js` — réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bfe139c8832a9a06a555b305b993)