### PR TITLE
Mettre à jour dynamiquement l'affichage de « Supprimer » dans le bottom sheet (page 1)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -846,6 +846,7 @@ import { firebaseAuth } from './firebase-core.js';
     const siteActionState = {
       activeSiteId: null,
       closeSheet: null,
+      refreshSheetContent: null,
       closeConfirmation: null,
       hasHistoryEntry: false,
       ignoreNextPopstate: false,
@@ -1181,20 +1182,22 @@ import { firebaseAuth } from './firebase-core.js';
       if (!sheet || !title || !lockToggleButton || !lockToggleLabel || !deleteButton) {
         return;
       }
-
-      const activeSite = currentSites.find((site) => site.id === siteId);
-      if (!activeSite) {
-        return;
-      }
-
-      siteActionState.activeSiteId = siteId;
-      title.textContent = String(activeSite.nom || '').trim() || 'Actions';
-      const siteIsLocked = isSiteLocked(activeSite);
-      const canDeleteSite = isAuthenticated && currentPermissions.canDelete && !siteIsLocked;
-      lockToggleLabel.textContent = siteIsLocked ? 'Déverrouiller' : 'Verrouiller';
-      deleteButton.hidden = !canDeleteSite;
-      deleteButton.disabled = !canDeleteSite;
       const closeTransitionDurationMs = 280;
+      const refreshSiteActionSheetContent = () => {
+        const latestSite = currentSites.find((site) => site.id === siteId);
+        if (!latestSite) {
+          closeSheet();
+          return null;
+        }
+
+        title.textContent = String(latestSite.nom || '').trim() || 'Actions';
+        const siteIsLocked = isSiteLocked(latestSite);
+        const canDeleteSite = isAuthenticated && currentPermissions.canDelete && !siteIsLocked;
+        lockToggleLabel.textContent = siteIsLocked ? 'Déverrouiller' : 'Verrouiller';
+        deleteButton.hidden = !canDeleteSite;
+        deleteButton.disabled = !canDeleteSite;
+        return latestSite;
+      };
 
       const clearCloseListeners = () => {
         if (overlay.__closeTimerId) {
@@ -1224,6 +1227,7 @@ import { firebaseAuth } from './firebase-core.js';
             overlay.classList.remove('is-open');
             siteActionState.activeSiteId = null;
             siteActionState.closeSheet = null;
+            siteActionState.refreshSheetContent = null;
             if (siteActionState.hasHistoryEntry && !fromPopState) {
               siteActionState.hasHistoryEntry = false;
               siteActionState.ignoreNextPopstate = true;
@@ -1245,7 +1249,13 @@ import { firebaseAuth } from './firebase-core.js';
           overlay.__closeTimerId = window.setTimeout(finish, closeTransitionDurationMs);
         });
 
+      siteActionState.activeSiteId = siteId;
       siteActionState.closeSheet = closeSheet;
+      siteActionState.refreshSheetContent = refreshSiteActionSheetContent;
+      const activeSite = refreshSiteActionSheetContent();
+      if (!activeSite) {
+        return;
+      }
       lockToggleButton.onclick = async () => {
         await closeSheet();
         openSiteLockActionDialog(siteId);
@@ -1715,6 +1725,9 @@ import { firebaseAuth } from './firebase-core.js';
       (sites) => {
         currentSites = sites;
         renderSites();
+        if (siteActionState.activeSiteId && typeof siteActionState.refreshSheetContent === 'function') {
+          siteActionState.refreshSheetContent();
+        }
       },
       () => {
         UiService.showToast('Synchronisation indisponible.');


### PR DESCRIPTION
### Motivation
- Améliorer le comportement du bottom sheet de la page 1 pour afficher ou masquer le bouton `Supprimer` selon l'état de verrouillage du site sans recharger la page.
- Faire en sorte que le libellé du bouton de verrouillage soit toujours synchronisé (`Verrouiller` / `Déverrouiller`).
- Mettre à jour uniquement l'affichage conditionnel du bouton `Supprimer` sans toucher à la logique métier du verrouillage.

### Description
- Ajout de la fonction `refreshSiteActionSheetContent` dans `js/app.js` qui recalcule le titre, le libellé du toggle et la visibilité/`disabled` du bouton `siteActionDeleteButton` à partir du dernier état du site.
- Ajout d'un champ `siteActionState.refreshSheetContent` pour garder une référence au rafraîchissement ciblé du bottom sheet et le nettoyer dans `closeSheet`.
- Remplacement de l'initialisation statique du contenu du sheet par un rendu via `refreshSiteActionSheetContent` lors de l'ouverture du sheet, de sorte que seul le contenu du bottom sheet soit mis à jour et non la page entière.
- Branchement du rafraîchissement sur `StorageService.subscribeSites` pour exécuter `siteActionState.refreshSheetContent()` dès qu'une mise à jour des sites est reçue, garantissant une mise à jour immédiate lorsque le site est verrouillé/déverrouillé.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` qui a réussi.
- Aucune suite de tests unitaires supplémentaire disponible; validation fonctionnelle attendue via intégration en navigateur (mise à jour en temps réel du bottom sheet déclenchée par `StorageService.subscribeSites`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea67ba7a24832ab21febfe90c850af)