### PR TITLE
Uniformiser la hauteur des boutons dans les modals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1259,6 +1259,13 @@ body[data-page="history"] .list-grid {
   gap: 0.75rem;
 }
 
+.modal-actions .btn {
+  min-height: 3.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .modal-actions--site-create {
   margin-top: 0.75rem;
   gap: 0.7rem;
@@ -1271,6 +1278,7 @@ body[data-page="history"] .list-grid {
 .modal-actions--site-create .btn {
   flex: 1 1 50%;
   width: 50%;
+  min-height: 3.35rem;
   justify-content: center;
   display: inline-flex;
   align-items: center;
@@ -2519,11 +2527,14 @@ body[data-page="site-detail"] .item-delete-confirm-actions {
 body[data-page="site-detail"] .item-delete-confirm-button {
   flex: 1 1 50%;
   width: 50%;
-  min-height: 44px;
+  min-height: 3.35rem;
   border-radius: 12px;
   font-size: 0.95rem;
   font-weight: 700;
   padding: 0.72rem 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 body[data-page="site-detail"] .item-delete-confirm-button--cancel {
@@ -3039,11 +3050,14 @@ body[data-page="home"] .item-delete-confirm-actions {
 body[data-page="home"] .item-delete-confirm-button {
   flex: 1 1 50%;
   width: 50%;
-  min-height: 44px;
+  min-height: 3.35rem;
   border-radius: 12px;
   font-size: 0.95rem;
   font-weight: 700;
   padding: 0.72rem 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 body[data-page="home"] .item-delete-confirm-button--cancel {


### PR DESCRIPTION
### Motivation
- Rendre homogène la hauteur des boutons présents dans les modals pour améliorer la cohérence visuelle et respecter la référence de la page 3 (`3.35rem`).
- Ne modifier que la hauteur et l’alignement vertical du contenu des boutons sans toucher à la logique métier, aux couleurs ou à la disposition.

### Description
- Ajout d’une règle globale ` .modal-actions .btn ` qui impose `min-height: 3.35rem` et centre le contenu avec `display: inline-flex`, `align-items: center` et `justify-content: center`.
- Application explicite de `min-height: 3.35rem` à ` .modal-actions--site-create .btn ` pour conserver la même référence que la page 3.
- Remplacement de `min-height: 44px` par `min-height: 3.35rem` pour ` .item-delete-confirm-button ` sur les pages `site-detail` et `home` et ajout du centrage (`inline-flex`, `align-items`, `justify-content`).
- Aucun autre style (couleurs, arrondis), structure HTML ou logique JavaScript n’a été modifié.

### Testing
- Exécution de `git diff --check` passée sans erreurs de style/whitespace.
- Le fichier `css/style.css` a été vérifié via `git status` et le changement a été commité avec succès (message de commit disponible dans l’historique).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4352a774832a89aa0a694e4a01d9)