### PR TITLE
Améliore la disposition UI des champs « Qté Sortie » et « Unité » (70/30)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1533,6 +1533,31 @@ body[data-page="item-detail"] .detail-form-modal__section {
   background: transparent;
 }
 
+
+body[data-page="item-detail"] .detail-form-row--qte-unit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field {
+  min-width: 0;
+}
+
+body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field--qte {
+  flex: 7 1 13rem;
+}
+
+body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field--unit {
+  flex: 3 1 7rem;
+}
+
+body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > input,
+body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > select {
+  height: 100%;
+}
+
 @keyframes detailModalIn {
   to {
     transform: translateY(0) scale(1);

--- a/page3.html
+++ b/page3.html
@@ -108,17 +108,19 @@
                 <span>Désignation</span>
                 <input id="designationInput" name="designation" type="text" maxlength="120" required />
               </label>
-              <label class="input-group">
-                <span>Qté Sortie</span>
-                <input id="qteSortieInput" name="qteSortie" type="number" min="0" step="1" />
-              </label>
-              <label class="input-group">
-                <span>Unité</span>
-                <select id="uniteInput" name="unite">
-                  <option value="m">m</option>
-                  <option value="Pcs">Pcs</option>
-                </select>
-              </label>
+              <div class="detail-form-row detail-form-row--qte-unit">
+                <label class="input-group detail-form-field detail-form-field--qte">
+                  <span>Qté Sortie</span>
+                  <input id="qteSortieInput" name="qteSortie" type="number" min="0" step="1" />
+                </label>
+                <label class="input-group detail-form-field detail-form-field--unit">
+                  <span>Unité</span>
+                  <select id="uniteInput" name="unite">
+                    <option value="m">m</option>
+                    <option value="Pcs">Pcs</option>
+                  </select>
+                </label>
+              </div>
               <div class="form-footer">
                 <p id="detailFormError" class="form-error" aria-live="polite"></p>
                 <button type="button" class="btn" id="cancelDetailFormButton">Annuler</button>


### PR DESCRIPTION
### Motivation
- Rendre la saisie plus compacte et professionnelle en plaçant les champs « Qté Sortie » et « Unité » sur une même ligne dans le formulaire "Ajouter une donnée" (page 3) en respectant un rendu mobile‑first.
- Conserver entièrement le style visuel existant, les labels au‑dessus des contrôles et la logique du formulaire, en limitant la modification à l'UI.

### Description
- Regroupe les deux champs dans un conteneur `div.detail-form-row.detail-form-row--qte-unit` et ajoute les classes `detail-form-field--qte` et `detail-form-field--unit` dans `page3.html` pour cibler la mise en page.
- Ajoute des règles CSS scoped `body[data-page="item-detail"] .detail-form-row--qte-unit` dans `css/style.css` pour un layout en `flex` responsive avec `flex-wrap` et un ratio visuel ~70/30 (`flex: 7` / `flex: 3`).
- Assure la même hauteur visuelle pour l'`input` et le `select` et autorise le retour à la ligne propre sur très petits écrans sans modifier couleurs, bordures, padding ni logique JS.

### Testing
- Exécution de `git diff --check` dans le projet, aucune erreur signalée (succès).
- Vérification de l'état avec `git status --short` après les modifications, l'arbre de travail est propre (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c45cb648832a95b3a0084544af6e)