### PR TITLE
Page 3 (item-detail) : skeleton shimmer et animation d'entrée pour le tableau

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1521,6 +1521,53 @@ body[data-page="item-detail"] .data-table td:nth-child(3) {
   text-align: left;
 }
 
+body[data-page="item-detail"] .detail-skeleton-row td {
+  padding-top: 0.72rem;
+  padding-bottom: 0.72rem;
+}
+
+body[data-page="item-detail"] .detail-skeleton-block {
+  display: block;
+  height: 0.82rem;
+  width: clamp(48px, 11vw, 122px);
+  margin-inline: auto;
+  border-radius: 999px;
+  background: linear-gradient(110deg, #e6ebf2 8%, #f3f6fa 18%, #e6ebf2 33%);
+  background-size: 220% 100%;
+  animation: detailSkeletonShimmer 1.25s ease-in-out infinite;
+}
+
+body[data-page="item-detail"] .detail-skeleton-block--short {
+  width: clamp(34px, 7vw, 80px);
+}
+
+body[data-page="item-detail"] .detail-row-enter {
+  opacity: 0;
+  transform: translateY(10px);
+  animation: detailRowEnter 0.24s ease-out forwards;
+  animation-delay: var(--detail-row-enter-delay, 0ms);
+}
+
+@keyframes detailSkeletonShimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+@keyframes detailRowEnter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 body[data-page="item-detail"] {
   --detail-primary: var(--primary-dark);
   --detail-primary-focus: rgba(39, 141, 218, 0.22);

--- a/js/app.js
+++ b/js/app.js
@@ -1774,6 +1774,10 @@ import { firebaseAuth } from './firebase-core.js';
     let currentSite = StorageService.getSite(siteId);
     let currentItem = StorageService.getItem(siteId, itemId);
     let currentDetails = [];
+    let hasResolvedInitialDetails = false;
+    let isDetailSkeletonVisible = false;
+    let detailSkeletonTimerId = null;
+    let animateNextTableRender = false;
     let codeSuggestionSource = [];
     let visibleCodeSuggestions = [];
     let activeSuggestionIndex = -1;
@@ -2044,11 +2048,12 @@ import { firebaseAuth } from './firebase-core.js';
 
       detailTableBody.innerHTML = filteredDetails
         .map(
-          (detail) => {
+          (detail, index) => {
             const ecart = computeEcart(detail);
             const ecartClassName = typeof ecart === 'number' && ecart !== 0 ? ' cell-input--ecart-alert' : '';
+            const enterAnimationStyle = animateNextTableRender ? ` style="--detail-row-enter-delay:${Math.min(index, 5) * 40}ms"` : '';
             return `
-            <tr data-detail-id="${detail.id}">
+            <tr data-detail-id="${detail.id}" class="${animateNextTableRender ? 'detail-row-enter' : ''}"${enterAnimationStyle}>
               <td><span class="field-badge">${detail.champ}</span></td>
               <td><input class="cell-input cell-input--autosize cell-input--left" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
               <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
@@ -2074,6 +2079,7 @@ import { firebaseAuth } from './firebase-core.js';
           },
         )
         .join('');
+      animateNextTableRender = false;
 
       detailTableBody.querySelectorAll('[data-field]').forEach((field) => {
         if (!canEditDetails) {
@@ -2237,6 +2243,33 @@ import { firebaseAuth } from './firebase-core.js';
       exportButton.addEventListener('click', exportDetails);
     }
 
+    function showDetailTableSkeleton() {
+      if (hasResolvedInitialDetails || isDetailSkeletonVisible) {
+        return;
+      }
+      isDetailSkeletonVisible = true;
+      detailTableBody.innerHTML = Array.from({ length: 4 }, (_, rowIndex) => `
+        <tr class="detail-skeleton-row" aria-hidden="true">
+          ${Array.from({ length: 11 }, (_, columnIndex) => {
+    const shouldUseShortBlock = (rowIndex + columnIndex) % 3 === 0;
+    return `<td><span class="detail-skeleton-block${shouldUseShortBlock ? ' detail-skeleton-block--short' : ''}"></span></td>`;
+  }).join('')}
+        </tr>
+      `).join('');
+    }
+
+    function hideDetailTableSkeleton() {
+      if (!isDetailSkeletonVisible) {
+        return;
+      }
+      isDetailSkeletonVisible = false;
+      detailTableBody.innerHTML = '';
+    }
+
+    detailSkeletonTimerId = window.setTimeout(() => {
+      showDetailTableSkeleton();
+    }, 120);
+
     StorageService.subscribeSites((sites) => {
       currentSite = sites.find((site) => site.id === siteId) || currentSite;
       renderTitle();
@@ -2256,6 +2289,13 @@ import { firebaseAuth } from './firebase-core.js';
       siteId,
       itemId,
       (details) => {
+        hasResolvedInitialDetails = true;
+        if (detailSkeletonTimerId !== null) {
+          window.clearTimeout(detailSkeletonTimerId);
+          detailSkeletonTimerId = null;
+        }
+        animateNextTableRender = isDetailSkeletonVisible;
+        hideDetailTableSkeleton();
         currentDetails = details;
         renderTable();
       },


### PR DESCRIPTION
### Motivation

- Améliorer l'expérience de chargement mobile de la page 3 (tableau de détails) en remplaçant le loader classique par un skeleton discret et en rendant l'apparition des lignes plus fluide sans toucher à la logique métier.

### Description

- Ajout d'un skeleton HTML injecté dans le `tbody` du tableau via `showDetailTableSkeleton()`/`hideDetailTableSkeleton()` et d'un déclencheur différé (`detailSkeletonTimerId`, 120ms) pour éviter les flashs quand les données sont déjà disponibles (`js/app.js`).
- Ajout d'états locaux (`hasResolvedInitialDetails`, `isDetailSkeletonVisible`, `animateNextTableRender`) pour contrôler l'affichage conditionnel du skeleton et animer la prochaine rendu de lignes lorsque les données arrivent après le skeleton (`js/app.js`).
- Lors du rendu réel des lignes, ajout d'une classe `detail-row-enter` et d'une variable inline `--detail-row-enter-delay` pour appliquer une animation d'entrée discrète (fade-in + slide-up, env. 240ms, delay échelonné par ligne) (`js/app.js`).
- Ajout de styles CSS ciblés sur `body[data-page="item-detail"]` pour le skeleton (blocs gris, animation shimmer) et pour l'animation d'entrée des lignes (`css/style.css`), en respectant la structure réelle du tableau (colonnes) et sans texte/spinner.

### Testing

- Exécution de la vérification de syntaxe JavaScript via `node --check js/app.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e901a96148832a980a1be6c5fb5c6a)