### PR TITLE
Sécuriser les actions Verrouiller/Déverrouiller et Supprimer (page d'accueil)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1189,8 +1189,9 @@ import { firebaseAuth } from './firebase-core.js';
 
       siteActionState.activeSiteId = siteId;
       title.textContent = String(activeSite.nom || '').trim() || 'Actions';
-      const canDeleteSite = isAuthenticated && currentPermissions.canDelete && !isSiteLocked(activeSite);
-      lockToggleLabel.textContent = isSiteLocked(activeSite) ? 'Déverrouiller' : 'Verrouiller';
+      const siteIsLocked = isSiteLocked(activeSite);
+      const canDeleteSite = isAuthenticated && currentPermissions.canDelete && !siteIsLocked;
+      lockToggleLabel.textContent = siteIsLocked ? 'Déverrouiller' : 'Verrouiller';
       deleteButton.hidden = !canDeleteSite;
       deleteButton.disabled = !canDeleteSite;
       const closeTransitionDurationMs = 280;
@@ -1250,6 +1251,11 @@ import { firebaseAuth } from './firebase-core.js';
         openSiteLockActionDialog(siteId);
       };
       deleteButton.onclick = async () => {
+        const latestSiteState = currentSites.find((site) => site.id === siteId);
+        if (!latestSiteState || isSiteLocked(latestSiteState)) {
+          UiService.showToast('Suppression impossible tant que le site est verrouillé.');
+          return;
+        }
         deleteButton.disabled = true;
         try {
           await closeSheet();


### PR DESCRIPTION
### Motivation
- Garantir que le bottom sheet d’actions pour un site reflète correctement son état verrouillé/déverrouillé et n’expose jamais l’option de suppression si le site est verrouillé.
- Bloquer toute tentative de suppression d’un site verrouillé même en cas d’interaction asynchrone ou état obsolète.
- Conserver les modals existants (`Créer un mot de passe`, `Gestion de l’accès sécurisé`) et le rendu visuel actuel.

### Description
- Calcul explicite de l’état `siteIsLocked` au moment de l’ouverture du bottom sheet et utilisation de cette valeur pour déterminer le libellé du bouton de verrouillage (`Verrouiller` / `Déverrouiller`).
- Masquage et désactivation de l’action `Supprimer` lorsque `siteIsLocked` est vrai, afin qu’elle n’apparaisse pas dans le bottom sheet pour un site verrouillé.
- Vérification défensive juste avant l’exécution de la suppression (relecture de l’état courant du site depuis `currentSites`) et affichage d’un toast si la suppression est interdite parce que le site est verrouillé.
- Modification limitée à la page d’accueil (`js/app.js`) ; les autres pages et les modals existants n’ont pas été modifiés.

### Testing
- Vérification de syntaxe JavaScript exécutée avec `node --check js/app.js` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea524e82d4832a9bbeda27a225d4e0)