### PR TITLE
Amélioration du champ de recherche (page 3) — alignement icône et placeholder

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -13,15 +13,16 @@
 
       body[data-page="item-detail"] .search-input__icon-wrap {
         position: absolute;
-        left: 0.95rem;
+        left: 0.85rem;
         top: 50%;
         transform: translateY(-50%);
-        width: 16px;
-        height: 16px;
+        width: 19px;
+        height: 19px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        opacity: 0.55;
+        opacity: 0.72;
+        filter: grayscale(1) brightness(0.65);
         pointer-events: none;
       }
 
@@ -32,7 +33,7 @@
       }
 
       body[data-page="item-detail"] #detailSearchInput {
-        padding-left: 2.6rem;
+        padding-left: 2.9rem;
       }
     </style>
   </head>
@@ -56,11 +57,10 @@
           </div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">
-              <span>Recherche</span>
               <span class="search-input__icon-wrap" aria-hidden="true">
                 <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
               </span>
-              <input id="detailSearchInput" class="search-input" type="text" placeholder="Entrer votre Recherche..." autocomplete="off" />
+              <input id="detailSearchInput" class="search-input" type="text" placeholder="Entrer votre recherche..." autocomplete="off" />
             </label>
           </div>
           <div class="table-container table-container--card" id="detailTableContainer">


### PR DESCRIPTION
### Motivation
- Moderniser et épurer le champ de recherche de la page détail pour un rendu professionnel et mobile-friendly.
- Éviter que le texte saisi ne chevauche l’icône et harmoniser l’apparence (taille, couleur et alignement de l’icône).

### Description
- Mise à jour de `page3.html` : suppression du libellé `Recherche` au-dessus du champ pour un rendu plus épuré.
- L’icône de recherche a été intégrée dans le champ en position absolute à gauche avec ajustement du `left`, de la taille à `19px` et d’un léger filtre pour une teinte grise douce.
- Augmentation du `padding-left` de l’input à `2.9rem` pour garantir un espacement propre entre l’icône et le texte.
- Correction du placeholder pour n’afficher que `Entrer votre recherche...` (suppression de la répétition de “Recherche”).

### Testing
- Contrôles automatiques du dépôt et état des fichiers ont été exécutés et sont passés.
- Aucun test unitaire ou automatisé d’interface graphique spécifique n’est présent dans le dépôt pour valider visuellement les changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c6eec6cc832a918bcbb9215bd280)