### PR TITLE
Améliorer le modal de création de site (mobile)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1088,11 +1088,26 @@ body[data-page="history"] .list-grid {
   border-radius: 999px;
   padding: 0.8rem 1.25rem;
   font-weight: 700;
+  min-height: 44px;
+  transition: transform 0.16s ease, filter 0.2s ease, opacity 0.2s ease;
 }
 
 .btn-success {
   color: #fff;
   background: var(--success);
+}
+
+.btn-neutral {
+  color: #273241;
+  background: #e8edf3;
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.btn[disabled] {
+  cursor: not-allowed;
 }
 
 .modal-actions--split {
@@ -1184,6 +1199,14 @@ body[data-page="history"] .list-grid {
   padding: 1rem;
 }
 
+.modal-content--site-create {
+  padding: 1.15rem;
+}
+
+.input-group--site-create {
+  margin-top: 0.35rem;
+}
+
 .modal-helper-text {
   margin: -0.2rem 0 0.9rem;
   color: var(--text-muted);
@@ -1223,6 +1246,39 @@ body[data-page="history"] .list-grid {
   justify-content: flex-end;
   align-items: center;
   gap: 0.75rem;
+}
+
+.modal-actions--site-create {
+  margin-top: 0.75rem;
+  gap: 0.7rem;
+}
+
+.modal-actions--site-create .btn {
+  flex: 1 1 50%;
+  width: 50%;
+  justify-content: center;
+  display: inline-flex;
+  align-items: center;
+}
+
+#siteCreateSubmitButton {
+  position: relative;
+}
+
+#siteCreateSubmitButton .btn-label-loading {
+  display: none;
+}
+
+#siteCreateSubmitButton.is-loading {
+  filter: saturate(0.95);
+}
+
+#siteCreateSubmitButton.is-loading .btn-label-default {
+  display: none;
+}
+
+#siteCreateSubmitButton.is-loading .btn-label-loading {
+  display: inline-flex;
 }
 
 .modal-actions--password {

--- a/index.html
+++ b/index.html
@@ -67,18 +67,21 @@
       <button id="openCreateSite" class="fab" type="button" aria-label="Créer un site">+</button>
 
       <dialog id="siteDialog" class="modal-card">
-        <form class="modal-content" id="siteForm">
+        <form class="modal-content modal-content--site-create" id="siteForm">
           <div class="modal-header">
             <h2>Entrer nom du site</h2>
-            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
           </div>
-          <label class="input-group">
+          <label class="input-group input-group--site-create">
             <span>Nom du site</span>
             <input id="siteNameInput" name="siteName" type="text" maxlength="20" />
           </label>
           <p id="siteFormError" class="form-error" aria-live="polite"></p>
-          <div class="modal-actions">
-            <button type="submit" class="btn btn-success">Créer</button>
+          <div class="modal-actions modal-actions--split modal-actions--site-create">
+            <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
+            <button id="siteCreateSubmitButton" type="submit" class="btn btn-success">
+              <span class="btn-label-default">Créer</span>
+              <span class="btn-label-loading" aria-hidden="true">Création...</span>
+            </button>
           </div>
         </form>
       </dialog>

--- a/js/app.js
+++ b/js/app.js
@@ -788,6 +788,7 @@ import { firebaseAuth } from './firebase-core.js';
     const siteForm = requireElement('siteForm');
     const siteNameInput = requireElement('siteNameInput');
     const siteFormError = requireElement('siteFormError');
+    const siteCreateSubmitButton = requireElement('siteCreateSubmitButton');
     const homeMenuButton = requireElement('homeMenuButton');
     const homeMenuPanel = requireElement('homeMenuPanel');
     const importDataButton = requireElement('importDataButton');
@@ -825,6 +826,17 @@ import { firebaseAuth } from './firebase-core.js';
       ignoreNextPopstate: false,
     };
     const transientErrorTimers = new WeakMap();
