### PR TITLE
Fix affichage et fermeture de la modal de déconnexion (page 1)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -631,7 +631,7 @@ import { firebaseAuth } from './firebase-core.js';
 
     overlay = document.createElement('div');
     overlay.id = 'logoutConfirmOverlay';
-    overlay.className = 'maintenance-overlay';
+    overlay.className = 'maintenance-overlay item-delete-confirm-overlay';
     overlay.hidden = true;
     overlay.innerHTML = `
       <article class="maintenance-card item-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="logoutConfirmTitle">
@@ -656,16 +656,36 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     return new Promise((resolve) => {
+      const closeAnimationDurationMs = 170;
+      let closeAnimationTimer = null;
+      let isClosing = false;
       const cleanup = () => {
+        if (closeAnimationTimer) {
+          window.clearTimeout(closeAnimationTimer);
+          closeAnimationTimer = null;
+        }
         overlay.hidden = true;
         overlay.classList.remove('is-open');
         overlay.onclick = null;
         cancelButton.onclick = null;
         submitButton.onclick = null;
+        document.removeEventListener('keydown', handleKeyDown);
       };
       const close = (value) => {
-        cleanup();
-        resolve(value);
+        if (isClosing) {
+          return;
+        }
+        isClosing = true;
+        overlay.classList.remove('is-open');
+        closeAnimationTimer = window.setTimeout(() => {
+          cleanup();
+          resolve(value);
+        }, closeAnimationDurationMs);
+      };
+      const handleKeyDown = (event) => {
+        if (event.key === 'Escape') {
+          close(false);
+        }
       };
 
       cancelButton.onclick = () => close(false);
@@ -675,6 +695,7 @@ import { firebaseAuth } from './firebase-core.js';
           close(false);
         }
       };
+      document.addEventListener('keydown', handleKeyDown);
       overlay.hidden = false;
       window.requestAnimationFrame(() => {
         overlay.classList.add('is-open');


### PR DESCRIPTION
### Motivation
- La confirmation de déconnexion sur la page d’accueil ne suivait pas le même pattern visuel et lifecycle que les autres modaux fonctionnels, ce qui pouvait empêcher l’affichage/fermeture corrects (z-index/opacity/animations). 
- Stabiliser l’ouverture/fermeture pour éviter doubles résolutions, fuites d’écouteurs et gérer l’appui sur `Escape` de façon cohérente.

### Description
- L’overlay de confirmation de déconnexion utilise désormais la même pile de classes que les confirmations existantes avec `className = 'maintenance-overlay item-delete-confirm-overlay'` dans `ensureLogoutConfirmationCard` (fichier modifié : `js/app.js`).
- La logique d’ouverture/fermeture de `askLogoutConfirmation` a été alignée sur le pattern des autres modals en ajoutant une durée d’animation (`closeAnimationDurationMs`), une temporisation pour finaliser la fermeture, et la suppression de la classe `is-open` avant de masquer l’overlay.
- Ajout d’une garde `isClosing` pour éviter les fermetures multiples, nettoyage explicite des timers et des listeners (`onclick`, `keydown`) lors du cleanup, et prise en charge de la touche `Escape` pour fermer la modal.
- Les modifications sont strictement limitées à `js/app.js` et au comportement de la modal de déconnexion de la page 1 sans toucher aux autres pages ni au design.

### Testing
- Vérification syntaxique du JavaScript avec `node --check js/app.js`, qui a réussi.
- Aucun test automatisé d’intégration UI n’a été exécuté dans cet environnement (seulement la vérification de syntaxe automatique ci-dessus).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92fc1ef94832ab622c916ab09447f)