### PR TITLE
Corriger l'espacement vertical du modal «Gestion de l’accès sécurisé»

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1233,6 +1233,18 @@ body[data-page="history"] .list-grid {
   line-height: 1.45;
 }
 
+#siteLockManageDialog .input-group {
+  gap: 0;
+}
+
+#siteLockManageDialog .input-group span {
+  margin-bottom: 8px;
+}
+
+#siteLockManageDialog .input-group + .input-group {
+  margin-top: 16px;
+}
+
 .modal-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Corriger précisément l’espacement vertical du modal `Gestion de l’accès sécurisé` sur la page 1 afin de supprimer l’effet « libellé collé au champ » et appliquer des valeurs exactes de `8px` et `16px`.

### Description
- Ajout de règles CSS ciblées dans `css/style.css` sous le sélecteur `#siteLockManageDialog` : `gap: 0`, `#siteLockManageDialog .input-group span { margin-bottom: 8px; }` et `#siteLockManageDialog .input-group + .input-group { margin-top: 16px; }`, sans toucher aux boutons, largeurs de champs ni autres modals.

### Testing
- Exécution et vérification réussies des commandes automatisées `git -C /workspace/Album diff -- css/style.css` et `git -C /workspace/Album status --short` (modifications appliquées et commitées).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6cac7cec832abc78053d2de8726a)