### PR TITLE
Align and size buttons in page 1 "Site verrouillé" modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
             <input id="siteUnlockPasswordInput" type="password" autocomplete="current-password" />
           </label>
           <p id="siteUnlockError" class="form-error" aria-live="polite"></p>
-          <div class="modal-actions modal-actions--split">
+          <div class="modal-actions modal-actions--split modal-actions--password">
             <button type="button" class="btn" data-close-dialog>Annuler</button>
             <button type="submit" class="btn btn-success">Valider</button>
           </div>


### PR DESCRIPTION
### Motivation
- Uniformize the `Annuler` / `Valider` buttons in the page 1 "Site verrouillé" modal so they match other corrected modals (same width, height and horizontal alignment) without changing colors, rounded corners, fields or business logic.

### Description
- Added the existing `modal-actions--password` class to the actions container of `#siteUnlockDialog` in `index.html` so the two buttons become a single horizontal row with equal width (50% / 50%) and the same `min-height` as the reference buttons; this is the only code change (`index.html` line updated).

### Testing
- Verified the change and surrounding styles with `rg` to locate `modal-actions--password` and inspected `css/style.css` to ensure it provides `width: 50%` and `min-height: 3.35rem`; these checks succeeded. 
- Confirmed the diff is limited to one line in `index.html` and created a commit (`74d7fcf`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea61307a80832aa10230d2191f90d0)