### PR TITLE
Disable long-press on saved sites when signed out

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1019,6 +1019,9 @@ import { firebaseAuth } from './firebase-core.js';
         };
 
         const openLockDialog = () => {
+          if (!isAuthenticated) {
+            return;
+          }
           const targetSite = currentSites.find((site) => site.id === siteId);
           if (isSiteLocked(targetSite)) {
             if (
@@ -1050,7 +1053,7 @@ import { firebaseAuth } from './firebase-core.js';
         };
 
         button.addEventListener('pointerdown', (event) => {
-          if (event.button !== 0) {
+          if (event.button !== 0 || !isAuthenticated) {
             return;
           }
           skipClickAfterLongPress = false;
@@ -1065,6 +1068,9 @@ import { firebaseAuth } from './firebase-core.js';
         button.addEventListener('pointerleave', clearLongPressTimer);
         button.addEventListener('pointercancel', clearLongPressTimer);
         button.addEventListener('contextmenu', (event) => {
+          if (!isAuthenticated) {
+            return;
+          }
           event.preventDefault();
           clearLongPressTimer();
           skipClickAfterLongPress = true;


### PR DESCRIPTION
### Motivation
- Prevent long-press lock/manage actions from running on the home (page 1) saved-sites list when there is no authenticated session, and ensure those actions are disabled immediately on sign-out using the existing real-time auth updates (`onAuthStateChanged`).

### Description
- In `initHomePage` (file `js/app.js`) added an `isAuthenticated` guard inside `openLockDialog` and blocked the long-press triggers by checking `!isAuthenticated` on the `pointerdown` and `contextmenu` handlers so long-press behavior is inert when signed out, without changing any UI or other logic.

### Testing
- Performed a local verification by inspecting the changes with `git diff -- js/app.js` and `git status --short`, and committed the update; no automated unit tests exist for this behavior in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7db7b7030832abacba6662abde7a9)