### PR TITLE
Raise 'Exporter' FAB vertical offset on page 2 (site-detail)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2853,7 +2853,7 @@ body[data-page="site-detail"] .list-card__meta-item--article {
 body[data-page="site-detail"] .fab--export {
   position: fixed;
   right: 1rem;
-  bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+  bottom: calc(38px + env(safe-area-inset-bottom, 0px));
   width: auto;
   min-width: 7rem;
   height: 2.25rem;


### PR DESCRIPTION
### Motivation
- Ensure the floating "Exporter" button on page 2 (`data-page="site-detail"`) is visually separated from the primary "+" FAB and avoids overlap while preserving the right alignment and visual hierarchy.
- The change targets only vertical positioning to produce a clean, professional mobile/desktop render without altering size, style, or behavior.

### Description
- Updated the `bottom` offset for the `body[data-page="site-detail"] .fab--export` rule from `calc(1rem + env(safe-area-inset-bottom, 0px))` to `calc(38px + env(safe-area-inset-bottom, 0px))` in `css/style.css` to raise the Exporter button.
- The change is scoped to the `site-detail` page selector and only touches the vertical position; horizontal alignment, dimensions, colors, shadows, outline, and click behavior were left unchanged.
- The primary "+" button (`.fab-add` / `#openCreateItem`) was not modified, preserving its visual priority above the Exporter button.

### Testing
- Inspected the modified CSS region with `nl -ba css/style.css | sed -n '2848,2870p'` to confirm the `bottom` value was updated and scoped correctly, and the change was present only on `body[data-page="site-detail"] .fab--export`.
- Ran repository file search (`rg`) to verify selectors and ensure no other pages/selectors were altered; checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba1c67cf8832a8d437bcd1d4bfec8)