### PR TITLE
Ajouter un card d'information de connexion sur les pages 1, 2 et 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -127,6 +127,21 @@ body[data-page="home"] .app-header--home > h1 {
   padding-inline: 0;
 }
 
+@media (max-width: 560px) {
+  .auth-required-card {
+    gap: 0.55rem;
+    padding: 0.62rem 0.68rem;
+  }
+
+  .auth-required-card__message {
+    font-size: 0.86rem;
+  }
+
+  .auth-required-card__action {
+    font-size: 0.82rem;
+  }
+}
+
 * {
   box-sizing: border-box;
 }
@@ -1516,6 +1531,72 @@ body[data-page="home"] .modal-actions--password:not(.modal-actions--password-man
 
 .search-panel--inline {
   padding-inline: 0;
+}
+
+.auth-required-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.68rem 0.82rem;
+  margin: 0;
+  border-radius: 14px;
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  min-height: 3.1rem;
+}
+
+.auth-required-card[hidden] {
+  display: none !important;
+}
+
+.auth-required-card--embedded {
+  margin-top: 0.7rem;
+  margin-bottom: 0.15rem;
+}
+
+.auth-required-card__icon {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  background: #3b82f6;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.auth-required-card__message {
+  margin: 0;
+  color: #1e3a8a;
+  font-size: 0.92rem;
+  line-height: 1.35;
+  font-weight: 500;
+}
+
+.auth-required-card__action {
+  border: 0;
+  background: transparent;
+  color: #2563eb;
+  font-weight: 700;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.2rem;
+  padding: 0.2rem 0;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.auth-required-card__action:hover,
+.auth-required-card__action:focus-visible {
+  text-decoration: underline;
 }
 
 .section-heading--table {

--- a/index.html
+++ b/index.html
@@ -60,6 +60,15 @@
           </label>
         </section>
 
+        <section class="auth-required-card section" data-auth-required-card hidden>
+          <span class="auth-required-card__icon" aria-hidden="true">i</span>
+          <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>
+          <button type="button" class="auth-required-card__action" data-auth-login-action>
+            <span>Se connecter</span>
+            <span aria-hidden="true">›</span>
+          </button>
+        </section>
+
         <section class="section-heading section-heading--sticky section-heading--saved">
           <div class="saved-sites-label">
             <img src="Icon/Site.png" alt="" aria-hidden="true" class="saved-sites-label__icon" />

--- a/js/app.js
+++ b/js/app.js
@@ -330,6 +330,33 @@ import { firebaseAuth } from './firebase-core.js';
     }
   }
 
+  function initAuthRequiredNoticeCard() {
+    const cards = Array.from(document.querySelectorAll('[data-auth-required-card]'));
+    if (!cards.length) {
+      return;
+    }
+
+    const loginActions = Array.from(document.querySelectorAll('[data-auth-login-action]'));
+    const updateCardVisibility = (user) => {
+      const isAuthenticated = Boolean(user?.uid);
+      cards.forEach((card) => {
+        card.hidden = isAuthenticated;
+        card.style.display = isAuthenticated ? 'none' : '';
+      });
+    };
+
+    loginActions.forEach((actionButton) => {
+      actionButton.addEventListener('click', () => {
+        UiService.navigate('login.html');
+      });
+    });
+
+    updateCardVisibility(firebaseAuth.currentUser);
+    onAuthStateChanged(firebaseAuth, (user) => {
+      updateCardVisibility(user || null);
+    });
+  }
+
   function setHomeAccessControlVisibility({ showAvatar, showLoginButton }) {
     const avatarButton = document.getElementById('userAvatarButton');
     const loginButton = document.getElementById('openLoginButton');
@@ -806,6 +833,8 @@ import { firebaseAuth } from './firebase-core.js';
   }
 
   function initHomePage(permissions, authState) {
+    initAuthRequiredNoticeCard();
+
     const searchInput = requireElement('searchInput');
     const siteList = requireElement('siteList');
     const siteCount = requireElement('siteCount');
@@ -1718,6 +1747,8 @@ import { firebaseAuth } from './firebase-core.js';
   }
 
   function initSiteDetailPage(permissions) {
+    initAuthRequiredNoticeCard();
+
     const params = UiService.getQueryParams();
     const siteId = params.get('siteId');
     if (!siteId) {
@@ -2324,6 +2355,8 @@ import { firebaseAuth } from './firebase-core.js';
   }
 
   function initItemDetailPage(permissions) {
+    initAuthRequiredNoticeCard();
+
     const params = UiService.getQueryParams();
     const siteId = params.get('siteId');
     const itemId = params.get('itemId');

--- a/page2.html
+++ b/page2.html
@@ -34,6 +34,14 @@
               autocomplete="off"
             />
           </label>
+          <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>
+            <span class="auth-required-card__icon" aria-hidden="true">i</span>
+            <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>
+            <button type="button" class="auth-required-card__action" data-auth-login-action>
+              <span>Se connecter</span>
+              <span aria-hidden="true">›</span>
+            </button>
+          </section>
           <div class="filter-chip-group filters" role="group" aria-label="Filtrer les résultats par date">
             <button class="filter-chip" type="button" data-filter-chip="all">Tous</button>
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>

--- a/page3.html
+++ b/page3.html
@@ -68,6 +68,14 @@
               <input id="detailSearchInput" class="search-input" type="text" placeholder="Entrer votre recherche..." autocomplete="off" />
             </label>
           </div>
+          <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>
+            <span class="auth-required-card__icon" aria-hidden="true">i</span>
+            <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>
+            <button type="button" class="auth-required-card__action" data-auth-login-action>
+              <span>Se connecter</span>
+              <span aria-hidden="true">›</span>
+            </button>
+          </section>
           <div class="table-container table-container--card" id="detailTableContainer">
             <div class="table-wrapper table-wrapper--shared" id="detailTableWrapper">
               <table class="data-table" id="detailDataTable">


### PR DESCRIPTION
### Motivation
- Informer clairement les utilisateurs non authentifiés qu'ils doivent se connecter pour modifier les données et uniformiser cet affichage sur les pages 1, 2 et 3.
- Préserver l'expérience mobile et le rendu visuel cohérent entre les trois pages sans toucher à la logique d'authentification ou aux droits existants.

### Description
- Ajout d'un composant HTML réutilisable (section `data-auth-required-card`) dans `index.html`, `page2.html` et `page3.html` placé aux emplacements demandés (sous la recherche / avant les sections ciblées). 
- Ajout de styles partagés dans `css/style.css` pour correspondre au design demandé (fond bleu clair, bordure bleue, coins arrondis, icône ronde, texte bleu foncé, bouton "Se connecter" avec flèche, responsive mobile).
- Implémentation d'une logique légère dans `js/app.js` (`initAuthRequiredNoticeCard`) qui attache l'action existante de connexion (`UiService.navigate('login.html')`) et qui montre/masque dynamiquement le card en s'abonnant à `onAuthStateChanged(firebaseAuth, ...)` et en lisant `firebaseAuth.currentUser`.
- Activation de cette initialisation dans les routines de démarrage des pages concernées via `initAuthRequiredNoticeCard()` appelée depuis `initHomePage`, `initSiteDetailPage` et `initItemDetailPage`.

### Testing
- Vérification de syntaxe JS avec `node --check js/app.js` exécutée et réussie.
- Aucune suite de tests automatisés additionnelle existante n'a été modifiée ou exécutée pour cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9b0ee4a8832aa99bf9d3acd1842d)