### PR TITLE
Améliore l'espacement vertical du modal « Créer un mot de passe »

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1218,6 +1218,14 @@ body[data-page="history"] .list-grid {
   margin-bottom: 0.3rem;
 }
 
+.input-group--site-lock-create {
+  gap: 0.65rem;
+}
+
+.input-group--site-lock-create + .input-group--site-lock-create {
+  margin-top: 0.35rem;
+}
+
 .modal-helper-text {
   margin: -0.2rem 0 0.9rem;
   color: var(--text-muted);

--- a/index.html
+++ b/index.html
@@ -91,11 +91,11 @@
           <div class="modal-header">
             <h2>Créer un mot de passe</h2>
           </div>
-          <label class="input-group">
+          <label class="input-group input-group--site-lock-create">
             <span>Entrer un mot de passe</span>
             <input id="siteLockPasswordInput" type="password" autocomplete="new-password" />
           </label>
-          <label class="input-group">
+          <label class="input-group input-group--site-lock-create">
             <span>Confirmer le mot de passe</span>
             <input id="siteLockConfirmPasswordInput" type="password" autocomplete="new-password" />
           </label>


### PR DESCRIPTION
### Motivation
- Corriger l'espacement vertical entre les libellés et les champs du modal "Créer un mot de passe" (page 1) pour améliorer la lisibilité et éviter que le texte paraisse collé à la bordure, sans modifier la structure, les boutons ni la logique.

### Description
- Ajout de la classe `input-group--site-lock-create` sur les deux `label.input-group` du modal dans `index.html`.
- Ajout de règles CSS dans `css/style.css` : `gap: 0.65rem` pour espacer le libellé et le champ, et `margin-top: 0.35rem` entre les deux groupes de champs pour assurer une cohérence visuelle.
- Les modifications sont limitées aux fichiers `index.html` et `css/style.css` et n'affectent pas d'autres modals ni la logique des boutons.

### Testing
- Recherches et vérifications automatiques avec `rg` pour localiser le modal et les champs ont été exécutées et ont réussi.
- Vérification du diff avec `git diff -- index.html css/style.css` et création du commit `git commit -m "Ajuste l'espacement des champs du modal mot de passe"` ont réussi.
- Aucune suite de tests automatisés (CI/unit tests) spécifique n'a été exécutée pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea634b4dbc832abf5bf6c97abd72dd)