### PR TITLE
Synchroniser l'affichage du bouton '+' avec l'état d'authentification (pages 1-3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1163,7 +1163,7 @@ import { firebaseAuth } from './firebase-core.js';
       currentPermissions = { ...currentPermissions, ...(nextPermissions || {}) };
 
       if (openCreateSite) {
-        openCreateSite.hidden = !currentPermissions.canCreate || !isAuthenticated;
+        openCreateSite.hidden = !isAuthenticated;
       }
 
       if (importDataButton) {
@@ -1586,7 +1586,7 @@ import { firebaseAuth } from './firebase-core.js';
       if (!openCreateItem) {
         return;
       }
-      openCreateItem.hidden = !permissions.canCreate || !isAuthenticated;
+      openCreateItem.hidden = !isAuthenticated;
     }
 
     updateCreateItemButtonVisibility();
@@ -1945,7 +1945,7 @@ import { firebaseAuth } from './firebase-core.js';
       if (!openDetailFormButton) {
         return;
       }
-      openDetailFormButton.hidden = !permissions.canCreate || permissions.isLecture || !isAuthenticated;
+      openDetailFormButton.hidden = !isAuthenticated;
     }
 
     if (!permissions.canCreate || permissions.isLecture) {


### PR DESCRIPTION
### Motivation
- Harmoniser le comportement des boutons flottants "+" sur les pages 1, 2 et 3 pour qu'ils apparaissent ou disparaissent immédiatement selon l'état d'authentification (connecté = visible, non connecté = caché) sans rechargement de page.

### Description
- Modifié `js/app.js` pour que `openCreateSite.hidden`, `openCreateItem.hidden` et `openDetailFormButton.hidden` soient tous contrôlés uniquement par `isAuthenticated` (ex: `openCreateSite.hidden = !isAuthenticated`), en conservant les listeners temps réel `onAuthStateChanged` existants et sans modifier le design ni d'autres logiques.

### Testing
- Vérifications automatisées exécutées: recherche de références avec `rg`, inspection du diff via `git diff` et engagement du changement avec `git commit`, toutes les commandes ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d9937494832aaaddbbc7b7ccfa90)