### PR TITLE
Remove close “X” button from “Site verrouillé” modal (page 1)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1253,24 +1253,6 @@ body[data-page="history"] .list-grid {
   margin-bottom: 1rem;
 }
 
-.modal-header .icon-button {
-  width: 2.25rem;
-  height: 2.25rem;
-  background: rgba(31, 42, 55, 0.08);
-  color: var(--text);
-  font-size: 1.4rem;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-
-.modal-header .icon-button:hover,
-.modal-header .icon-button:focus-visible {
-  background: rgba(31, 42, 55, 0.16);
-}
-
 .modal-actions,
 .form-footer {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -138,7 +138,6 @@
         <form class="modal-content" id="siteUnlockForm">
           <div class="modal-header">
             <h2>Site verrouillé</h2>
-            <button type="button" class="icon-button" data-close-dialog aria-label="Fermer">×</button>
           </div>
           <label class="input-group">
             <span>Mot de passe</span>


### PR DESCRIPTION
### Motivation
- Remove the redundant header close button "X" from the `Site verrouillé` modal to simplify the UI and avoid duplication with the existing `Annuler` action.

### Description
- Remove the close button element from `#siteUnlockDialog` in `index.html` and delete the `.modal-header .icon-button` CSS rules (including `:hover`/`:focus-visible`) from `css/style.css`, preserving the bottom `Annuler` button and outside-click closing behavior.

### Testing
- Verified removal and remaining references with `rg -n "siteUnlockDialog|Site verrouillé|data-close-dialog aria-label=\"Fermer\"|modal-header \\.icon-button" index.html css/style.css`, and inspected the diff with `git diff -- index.html css/style.css && git status --short`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6e4f5820832a9efdf9eaab4c4ca9)