### PR TITLE
Add site lock/unlock UI and actions (long-press & action sheet)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2944,7 +2944,7 @@ body[data-page="home"] .item-action-sheet .bottom-sheet__handle {
 }
 
 body[data-page="home"] .item-action-sheet__title {
-  margin: 0 0 0.75rem;
+  margin: 0.2rem 0 0.75rem;
   text-align: center;
   font-size: 0.88rem;
   font-weight: 500;

--- a/js/app.js
+++ b/js/app.js
@@ -1012,6 +1012,10 @@ import { firebaseAuth } from './firebase-core.js';
           <div class="bottom-sheet__handle" aria-hidden="true"></div>
           <p class="item-action-sheet__title" id="siteActionSheetTitle">Actions</p>
           <div class="item-action-sheet__content">
+            <button type="button" class="item-action-sheet__row" id="siteActionLockToggleButton">
+              <img src="Icon/cle.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
+              <span id="siteActionLockToggleLabel">Verrouiller</span>
+            </button>
             <button type="button" class="item-action-sheet__row item-action-sheet__row--danger" id="siteActionDeleteButton">
               <img src="Icon/poubelle.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
               <span>Supprimer</span>
@@ -1125,6 +1129,40 @@ import { firebaseAuth } from './firebase-core.js';
       return false;
     }
 
