### PR TITLE
Améliore l'espacement et l'alignement des boutons du modal « Ajouter une donnée »

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1533,6 +1533,25 @@ body[data-page="item-detail"] .detail-form-modal__section {
   background: transparent;
 }
 
+body[data-page="item-detail"] .detail-form-modal .form-footer {
+  align-items: stretch;
+}
+
+body[data-page="item-detail"] #detailFormError {
+  flex-basis: 100%;
+}
+
+body[data-page="item-detail"] .detail-form-actions {
+  display: flex;
+  width: 100%;
+  gap: 10px;
+  flex-wrap: nowrap;
+}
+
+body[data-page="item-detail"] .detail-form-actions .btn {
+  flex: 1 1 50%;
+  min-width: 0;
+}
 
 body[data-page="item-detail"] .detail-form-row--qte-unit {
   display: flex;

--- a/page3.html
+++ b/page3.html
@@ -123,8 +123,10 @@
               </div>
               <div class="form-footer">
                 <p id="detailFormError" class="form-error" aria-live="polite"></p>
-                <button type="button" class="btn" id="cancelDetailFormButton">Annuler</button>
-                <button type="submit" class="btn btn-success">Enregistrer</button>
+                <div class="detail-form-actions">
+                  <button type="button" class="btn" id="cancelDetailFormButton">Annuler</button>
+                  <button type="submit" class="btn btn-success">Enregistrer</button>
+                </div>
               </div>
             </form>
           </section>


### PR DESCRIPTION
### Motivation
- Améliorer l'apparence du modal « Ajouter une donnée » en ajoutant un léger espacement entre les actions et en garantissant un alignement horizontal propre et moderne.
- Les boutons doivent rester sur une seule ligne, avoir des largeurs égales (50%/50%) et conserver l'alignement sans toucher à la logique JavaScript.
- Changer uniquement le HTML/CSS du modal ciblé et ne pas impacter les autres modals ou pages.

### Description
- Regroupement des boutons d'action dans un wrapper `.detail-form-actions` ajouté dans `page3.html` pour isoler la mise en page du footer du formulaire.
- Ajout de styles scoped dans `css/style.css` sous `body[data-page="item-detail"]` pour: appliquer `display:flex`, `gap:10px`, `flex-wrap:nowrap` et définir `flex: 1 1 50%` sur chaque bouton afin d'obtenir un rendu 50/50 et un espacement horizontal propre.
- Forçage du message d'erreur `#detailFormError` à occuper sa propre ligne (`flex-basis: 100%`) pour préserver l'alignement parfait des boutons.
- Modifications limitées à `page3.html` et `css/style.css` et aucune modification JavaScript ou fonctions existantes.

### Testing
- Vérification du diff des fichiers modifiés avec `git status --short && git diff -- page3.html css/style.css`, commande exécutée avec succès.
- Validation du commit via `git add page3.html css/style.css && git commit -m "Improve add-data modal action button spacing"`, commande exécutée avec succès.
- Inspection des fichiers et lignes ciblées avec `nl`/`sed` a été effectuée pour confirmer l'emplacement des changements, sans erreurs détectées.
- Aucun test automatisé d'UI (screenshot) n'a été exécuté dans cet environnement, et aucune modification n'a cassé la base de code selon les vérifications réalisées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7cb24dd04832a8ac65995d0a04889)