### PR TITLE
Augmenter l'espacement vertical entre '+' et 'Exporter' (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2853,7 +2853,7 @@ body[data-page="site-detail"] .list-card__meta-item--article {
 body[data-page="site-detail"] .fab--export {
   position: fixed;
   right: 1rem;
-  bottom: calc(38px + env(safe-area-inset-bottom, 0px));
+  bottom: calc(30px + env(safe-area-inset-bottom, 0px));
   width: auto;
   min-width: 7rem;
   height: 2.25rem;


### PR DESCRIPTION
### Motivation
- Augmenter l'espace visuel entre le bouton flottant `+` et le bouton `Exporter` sur la page 2 (`site-detail`) pour un rendu plus aéré sans modifier le positionnement horizontal, les tailles, les couleurs ou le style d'outline.

### Description
- Dans `css/style.css` j'ai modifié la règle `body[data-page="site-detail"] .fab--export` en passant `bottom` de `calc(38px + env(safe-area-inset-bottom, 0px))` à `calc(30px + env(safe-area-inset-bottom, 0px))`, ce qui augmente l'espace vertical entre les deux boutons et ne touche à rien d'autre.

### Testing
- Exécuté `git diff --check` qui n'a retourné aucune erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba396bd80832a9f9661cef45786fd)