### PR TITLE
Uniformiser les headers titrés avec un style premium commun

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,121 @@
   --primary-color: #2e6ce5;
 }
 
+/* Unified premium header system - final overrides */
+.app-header {
+  min-height: var(--header-height);
+  height: var(--header-height);
+  padding: 0.75rem clamp(0.75rem, 2.6vw, 1.1rem);
+  background: linear-gradient(180deg, #66beff 0%, #2f89d8 100%);
+  box-shadow: 0 8px 22px rgba(17, 58, 94, 0.18);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.24);
+}
+
+.app-header--detail {
+  display: grid;
+  grid-template-columns: var(--header-side-width) minmax(0, 1fr) var(--header-side-width);
+  gap: 0.55rem;
+  justify-content: stretch;
+}
+
+.app-header--home {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  gap: 0.55rem;
+}
+
+.app-header__side {
+  min-width: 0;
+  min-height: 100%;
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-header__side--left {
+  justify-content: flex-start;
+}
+
+.app-header__side--right {
+  justify-content: flex-end;
+}
+
+.app-header__center {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-title {
+  width: min(100%, 34rem);
+  min-width: 0;
+}
+
+.header-title h1 {
+  margin: 0;
+  width: 100%;
+  font-size: clamp(1.08rem, 3.7vw, 1.5rem);
+  font-weight: 700;
+  color: #ffffff;
+  text-align: center;
+  line-height: 1.18;
+}
+
+.header-title--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.22rem;
+}
+
+.header-title--stacked h1 {
+  display: block;
+}
+
+.site-detail-subtitle {
+  margin: 0;
+  width: 100%;
+  text-align: center;
+  font-size: clamp(0.8rem, 2.6vw, 0.95rem);
+  font-weight: 500;
+  line-height: 1.2;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.app-header .back-button,
+.app-header .icon-button {
+  width: 2.65rem;
+  height: 2.65rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.app-header--detail .back-button {
+  position: static;
+  transform: none;
+}
+
+body[data-page="home"] #userAvatarButton,
+body[data-page="home"] #openLoginButton,
+body[data-page="home"] .header-menu {
+  position: static;
+  transform: none;
+}
+
+body[data-page="home"] .app-header--home > h1 {
+  width: auto;
+  padding-inline: 0;
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding-block: 0.65rem;
+  }
+}
+
 * {
   box-sizing: border-box;
 }
@@ -2043,6 +2158,139 @@ body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > se
   }
 }
 
