### PR TITLE
Harmonize page 2 OUT creation modal with page 1 design

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1203,8 +1203,16 @@ body[data-page="history"] .list-grid {
   padding: 1.15rem;
 }
 
+.modal-content--item-create {
+  padding-bottom: 1.2rem;
+}
+
 .input-group--site-create {
   margin-top: 0.35rem;
+}
+
+.input-group--item-create {
+  margin-bottom: 0.3rem;
 }
 
 .modal-helper-text {
@@ -1253,12 +1261,36 @@ body[data-page="history"] .list-grid {
   gap: 0.7rem;
 }
 
+.modal-actions--item-create {
+  margin-top: 1.1rem;
+}
+
 .modal-actions--site-create .btn {
   flex: 1 1 50%;
   width: 50%;
   justify-content: center;
   display: inline-flex;
   align-items: center;
+}
+
+#itemCreateSubmitButton {
+  position: relative;
+}
+
+#itemCreateSubmitButton .btn-label-loading {
+  display: none;
+}
+
+#itemCreateSubmitButton.is-loading {
+  filter: saturate(0.95);
+}
+
+#itemCreateSubmitButton.is-loading .btn-label-default {
+  display: none;
+}
+
+#itemCreateSubmitButton.is-loading .btn-label-loading {
+  display: inline-flex;
 }
 
 #siteCreateSubmitButton {

--- a/js/app.js
+++ b/js/app.js
@@ -1701,6 +1701,7 @@ import { firebaseAuth } from './firebase-core.js';
     const itemForm = requireElement('itemForm');
     const itemNumberInput = requireElement('itemNumberInput');
     const itemFormError = requireElement('itemFormError');
+    const itemCreateSubmitButton = requireElement('itemCreateSubmitButton');
     const openExportItems = requireElement('openExportItems');
     const itemSearchInput = requireElement('itemSearchInput');
     const itemDateFilter = requireElement('itemDateFilter');
@@ -2143,6 +2144,8 @@ import { firebaseAuth } from './firebase-core.js';
     openCreateItem?.addEventListener('click', () => {
       itemForm.reset();
       itemFormError.textContent = '';
+      itemCreateSubmitButton.disabled = false;
+      itemCreateSubmitButton.classList.remove('is-loading');
       itemDialog.showModal();
       itemNumberInput.focus();
     });
@@ -2197,6 +2200,9 @@ import { firebaseAuth } from './firebase-core.js';
 
     itemForm.addEventListener('submit', async (event) => {
       event.preventDefault();
+      if (itemCreateSubmitButton.disabled) {
+        return;
+      }
       const value = itemNumberInput.value.trim();
       if (!value) {
         itemFormError.textContent = 'Veuillez remplir ce champ';
@@ -2214,16 +2220,27 @@ import { firebaseAuth } from './firebase-core.js';
         itemFormError.textContent = 'Action non autorisée.';
         return;
       }
-      const result = await StorageService.createItem(siteId, value);
-      if (!result?.ok) {
-        itemFormError.textContent =
-          result?.reason === 'duplicate_out'
-            ? 'Ce N° OUT existe déjà pour ce site.'
-            : 'Veuillez saisir au moins 4 chiffres.';
-        return;
+      itemCreateSubmitButton.disabled = true;
+      itemCreateSubmitButton.classList.add('is-loading');
+      try {
+        const result = await StorageService.createItem(siteId, value);
+        if (!result?.ok) {
+          itemFormError.textContent =
+            result?.reason === 'duplicate_out'
+              ? 'Ce N° OUT existe déjà pour ce site.'
+              : 'Veuillez saisir au moins 4 chiffres.';
+          return;
+        }
+        itemCreateSubmitButton.classList.remove('is-loading');
+        itemCreateSubmitButton.disabled = false;
+        itemDialog.close();
+        UiService.showToast('N° OUT ajouté .');
+      } finally {
+        if (itemDialog.open) {
+          itemCreateSubmitButton.classList.remove('is-loading');
+          itemCreateSubmitButton.disabled = false;
+        }
       }
-      itemDialog.close();
-      UiService.showToast('N° OUT ajouté .');
     });
 
     StorageService.subscribeSites((sites) => {

--- a/page2.html
+++ b/page2.html
@@ -59,13 +59,12 @@
       <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>
 
       <dialog id="itemDialog" class="modal-card">
-        <form method="dialog" class="modal-content" id="itemForm">
+        <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="itemForm">
           <div class="modal-header">
-            <h2>N° OUT-</h2>
-            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
+            <h2>Créer un numéro OUT</h2>
           </div>
-          <label class="input-group">
-            <span>Numéro</span>
+          <label class="input-group input-group--site-create input-group--item-create">
+            <span>Numéro OUT</span>
             <input
               id="itemNumberInput"
               name="itemNumber"
@@ -78,8 +77,12 @@
             />
           </label>
           <p id="itemFormError" class="form-error" aria-live="polite"></p>
-          <div class="modal-actions">
-            <button type="submit" class="btn btn-success">Créer</button>
+          <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
+            <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
+            <button id="itemCreateSubmitButton" type="submit" class="btn btn-success">
+              <span class="btn-label-default">Créer</span>
+              <span class="btn-label-loading" aria-hidden="true">Création...</span>
+            </button>
           </div>
         </form>
       </dialog>


### PR DESCRIPTION
### Motivation
- Harmoniser l’apparence et l’expérience de la popup de création d’un N° OUT (page 2) avec la popup corrigée de la page 1 pour obtenir une cohérence visuelle et UX premium.
- Rendre la popup de page 2 plus professionnelle et mobile-friendly tout en conservant la logique métier existante de création d’un OUT.
- Éviter les doubles-soumissions et offrir un retour visuel clair pendant l’opération de création.

### Description
- Mise à jour de `page2.html` pour remplacer le titre par `Créer un numéro OUT`, supprimer le bouton de fermeture “X”, conserver l’input existant (placeholder `OUT-123456`) et ajouter une structure d’actions à deux boutons (`Annuler` + `Créer`) avec largeur égale et labels de chargement; le bouton submit a désormais l’id `itemCreateSubmitButton`.
- Ajout dans `css/style.css` de classes spécifiques réutilisant le pattern de la popup page 1 (`.modal-content--item-create`, `.input-group--item-create`, `.modal-actions--item-create`) et styles pour l’état de chargement du bouton `#itemCreateSubmitButton` afin d’assurer espacement, padding et rendu mobile cohérents.
- Adaptation de `js/app.js` pour référencer `itemCreateSubmitButton`, réinitialiser son état à l’ouverture de la popup, empêcher les doubles clics en vérifiant `disabled`, activer la classe `.is-loading` et désactiver le bouton pendant l’appel `StorageService.createItem`, puis restaurer l’état du bouton en cas de succès ou d’erreur sans modifier les messages d’erreur ni la logique métier existante.

### Testing
- Exécution de `node --check js/app.js` et `node --check js/ui.js`, les deux contrôles de syntaxe sont passés avec succès.
- Revue statique des diffs et vérification que les modifications n’altèrent pas la logique métier de création d’un OUT.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9222cf5c8832a81278ef6a690cb45)