### PR TITLE
Uniformiser hauteur et alignement des boutons des modals sécurisés (page 1)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1330,12 +1330,46 @@ body[data-page="history"] .list-grid {
 }
 
 .modal-actions--password .btn {
-  flex: 0 1 auto;
-  min-width: fit-content;
+  flex: 1 1 50%;
+  width: 50%;
+  min-height: 3.35rem;
+  padding: 0.8rem 1.25rem;
 }
 
 .modal-actions--password-manage {
-  justify-content: space-between;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.modal-actions__row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.modal-actions__row--pair .btn {
+  flex: 1 1 50%;
+  width: 50%;
+}
+
+.modal-actions__row--single .btn {
+  width: 100%;
+  flex: 1 1 100%;
+}
+
+body[data-page="home"] .modal-actions--password {
+  width: 100%;
+}
+
+body[data-page="home"] .modal-actions--password:not(.modal-actions--password-manage) {
+  flex-wrap: nowrap;
+}
+
+body[data-page="home"] .modal-actions--password:not(.modal-actions--password-manage) .btn {
+  flex: 1 1 50%;
+  width: 50%;
 }
 
 .form-footer {

--- a/index.html
+++ b/index.html
@@ -123,9 +123,13 @@
           </label>
           <p id="siteLockManageError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--password modal-actions--password-manage">
-            <button type="submit" class="btn btn-danger" data-lock-manage-action="unlock">Déverrouiller</button>
-            <button type="submit" class="btn btn-success" data-lock-manage-action="update">Mettre à jour</button>
-            <button type="button" class="btn" data-close-dialog>Annuler</button>
+            <div class="modal-actions__row modal-actions__row--pair">
+              <button type="button" class="btn" data-close-dialog>Annuler</button>
+              <button type="submit" class="btn btn-success" data-lock-manage-action="update">Mettre à jour</button>
+            </div>
+            <div class="modal-actions__row modal-actions__row--single">
+              <button type="submit" class="btn btn-danger" data-lock-manage-action="unlock">Déverrouiller</button>
+            </div>
           </div>
         </form>
       </dialog>


### PR DESCRIPTION
### Motivation
- Uniformiser la hauteur et le padding des boutons des modals de création/gestion du mot de passe pour correspondre à la référence existante sur la page 3. 
- Corriger l’alignement horizontal et empêcher que trois boutons se retrouvent sur une seule ligne, afin d’obtenir un rendu mobile professionnel et cohérent. 
- Appliquer la modification uniquement sur la page 1 sans toucher à la logique métier ni aux champs du formulaire.

### Description
- `index.html` : restructuration du bloc d’actions du modal `siteLockManageDialog` en deux rangées (`.modal-actions__row`), avec première ligne `Annuler` + `Mettre à jour` (50/50) et deuxième ligne `Déverrouiller` (plein largeur). 
- `css/style.css` : harmonisation de la hauteur et du padding des boutons dans `.modal-actions--password .btn` (`min-height: 3.35rem; padding: 0.8rem 1.25rem; width: 50%`) pour correspondre à la taille de référence. 
- `css/style.css` : ajout de classes de disposition (`.modal-actions__row`, `--pair`, `--single`) et portée via `body[data-page="home"]` pour garantir que ces ajustements restent ciblés sur la page 1. 
- Aucun changement de JavaScript ou de logique métier n’a été effectué, seules la structure HTML des actions et les règles CSS ont été modifiées.

### Testing
- Recherche et inspection statique du code avec `rg` pour localiser les modals et les boutons (réussite). 
- Vérification des diffs ciblés avec `git diff -- index.html css/style.css` (vérification du contenu modifié réussie). 
- Inspection des extraits modifiés avec `nl -ba index.html | sed -n '116,145p'` et `nl -ba css/style.css | sed -n '1322,1388p'` pour confirmer les lignes insérées/ajustées (réussite). 
- Aucun test automatique d’intégration visuelle/écran n’a été exécuté dans cet environnement (outil de capture non disponible).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5f1321ac832ab008f348e29f8019)