### PR TITLE
Fluidifier l’animation du bouton Exporter pendant le scroll (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2854,7 +2854,7 @@ body[data-page="site-detail"] .fab--export {
   position: fixed;
   right: 1rem;
   bottom: calc(30px + env(safe-area-inset-bottom, 0px));
-  width: auto;
+  width: var(--export-button-expanded-width, 7.6rem);
   min-width: 7rem;
   height: 2.25rem;
   border-radius: 22px;
@@ -2871,13 +2871,8 @@ body[data-page="site-detail"] .fab--export {
   box-shadow: 0 4px 10px rgba(8, 112, 62, 0.08);
   z-index: 40;
   overflow: hidden;
-  transition:
-    width 0.25s ease,
-    transform 0.25s ease,
-    box-shadow 0.25s ease,
-    background-color 0.25s ease,
-    border-color 0.25s ease,
-    padding-inline 0.25s ease;
+  will-change: transform, width;
+  transition: width 0.25s ease, opacity 0.2s ease, transform 0.2s ease;
 }
 
 body[data-page="site-detail"] .fab--export__icon {
@@ -2892,7 +2887,7 @@ body[data-page="site-detail"] .fab--export__label {
   opacity: 1;
   transform: translateX(0);
   max-width: 10ch;
-  transition: opacity 0.25s ease, transform 0.25s ease, max-width 0.25s ease;
+  transition: opacity 0.2s ease, transform 0.2s ease, max-width 0.2s ease;
 }
 
 body[data-page="site-detail"] .fab--export.is-scrolling {
@@ -2900,7 +2895,7 @@ body[data-page="site-detail"] .fab--export.is-scrolling {
   min-width: 2.25rem;
   padding-inline: 0;
   gap: 0;
-  transform: scale(0.96);
+  transform: scale(0.95);
 }
 
 body[data-page="site-detail"] .fab--export.is-scrolling .fab--export__label {

--- a/js/app.js
+++ b/js/app.js
@@ -2228,6 +2228,14 @@ import { firebaseAuth } from './firebase-core.js';
       let exportButtonScrollTimerId = null;
       const SCROLL_IDLE_DELAY_MS = 400;
 
+      const syncExportButtonExpandedWidth = () => {
+        openExportItems.classList.remove('is-scrolling');
+        const measuredWidth = openExportItems.scrollWidth;
+        if (measuredWidth > 0) {
+          openExportItems.style.setProperty('--export-button-expanded-width', `${measuredWidth}px`);
+        }
+      };
+
       const setExportButtonScrollingState = (isScrolling) => {
         openExportItems.classList.toggle('is-scrolling', isScrolling);
       };
@@ -2243,6 +2251,8 @@ import { firebaseAuth } from './firebase-core.js';
         }, SCROLL_IDLE_DELAY_MS);
       };
 
+      syncExportButtonExpandedWidth();
+      window.addEventListener('resize', syncExportButtonExpandedWidth);
       siteDetailScrollContainer.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
     }
 


### PR DESCRIPTION
### Motivation
- Améliorer visuellement le bouton « Exporter » sur la page 2 (`site-detail`) pour qu’il passe de texte+icône à icône seule pendant le scroll avec une animation fluide et sans transition brutale.
- Priorité à la fluidité mobile et à la stabilité visuelle sans modifier la position, l’espacement (bouton `+`) ni la logique d’export.

### Description
- CSS: remplacement de `width: auto` par une variable `--export-button-expanded-width` et ajout de `will-change: transform, width` ainsi que des transitions demandées `width 0.25s ease, opacity 0.2s ease, transform 0.2s ease` pour lisser l’animation; réduction en scroll en `scale(0.95)` et fondu du label via `opacity`.
- CSS: ajustement des transitions sur le label (`.fab--export__label`) pour `opacity`, `transform` et `max-width` à `0.2s` afin d’éviter les effets brutaux.
- JS: ajout d’une fonction `syncExportButtonExpandedWidth` qui mesure la largeur réelle du bouton (`scrollWidth`) et écrit la valeur dans la variable CSS `--export-button-expanded-width` pour assurer une transition propre entre états, et recalcul au `resize`.
- JS: conservation de la logique de détection de scroll existante et du délai d’inactivité (`400ms`) avant restauration de l’état normal (dans la plage demandée 300–500ms) en togglant la classe `is-scrolling`.

### Testing
- Vérification syntaxique JavaScript avec `node --check js/app.js` — succès.
- Aucun test automatisé supplémentaire présent dans le dépôt; les changements ciblent uniquement le rendu/CSS côté client et seront vérifiés visuellement en environnement de préprod ou navigateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebaad6061c832aacb700da9c6c0fd8)