### PR TITLE
Améliore l'expérience de chargement lors des transitions de pages (mobile)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -270,6 +270,67 @@ button {
   gap: 0.75rem;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  position: relative;
+}
+
+.page-content > :not(.page-inline-loader) {
+  transition: opacity 0.2s ease;
+}
+
+body.app-content-loading .page-content > :not(.page-inline-loader) {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.page-inline-loader {
+  display: none;
+  gap: 0.6rem;
+  padding: 0.3rem 0;
+}
+
+body.app-content-loading .page-inline-loader {
+  display: grid;
+}
+
+.page-inline-loader__block {
+  height: 0.95rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #ebf1f7 15%, #f7fafd 50%, #ebf1f7 85%);
+  background-size: 210% 100%;
+  animation: inline-loader-shimmer 1.1s ease-in-out infinite;
+}
+
+.page-inline-loader__block--title {
+  width: min(65%, 17rem);
+  height: 1.25rem;
+  margin-bottom: 0.2rem;
+}
+
+.page-inline-loader__block--short {
+  width: min(42%, 10rem);
+}
+
+@keyframes inline-loader-shimmer {
+  from {
+    background-position: 100% 0;
+  }
+  to {
+    background-position: -100% 0;
+  }
+}
+
+body.app-content-pending .fab,
+body.app-content-loading .fab,
+body.app-content-pending .fab-add,
+body.app-content-loading .fab-add,
+body.app-content-pending .fab-add--item-detail,
+body.app-content-loading .fab-add--item-detail,
+body.app-content-pending .fab--export,
+body.app-content-loading .fab--export,
+body.app-content-pending #exportDetailsButton,
+body.app-content-loading #exportDetailsButton {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .page-content--wide {
@@ -1941,15 +2002,6 @@ body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > se
   border-top-color: var(--primary-dark);
   border-radius: 50%;
   animation: global-spinner-rotate 0.9s linear infinite;
-}
-
-.global-loader-text {
-  margin-top: 0.65rem;
-  color: #666;
-  font-size: 15px;
-  font-family: "Inter", "Segoe UI", Roboto, Arial, sans-serif;
-  line-height: 1.3;
-  text-align: center;
 }
 
 @keyframes global-spinner-rotate {

--- a/js/ui.js
+++ b/js/ui.js
@@ -4,10 +4,18 @@
   const DEFAULT_SNACKBAR_DURATION = 5000;
   const GLOBAL_LOADER_ID = "globalPageLoader";
   const GLOBAL_LOADER_HIDDEN_CLASS = "global-loader-overlay--hidden";
+  const APP_LOADED_STORAGE_KEY = "albumAppHasLoadedOnce";
+  const CONTENT_PENDING_CLASS = "app-content-pending";
+  const CONTENT_LOADING_CLASS = "app-content-loading";
+  const CONTENT_READY_CLASS = "app-content-ready";
+  const INLINE_LOADER_ID = "pageInlineLoader";
+  const CONTENT_LOADING_DELAY_MS = 120;
   let hideTimerId = null;
   let globalLoader = null;
   let hasWindowLoaded = document.readyState === "complete";
   let isAppReady = false;
+  let shouldUseGlobalLoader = false;
+  let inlineLoaderTimerId = null;
 
   function ensureGlobalLoader() {
     if (globalLoader) {
@@ -34,11 +42,6 @@
     spinner.setAttribute("aria-hidden", "true");
     loaderContent.appendChild(spinner);
 
-    const loaderText = document.createElement("p");
-    loaderText.className = "global-loader-text";
-    loaderText.textContent = "Chargement en cours...";
-    loaderContent.appendChild(loaderText);
-
     overlay.appendChild(loaderContent);
 
     document.body.appendChild(overlay);
@@ -51,7 +54,57 @@
   }
 
   function hideGlobalLoader() {
-    ensureGlobalLoader().classList.add(GLOBAL_LOADER_HIDDEN_CLASS);
+    if (!globalLoader) {
+      return;
+    }
+    globalLoader.classList.add(GLOBAL_LOADER_HIDDEN_CLASS);
+  }
+
+  function ensureInlineLoader() {
+    const pageContent = document.querySelector(".page-content");
+    if (!pageContent) {
+      return null;
+    }
+
+    let inlineLoader = document.getElementById(INLINE_LOADER_ID);
+    if (inlineLoader) {
+      return inlineLoader;
+    }
+
+    inlineLoader = document.createElement("div");
+    inlineLoader.id = INLINE_LOADER_ID;
+    inlineLoader.className = "page-inline-loader";
+    inlineLoader.setAttribute("aria-hidden", "true");
+    inlineLoader.innerHTML = `
+      <div class="page-inline-loader__block page-inline-loader__block--title"></div>
+      <div class="page-inline-loader__block"></div>
+      <div class="page-inline-loader__block"></div>
+      <div class="page-inline-loader__block page-inline-loader__block--short"></div>
+    `;
+    pageContent.prepend(inlineLoader);
+    return inlineLoader;
+  }
+
+  function startContentLoadingState() {
+    document.body.classList.add(CONTENT_PENDING_CLASS);
+    document.body.classList.remove(CONTENT_LOADING_CLASS, CONTENT_READY_CLASS);
+
+    inlineLoaderTimerId = window.setTimeout(() => {
+      if (isAppReady) {
+        return;
+      }
+      ensureInlineLoader();
+      document.body.classList.add(CONTENT_LOADING_CLASS);
+    }, CONTENT_LOADING_DELAY_MS);
+  }
+
+  function stopContentLoadingState() {
+    if (inlineLoaderTimerId) {
+      window.clearTimeout(inlineLoaderTimerId);
+      inlineLoaderTimerId = null;
+    }
+    document.body.classList.remove(CONTENT_PENDING_CLASS, CONTENT_LOADING_CLASS);
+    document.body.classList.add(CONTENT_READY_CLASS);
   }
 
   function waitForImagesReady() {
@@ -81,6 +134,12 @@
 
   function markAppReady() {
     isAppReady = true;
+    stopContentLoadingState();
+    try {
+      sessionStorage.setItem(APP_LOADED_STORAGE_KEY, "1");
+    } catch (_error) {
+      // Ignore storage restrictions.
+    }
     maybeHideGlobalLoader();
   }
 
@@ -179,16 +238,28 @@
   }
 
   function navigate(url) {
-    showGlobalLoader();
     window.requestAnimationFrame(() => {
       window.location.href = url;
     });
   }
 
-  ensureGlobalLoader();
-  showGlobalLoader();
+  try {
+    shouldUseGlobalLoader = sessionStorage.getItem(APP_LOADED_STORAGE_KEY) !== "1";
+  } catch (_error) {
+    shouldUseGlobalLoader = true;
+  }
 
-  window.addEventListener("beforeunload", showGlobalLoader);
+  if (shouldUseGlobalLoader) {
+    ensureGlobalLoader();
+    showGlobalLoader();
+  }
+  startContentLoadingState();
+
+  window.addEventListener("beforeunload", () => {
+    if (shouldUseGlobalLoader) {
+      showGlobalLoader();
+    }
+  });
   window.addEventListener("load", () => {
     hasWindowLoaded = true;
     maybeHideGlobalLoader();


### PR DESCRIPTION
### Motivation
- Éviter l’affichage d’un loader plein écran bloquant lors des navigations internes tout en conservant la logique actuelle de chargement des données.
- Supprimer l’effet de page floutée/blanchie pendant les transitions et permettre au `header` d’apparaître immédiatement.
- Fournir un rendu fluide et discret pour les contenus non prêts en utilisant un skeleton local plutôt qu’un spinner centré.

### Description
- Limite l’overlay global (`globalPageLoader`) au premier vrai chargement de l’application en enregistrant un flag en `sessionStorage` (`albumAppHasLoadedOnce`) et n’affiche plus ce loader sur les navigations internes dans `js/ui.js`.
- Supprime le texte visible « Chargement en cours... » du loader global et conserve uniquement le spinner pour les scénarios de premier chargement (modification dans `js/ui.js`).
- Introduit un loader inline discret injecté dans `.page-content` (`pageInlineLoader`) avec un petit délai (`120ms`) pour empêcher les flashs lorsque les données sont rapides ou en cache, et gère les états de chargement via les classes `app-content-pending`, `app-content-loading` et `app-content-ready` (implémentation dans `js/ui.js`).
- Ajoute des styles CSS (`css/style.css`) pour le skeleton (shimmer léger), des transitions d’opacité sur le contenu principal et cache les boutons flottants/actions (`.fab`, `.fab-add`, `.fab--export`, etc.) tant que les données ne sont pas prêtes.
- Modifie `navigate()` pour ne plus forcer l’affichage du loader global lors des changements de page internes afin de préserver une UX non bloquante.

### Testing
- Vérification statique du JS avec `node --check js/ui.js` — réussite.
- Vérification statique du JS avec `node --check js/app.js` — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ffbd4c08832abb66829b74bda322)