### PR TITLE
Align page 3 '+' FAB auth visibility behavior with pages 1 and 2

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1951,11 +1951,17 @@ import { firebaseAuth } from './firebase-core.js';
       document.querySelector('.data-table')?.classList.add('data-table--hide-action');
     }
 
-    function updateDetailCreateButtonVisibility(isAuthenticated) {
+    function isFirebaseUserAuthenticated(user) {
+      return Boolean(user?.uid);
+    }
+
+    function updateDetailCreateButtonVisibility(user) {
       if (!openDetailFormButton) {
         return;
       }
+      const isAuthenticated = isFirebaseUserAuthenticated(user);
       openDetailFormButton.hidden = !isAuthenticated;
+      openDetailFormButton.style.display = isAuthenticated ? 'inline-flex' : 'none';
     }
 
     if (!permissions.canCreate || permissions.isLecture) {
@@ -1964,9 +1970,9 @@ import { firebaseAuth } from './firebase-core.js';
       detailFormSection.hidden = false;
     }
 
-    updateDetailCreateButtonVisibility(Boolean(firebaseAuth.currentUser));
+    updateDetailCreateButtonVisibility(firebaseAuth.currentUser);
     onAuthStateChanged(firebaseAuth, (user) => {
-      updateDetailCreateButtonVisibility(Boolean(user));
+      updateDetailCreateButtonVisibility(user || null);
     });
 
     function renderTitle() {


### PR DESCRIPTION
### Motivation
- Make the floating "+" button on page 3 follow the exact same Firebase Auth real-time visibility behavior as pages 1 and 2 so that unauthenticated users immediately don't see the FAB and authenticated users see it without reloading.

### Description
- Modified only the page 3 logic in `js/app.js` by adding `isFirebaseUserAuthenticated(user)` and updating `updateDetailCreateButtonVisibility` to take the Firebase `user` object and set both `hidden` and `style.display` (`none` / `inline-flex`) based on `user?.uid`, and wired the initial state to `firebaseAuth.currentUser` plus `onAuthStateChanged(firebaseAuth, ...)` for instant updates.

### Testing
- Ran `node --check js/app.js` and the syntax check passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fc911ca4832a9730e8518404f9bc)