### PR TITLE
Fix comportement du modal de suppression (page 2) après clic "Supprimer" dans le bottom sheet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2355,6 +2355,12 @@ body[data-page="site-detail"] .item-action-sheet__icon {
 
 body[data-page="site-detail"] .item-delete-confirm-overlay {
   z-index: 1260;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-overlay.is-open {
+  opacity: 1;
 }
 
 body[data-page="site-detail"] .item-delete-confirm-card {
@@ -2362,6 +2368,14 @@ body[data-page="site-detail"] .item-delete-confirm-card {
   border-radius: 20px;
   border: 1px solid #dbe3ef;
   box-shadow: 0 18px 38px rgba(15, 23, 42, 0.2);
+  transform: translateY(8px) scale(0.985);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-overlay.is-open .item-delete-confirm-card {
+  transform: translateY(0) scale(1);
+  opacity: 1;
 }
 
 body[data-page="site-detail"] .list-card__button:active {

--- a/js/app.js
+++ b/js/app.js
@@ -1439,6 +1439,7 @@ import { firebaseAuth } from './firebase-core.js';
       closeSheet: null,
       closeConfirmation: null,
       hasHistoryEntry: false,
+      ignoreNextPopstate: false,
     };
     const dateFilterStorageKey = `site-detail:item-date-filter:${siteId}`;
     const searchStorageKey = `site-detail:item-search:${siteId}`;
@@ -1575,8 +1576,16 @@ import { firebaseAuth } from './firebase-core.js';
       text.textContent = `Voulez-vous vraiment supprimer ${itemLabel} ? Cette action peut être annulée depuis la notification.`;
 
       return new Promise((resolve) => {
+        const closeAnimationDurationMs = 170;
+        let closeAnimationTimer = null;
+        let isClosing = false;
         const cleanup = () => {
+          if (closeAnimationTimer) {
+            window.clearTimeout(closeAnimationTimer);
+            closeAnimationTimer = null;
+          }
           overlay.hidden = true;
+          overlay.classList.remove('is-open');
           overlay.onclick = null;
           cancelButton.onclick = null;
           confirmButton.onclick = null;
@@ -1584,8 +1593,15 @@ import { firebaseAuth } from './firebase-core.js';
           itemActionState.closeConfirmation = null;
         };
         const close = (value) => {
-          cleanup();
-          resolve(value);
+          if (isClosing) {
+            return;
+          }
+          isClosing = true;
+          overlay.classList.remove('is-open');
+          closeAnimationTimer = window.setTimeout(() => {
+            cleanup();
+            resolve(value);
+          }, closeAnimationDurationMs);
         };
         const handleKeyDown = (event) => {
           if (event.key === 'Escape') {
@@ -1603,6 +1619,9 @@ import { firebaseAuth } from './firebase-core.js';
         };
         document.addEventListener('keydown', handleKeyDown);
         overlay.hidden = false;
+        window.requestAnimationFrame(() => {
+          overlay.classList.add('is-open');
+        });
       });
     }
 
@@ -1619,6 +1638,10 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     window.addEventListener('popstate', () => {
+      if (itemActionState.ignoreNextPopstate) {
+        itemActionState.ignoreNextPopstate = false;
+        return;
+      }
       closeActiveTransientLayer();
     });
 
@@ -1670,6 +1693,7 @@ import { firebaseAuth } from './firebase-core.js';
             itemActionState.closeSheet = null;
             if (itemActionState.hasHistoryEntry && !fromPopState) {
               itemActionState.hasHistoryEntry = false;
+              itemActionState.ignoreNextPopstate = true;
               window.history.back();
             } else if (fromPopState) {
               itemActionState.hasHistoryEntry = false;


### PR DESCRIPTION
### Motivation
- Corriger le flux visuel sur la page 2 pour que le clic sur « Supprimer » dans le bottom sheet ferme d’abord la sheet puis affiche correctement le modal de confirmation centré avec overlay.
- Éviter que le modal soit immédiatement refermé par le `popstate` causé par la fermeture du sheet, et garantir des fermetures robustes (Annuler, clic hors modal, Échap, après confirmation).
- Améliorer l’expérience utilisateur avec une animation fluide sans toucher à la logique métier de suppression.

### Description
- Ajouté `ignoreNextPopstate` dans `itemActionState` et modifié le gestionnaire `popstate` pour ignorer le `popstate` interne déclenché par la fermeture du sheet (`js/app.js`).
- Modifié `askItemDeleteConfirmation` dans `js/app.js` pour utiliser une classe visuelle `is-open`, ouvrir l’overlay via `requestAnimationFrame`, et fermer via un délai (`170ms`) permettant l’animation; ajouté une garde `isClosing` pour empêcher double-fermeture.
- Lors de la fermeture du bottom sheet, on positionne `itemActionState.ignoreNextPopstate = true` avant d’appeler `history.back()` pour empêcher la fermeture accidentelle du modal suivant la navigation interne (`js/app.js`).
- Ajouté des transitions CSS scoped à la page 2 pour l’overlay et la card de confirmation (`body[data-page="site-detail"] .item-delete-confirm-overlay` et `.item-delete-confirm-card`) pour un léger fade + translate/scale sans modifier la logique de suppression (`css/style.css`).

### Testing
- Executed `node --check js/app.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9128c6308832aae3d347ee789810e)