### PR TITLE
Integrate search icon inside search input on page 3

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -6,6 +6,35 @@
     <title>Détail complet - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+      body[data-page="item-detail"] .search-panel .input-group {
+        position: relative;
+      }
+
+      body[data-page="item-detail"] .search-input__icon-wrap {
+        position: absolute;
+        left: 0.95rem;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 16px;
+        height: 16px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      body[data-page="item-detail"] .search-input__icon {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+      }
+
+      body[data-page="item-detail"] #detailSearchInput {
+        padding-left: 2.6rem;
+      }
+    </style>
   </head>
   <body data-page="item-detail">
     <div class="app-shell app-shell--wide">
@@ -27,7 +56,10 @@
           </div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">
-              <span class="label-with-icon"><img src="Icon/Recherche.png" alt="" class="label-icon icon" aria-hidden="true" /><span>Recherche</span></span>
+              <span>Recherche</span>
+              <span class="search-input__icon-wrap" aria-hidden="true">
+                <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
+              </span>
               <input id="detailSearchInput" class="search-input" type="text" placeholder="Entrer votre Recherche..." autocomplete="off" />
             </label>
           </div>


### PR DESCRIPTION
### Motivation
- Rendre le champ de recherche de la page 3 plus moderne en plaçant l’icône de recherche directement à l’intérieur du champ, alignée à gauche, tout en conservant le style visuel existant.
- Respecter les règles UX/techniques imposées (centering via `top: 50%` + `transform`, conteneur en `position: relative`, ajustement du `padding-left`) sans toucher aux autres éléments de la page.

### Description
- Modifié uniquement le fichier `page3.html` pour supprimer l’icône externe et ajouter une structure d’icône interne (`.search-input__icon-wrap` contenant `.search-input__icon`) à côté du label `Recherche`.
- Ajouté du CSS scoped dans une balise `<style>` ciblant `body[data-page="item-detail"]` pour définir l’input-group en `position: relative` et positionner l’icône en `position: absolute` à gauche avec centrage vertical via `top: 50%` + `transform: translateY(-50%)`.
- Ajusté le `padding-left` de `#detailSearchInput` pour éviter le chevauchement texte/icône et défini dimensions/opacité discrète de l’icône pour un rendu professionnel.
- Conservé le placeholder `"Entrer votre Recherche..."`, la largeur et l’alignement du champ, ainsi que les éléments et la logique non concernés (`Exporter`, compteur, tableau, header, autres champs de formulaire).

### Testing
- Exécuté `git diff --check` pour vérifier l’absence de conflits d’espacement et l’opération a réussi.
- Vérifié l’état des modifications avec `git status --short` et la vérification a réussi.
- Enregistré les changements avec `git commit -m "Refine page 3 search input with embedded icon"` et le commit a été créé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c30544b4832aa4b0de3fe9034058)