### PR TITLE
Améliore le design mobile de la popup de suppression OUT (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2364,10 +2364,11 @@ body[data-page="site-detail"] .item-delete-confirm-overlay.is-open {
 }
 
 body[data-page="site-detail"] .item-delete-confirm-card {
-  width: min(90vw, 22rem);
-  border-radius: 20px;
-  border: 1px solid #dbe3ef;
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.2);
+  width: min(92vw, 24rem);
+  border-radius: 22px;
+  border: 1px solid #d7e0ee;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  padding: 1.25rem 1rem 1rem;
   transform: translateY(8px) scale(0.985);
   opacity: 0;
   transition: transform 0.2s ease, opacity 0.2s ease;
@@ -2376,6 +2377,53 @@ body[data-page="site-detail"] .item-delete-confirm-card {
 body[data-page="site-detail"] .item-delete-confirm-overlay.is-open .item-delete-confirm-card {
   transform: translateY(0) scale(1);
   opacity: 1;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-card h3 {
+  margin: 0;
+  font-size: 1.16rem;
+  font-weight: 800;
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+  text-align: center;
+  color: #111827;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-card p {
+  margin-top: 0.82rem;
+  font-size: 0.94rem;
+  line-height: 1.45;
+  font-weight: 500;
+  text-align: center;
+  color: #4b5563;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-actions {
+  margin-top: 1.1rem;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-button {
+  flex: 1 1 50%;
+  width: 50%;
+  min-height: 44px;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  padding: 0.72rem 0.8rem;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-button--cancel {
+  background: #eceff3;
+  color: #1f2937;
+}
+
+body[data-page="site-detail"] .item-delete-confirm-button--danger {
+  background: #dc2626;
+  color: #fff;
 }
 
 body[data-page="site-detail"] .list-card__button:active {

--- a/js/app.js
+++ b/js/app.js
@@ -1554,9 +1554,9 @@ import { firebaseAuth } from './firebase-core.js';
         <article class="maintenance-card item-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="itemDeleteConfirmTitle">
           <h3 id="itemDeleteConfirmTitle">Supprimer cet OUT ?</h3>
           <p id="itemDeleteConfirmText">Cette action peut être annulée depuis la notification.</p>
-          <div class="modal-actions">
-            <button type="button" class="btn btn-ghost" id="itemDeleteCancelButton">Annuler</button>
-            <button type="button" class="btn btn-danger" id="itemDeleteConfirmButton">Supprimer</button>
+          <div class="modal-actions item-delete-confirm-actions">
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--cancel" id="itemDeleteCancelButton">Annuler</button>
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--danger" id="itemDeleteConfirmButton">Supprimer</button>
           </div>
         </article>
       `;
@@ -1573,7 +1573,12 @@ import { firebaseAuth } from './firebase-core.js';
         return Promise.resolve(false);
       }
 
-      text.textContent = `Voulez-vous vraiment supprimer ${itemLabel} ? Cette action peut être annulée depuis la notification.`;
+      const title = overlay.querySelector('#itemDeleteConfirmTitle');
+      const normalizedLabel = String(itemLabel || '').trim() || 'OUT inconnu';
+      if (title) {
+        title.textContent = `Supprimer cet ${normalizedLabel} ?`;
+      }
+      text.textContent = 'Cette action peut être annulée depuis la notification.';
 
       return new Promise((resolve) => {
         const closeAnimationDurationMs = 170;


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité et l’expérience utilisateur de la popup de confirmation de suppression sur la page 2 pour un rendu mobile professionnel, minimaliste et équilibré.
- Conserver la logique de suppression existante sans modification, en ne touchant que l’interface et le texte.

### Description
- Mise à jour de `js/app.js` pour injecter dynamiquement le titre au format `Supprimer cet OUT-xxxxxx ?` et ajouter les classes d’action (`item-delete-confirm-actions`, `item-delete-confirm-button--cancel`, `item-delete-confirm-button--danger`) sans modifier le flux de suppression/annulation.
- Ajout et ajustement de styles dans `css/style.css` (scopés via `body[data-page="site-detail"]`) pour moderniser la carte de confirmation (coins arrondis, ombre douce, padding, typographie) et présenter les boutons `Annuler` et `Supprimer` sur une seule ligne à 50% chacun avec `min-height: 44px`, gap, coins arrondis et couleurs demandées (gris discret / rouge prioritaire).
- Réorganisation légère du HTML injecté par le script pour assurer l’alignement, l’espacement tactile et la lisibilité tout en limitant l’impact au contexte de la page 2.

### Testing
- Exécution de `node --check js/app.js` qui a réussi sans erreur de syntaxe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9163b984c832aad44ec309b26bd79)