### PR TITLE
Remove mobile/desktop-specific responsive logic for a unified UI

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -97,6 +97,3 @@ body {
 .btn.is-loading .btn__loader { display: inline-block; }
 .btn.is-loading .btn__label { opacity: .7; }
 @keyframes spin { to { transform: rotate(360deg);} }
-@media (max-width: 480px) {
-  .login-card { padding: 1rem; border-radius: 1rem; }
-}

--- a/css/style.css
+++ b/css/style.css
@@ -127,12 +127,6 @@ body[data-page="home"] .app-header--home > h1 {
   padding-inline: 0;
 }
 
-@media (max-width: 600px) {
-  .app-header {
-    padding-block: 0.65rem;
-  }
-}
-
 * {
   box-sizing: border-box;
 }
@@ -355,21 +349,6 @@ button {
   font-size: 0.85em;
   opacity: 0.95;
   font-weight: 500;
-}
-
-@media (max-width: 600px) {
-  :root {
-    --header-height: 5.25rem;
-    --header-side-width: 2.75rem;
-  }
-
-  .app-header {
-    padding: 0.65rem 0.85rem;
-  }
-
-  .app-header--detail .back-button {
-    left: 0.85rem;
-  }
 }
 
 .back-button .btn-retour {
@@ -2092,72 +2071,6 @@ body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > se
   padding: 0.25rem 0.35rem;
 }
 
-@media (min-width: 768px) {
-  .page-content {
-    padding: 1.5rem 1.5rem 7rem;
-  }
-
-  .list-grid {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  }
-
-  body[data-page="history"] .list-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .responsive-form {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 767px) {
-  .app-header {
-    flex-wrap: wrap;
-  }
-
-  body[data-page="home"] .app-header {
-    flex-wrap: nowrap;
-  }
-
-  body[data-page="users-management"] .app-header--detail {
-    justify-content: center;
-    gap: 0.55rem 0.8rem;
-  }
-
-  body[data-page="users-management"] .app-header--detail .back-button {
-    order: 0;
-  }
-
-  body[data-page="users-management"] .app-header--detail h1 {
-    width: 100%;
-    text-align: center;
-    font-size: clamp(1.22rem, 6vw, 1.5rem);
-  }
-
-  body[data-page="users-management"] .surface-card {
-    padding: 0.9rem;
-  }
-
-  body[data-page="users-management"] .pending-user-card {
-    align-items: stretch;
-  }
-
-  body[data-page="users-management"] .pending-user-card__actions {
-    width: 100%;
-    margin-left: 0;
-    justify-content: stretch;
-  }
-
-  body[data-page="users-management"] .pending-user-card__actions .btn {
-    flex: 1 1 8.5rem;
-    min-width: 0;
-  }
-
-  body[data-page="users-management"] .table-wrapper--users .data-table {
-    min-width: 48rem;
-  }
-}
-
 /* Unified premium header system */
 :root {
   --header-gradient-top: #66beff;
@@ -2275,20 +2188,6 @@ body[data-page="home"] .header-menu {
 body[data-page="home"] .app-header--home > h1 {
   width: auto;
   padding-inline: 0;
-}
-
-@media (max-width: 600px) {
-  .app-header {
-    padding-block: 0.65rem;
-  }
-
-  .app-header .back-button,
-  .app-header .icon-button,
-  body[data-page="home"] #userAvatarButton,
-  body[data-page="home"] .header-menu__trigger {
-    width: 2.45rem;
-    height: 2.45rem;
-  }
 }
 
 .avatar-button {
@@ -3519,115 +3418,6 @@ body[data-page="site-detail"] .list-separator {
   margin-inline: auto;
 }
 
-@media (min-width: 1024px) {
-  body[data-page="home"] .page-content {
-    width: min(100%, 1360px);
-    margin-inline: auto;
-    padding-inline: clamp(1.25rem, 2.5vw, 2.5rem);
-  }
-
-  body[data-page="home"] .search-panel,
-  body[data-page="home"] .section-heading--sticky,
-  body[data-page="home"] .list-grid {
-    width: min(100%, 1240px);
-  }
-}
-
-@media (max-width: 900px) {
-  body[data-page="site-detail"] .filter-chip-group {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    scrollbar-width: thin;
-    padding-bottom: 0.2rem;
-  }
-}
-
-@media (max-width: 767px) {
-  .app-header {
-    padding-inline: 0.7rem;
-  }
-
-  body[data-page="home"] .app-header--home {
-    min-height: var(--header-height);
-    height: var(--header-height);
-    padding-block: 0.6rem;
-  }
-
-  body[data-page="home"] .app-header--home > h1 {
-    font-size: clamp(1.05rem, 5.1vw, 1.3rem);
-    padding-inline: clamp(2.3rem, 13vw, 4.8rem);
-    white-space: normal;
-  }
-
-  body[data-page="home"] #openLoginButton {
-    font-size: 0.8rem;
-    padding: 0.46rem 0.7rem;
-    max-width: min(43vw, 9.3rem);
-  }
-
-  body[data-page="home"] #userAvatarButton,
-  body[data-page="home"] .header-menu__trigger {
-    width: 2.45rem;
-    height: 2.45rem;
-  }
-
-  body[data-page="home"] .page-content {
-    padding: 0.8rem 0.72rem 6.1rem;
-    gap: 0.65rem;
-  }
-
-  body[data-page="home"] .section-heading--sticky {
-    padding: 0.5rem 0.68rem;
-  }
-
-  body[data-page="home"] .list-card__lock-icon {
-    right: 0.7rem;
-    bottom: 0.75rem;
-    width: 1.2rem;
-    height: 1.2rem;
-  }
-
-  body[data-page="site-detail"] .app-header--detail {
-    --detail-side-size: 2.5rem;
-    min-height: var(--header-height);
-    height: var(--header-height);
-    padding-block: 0.6rem;
-  }
-
-  body[data-page="site-detail"] .filter-chip {
-    padding: 0.42rem 0.74rem;
-    font-size: 0.8rem;
-  }
-
-  body[data-page="site-detail"] .list-separator__label {
-    font-size: 0.76rem;
-  }
-
-  body[data-page="site-detail"] .fab--export {
-    right: 0.72rem;
-    bottom: calc(0.7rem + env(safe-area-inset-bottom, 0px));
-    min-width: 7.8rem;
-    height: 2.8rem;
-    padding-inline: 0.8rem;
-    font-size: 0.88rem;
-    gap: 0.4rem;
-  }
-
-  body[data-page="site-detail"] .fab--export img {
-    width: 16px;
-    height: 16px;
-  }
-
-  body[data-page="site-detail"] .fab-add,
-  body[data-page="site-detail"] #openCreateItem {
-    right: 0.72rem;
-    bottom: calc(4.9rem + env(safe-area-inset-bottom, 0px));
-    width: 50px;
-    height: 50px;
-    font-size: 1.6rem;
-  }
-}
-
 /* Unified premium header system - final overrides */
 .app-header {
   min-height: var(--header-height);
@@ -3737,8 +3527,3 @@ body[data-page="home"] .app-header--home > h1 {
   padding-inline: 0;
 }
 
-@media (max-width: 600px) {
-  .app-header {
-    padding-block: 0.65rem;
-  }
-}

--- a/js/login.js
+++ b/js/login.js
@@ -13,19 +13,6 @@ const auth = firebaseAuth;
 const provider = new GoogleAuthProvider();
 provider.setCustomParameters({ prompt: 'select_account' });
 
-function isMobileDevice() {
-  if (navigator.userAgentData?.mobile) {
-    return true;
-  }
-
-  const touchDevice = window.matchMedia('(pointer: coarse)').matches;
-  const smallViewport = window.matchMedia('(max-width: 900px)').matches;
-  const userAgent = navigator.userAgent.toLowerCase();
-  const isMobileUserAgent = /android|iphone|ipad|ipod|mobile/.test(userAgent);
-
-  return isMobileUserAgent || (touchDevice && smallViewport);
-}
-
 function isInAppBrowser() {
   return /FBAN|FBAV|Instagram|Messenger|WhatsApp/i.test(navigator.userAgent);
 }

--- a/users.html
+++ b/users.html
@@ -99,20 +99,7 @@
         text-align: center;
       }
 
-      @media (max-width: 920px) {
-        body[data-page='users-management'] .page-content.page-content--wide {
-          grid-template-rows: auto minmax(0, 1fr);
-        }
-
-        body[data-page='users-management'] .maintenance-card-header {
-          align-items: flex-start;
-        }
-
-        body[data-page='users-management'] .maintenance-toggle-row {
-          margin-left: 0;
-        }
-      }
-    </style>
+      </style>
   </head>
   <body data-page="users-management">
     <div class="app-shell app-shell--wide">


### PR DESCRIPTION
### Motivation
- Enforce a single, identical UI across mobile and desktop by removing any CSS/JS branching based on viewport or device.
- Eliminate media-query driven layout changes and user-agent / matchMedia checks so styling and behavior follow one fixed path.

### Description
- Removed `@media` breakpoint blocks from `css/style.css` so layout/styling no longer diverges by screen size.  
- Removed the mobile breakpoint block from `css/login.css` to keep the login card styling identical on all devices.  
- Removed the inline media query block from `users.html` to avoid device-specific changes inside that page.  
- Removed unused device detection logic (`isMobileDevice`) from `js/login.js` so no JavaScript behavior is conditional on mobile/desktop.

### Testing
- Ran `node --check js/login.js` and it completed successfully.  
- Searched for remaining responsive/device-specific tokens with `rg -n "@media|matchMedia|\(max-width:|\(min-width:" css/login.css css/style.css users.html js/login.js` and found no matches.  
- The automated checks above passed, confirming removal of media queries and device-detection logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7a4d2e7c832a8c7caef6656b0a51)