### PR TITLE
Harmonize home site deletion UX with page-2 action flow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2779,21 +2779,171 @@ body[data-page="home"] .list-card__status--locked {
   color: #dc2626;
 }
 
-body[data-page="home"] .list-card__delete-button {
-  top: 0.7rem;
-  right: 0.72rem;
-  width: 26px;
-  height: 26px;
-  border-radius: 8px;
-  background: rgba(148, 163, 184, 0.2);
-  color: #1f2937;
-  opacity: 1;
-  z-index: 2;
+body[data-page="home"] .list-card__menu-button {
+  top: 0.92rem;
+  right: 0.86rem;
 }
 
-body[data-page="home"] .list-card__delete-button:hover,
-body[data-page="home"] .list-card__delete-button:focus-visible {
-  background: rgba(148, 163, 184, 0.32);
+body[data-page="home"] .list-card__menu-icon {
+  width: 0.88rem;
+  height: 0.88rem;
+}
+
+body[data-page="home"] .item-action-sheet-overlay {
+  z-index: 1250;
+  transition: background-color 0.28s ease;
+}
+
+body[data-page="home"] .item-action-sheet-overlay.is-open {
+  background: rgba(15, 23, 42, 0.3);
+}
+
+body[data-page="home"] .item-action-sheet {
+  width: min(100%, 28rem);
+  border-radius: 22px 22px 0 0;
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(226, 232, 240, 0.96);
+  border-bottom: 0;
+  transform: translateY(100%);
+  opacity: 0;
+  transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.22s ease;
+  padding: 0.7rem 1rem calc(0.95rem + env(safe-area-inset-bottom, 0px));
+}
+
+body[data-page="home"] .bottom-sheet-overlay.is-open .item-action-sheet {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+body[data-page="home"] .item-action-sheet .bottom-sheet__handle {
+  width: 2.45rem;
+  height: 0.27rem;
+  margin-bottom: 0.5rem;
+  background: #cbd5e1;
+}
+
+body[data-page="home"] .item-action-sheet__title {
+  margin: 0 0 0.75rem;
+  text-align: center;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: #64748b;
+  letter-spacing: 0.02em;
+}
+
+body[data-page="home"] .item-action-sheet__content {
+  display: grid;
+  gap: 0.4rem;
+}
+
+body[data-page="home"] .item-action-sheet__row {
+  border: 0;
+  width: 100%;
+  min-height: 3.1rem;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.68rem;
+  padding: 0.72rem 0.95rem;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.98rem;
+  text-align: left;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="home"] .item-action-sheet__row:active {
+  transform: scale(0.99);
+}
+
+body[data-page="home"] .item-action-sheet__row--danger {
+  color: #c92a2f;
+  background: #fff5f5;
+}
+
+body[data-page="home"] .item-action-sheet__row--danger:hover,
+body[data-page="home"] .item-action-sheet__row--danger:focus-visible {
+  background: #ffe9ea;
+}
+
+body[data-page="home"] .item-action-sheet__icon {
+  width: 1.06rem;
+  height: 1.06rem;
+  object-fit: contain;
+}
+
+body[data-page="home"] .item-delete-confirm-overlay {
+  z-index: 1260;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+body[data-page="home"] .item-delete-confirm-overlay.is-open {
+  opacity: 1;
+}
+
+body[data-page="home"] .item-delete-confirm-card {
+  width: min(92vw, 24rem);
+  border-radius: 22px;
+  border: 1px solid #d7e0ee;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  padding: 1.25rem 1rem 1rem;
+  transform: translateY(8px) scale(0.985);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+body[data-page="home"] .item-delete-confirm-overlay.is-open .item-delete-confirm-card {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+body[data-page="home"] .item-delete-confirm-card h3 {
+  margin: 0;
+  font-size: 1.16rem;
+  font-weight: 800;
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+  text-align: center;
+  color: #111827;
+}
+
+body[data-page="home"] .item-delete-confirm-card p {
+  margin-top: 0.82rem;
+  font-size: 0.94rem;
+  line-height: 1.45;
+  font-weight: 500;
+  text-align: center;
+  color: #4b5563;
+}
+
+body[data-page="home"] .item-delete-confirm-actions {
+  margin-top: 1.1rem;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+}
+
+body[data-page="home"] .item-delete-confirm-button {
+  flex: 1 1 50%;
+  width: 50%;
+  min-height: 44px;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  padding: 0.72rem 0.8rem;
+}
+
+body[data-page="home"] .item-delete-confirm-button--cancel {
+  background: #eceff3;
+  color: #1f2937;
+}
+
+body[data-page="home"] .item-delete-confirm-button--danger {
+  background: #dc2626;
+  color: #fff;
 }
 
 body[data-page="home"] .list-card__lock-icon {

--- a/js/app.js
+++ b/js/app.js
@@ -817,6 +817,13 @@ import { firebaseAuth } from './firebase-core.js';
     let siteIdPendingLock = null;
     let siteIdPendingUnlock = null;
     let siteIdPendingLockManage = null;
+    const siteActionState = {
+      activeSiteId: null,
+      closeSheet: null,
+      closeConfirmation: null,
+      hasHistoryEntry: false,
+      ignoreNextPopstate: false,
+    };
     const transientErrorTimers = new WeakMap();
 
     function clearTransientError(errorElement) {
@@ -953,6 +960,264 @@ import { firebaseAuth } from './firebase-core.js';
       fileInput.click();
     }
 
+    function ensureSiteActionBottomSheet() {
+      let overlay = document.getElementById('siteActionSheetOverlay');
+      if (overlay) {
+        return overlay;
+      }
+
+      overlay = document.createElement('div');
+      overlay.id = 'siteActionSheetOverlay';
+      overlay.className = 'bottom-sheet-overlay item-action-sheet-overlay';
+      overlay.hidden = true;
+      overlay.innerHTML = `
+        <div class="bottom-sheet item-action-sheet" id="siteActionSheet" role="dialog" aria-modal="true" aria-label="Actions du site">
+          <div class="bottom-sheet__handle" aria-hidden="true"></div>
+          <p class="item-action-sheet__title" id="siteActionSheetTitle">Actions</p>
+          <div class="item-action-sheet__content">
+            <button type="button" class="item-action-sheet__row item-action-sheet__row--danger" id="siteActionDeleteButton">
+              <img src="Icon/poubelle.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
+              <span>Supprimer</span>
+            </button>
+          </div>
+        </div>
+      `;
+      document.body.appendChild(overlay);
+      return overlay;
+    }
+
+    function ensureSiteDeleteConfirmationDialog() {
+      let overlay = document.getElementById('siteDeleteConfirmOverlay');
+      if (overlay) {
+        return overlay;
+      }
+
+      overlay = document.createElement('div');
+      overlay.id = 'siteDeleteConfirmOverlay';
+      overlay.className = 'maintenance-overlay item-delete-confirm-overlay';
+      overlay.hidden = true;
+      overlay.innerHTML = `
+        <article class="maintenance-card item-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="siteDeleteConfirmTitle">
+          <h3 id="siteDeleteConfirmTitle">Supprimer ce site ?</h3>
+          <p id="siteDeleteConfirmText">Cette action est irréversible.</p>
+          <div class="modal-actions item-delete-confirm-actions">
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--cancel" id="siteDeleteCancelButton">Annuler</button>
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--danger" id="siteDeleteConfirmButton">Supprimer</button>
+          </div>
+        </article>
+      `;
+      document.body.appendChild(overlay);
+      return overlay;
+    }
+
+    function askSiteDeleteConfirmation(siteName) {
+      const overlay = ensureSiteDeleteConfirmationDialog();
+      const text = overlay.querySelector('#siteDeleteConfirmText');
+      const cancelButton = overlay.querySelector('#siteDeleteCancelButton');
+      const confirmButton = overlay.querySelector('#siteDeleteConfirmButton');
+      if (!text || !cancelButton || !confirmButton) {
+        return Promise.resolve(false);
+      }
+
+      const title = overlay.querySelector('#siteDeleteConfirmTitle');
+      const normalizedSiteName = String(siteName || '').trim() || 'inconnu';
+      if (title) {
+        title.textContent = `Supprimer ce site ${normalizedSiteName} ?`;
+      }
+      text.textContent = 'Cette action est irréversible.';
+
+      return new Promise((resolve) => {
+        const closeAnimationDurationMs = 170;
+        let closeAnimationTimer = null;
+        let isClosing = false;
+        const cleanup = () => {
+          if (closeAnimationTimer) {
+            window.clearTimeout(closeAnimationTimer);
+            closeAnimationTimer = null;
+          }
+          overlay.hidden = true;
+          overlay.classList.remove('is-open');
+          overlay.onclick = null;
+          cancelButton.onclick = null;
+          confirmButton.onclick = null;
+          document.removeEventListener('keydown', handleKeyDown);
+          siteActionState.closeConfirmation = null;
+        };
+        const close = (value) => {
+          if (isClosing) {
+            return;
+          }
+          isClosing = true;
+          overlay.classList.remove('is-open');
+          closeAnimationTimer = window.setTimeout(() => {
+            cleanup();
+            resolve(value);
+          }, closeAnimationDurationMs);
+        };
+        const handleKeyDown = (event) => {
+          if (event.key === 'Escape') {
+            close(false);
+          }
+        };
+
+        siteActionState.closeConfirmation = () => close(false);
+        cancelButton.onclick = () => close(false);
+        confirmButton.onclick = () => close(true);
+        overlay.onclick = (event) => {
+          if (event.target === overlay) {
+            close(false);
+          }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        overlay.hidden = false;
+        window.requestAnimationFrame(() => {
+          overlay.classList.add('is-open');
+        });
+      });
+    }
+
+    function closeActiveSiteTransientLayer() {
+      if (typeof siteActionState.closeConfirmation === 'function') {
+        siteActionState.closeConfirmation();
+        return true;
+      }
+      if (typeof siteActionState.closeSheet === 'function') {
+        siteActionState.closeSheet({ fromPopState: true });
+        return true;
+      }
+      return false;
+    }
+
+    window.addEventListener('popstate', () => {
+      if (siteActionState.ignoreNextPopstate) {
+        siteActionState.ignoreNextPopstate = false;
+        return;
+      }
+      closeActiveSiteTransientLayer();
+    });
+
+    function openSiteActionSheet(siteId) {
+      const overlay = ensureSiteActionBottomSheet();
+      const sheet = overlay.querySelector('#siteActionSheet');
+      const title = overlay.querySelector('#siteActionSheetTitle');
+      const deleteButton = overlay.querySelector('#siteActionDeleteButton');
+      if (!sheet || !title || !deleteButton) {
+        return;
+      }
+
+      const activeSite = currentSites.find((site) => site.id === siteId);
+      if (!activeSite) {
+        return;
+      }
+
+      siteActionState.activeSiteId = siteId;
+      title.textContent = String(activeSite.nom || '').trim() || 'Actions';
+      const closeTransitionDurationMs = 280;
+
+      const clearCloseListeners = () => {
+        if (overlay.__closeTimerId) {
+          window.clearTimeout(overlay.__closeTimerId);
+          overlay.__closeTimerId = null;
+        }
+        if (overlay.__closeTransitionHandler) {
+          overlay.removeEventListener('transitionend', overlay.__closeTransitionHandler);
+          overlay.__closeTransitionHandler = null;
+        }
+      };
+
+      const closeSheet = ({ fromPopState = false } = {}) =>
+        new Promise((resolve) => {
+          if (overlay.hidden) {
+            resolve();
+            return;
+          }
+          let isResolved = false;
+          const finish = () => {
+            if (isResolved) {
+              return;
+            }
+            isResolved = true;
+            clearCloseListeners();
+            overlay.hidden = true;
+            overlay.classList.remove('is-open');
+            siteActionState.activeSiteId = null;
+            siteActionState.closeSheet = null;
+            if (siteActionState.hasHistoryEntry && !fromPopState) {
+              siteActionState.hasHistoryEntry = false;
+              siteActionState.ignoreNextPopstate = true;
+              window.history.back();
+            } else if (fromPopState) {
+              siteActionState.hasHistoryEntry = false;
+            }
+            resolve();
+          };
+
+          overlay.classList.remove('is-open');
+          overlay.__closeTransitionHandler = (event) => {
+            if (event.target !== overlay && event.target !== sheet) {
+              return;
+            }
+            finish();
+          };
+          overlay.addEventListener('transitionend', overlay.__closeTransitionHandler);
+          overlay.__closeTimerId = window.setTimeout(finish, closeTransitionDurationMs);
+        });
+
+      siteActionState.closeSheet = closeSheet;
+      deleteButton.onclick = async () => {
+        deleteButton.disabled = true;
+        try {
+          await closeSheet();
+          const shouldDelete = await askSiteDeleteConfirmation(activeSite.nom || 'inconnu');
+          if (!shouldDelete) {
+            return;
+          }
+          const removedSnapshot = await StorageService.removeSite(siteId);
+          if (!removedSnapshot) {
+            UiService.showToast('Suppression impossible.');
+            return;
+          }
+          UiService.showUndoSnackbar('Site supprimé.', async () => {
+            const restored = await StorageService.restoreSite(removedSnapshot);
+            UiService.showToast(restored ? 'Suppression annulée.' : 'Restauration impossible.');
+          });
+        } finally {
+          deleteButton.disabled = false;
+        }
+      };
+
+      overlay.onclick = (event) => {
+        if (event.target === overlay) {
+          closeSheet();
+        }
+      };
+
+      let touchStartY = null;
+      sheet.ontouchstart = (event) => {
+        touchStartY = event.touches[0]?.clientY ?? null;
+      };
+      sheet.ontouchend = (event) => {
+        if (touchStartY === null) {
+          return;
+        }
+        const touchEndY = event.changedTouches[0]?.clientY ?? touchStartY;
+        if (touchEndY - touchStartY > 60) {
+          closeSheet();
+        }
+        touchStartY = null;
+      };
+
+      overlay.hidden = false;
+      clearCloseListeners();
+      if (!siteActionState.hasHistoryEntry) {
+        window.history.pushState({ siteActionSheet: true }, '');
+        siteActionState.hasHistoryEntry = true;
+      }
+      window.requestAnimationFrame(() => {
+        overlay.classList.add('is-open');
+      });
+    }
+
     function renderSites() {
       const query = searchInput.value.trim().toUpperCase();
       const sites = currentSites.filter((site) => String(site.nom || '').toUpperCase().includes(query));
@@ -977,7 +1242,7 @@ import { firebaseAuth } from './firebase-core.js';
             isAuthenticated && currentPermissions.canDelete && !isSiteLocked(site);
           return `
             <article class="list-card">
-              ${canShowDeleteButton ? `<button class="list-card__delete-button" type="button" data-site-delete="${site.id}" aria-label="Supprimer" title="Supprimer">×</button>` : ''}
+              ${canShowDeleteButton ? `<button class="list-card__menu-button" type="button" data-site-menu="${site.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
@@ -1098,17 +1363,9 @@ import { firebaseAuth } from './firebase-core.js';
         });
       });
 
-      siteList.querySelectorAll('[data-site-delete]').forEach((button) => {
-        button.addEventListener('click', async () => {
-          const removedSnapshot = await StorageService.removeSite(button.dataset.siteDelete);
-          if (!removedSnapshot) {
-            UiService.showToast('Suppression impossible.');
-            return;
-          }
-          UiService.showUndoSnackbar('Site supprimé.', async () => {
-            const restored = await StorageService.restoreSite(removedSnapshot);
-            UiService.showToast(restored ? 'Suppression annulée.' : 'Restauration impossible.');
-          });
+      siteList.querySelectorAll('[data-site-menu]').forEach((button) => {
+        button.addEventListener('click', () => {
+          openSiteActionSheet(button.dataset.siteMenu);
         });
       });
     }


### PR DESCRIPTION
### Motivation
- Assurer une parfaite cohérence UX/UI entre la page d’accueil (page 1) et la page détail (page 2) pour l’action de suppression des sites en réutilisant exactement le même flux d’actions, rendu visuel et comportement.

### Description
- Remplacement du bouton `X` (`list-card__delete-button`) par le bouton menu à trois points (`list-card__menu-button`) et changement du déclencheur vers `data-site-menu` pour la page `home` afin d’utiliser la même icône et le même placement que sur la page 2.
- Ajout du bottom sheet pour la page `home` via `ensureSiteActionBottomSheet` et `openSiteActionSheet`, reproduisant l’ouverture/fermeture animée, le clic extérieur pour fermer, le glissement vers le bas et la gestion `history/popstate` identiques à la page 2.
- Ajout de la confirmation de suppression via `ensureSiteDeleteConfirmationDialog` et `askSiteDeleteConfirmation` avec titre dynamique `Supprimer ce site {nom du site} ?`, texte de confirmation `Cette action est irréversible.` et mêmes boutons horizontaux `Annuler` / `Supprimer` (styles et hiérarchie conservés).
- Conservation intégrale de la logique métier de suppression/undo existante (`StorageService.removeSite(...)` + `UiService.showUndoSnackbar(...)` et `StorageService.restoreSite(...)`) et ajout/alignement des styles CSS dans `css/style.css` sous `body[data-page="home"]` pour garantir l’apparence premium identique.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` et succès de la vérification.
- Aucune suite de test E2E/visuelle automatisée n’a été exécutée dans cet environnement (vérification manuelle UI recommandée en navigateur).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9198d9980832a9c6b3f7f572764b1)