+/* Unified premium header system */
+:root {
+  --header-gradient-top: #66beff;
+  --header-gradient-bottom: #2f89d8;
+  --header-shadow: 0 8px 22px rgba(17, 58, 94, 0.18);
+  --header-title-size: clamp(1.08rem, 3.7vw, 1.5rem);
+  --header-subtitle-size: clamp(0.8rem, 2.6vw, 0.95rem);
+}
+
+.app-header {
+  min-height: var(--header-height);
+  height: var(--header-height);
+  padding: 0.75rem clamp(0.75rem, 2.6vw, 1.1rem);
+  background: linear-gradient(180deg, var(--header-gradient-top) 0%, var(--header-gradient-bottom) 100%);
+  box-shadow: var(--header-shadow);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.24);
+  align-items: center;
+}
+
+.app-header--detail {
+  display: grid;
+  grid-template-columns: var(--header-side-width) minmax(0, 1fr) var(--header-side-width);
+  gap: 0.55rem;
+  justify-content: stretch;
+}
+
+.app-header--home {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  gap: 0.55rem;
+}
+
+.app-header__side {
+  min-width: 0;
+  min-height: 100%;
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-header__side--left {
+  justify-content: flex-start;
+}
+
+.app-header__side--right {
+  justify-content: flex-end;
+}
+
+.app-header__center {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-title {
+  width: min(100%, 34rem);
+  min-width: 0;
+}
+
+.header-title h1 {
+  margin: 0;
+  width: 100%;
+  font-size: var(--header-title-size);
+  font-weight: 700;
+  color: #ffffff;
+  text-align: center;
+  line-height: 1.18;
+  text-wrap: balance;
+}
+
+.header-title--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.22rem;
+}
+
+.header-title--stacked h1 {
+  display: block;
+}
+
+.site-detail-subtitle {
+  margin: 0;
+  width: 100%;
+  text-align: center;
+  font-size: var(--header-subtitle-size);
+  font-weight: 500;
+  line-height: 1.2;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.app-header .back-button,
+.app-header .icon-button {
+  width: 2.65rem;
+  height: 2.65rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.app-header--detail .back-button {
+  position: static;
+  transform: none;
+}
+
+body[data-page="home"] #userAvatarButton,
+body[data-page="home"] #openLoginButton,
+body[data-page="home"] .header-menu {
+  position: static;
+  transform: none;
+}
+
+body[data-page="home"] .app-header--home > h1 {
+  width: auto;
+  padding-inline: 0;
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding-block: 0.65rem;
+  }
+
+  .app-header .back-button,
+  .app-header .icon-button,
+  body[data-page="home"] #userAvatarButton,
+  body[data-page="home"] .header-menu__trigger {
+    width: 2.45rem;
+    height: 2.45rem;
+  }
+}
+
 .avatar-button {
   border: 0;
   width: 2.75rem;
@@ -3377,5 +3625,120 @@ body[data-page="site-detail"] .list-separator {
     width: 50px;
     height: 50px;
     font-size: 1.6rem;
+  }
+}
+
+/* Unified premium header system - final overrides */
+.app-header {
+  min-height: var(--header-height);
+  height: var(--header-height);
+  padding: 0.75rem clamp(0.75rem, 2.6vw, 1.1rem);
+  background: linear-gradient(180deg, #66beff 0%, #2f89d8 100%);
+  box-shadow: 0 8px 22px rgba(17, 58, 94, 0.18);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.24);
+}
+
+.app-header--detail {
+  display: grid;
+  grid-template-columns: var(--header-side-width) minmax(0, 1fr) var(--header-side-width);
+  gap: 0.55rem;
+  justify-content: stretch;
+}
+
+.app-header--home {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  gap: 0.55rem;
+}
+
+.app-header__side {
+  min-width: 0;
+  min-height: 100%;
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-header__side--left {
+  justify-content: flex-start;
+}
+
+.app-header__side--right {
+  justify-content: flex-end;
+}
+
+.app-header__center {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-title {
+  width: min(100%, 34rem);
+  min-width: 0;
+}
+
+.header-title h1 {
+  margin: 0;
+  width: 100%;
+  font-size: clamp(1.08rem, 3.7vw, 1.5rem);
+  font-weight: 700;
+  color: #ffffff;
+  text-align: center;
+  line-height: 1.18;
+}
+
+.header-title--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.22rem;
+}
+
+.header-title--stacked h1 {
+  display: block;
+}
+
+.site-detail-subtitle {
+  margin: 0;
+  width: 100%;
+  text-align: center;
+  font-size: clamp(0.8rem, 2.6vw, 0.95rem);
+  font-weight: 500;
+  line-height: 1.2;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.app-header .back-button,
+.app-header .icon-button {
+  width: 2.65rem;
+  height: 2.65rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.app-header--detail .back-button {
+  position: static;
+  transform: none;
+}
+
+body[data-page="home"] #userAvatarButton,
+body[data-page="home"] #openLoginButton,
+body[data-page="home"] .header-menu {
+  position: static;
+  transform: none;
+}
+
+body[data-page="home"] .app-header--home > h1 {
+  width: auto;
+  padding-inline: 0;
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding-block: 0.65rem;
   }
 }

--- a/historiques.html
+++ b/historiques.html
@@ -9,8 +9,13 @@
   <body data-page="history">
     <div class="app-shell">
       <header class="app-header app-header--detail">
-        <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
-        <div class="header-title"><h1>Historiques</h1></div>
+        <div class="app-header__side app-header__side--left">
+          <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
+        </div>
+        <div class="app-header__center">
+          <div class="header-title"><h1>Historiques</h1></div>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
       </header>
 
       <main class="page-content page-content--history">

--- a/index.html
+++ b/index.html
@@ -10,33 +10,41 @@
   <body data-page="home">
     <div class="app-shell">
       <header class="app-header app-header--home">
-        <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>U</button>
-        <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
-        <h1>Suivi Matériel</h1>
-        <div class="header-menu">
-          <button
-            id="homeMenuButton"
-            class="icon-button header-menu__trigger"
-            type="button"
-            aria-label="Plus d'options"
-            aria-haspopup="menu"
-            aria-expanded="false"
-          >
-            <img src="Icon/Trois point.png" alt="" aria-hidden="true" class="header-menu__icon" />
-          </button>
-          <div id="homeMenuPanel" class="header-menu__panel" role="menu" hidden>
-            <button id="historyButton" class="header-menu__option" type="button" role="menuitem">
-              Historiques
+        <div class="app-header__side app-header__side--left">
+          <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>U</button>
+          <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
+        </div>
+        <div class="app-header__center">
+          <div class="header-title">
+            <h1>Suivi Matériel</h1>
+          </div>
+        </div>
+        <div class="app-header__side app-header__side--right">
+          <div class="header-menu">
+            <button
+              id="homeMenuButton"
+              class="icon-button header-menu__trigger"
+              type="button"
+              aria-label="Plus d'options"
+              aria-haspopup="menu"
+              aria-expanded="false"
+            >
+              <img src="Icon/Trois point.png" alt="" aria-hidden="true" class="header-menu__icon" />
             </button>
-            <button id="importDataButton" class="header-menu__option" type="button" role="menuitem">
-              Importer les données
-            </button>
-            <button id="exportDataButton" class="header-menu__option" type="button" role="menuitem">
-              Exporter les données
-            </button>
-            <button id="manageUsersButton" class="header-menu__option" type="button" role="menuitem" hidden>
-              Gestion des utilisateurs
-            </button>
+            <div id="homeMenuPanel" class="header-menu__panel" role="menu" hidden>
+              <button id="historyButton" class="header-menu__option" type="button" role="menuitem">
+                Historiques
+              </button>
+              <button id="importDataButton" class="header-menu__option" type="button" role="menuitem">
+                Importer les données
+              </button>
+              <button id="exportDataButton" class="header-menu__option" type="button" role="menuitem">
+                Exporter les données
+              </button>
+              <button id="manageUsersButton" class="header-menu__option" type="button" role="menuitem" hidden>
+                Gestion des utilisateurs
+              </button>
+            </div>
           </div>
         </div>
       </header>

--- a/page2.html
+++ b/page2.html
@@ -9,16 +9,16 @@
   <body data-page="site-detail">
     <div class="app-shell">
       <header class="app-header app-header--detail">
-        <div class="detail-header__side detail-header__side--left">
+        <div class="app-header__side app-header__side--left">
           <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
         </div>
-        <div class="detail-header__center">
+        <div class="app-header__center">
           <div class="header-title header-title--stacked">
             <h1 id="siteTitle">Chargement...</h1>
             <p id="itemCount" class="site-detail-subtitle">0 OUTS</p>
           </div>
         </div>
-        <div class="detail-header__side detail-header__side--right" aria-hidden="true"></div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
       </header>
 
       <main class="page-content">

--- a/page3.html
+++ b/page3.html
@@ -40,10 +40,15 @@
   <body data-page="item-detail">
     <div class="app-shell app-shell--wide">
       <header class="app-header app-header--detail">
-        <button class="back-button" type="button" id="itemBackButton" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
-        <div class="header-title header-title--stacked">
-          <h1 id="itemTitle">Chargement...</h1>
+        <div class="app-header__side app-header__side--left">
+          <button class="back-button" type="button" id="itemBackButton" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
         </div>
+        <div class="app-header__center">
+          <div class="header-title header-title--stacked">
+            <h1 id="itemTitle">Chargement...</h1>
+          </div>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
       </header>
 
       <main class="page-content page-content--wide">

--- a/users.html
+++ b/users.html
@@ -117,8 +117,13 @@
   <body data-page="users-management">
     <div class="app-shell app-shell--wide">
       <header class="app-header app-header--detail">
-        <button id="usersBackButton" class="back-button" type="button" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
-        <div class="header-title"><h1>Gestion Admin</h1></div>
+        <div class="app-header__side app-header__side--left">
+          <button id="usersBackButton" class="back-button" type="button" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
+        </div>
+        <div class="app-header__center">
+          <div class="header-title"><h1>Gestion Admin</h1></div>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
       </header>
       <main class="page-content page-content--wide">
         <section class="surface-card details-card">


### PR DESCRIPTION
### Motivation
- Rendre visuellement cohérents tous les headers qui contiennent un titre afin d'obtenir un rendu mobile professionnel, moderne et premium sans toucher à la logique métier ou au contenu.
- Supprimer l'effet « plat » actuel en introduisant une profondeur discrète (dégradé et ombre) et une hauteur/espacement uniformisés.

### Description
- Réorganisation HTML des headers sur les pages concernées (`index.html`, `page2.html`, `page3.html`, `users.html`, `historiques.html`) en une structure commune gauche / centre / droite (`app-header__side`, `app-header__center`) sans modifier les IDs ou les actions existantes.
- Ajout de styles centralisés à la fin de `css/style.css` qui imposent un gradient bleu vertical discret, une ombre légère de séparation, hauteur et padding unifiés, styles de titre et sous-titre cohérents, et dimensions/alignements homogènes pour les boutons retour et actions.
- Les modifications sont purement visuelles et conçues pour préserver entièrement le comportement JavaScript et les contenus textuels existants.

### Testing
- Exécution de la vérification de diff (`git diff --check`) qui a réussi.
- Recherches automatisées par motif (`rg`) pour valider que les headers ont été migrés vers la nouvelle structure, toutes réussies.
- Vérification d'état du dépôt (`git status --short`) pour confirmer les fichiers modifiés, opération réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea73d163cc832a8f84e9219dbb7879)