### PR TITLE
Affiner l'apparence du bouton «Exporter» (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2770,17 +2770,19 @@ body[data-page="site-detail"] .fab--export {
   right: 1rem;
   bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   width: auto;
-  min-width: 8.8rem;
-  height: 3.1rem;
-  border-radius: 999px;
-  background: #18a85f;
+  min-width: 7rem;
+  height: 2.35rem;
+  border-radius: 12px;
+  background: rgba(24, 168, 95, 0.95);
   color: #fff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.55rem;
-  padding-inline: 1rem;
-  box-shadow: 0 14px 28px rgba(8, 112, 62, 0.3);
+  gap: 0.4rem;
+  padding-inline: 0.8rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-shadow: 0 8px 16px rgba(8, 112, 62, 0.2);
   z-index: 40;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
@@ -2792,8 +2794,8 @@ body[data-page="site-detail"] .fab--export img {
 }
 
 body[data-page="site-detail"] .fab--export:hover {
-  background: #159154;
-  box-shadow: 0 16px 30px rgba(8, 112, 62, 0.35);
+  background: rgba(21, 145, 84, 0.95);
+  box-shadow: 0 10px 18px rgba(8, 112, 62, 0.24);
 }
 
 body[data-page="site-detail"] .fab--export:active {


### PR DESCRIPTION
### Motivation
- Rendre le bouton `Exporter` sur la page 2 (`data-page="site-detail"`) plus discret et professionnel tout en conservant la hiérarchie visuelle avec le bouton `+`.

### Description
- Ajusté uniquement le style CSS du sélecteur `body[data-page="site-detail"] .fab--export` dans `css/style.css`: réduit `min-width`, `height` et `padding-inline`, diminué la `border-radius` à `12px`, réduit l'espacement interne (`gap`), ajouté `font-size: 0.875rem` et `font-weight: 600`, appliqué une couleur verte avec légère transparence (`rgba(...)`) et adouci le `box-shadow` ainsi que l'état `:hover`.

### Testing
- Exécuté `git diff --check` (OK) et réalisé un commit; aucune modification de la logique JavaScript ni des autres pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7c83e244832aafef17d44746c306)