### PR TITLE
Désactiver le clic long sur les cards (page 1)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1380,52 +1380,13 @@ import { firebaseAuth } from './firebase-core.js';
         .join('');
 
       siteList.querySelectorAll('[data-site-open]').forEach((button) => {
-        let longPressTimer = null;
-        let skipClickAfterLongPress = false;
         const siteId = button.dataset.siteOpen;
 
-        const clearLongPressTimer = () => {
-          if (!longPressTimer) {
-            return;
-          }
-          window.clearTimeout(longPressTimer);
-          longPressTimer = null;
-        };
-
-        const openLockDialog = () => {
-          openSiteLockActionDialog(siteId);
-        };
-
-        button.addEventListener('pointerdown', (event) => {
-          if (event.button !== 0 || !isAuthenticated) {
-            return;
-          }
-          skipClickAfterLongPress = false;
-          clearLongPressTimer();
-          longPressTimer = window.setTimeout(() => {
-            skipClickAfterLongPress = true;
-            openLockDialog();
-          }, 650);
-        });
-
-        button.addEventListener('pointerup', clearLongPressTimer);
-        button.addEventListener('pointerleave', clearLongPressTimer);
-        button.addEventListener('pointercancel', clearLongPressTimer);
         button.addEventListener('contextmenu', (event) => {
-          if (!isAuthenticated) {
-            return;
-          }
           event.preventDefault();
-          clearLongPressTimer();
-          skipClickAfterLongPress = true;
-          openLockDialog();
         });
 
         button.addEventListener('click', () => {
-          if (skipClickAfterLongPress) {
-            skipClickAfterLongPress = false;
-            return;
-          }
           const targetSite = getLatestSiteState(siteId);
           if (!isSiteLocked(targetSite)) {
             UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);


### PR DESCRIPTION
### Motivation
- Empêcher toute action déclenchée par un clic long sur les cards de la page 1 (sites enregistrés) afin d'éviter des actions cachées ou involontaires. 
- Conserver les interactions normales telles que le clic simple et le bouton « trois points ». 
- Bloquer également le menu contextuel navigateur sur long-press/clic droit sans lancer d'action applicative.

### Description
- Supprimé la logique de long-press dans le bloc gérant les éléments `data-site-open`, en retirant les variables timer (`longPressTimer`, `skipClickAfterLongPress`) et la logique `pointerdown`/`pointerup`/`pointerleave`/`pointercancel` qui ouvrait le dialogue de verrouillage. 
- Modifié le gestionnaire `contextmenu` sur les cards pour appeler uniquement `event.preventDefault()` et ainsi empêcher le menu navigateur sans déclencher d'action interne. 
- Conservé inchangés le comportement du `click` (navigation vers `page2.html` ou ouverture du modal de déverrouillage) et les handlers des boutons `data-site-menu` (trois points / bottom sheet).

### Testing
- Exécuté `rg -n "data-site-open|pointerdown|openSiteLockActionDialog|contextmenu" js/app.js` pour vérifier la suppression de la logique de long-press, et la commande a retourné les résultats attendus. 
- Vérifié l'état Git avec `git -C /workspace/Album status --short`, puis ajouté et validé la modification avec `git -C /workspace/Album commit`, et les commandes ont réussi. 
- Aucune suite de tests unitaires automatique n'a été disponible/exécutée pour ce changement de comportement d'interface utilisateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea70582a5c832ab4d437c8b706ecfd)