### PR TITLE
Corrige visibilité du bouton "+" sur la page 2 (site-detail) selon l'auth Firebase

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1585,20 +1585,24 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
-    const openCreateItem = requireElement('openCreateItem');
-    let isAuthenticated = false;
+    const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
 
-    function updateCreateItemButtonVisibility() {
+    function isFirebaseUserAuthenticated(user) {
+      return Boolean(user?.uid);
+    }
+
+    function updateCreateItemButtonVisibility(user) {
       if (!openCreateItem) {
         return;
       }
+      const isAuthenticated = isFirebaseUserAuthenticated(user);
       openCreateItem.hidden = !isAuthenticated;
+      openCreateItem.style.display = isAuthenticated ? 'inline-flex' : 'none';
     }
 
-    updateCreateItemButtonVisibility();
+    updateCreateItemButtonVisibility(firebaseAuth.currentUser);
     onAuthStateChanged(firebaseAuth, (user) => {
-      isAuthenticated = Boolean(user);
-      updateCreateItemButtonVisibility();
+      updateCreateItemButtonVisibility(user || null);
     });
 
     openCreateItem?.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- La page 2 (`site-detail`) laissait apparaître le bouton flottant `+` pour les utilisateurs non authentifiés, contrairement à la page 1, il fallait aligner les comportements.
- Il est nécessaire d'utiliser la vraie condition d'authentification Firebase et d'écouter les changements d'état en temps réel pour que l'affichage soit instantané sans rechargement.

### Description
- Ciblage explicite du bouton de la page 2 via `document.querySelector('body[data-page="site-detail"] #openCreateItem')` afin d'agir uniquement sur la page concernée et d'éviter de toucher d'autres pages ou éléments.
- Ajout d'une vérification fiable d'authentification `isFirebaseUserAuthenticated(user)` qui utilise `user?.uid` pour déterminer si l'utilisateur est connecté.
- Remplacement de la logique précédente par un contrôle lié à `onAuthStateChanged(firebaseAuth, ...)` et application immédiate de visibilité via `hidden` et `style.display` (`none` si non connecté, `inline-flex` si connecté) pour empêcher toute réapparition visuelle non voulue.
- Aucun autre comportement, design, bouton `Exporter`, filtres, cards, header ou fonctionnalités connexes n'a été modifié.

### Testing
- Exécution de `node --check js/app.js` s'est terminée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f9df78f4832a803974ffbc497ad1)