### PR TITLE
Formulaire détail : boutons 50/50 et état de chargement pour Enregistrer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1775,7 +1775,7 @@ body[data-page="item-detail"] #detailFormError {
 
 body[data-page="item-detail"] .detail-form-actions {
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.35fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   width: 100%;
   gap: 0.7rem;
 }
@@ -1785,6 +1785,25 @@ body[data-page="item-detail"] .detail-form-actions .btn {
   min-width: 0;
   min-height: 3.35rem;
   padding-inline: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body[data-page="item-detail"] #detailCreateSubmitButton .btn-label-loading {
+  display: none;
+}
+
+body[data-page="item-detail"] #detailCreateSubmitButton.is-loading {
+  filter: saturate(0.95);
+}
+
+body[data-page="item-detail"] #detailCreateSubmitButton.is-loading .btn-label-default {
+  display: none;
+}
+
+body[data-page="item-detail"] #detailCreateSubmitButton.is-loading .btn-label-loading {
+  display: inline-flex;
 }
 
 body[data-page="item-detail"] .detail-form-row--qte-unit {

--- a/js/app.js
+++ b/js/app.js
@@ -2311,6 +2311,7 @@ import { firebaseAuth } from './firebase-core.js';
     const detailFormModal = requireElement('detailFormModal');
     const openDetailFormButton = requireElement('openDetailFormButton');
     const cancelDetailFormButton = requireElement('cancelDetailFormButton');
+    const detailCreateSubmitButton = requireElement('detailCreateSubmitButton');
     const detailCount = requireElement('detailCount');
     const detailTableBody = requireElement('detailTableBody');
     const detailSearchInput = requireElement('detailSearchInput');
@@ -2358,6 +2359,14 @@ import { firebaseAuth } from './firebase-core.js';
       window.setTimeout(() => {
         codeInput?.focus();
       }, 60);
+    }
+
+    function setDetailFormSavingState(isSaving) {
+      if (!detailCreateSubmitButton) {
+        return;
+      }
+      detailCreateSubmitButton.disabled = isSaving;
+      detailCreateSubmitButton.classList.toggle('is-loading', isSaving);
     }
 
     function buildCodeSuggestionSource(details) {
@@ -2681,24 +2690,29 @@ import { firebaseAuth } from './firebase-core.js';
         return;
       }
 
-      const result = await StorageService.createDetail(siteId, itemId, {
-        code: requireElement('codeInput').value,
-        designation: designationInput.value,
-        qteSortie: requireElement('qteSortieInput').value,
-        unite: requireElement('uniteInput').value,
-      });
-      if (!result?.ok) {
-        detailFormError.textContent =
-          result?.reason === 'duplicate_designation'
-            ? 'Cette désignation existe déjà pour ce N° OUT.'
-            : 'Création impossible. Vérifiez la désignation.';
-        return;
+      setDetailFormSavingState(true);
+      try {
+        const result = await StorageService.createDetail(siteId, itemId, {
+          code: requireElement('codeInput').value,
+          designation: designationInput.value,
+          qteSortie: requireElement('qteSortieInput').value,
+          unite: requireElement('uniteInput').value,
+        });
+        if (!result?.ok) {
+          detailFormError.textContent =
+            result?.reason === 'duplicate_designation'
+              ? 'Cette désignation existe déjà pour ce N° OUT.'
+              : 'Création impossible. Vérifiez la désignation.';
+          return;
+        }
+        detailForm.reset();
+        requireElement('uniteInput').value = 'm';
+        hideCodeSuggestions();
+        closeDetailModal();
+        UiService.showToast('Article ajoutée .');
+      } finally {
+        setDetailFormSavingState(false);
       }
-      detailForm.reset();
-      requireElement('uniteInput').value = 'm';
-      hideCodeSuggestions();
-      closeDetailModal();
-      UiService.showToast('Article ajoutée .');
     });
 
     if (openDetailFormButton) {

--- a/page3.html
+++ b/page3.html
@@ -125,7 +125,10 @@
                 <p id="detailFormError" class="form-error" aria-live="polite"></p>
                 <div class="detail-form-actions">
                   <button type="button" class="btn" id="cancelDetailFormButton">Annuler</button>
-                  <button type="submit" class="btn btn-success">Enregistrer</button>
+                  <button type="submit" class="btn btn-success" id="detailCreateSubmitButton">
+                    <span class="btn-label-default">Enregistrer</span>
+                    <span class="btn-label-loading" aria-hidden="true">Enregistrement...</span>
+                  </button>
                 </div>
               </div>
             </form>


### PR DESCRIPTION
### Motivation
- Améliorer uniquement la largeur et la disposition des boutons "Annuler" et "Enregistrer" sur la page du formulaire "Ajouter une donnée" sans toucher aux champs ni à la logique métier.
- Fournir un feedback visuel professionnel pendant l’enregistrement pour éviter les doubles clics et conserver un rendu stable et adapté au mobile.

### Description
- HTML : ajout de l'ID `detailCreateSubmitButton` et de deux labels internes (`.btn-label-default` et `.btn-label-loading`) pour afficher temporairement le texte `Enregistrement...` dans le bouton de soumission.
- CSS : modification de `.detail-form-actions` pour afficher les deux boutons sur une seule ligne en deux colonnes égales (`repeat(2, minmax(0, 1fr))`), centrage du contenu des boutons et règles pour basculer l'affichage des labels lors de l'état `.is-loading`.
- JS : ajout de la référence `detailCreateSubmitButton` et de la fonction `setDetailFormSavingState(isSaving)` qui désactive immédiatement le bouton, ajoute/supprime la classe `.is-loading` au submit, et restaure l'état dans un bloc `finally` afin de gérer succès et erreurs sans modifier la logique métier existante de `StorageService.createDetail`.
- Aucun champ, structure de champ, libellé ou logique métier n’a été modifié.

### Testing
- Vérification statique du JavaScript avec `node --check js/app.js` (réussi).
- Aucun autre test automatisé additionnel disponible; les comportements ont été vérifiés via les contrôles statiques mentionnés ci‑dessus.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e925f0530c832a8c81719d735137f4)