### PR TITLE
Masquer le bouton flottant “+” sur pages 1–3 pour les utilisateurs non connectés

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1188,6 +1188,7 @@ import { firebaseAuth } from './firebase-core.js';
       isAuthenticated = Boolean(user);
       renderUserAvatar(user || null);
       mettreAJourHeaderUtilisateur(user || null);
+      mettreAJourPermissionsUI(currentPermissions);
       renderSites();
     });
 
@@ -1579,10 +1580,20 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     const openCreateItem = requireElement('openCreateItem');
-    const isAuthenticated = Boolean(firebaseAuth.currentUser);
-    if ((!permissions.canCreate || !isAuthenticated) && openCreateItem) {
-      openCreateItem.hidden = true;
+    let isAuthenticated = Boolean(firebaseAuth.currentUser);
+
+    function updateCreateItemButtonVisibility() {
+      if (!openCreateItem) {
+        return;
+      }
+      openCreateItem.hidden = !permissions.canCreate || !isAuthenticated;
     }
+
+    updateCreateItemButtonVisibility();
+    onAuthStateChanged(firebaseAuth, (user) => {
+      isAuthenticated = Boolean(user);
+      updateCreateItemButtonVisibility();
+    });
 
     openCreateItem?.addEventListener('click', () => {
       itemForm.reset();
@@ -1930,14 +1941,23 @@ import { firebaseAuth } from './firebase-core.js';
       document.querySelector('.data-table')?.classList.add('data-table--hide-action');
     }
 
+    function updateDetailCreateButtonVisibility(isAuthenticated) {
+      if (!openDetailFormButton) {
+        return;
+      }
+      openDetailFormButton.hidden = !permissions.canCreate || permissions.isLecture || !isAuthenticated;
+    }
+
     if (!permissions.canCreate || permissions.isLecture) {
       detailFormSection.hidden = true;
-      if (openDetailFormButton) {
-        openDetailFormButton.hidden = true;
-      }
     } else if (detailFormSection) {
       detailFormSection.hidden = false;
     }
+
+    updateDetailCreateButtonVisibility(Boolean(firebaseAuth.currentUser));
+    onAuthStateChanged(firebaseAuth, (user) => {
+      updateDetailCreateButtonVisibility(Boolean(user));
+    });
 
     function renderTitle() {
       const itemTitle = requireElement('itemTitle');


### PR DESCRIPTION
### Motivation

- Assurer que le bouton flottant “+” des pages 1 (home), 2 (page2) et 3 (page3) soit caché immédiatement lorsque l’utilisateur n’est pas connecté, sans nécessiter de rafraîchissement de page.

### Description

- Rafraîchissement des contrôles liés aux permissions sur la page d’accueil lors de `onAuthStateChanged` pour recalculer et appliquer immédiatement la visibilité du bouton `openCreateSite`/`+`.
- Page 2 : ajout d’un `isAuthenticated` réactif et de la fonction `updateCreateItemButtonVisibility()` qui s’abonne à `onAuthStateChanged` pour masquer/afficher `openCreateItem` en temps réel.
- Page 3 : ajout de la fonction `updateDetailCreateButtonVisibility()` et abonnement à `onAuthStateChanged` pour piloter la visibilité de `openDetailFormButton` sans modifier les autres règles de permission.
- Changements restreints à `js/app.js` ; aucune modification de logique métier ou du design n’a été effectuée.

### Testing

- Exécution de la vérification statique `node --check js/app.js` réussie.
- Tests manuels d’intégration non automatisés non inclus dans cet environnement de CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d294b860832abff1eff538409942)