### PR TITLE
Hide page 2 '+' button until Firebase auth state is confirmed

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1586,7 +1586,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     const openCreateItem = requireElement('openCreateItem');
-    let isAuthenticated = Boolean(firebaseAuth.currentUser);
+    let isAuthenticated = false;
 
     function updateCreateItemButtonVisibility() {
       if (!openCreateItem) {


### PR DESCRIPTION
### Motivation
- Masquer immédiatement le bouton flottant `#openCreateItem` sur la page 2 tant que l’état de connexion Firebase n’a pas été confirmé afin d’éviter qu’il s’affiche brièvement pour des utilisateurs non authentifiés.

### Description
- Initialisation de `isAuthenticated` à `false` dans `js/app.js` (remplacement de `Boolean(firebaseAuth.currentUser)`) pour garder le bouton `#openCreateItem` caché jusqu’à ce que `onAuthStateChanged` fournisse l’état réel, en conservant le listener existant pour des affichages/disparitions instantanés.

### Testing
- Exécution de `node --check js/app.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f775e008832a91eaa0a16ce7c162)