### PR TITLE
Retire l’icône et ajuste l’espacement du bouton Exporter (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2906,7 +2906,7 @@ body[data-page="site-detail"] #openCreateItem {
   position: fixed;
   right: 20px;
   left: auto;
-  bottom: calc(110px + env(safe-area-inset-bottom, 0px));
+  bottom: calc(88px + env(safe-area-inset-bottom, 0px));
   width: 56px;
   height: 56px;
   border-radius: 50%;
@@ -3621,7 +3621,7 @@ body[data-page="site-detail"] .list-separator {
   body[data-page="site-detail"] .fab-add,
   body[data-page="site-detail"] #openCreateItem {
     right: 0.72rem;
-    bottom: calc(4.1rem + env(safe-area-inset-bottom, 0px));
+    bottom: calc(4.9rem + env(safe-area-inset-bottom, 0px));
     width: 50px;
     height: 50px;
     font-size: 1.6rem;

--- a/page2.html
+++ b/page2.html
@@ -53,7 +53,6 @@
       </main>
 
       <button type="button" id="openExportItems" class="fab fab--export" aria-label="Exporter">
-        <img src="Icon/Exporter.png" alt="" aria-hidden="true" class="icon" />
         <span>Exporter</span>
       </button>
       <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>


### PR DESCRIPTION
### Motivation
- Améliorer l’espacement vertical entre les boutons flottants sur la page 2 et simplifier le bouton “Exporter” pour un rendu mobile propre sans changer son style ou sa logique.
- Conserver l’alignement à droite et l’apparence visuelle actuelle tout en garantissant un espacement cohérent entre `+` et `Exporter` (≈22px sur desktop).

### Description
- Suppression de l’élément `<img>` dans le bouton `#openExportItems` de `page2.html` pour n’afficher que le texte `Exporter`.
- Ajustement du positionnement du bouton `#openCreateItem` dans `css/style.css` pour desktop en changeant `bottom: calc(110px + env(...))` à `bottom: calc(88px + env(...))` afin d’augmenter l’écart vertical.
- Ajustement responsive en mobile en passant `bottom: calc(4.1rem + env(...))` à `bottom: calc(4.9rem + env(...))` pour maintenir un espacement propre sur petits écrans.
- Modifications limitées à la page 2 (`body[data-page="site-detail"]`) et aux sélecteurs concernés, sans changement de couleur, taille, forme ni logique des boutons.

### Testing
- Local recherche des occurrences avec `rg -n "Exporter|\+" -S .` pour vérifier la portée des modifications, et cette recherche a renvoyé les fichiers ciblés.
- Vérification du diff avec `git diff -- page2.html css/style.css` et inspection des fichiers modifiés; la diff reflète uniquement la suppression de l’icône et les ajustements `bottom` et a réussi.
- Commit et validation de l’état du HEAD via `git show --stat --oneline HEAD` ont été exécutés avec succès et confirment les modifications appliquées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea77d824e8832a901d42d63c0a3f0f)