+    let isSiteCreationPending = false;
+
+    function setSiteCreateLoadingState(isLoading) {
+      isSiteCreationPending = Boolean(isLoading);
+      if (!siteCreateSubmitButton) {
+        return;
+      }
+      siteCreateSubmitButton.disabled = isSiteCreationPending;
+      siteCreateSubmitButton.classList.toggle('is-loading', isSiteCreationPending);
+      siteCreateSubmitButton.setAttribute('aria-busy', String(isSiteCreationPending));
+    }
 
     function clearTransientError(errorElement) {
       if (!errorElement) {
@@ -1462,6 +1474,7 @@ import { firebaseAuth } from './firebase-core.js';
       }
       siteForm.reset();
       siteFormError.textContent = '';
+      setSiteCreateLoadingState(false);
       siteDialog.showModal();
       siteNameInput.focus();
     });
@@ -1470,6 +1483,9 @@ import { firebaseAuth } from './firebase-core.js';
 
     siteForm.addEventListener('submit', async (event) => {
       event.preventDefault();
+      if (isSiteCreationPending) {
+        return;
+      }
       const name = siteNameInput.value.trim();
       if (!name) {
         siteFormError.textContent = 'Veuillez remplir ce champ';
@@ -1482,20 +1498,24 @@ import { firebaseAuth } from './firebase-core.js';
       }
 
       try {
+        setSiteCreateLoadingState(true);
         const result = await StorageService.createSite(name);
         if (!result?.ok) {
           siteFormError.textContent =
             result?.reason === 'duplicate_site'
               ? 'Ce nom de site existe déjà.'
               : 'Création impossible. Vérifiez le nom du site.';
+          setSiteCreateLoadingState(false);
           return;
         }
 
+        setSiteCreateLoadingState(false);
         siteDialog.close();
         UiService.showToast('Site créé avec succés.');
       } catch (error) {
         console.error('Erreur lors de la création du site :', error);
         siteFormError.textContent = "Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.";
+        setSiteCreateLoadingState(false);
       }
     });
 


### PR DESCRIPTION
### Motivation

- Améliorer l'ergonomie mobile et la cohérence visuelle du modal de création de site (page 1) sans toucher à la logique métier existante.
- Éviter les doubles-soumissions et fournir un feedback visuel professionnel pendant l'opération de création.

### Description

- Suppression du bouton de fermeture `X` dans le modal de création et conservation du titre `Entrer nom du site` et du champ `siteNameInput` dans `index.html` (nouvelle structure plus équilibrée). 
- Ajout de deux boutons d'action sur une ligne avec largeur égale 50/50 : `Annuler` (`btn-neutral`) et `Créer` (`btn-success`) dans `index.html`, avec balises de texte pour l'état par défaut et l'état de chargement (`btn-label-default` / `btn-label-loading`).
- Styles CSS ajoutés dans `css/style.css` pour améliorer le padding du modal (`.modal-content--site-create`), l'espacement autour du champ (`.input-group--site-create`), la hauteur minimale des boutons (`min-height: 44px`), le style discret du bouton `Annuler` (`.btn-neutral`) et les classes d'état de chargement (`#siteCreateSubmitButton.is-loading`).
- Comportement JS ajouté dans `js/app.js` : référence à `siteCreateSubmitButton`, fonction `setSiteCreateLoadingState` pour activer/désactiver le bouton et appliquer l'état visuel et `isSiteCreationPending` pour bloquer les soumissions multiples, appel de la fonction avant/après l'appel à `StorageService.createSite`, et réinitialisation de l'état au moment d'ouvrir le modal.

### Testing

- Vérification de validité syntaxique JS via `node --check js/app.js` et `node --check js/ui.js`, les commandes ont réussi.
- Aucun test automatisé supplémentaire ajouté; les modifications UI n'altèrent pas la logique métier de création (`StorageService.createSite`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91ebc4974832a9030ef9d035ced3b)