### PR TITLE
Add bottom-sheet item actions and delete confirmation to site-detail list cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1036,6 +1036,38 @@ body[data-page="history"] .list-grid {
   background: rgba(31, 42, 55, 0.08);
 }
 
+.list-card__menu-button {
+  position: absolute;
+  top: 0.72rem;
+  right: 0.72rem;
+  width: 1.9rem;
+  height: 1.9rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.62;
+  transition: background-color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
+}
+
+.list-card__menu-button:hover,
+.list-card__menu-button:focus-visible {
+  background: rgba(17, 24, 39, 0.07);
+  opacity: 1;
+}
+
+.list-card__menu-button:active {
+  transform: scale(0.96);
+}
+
+.list-card__menu-icon {
+  width: 0.95rem;
+  height: 0.95rem;
+  object-fit: contain;
+}
+
 .list-card__lock-icon {
   position: absolute;
   right: 0.85rem;
@@ -2225,6 +2257,100 @@ body[data-page="site-detail"] .list-card__button {
   padding: 1rem 2.9rem 1rem 1.05rem;
   display: grid;
   gap: 0.62rem;
+}
+
+body[data-page="site-detail"] .list-card__menu-button {
+  top: 0.92rem;
+  right: 0.86rem;
+}
+
+body[data-page="site-detail"] .list-card__menu-icon {
+  width: 0.88rem;
+  height: 0.88rem;
+}
+
+body[data-page="site-detail"] .item-action-sheet-overlay {
+  z-index: 1250;
+  transition: background 0.22s ease;
+}
+
+body[data-page="site-detail"] .item-action-sheet-overlay.is-open {
+  background: rgba(15, 23, 42, 0.3);
+}
+
+body[data-page="site-detail"] .item-action-sheet {
+  width: min(100%, 28rem);
+  border-radius: 22px 22px 0 0;
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(226, 232, 240, 0.96);
+  border-bottom: 0;
+  transform: translateY(100%);
+  transition: transform 0.23s ease;
+  padding: 0.62rem 1rem calc(0.95rem + env(safe-area-inset-bottom, 0px));
+}
+
+body[data-page="site-detail"] .bottom-sheet-overlay.is-open .item-action-sheet {
+  transform: translateY(0);
+}
+
+body[data-page="site-detail"] .item-action-sheet .bottom-sheet__handle {
+  width: 2.45rem;
+  height: 0.27rem;
+  margin-bottom: 0.65rem;
+  background: #cbd5e1;
+}
+
+body[data-page="site-detail"] .item-action-sheet__content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+body[data-page="site-detail"] .item-action-sheet__row {
+  border: 0;
+  width: 100%;
+  min-height: 3.1rem;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.68rem;
+  padding: 0.72rem 0.95rem;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.98rem;
+  text-align: left;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="site-detail"] .item-action-sheet__row:active {
+  transform: scale(0.99);
+}
+
+body[data-page="site-detail"] .item-action-sheet__row--danger {
+  color: #c92a2f;
+  background: #fff5f5;
+}
+
+body[data-page="site-detail"] .item-action-sheet__row--danger:hover,
+body[data-page="site-detail"] .item-action-sheet__row--danger:focus-visible {
+  background: #ffe9ea;
+}
+
+body[data-page="site-detail"] .item-action-sheet__icon {
+  width: 1.06rem;
+  height: 1.06rem;
+  object-fit: contain;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-overlay {
+  z-index: 1260;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-card {
+  width: min(90vw, 22rem);
+  border-radius: 20px;
+  border: 1px solid #dbe3ef;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.2);
 }
 
 body[data-page="site-detail"] .list-card__button:active {

--- a/js/app.js
+++ b/js/app.js
@@ -1434,6 +1434,12 @@ import { firebaseAuth } from './firebase-core.js';
     let detailDesignationsByItem = {};
     let detailRowsByItem = {};
     let userNamesById = {};
+    const itemActionState = {
+      activeItemId: null,
+      closeSheet: null,
+      closeConfirmation: null,
+      hasHistoryEntry: false,
+    };
     const dateFilterStorageKey = `site-detail:item-date-filter:${siteId}`;
     const searchStorageKey = `site-detail:item-search:${siteId}`;
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
@@ -1507,6 +1513,228 @@ import { firebaseAuth } from './firebase-core.js';
       downloadExcelFile(`${title}.xls`, 'Export Excel', workbook);
     }
 
+    function ensureItemActionBottomSheet() {
+      let overlay = document.getElementById('itemActionSheetOverlay');
+      if (overlay) {
+        return overlay;
+      }
+
+      overlay = document.createElement('div');
+      overlay.id = 'itemActionSheetOverlay';
+      overlay.className = 'bottom-sheet-overlay item-action-sheet-overlay';
+      overlay.hidden = true;
+      overlay.innerHTML = `
+        <div class="bottom-sheet item-action-sheet" id="itemActionSheet" role="dialog" aria-modal="true" aria-label="Actions de l'élément">
+          <div class="bottom-sheet__handle" aria-hidden="true"></div>
+          <div class="item-action-sheet__content">
+            <button type="button" class="item-action-sheet__row item-action-sheet__row--danger" id="itemActionDeleteButton">
+              <img src="Icon/poubelle.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
+              <span>Supprimer</span>
+            </button>
+          </div>
+        </div>
+      `;
+      document.body.appendChild(overlay);
+      return overlay;
+    }
+
+    function ensureItemDeleteConfirmationDialog() {
+      let overlay = document.getElementById('itemDeleteConfirmOverlay');
+      if (overlay) {
+        return overlay;
+      }
+
+      overlay = document.createElement('div');
+      overlay.id = 'itemDeleteConfirmOverlay';
+      overlay.className = 'maintenance-overlay item-delete-confirm-overlay';
+      overlay.hidden = true;
+      overlay.innerHTML = `
+        <article class="maintenance-card item-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="itemDeleteConfirmTitle">
+          <h3 id="itemDeleteConfirmTitle">Supprimer cet OUT ?</h3>
+          <p id="itemDeleteConfirmText">Cette action peut être annulée depuis la notification.</p>
+          <div class="modal-actions">
+            <button type="button" class="btn btn-ghost" id="itemDeleteCancelButton">Annuler</button>
+            <button type="button" class="btn btn-danger" id="itemDeleteConfirmButton">Supprimer</button>
+          </div>
+        </article>
+      `;
+      document.body.appendChild(overlay);
+      return overlay;
+    }
+
+    function askItemDeleteConfirmation(itemLabel) {
+      const overlay = ensureItemDeleteConfirmationDialog();
+      const text = overlay.querySelector('#itemDeleteConfirmText');
+      const cancelButton = overlay.querySelector('#itemDeleteCancelButton');
+      const confirmButton = overlay.querySelector('#itemDeleteConfirmButton');
+      if (!text || !cancelButton || !confirmButton) {
+        return Promise.resolve(false);
+      }
+
+      text.textContent = `Voulez-vous vraiment supprimer ${itemLabel} ? Cette action peut être annulée depuis la notification.`;
+
+      return new Promise((resolve) => {
+        const cleanup = () => {
+          overlay.hidden = true;
+          overlay.onclick = null;
+          cancelButton.onclick = null;
+          confirmButton.onclick = null;
+          document.removeEventListener('keydown', handleKeyDown);
+          itemActionState.closeConfirmation = null;
+        };
+        const close = (value) => {
+          cleanup();
+          resolve(value);
+        };
+        const handleKeyDown = (event) => {
+          if (event.key === 'Escape') {
+            close(false);
+          }
+        };
+
+        itemActionState.closeConfirmation = () => close(false);
+        cancelButton.onclick = () => close(false);
+        confirmButton.onclick = () => close(true);
+        overlay.onclick = (event) => {
+          if (event.target === overlay) {
+            close(false);
+          }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        overlay.hidden = false;
+      });
+    }
+
+    function closeActiveTransientLayer() {
+      if (typeof itemActionState.closeConfirmation === 'function') {
+        itemActionState.closeConfirmation();
+        return true;
+      }
+      if (typeof itemActionState.closeSheet === 'function') {
+        itemActionState.closeSheet({ fromPopState: true });
+        return true;
+      }
+      return false;
+    }
+
+    window.addEventListener('popstate', () => {
+      closeActiveTransientLayer();
+    });
+
+    function openItemActionSheet(itemId) {
+      const overlay = ensureItemActionBottomSheet();
+      const sheet = overlay.querySelector('#itemActionSheet');
+      const deleteButton = overlay.querySelector('#itemActionDeleteButton');
+      if (!sheet || !deleteButton) {
+        return;
+      }
+
+      const activeItem = currentItems.find((item) => item.id === itemId);
+      if (!activeItem) {
+        return;
+      }
+
+      itemActionState.activeItemId = itemId;
+      const closeTransitionDurationMs = 280;
+
+      const clearCloseListeners = () => {
+        if (overlay.__closeTimerId) {
+          window.clearTimeout(overlay.__closeTimerId);
+          overlay.__closeTimerId = null;
+        }
+        if (overlay.__closeTransitionHandler) {
+          overlay.removeEventListener('transitionend', overlay.__closeTransitionHandler);
+          overlay.__closeTransitionHandler = null;
+        }
+      };
+
+      const closeSheet = ({ fromPopState = false } = {}) =>
+        new Promise((resolve) => {
+          if (overlay.hidden) {
+            resolve();
+            return;
+          }
+          let isResolved = false;
+          const finish = () => {
+            if (isResolved) {
+              return;
+            }
+            isResolved = true;
+            clearCloseListeners();
+            overlay.hidden = true;
+            overlay.classList.remove('is-open');
+            itemActionState.activeItemId = null;
+            itemActionState.closeSheet = null;
+            if (itemActionState.hasHistoryEntry && !fromPopState) {
+              itemActionState.hasHistoryEntry = false;
+              window.history.back();
+            } else if (fromPopState) {
+              itemActionState.hasHistoryEntry = false;
+            }
+            resolve();
+          };
+
+          overlay.classList.remove('is-open');
+          overlay.__closeTransitionHandler = (event) => {
+            if (event.target !== overlay && event.target !== sheet) {
+              return;
+            }
+            finish();
+          };
+          overlay.addEventListener('transitionend', overlay.__closeTransitionHandler);
+          overlay.__closeTimerId = window.setTimeout(finish, closeTransitionDurationMs);
+        });
+
+      itemActionState.closeSheet = closeSheet;
+      deleteButton.onclick = async () => {
+        await closeSheet();
+        const shouldDelete = await askItemDeleteConfirmation(activeItem.numero || "cet élément");
+        if (!shouldDelete) {
+          return;
+        }
+        const removedSnapshot = await StorageService.removeItem(siteId, itemId);
+        if (!removedSnapshot) {
+          UiService.showToast('Suppression impossible.');
+          return;
+        }
+        UiService.showUndoSnackbar('Élément supprimé.', async () => {
+          const restored = await StorageService.restoreItem(removedSnapshot);
+          UiService.showToast(restored ? 'Suppression annulée.' : 'Restauration impossible.');
+        });
+      };
+
+      overlay.onclick = (event) => {
+        if (event.target === overlay) {
+          closeSheet();
+        }
+      };
+
+      let touchStartY = null;
+      sheet.ontouchstart = (event) => {
+        touchStartY = event.touches[0]?.clientY ?? null;
+      };
+      sheet.ontouchend = (event) => {
+        if (touchStartY === null) {
+          return;
+        }
+        const touchEndY = event.changedTouches[0]?.clientY ?? touchStartY;
+        if (touchEndY - touchStartY > 60) {
+          closeSheet();
+        }
+        touchStartY = null;
+      };
+
+      overlay.hidden = false;
+      clearCloseListeners();
+      if (!itemActionState.hasHistoryEntry) {
+        window.history.pushState({ itemActionSheet: true }, '');
+        itemActionState.hasHistoryEntry = true;
+      }
+      window.requestAnimationFrame(() => {
+        overlay.classList.add('is-open');
+      });
+    }
+
     function renderItems() {
       const query = itemSearchInput.value.trim().toUpperCase();
       const filteredItems = currentItems.filter((item) => {
@@ -1550,7 +1778,7 @@ import { firebaseAuth } from './firebase-core.js';
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
         htmlParts.push(`
             <article class="list-card">
-              ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__delete-button" type="button" data-item-delete="${item.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
+              ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-item-menu="${item.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
@@ -1570,17 +1798,10 @@ import { firebaseAuth } from './firebase-core.js';
         });
       });
 
-      itemList.querySelectorAll('[data-item-delete]').forEach((button) => {
-        button.addEventListener('click', async () => {
-          const removedSnapshot = await StorageService.removeItem(siteId, button.dataset.itemDelete);
-          if (!removedSnapshot) {
-            UiService.showToast('Suppression impossible.');
-            return;
-          }
-          UiService.showUndoSnackbar('Élément supprimé.', async () => {
-            const restored = await StorageService.restoreItem(removedSnapshot);
-            UiService.showToast(restored ? 'Suppression annulée.' : 'Restauration impossible.');
-          });
+      itemList.querySelectorAll('[data-item-menu]').forEach((button) => {
+        button.addEventListener('click', (event) => {
+          event.stopPropagation();
+          openItemActionSheet(button.dataset.itemMenu);
         });
       });
     }


### PR DESCRIPTION
### Motivation
- Replace inline destructive delete button with a more flexible action menu to provide additional actions and a better mobile UX. 
- Surface a confirmation dialog and provide an undo flow for deletions to reduce accidental data loss. 

### Description
- Added CSS for `.list-card__menu-button`, `.list-card__menu-icon`, `.item-action-sheet`, `.item-delete-confirm-card`, and related styles to support the bottom-sheet UI and confirmation dialog. 
- Implemented `itemActionState` and functions in `initSiteDetailPage`: `ensureItemActionBottomSheet`, `ensureItemDeleteConfirmationDialog`, `askItemDeleteConfirmation`, `openItemActionSheet`, and `closeActiveTransientLayer` to manage opening/closing the sheet, touch gestures, history `popstate` integration, and delete confirmation flow. 
- Replaced the inline delete button markup in `renderItems` with a menu button (`data-item-menu`) and wired menu buttons to open the action sheet instead of performing immediate deletion, while preserving the undo/restore behavior via `StorageService` and `UiService`. 

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e905a11470832a9484a9b01e47bf57)