### PR TITLE
Espacement sous le card d'information sur la page 3 (margin-bottom 20px)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1811,6 +1811,10 @@ body[data-page="item-detail"] .app-header--detail {
   height: var(--header-height);
 }
 
+body[data-page="item-detail"] .auth-required-card--embedded {
+  margin-bottom: 20px;
+}
+
 body[data-page="item-detail"] .table-container input,
 body[data-page="item-detail"] .table-container select,
 body[data-page="item-detail"] .table-container button,


### PR DESCRIPTION
### Motivation
- Corriger l'espace visuel insuffisant entre le card d'information (bloc bleu avec l'icône "i") et le tableau uniquement sur la page 3 (détaillée). 

### Description
- Ajout d'une règle CSS ciblée `body[data-page="item-detail"] .auth-required-card--embedded { margin-bottom: 20px; }` dans `css/style.css` pour créer l'espace sous le card. 
- Le changement est scoped à la page 3 grâce au sélecteur `body[data-page="item-detail"]` et n'affecte pas les pages 1 et 2. 
- Aucun margin-top n'a été ajouté au tableau et aucun autre élément ou contenu n'a été modifié.

### Testing
- Vérification automatisée que la règle existe dans `css/style.css` et que le sélecteur est bien `body[data-page="item-detail"] .auth-required-card--embedded`, réussie via recherche dans les fichiers (`rg`).
- Inspection du diff pour confirmer que seule la feuille `css/style.css` a été modifiée, réussie.
- Aucune suite de tests automatisée n'est configurée pour ce changement CSS; aucune erreur automatique détectée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9e442168832a8d716795b66f72cd)