+    function openSiteLockActionDialog(siteId) {
+      if (!isAuthenticated) {
+        return;
+      }
+      const targetSite = currentSites.find((site) => site.id === siteId);
+      if (isSiteLocked(targetSite)) {
+        if (
+          !siteLockManageDialog ||
+          !siteLockCurrentPasswordInput ||
+          !siteLockNewPasswordInput ||
+          !siteLockManageError
+        ) {
+          return;
+        }
+        siteIdPendingLockManage = siteId;
+        siteLockCurrentPasswordInput.value = '';
+        siteLockNewPasswordInput.value = '';
+        clearTransientError(siteLockManageError);
+        siteLockManageDialog.showModal();
+        siteLockCurrentPasswordInput.focus();
+        return;
+      }
+
+      if (!siteLockDialog || !siteLockPasswordInput || !siteLockConfirmPasswordInput || !siteLockError) {
+        return;
+      }
+      siteIdPendingLock = siteId;
+      siteLockPasswordInput.value = '';
+      siteLockConfirmPasswordInput.value = '';
+      clearTransientError(siteLockError);
+      siteLockDialog.showModal();
+      siteLockPasswordInput.focus();
+    }
+
     window.addEventListener('popstate', () => {
       if (siteActionState.ignoreNextPopstate) {
         siteActionState.ignoreNextPopstate = false;
@@ -1137,8 +1175,10 @@ import { firebaseAuth } from './firebase-core.js';
       const overlay = ensureSiteActionBottomSheet();
       const sheet = overlay.querySelector('#siteActionSheet');
       const title = overlay.querySelector('#siteActionSheetTitle');
+      const lockToggleButton = overlay.querySelector('#siteActionLockToggleButton');
+      const lockToggleLabel = overlay.querySelector('#siteActionLockToggleLabel');
       const deleteButton = overlay.querySelector('#siteActionDeleteButton');
-      if (!sheet || !title || !deleteButton) {
+      if (!sheet || !title || !lockToggleButton || !lockToggleLabel || !deleteButton) {
         return;
       }
 
@@ -1149,6 +1189,10 @@ import { firebaseAuth } from './firebase-core.js';
 
       siteActionState.activeSiteId = siteId;
       title.textContent = String(activeSite.nom || '').trim() || 'Actions';
+      const canDeleteSite = isAuthenticated && currentPermissions.canDelete && !isSiteLocked(activeSite);
+      lockToggleLabel.textContent = isSiteLocked(activeSite) ? 'Déverrouiller' : 'Verrouiller';
+      deleteButton.hidden = !canDeleteSite;
+      deleteButton.disabled = !canDeleteSite;
       const closeTransitionDurationMs = 280;
 
       const clearCloseListeners = () => {
@@ -1201,6 +1245,10 @@ import { firebaseAuth } from './firebase-core.js';
         });
 
       siteActionState.closeSheet = closeSheet;
+      lockToggleButton.onclick = async () => {
+        await closeSheet();
+        openSiteLockActionDialog(siteId);
+      };
       deleteButton.onclick = async () => {
         deleteButton.disabled = true;
         try {
@@ -1275,11 +1323,10 @@ import { firebaseAuth } from './firebase-core.js';
           const createdBy = resolveActorLabel(site?.createdBy, userNamesById, site?.createdByName);
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
           const lockLabel = isSiteLocked(site) ? 'Verrouillé' : 'Déverrouillé';
-          const canShowDeleteButton =
-            isAuthenticated && currentPermissions.canDelete && !isSiteLocked(site);
+          const canShowSiteActions = isAuthenticated;
           return `
             <article class="list-card">
-              ${canShowDeleteButton ? `<button class="list-card__menu-button" type="button" data-site-menu="${site.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
+              ${canShowSiteActions ? `<button class="list-card__menu-button" type="button" data-site-menu="${site.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
                 <div class="list-card__meta">
@@ -1321,37 +1368,7 @@ import { firebaseAuth } from './firebase-core.js';
         };
 
         const openLockDialog = () => {
-          if (!isAuthenticated) {
-            return;
-          }
-          const targetSite = currentSites.find((site) => site.id === siteId);
-          if (isSiteLocked(targetSite)) {
-            if (
-              !siteLockManageDialog ||
-              !siteLockCurrentPasswordInput ||
-              !siteLockNewPasswordInput ||
-              !siteLockManageError
-            ) {
-              return;
-            }
-            siteIdPendingLockManage = siteId;
-            siteLockCurrentPasswordInput.value = '';
-            siteLockNewPasswordInput.value = '';
-            clearTransientError(siteLockManageError);
-            siteLockManageDialog.showModal();
-            siteLockCurrentPasswordInput.focus();
-            return;
-          }
-
-          if (!siteLockDialog || !siteLockPasswordInput || !siteLockConfirmPasswordInput || !siteLockError) {
-            return;
-          }
-          siteIdPendingLock = siteId;
-          siteLockPasswordInput.value = '';
-          siteLockConfirmPasswordInput.value = '';
-          clearTransientError(siteLockError);
-          siteLockDialog.showModal();
-          siteLockPasswordInput.focus();
+          openSiteLockActionDialog(siteId);
         };
 
         button.addEventListener('pointerdown', (event) => {


### PR DESCRIPTION
### Motivation
- Provide users with the ability to lock and unlock sites from the UI and via long-press, and prevent destructive actions on locked sites.
- Surface site lock status in the list view and adjust available actions when a site is locked.
- Improve action sheet spacing for better visual alignment.

### Description
- Added a lock/unlock row to the site action bottom sheet and a new `openSiteLockActionDialog` helper to open the appropriate lock or manage-password dialog for a site via `siteId`.
- Wired the new lock toggle button (`#siteActionLockToggleButton` / `#siteActionLockToggleLabel`) so clicking it closes the sheet and opens the lock dialog, and made the delete action hidden/disabled when a site is locked by checking `isSiteLocked(activeSite)`.
- Updated `renderSites` to always show the site actions menu for authenticated users, render lock icon/label (`Icon/Cadenas_close.png` / `Icon/Cadenas_Open.png`) and replaced the inline long-press lock dialog logic with a call to `openSiteLockActionDialog(siteId)`.
- Minor CSS tweak to `.item-action-sheet__title` top margin to improve spacing.

### Testing
- Ran lint (`npm run lint`) against modified files and it passed. 
- Ran the project's automated test suite (`npm test`) and it passed; no new automated tests were added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4ac514a4832a80ea3dfeba27c6c6)