### PR TITLE
Ajuster disposition des boutons et alignement du footer du modal détail

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1534,23 +1534,29 @@ body[data-page="item-detail"] .detail-form-modal__section {
 }
 
 body[data-page="item-detail"] .detail-form-modal .form-footer {
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 0.65rem;
+  align-items: start;
 }
 
 body[data-page="item-detail"] #detailFormError {
-  flex-basis: 100%;
+  margin: 0;
+  min-height: 1.2rem;
 }
 
 body[data-page="item-detail"] .detail-form-actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.35fr);
   width: 100%;
-  gap: 10px;
-  flex-wrap: nowrap;
+  gap: 0.7rem;
 }
 
 body[data-page="item-detail"] .detail-form-actions .btn {
-  flex: 1 1 50%;
+  width: 100%;
   min-width: 0;
+  min-height: 3.35rem;
+  padding-inline: 1rem;
 }
 
 body[data-page="item-detail"] .detail-form-row--qte-unit {


### PR DESCRIPTION
### Motivation
- Stabiliser l’affichage du bas du modal de détail pour que le message d’erreur rouge n’altère pas l’alignement des boutons et pour obtenir le rendu attendu (Annuler + Enregistrer sur la même ligne, espacés et équilibrés). 

### Description
- Modifié uniquement le CSS dans `css/style.css` pour restructurer la zone basse du formulaire sans toucher à la logique, aux IDs, aux classes ou au JavaScript. 
- Transformé `.detail-form-modal .form-footer` en grille verticale pour séparer proprement le message d’erreur et la rangée d’actions. 
- Converti `.detail-form-actions` en grille 2 colonnes (`minmax(0, 0.95fr)` / `minmax(0, 1.35fr)`), avec un `gap` réduit pour un petit espace horizontal entre les boutons. 
- Rendu les boutons pleins largeur dans leur colonne, augmenté la hauteur minimale et ajouté du `padding-inline` pour obtenir des largeurs visuellement équilibrées et un rendu mobile propre.

### Testing
- Exécuté `git diff --check` et la vérification a retourné aucune erreur. 
- Vérification manuelle des règles CSS ciblées et de la conservation des identifiants et du comportement JavaScript (aucune modification JS effectuée). 
- Pas de capture visuelle automatique disponible dans cet environnement, les changements sont limités au CSS pour faciliter revue/design validation en navigateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7cdf88778832aa17b057767946fda)