### PR TITLE
Aligner 'Qté Sortie' et 'Unité' sur la même ligne dans la modale de détail

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1536,8 +1536,8 @@ body[data-page="item-detail"] .detail-form-modal__section {
 
 body[data-page="item-detail"] .detail-form-row--qte-unit {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-wrap: nowrap;
+  gap: 1rem;
   align-items: stretch;
 }
 
@@ -1546,11 +1546,11 @@ body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field {
 }
 
 body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field--qte {
-  flex: 7 1 13rem;
+  flex: 1 1 0;
 }
 
 body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field--unit {
-  flex: 3 1 7rem;
+  flex: 1 1 0;
 }
 
 body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > input,


### PR DESCRIPTION
### Motivation
- Harmoniser l'interface de la modale d'ajout pour que les champs `Qté Sortie` et `Unité` apparaissent côte à côte et correspondent exactement au rendu attendu sans modifier la logique existante.

### Description
- Adjustement CSS dans `css/style.css` : la règle `.detail-form-row--qte-unit` passe en `flex-wrap: nowrap` avec `gap: 1rem` et les champs `.detail-form-field--qte` et `.detail-form-field--unit` reçoivent `flex: 1 1 0` pour un alignement et des proportions équilibrées, sans aucun changement JavaScript, d'IDs, de noms ou de structure fonctionnelle.

### Testing
- Aucun test automatisé n'a été exécuté pour ce changement purement UI/CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c939dfbc832aac2b1d40ec4cab9d)