### PR TITLE
Bouton « Exporter » (page 2) : style secondaire outline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2771,20 +2771,21 @@ body[data-page="site-detail"] .fab--export {
   bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   width: auto;
   min-width: 7rem;
-  height: 2.35rem;
-  border-radius: 12px;
-  background: rgba(24, 168, 95, 0.95);
-  color: #fff;
+  height: 2.25rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #18a85f;
+  border: 1.5px solid #18a85f;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  padding-inline: 0.8rem;
-  font-size: 0.875rem;
+  padding-inline: 0.95rem;
+  font-size: 0.84rem;
   font-weight: 600;
-  box-shadow: 0 8px 16px rgba(8, 112, 62, 0.2);
+  box-shadow: 0 4px 10px rgba(8, 112, 62, 0.08);
   z-index: 40;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
 }
 
 body[data-page="site-detail"] .fab--export img {
@@ -2794,12 +2795,13 @@ body[data-page="site-detail"] .fab--export img {
 }
 
 body[data-page="site-detail"] .fab--export:hover {
-  background: rgba(21, 145, 84, 0.95);
-  box-shadow: 0 10px 18px rgba(8, 112, 62, 0.24);
+  background: rgba(24, 168, 95, 0.12);
+  box-shadow: 0 6px 12px rgba(8, 112, 62, 0.12);
 }
 
 body[data-page="site-detail"] .fab--export:active {
-  transform: scale(0.95);
+  background: rgba(24, 168, 95, 0.18);
+  transform: scale(0.97);
 }
 
 body[data-page="site-detail"] .fab-add,
@@ -3528,4 +3530,3 @@ body[data-page="home"] .app-header--home > h1 {
   width: auto;
   padding-inline: 0;
 }
-


### PR DESCRIPTION
### Motivation
- Rendre le bouton « Exporter » sur la page 2 plus discret et premium pour clarifier la hiérarchie visuelle (le « + » reste l’action principale). 

### Description
- Remplacement du fond vert plein par un fond blanc/translucide et ajout d’une bordure verte `1.5px` avec texte en vert en ciblant `body[data-page="site-detail"] .fab--export` dans `css/style.css`. 
- Ajustement des dimensions et du rendu : `height: 2.25rem`, `padding-inline: 0.95rem`, `font-size: 0.84rem` et `border-radius: 22px` pour un profil plus fin et arrondi. 
- Ombre fortement réduite et interactions mises à jour : `:hover` utilise `background: rgba(24,168,95,0.12)` et `:active` utilise `background: rgba(24,168,95,0.18)` avec `transform: scale(0.97)`. 
- La position (bas droite), l’espacement avec le bouton « + », la logique JavaScript et les autres pages n’ont pas été modifiés. 

### Testing
- J’ai vérifié que les règles CSS modifiées apparaissent bien en recherchant `.fab--export` avec `rg` et en inspectant les lignes modifiées de `css/style.css` via `sed`/`nl`. 
- J’ai confirmé que les sélecteurs `:hover` et `:active` pour `body[data-page="site-detail"] .fab--export` sont présents et correspondent au comportement demandé. 
- Il n’existe pas de tests unitaires automatisés pour le style; toutes les vérifications automatisées réalisées en CLI se sont déroulées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7ff9aa38832abbc9f50aa2129346)