### PR TITLE
Utiliser l'icône existante Icon/Trois point.png pour le bouton menu (page 1)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -140,8 +140,11 @@ button {
   line-height: 1;
 }
 
-.header-menu__trigger span {
-  transform: translateY(-0.08em);
+.header-menu__icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  object-fit: contain;
+  display: block;
 }
 
 .header-menu__panel {
@@ -3259,10 +3262,6 @@ body[data-page="site-detail"] .list-separator {
   body[data-page="home"] .header-menu__trigger {
     width: 2.45rem;
     height: 2.45rem;
-  }
-
-  body[data-page="home"] .header-menu__trigger {
-    font-size: 1.65rem;
   }
 
   body[data-page="home"] .page-content {

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             aria-haspopup="menu"
             aria-expanded="false"
           >
-            <span aria-hidden="true">⋯</span>
+            <img src="Icon/Trois point.png" alt="" aria-hidden="true" class="header-menu__icon" />
           </button>
           <div id="homeMenuPanel" class="header-menu__panel" role="menu" hidden>
             <button id="historyButton" class="header-menu__option" type="button" role="menuitem">


### PR DESCRIPTION
### Motivation
- Remplacer l’icône texte du bouton « trois points » du header de la page d’accueil par l’asset déjà présent dans le dépôt sans créer de nouveau fichier et en conservant le comportement existant.

### Description
- Remplacé le contenu du bouton `#homeMenuButton` dans `index.html` : le glyphe texte a été remplacé par `<img src="Icon/Trois point.png" alt="" aria-hidden="true" class="header-menu__icon" />` pour réutiliser l’image existante.
- Ajouté la règle CSS `.header-menu__icon` dans `css/style.css` pour contraindre la taille et le rendu (taille nette et adaptée au mobile, `object-fit: contain`) sans modifier la position ni l’alignement du bouton.
- Retiré l’ajustement de `font-size` lié au glyphe texte puisque l’icône est désormais une image, et conservé tous les attributs ARIA, `id` et classes du bouton pour préserver la logique et l’interaction.

### Testing
- Confirmé que seules les fichiers `index.html` et `css/style.css` ont été modifiés (vérification des diffs passée).
- Vérifié que la logique du menu et la liaison du bouton dans `js/app.js` restent inchangées (inspection passée).
- Effectué des contrôles d’état/diff du dépôt pour valider l’état propre après modification (passé).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e929ae3ba0832a8425deffa0d2781d)