### PR TITLE
Animate page 2 Export button while scrolling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2870,13 +2870,43 @@ body[data-page="site-detail"] .fab--export {
   font-weight: 600;
   box-shadow: 0 4px 10px rgba(8, 112, 62, 0.08);
   z-index: 40;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  overflow: hidden;
+  transition:
+    width 0.25s ease,
+    transform 0.25s ease,
+    box-shadow 0.25s ease,
+    background-color 0.25s ease,
+    border-color 0.25s ease,
+    padding-inline 0.25s ease;
 }
 
-body[data-page="site-detail"] .fab--export img {
+body[data-page="site-detail"] .fab--export__icon {
   width: 18px;
   height: 18px;
-  margin-right: 0;
+  flex-shrink: 0;
+}
+
+body[data-page="site-detail"] .fab--export__label {
+  display: inline-block;
+  white-space: nowrap;
+  opacity: 1;
+  transform: translateX(0);
+  max-width: 10ch;
+  transition: opacity 0.25s ease, transform 0.25s ease, max-width 0.25s ease;
+}
+
+body[data-page="site-detail"] .fab--export.is-scrolling {
+  width: 2.25rem;
+  min-width: 2.25rem;
+  padding-inline: 0;
+  gap: 0;
+  transform: scale(0.96);
+}
+
+body[data-page="site-detail"] .fab--export.is-scrolling .fab--export__label {
+  opacity: 0;
+  transform: translateX(6px);
+  max-width: 0;
 }
 
 body[data-page="site-detail"] .fab--export:hover {

--- a/js/app.js
+++ b/js/app.js
@@ -2223,6 +2223,29 @@ import { firebaseAuth } from './firebase-core.js';
       openExportItems.addEventListener('click', exportItems);
     }
 
+    const siteDetailScrollContainer = document.querySelector('body[data-page="site-detail"] .page-content');
+    if (openExportItems && siteDetailScrollContainer) {
+      let exportButtonScrollTimerId = null;
+      const SCROLL_IDLE_DELAY_MS = 400;
+
+      const setExportButtonScrollingState = (isScrolling) => {
+        openExportItems.classList.toggle('is-scrolling', isScrolling);
+      };
+
+      const handleSiteDetailScroll = () => {
+        setExportButtonScrollingState(true);
+        if (exportButtonScrollTimerId) {
+          window.clearTimeout(exportButtonScrollTimerId);
+        }
+        exportButtonScrollTimerId = window.setTimeout(() => {
+          setExportButtonScrollingState(false);
+          exportButtonScrollTimerId = null;
+        }, SCROLL_IDLE_DELAY_MS);
+      };
+
+      siteDetailScrollContainer.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
+    }
+
     itemSearchInput.addEventListener('input', () => {
       window.localStorage.setItem(searchStorageKey, itemSearchInput.value);
       renderItems();

--- a/page2.html
+++ b/page2.html
@@ -61,7 +61,8 @@
       </main>
 
       <button type="button" id="openExportItems" class="fab fab--export" aria-label="Exporter">
-        <span>Exporter</span>
+        <img src="Icon/Exporter.png" alt="" aria-hidden="true" class="fab--export__icon" />
+        <span class="fab--export__label">Exporter</span>
       </button>
       <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>
 


### PR DESCRIPTION
### Motivation
- Improve the UX on page 2 by collapsing the `Exporter` FAB to an icon-only state while the user scrolls, then restoring the label when scrolling stops.
- Keep existing export behavior, button position and the `+` button unchanged, and reuse the repository icon without adding new files.

### Description
- Updated `page2.html` to include the existing icon `Icon/Exporter.png` and a dedicated label span: `<img src="Icon/Exporter.png" ... />` + `<span class="fab--export__label">Exporter</span>`.
- Added scoped styles in `css/style.css` to animate `width`, `transform`, `opacity` (label) and `padding-inline` with ~250ms transitions and an `.is-scrolling` state that reduces the FAB to icon-only while preserving the outline style.
- Added scroll-state logic in `js/app.js` inside `initSiteDetailPage` that toggles the `is-scrolling` class on the export button during scroll and removes it after a 400ms idle delay.
- All changes are limited to page 2 (`body[data-page="site-detail"]`) and do not modify the export implementation or other pages.

### Testing
- Ran `git diff --check` and it returned clean results (success).
- Ran `git status --short` to verify changed files (`page2.html`, `css/style.css`, `js/app.js`) and it matched expectations (success).
- Committed the changes with a descriptive message using `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba8125e94832abd3e7036b2494ec5)