### PR TITLE
Refactor site-detail FAB into stacked layout, improve scroll hide behavior, and update JS visibility logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2875,89 +2875,102 @@ body[data-page="site-detail"] .list-card__meta-item--article {
   font-weight: 600;
 }
 
-body[data-page="site-detail"] .fab--export {
+body[data-page="site-detail"] .site-detail-fab-stack {
   position: fixed;
-  right: 1rem;
+  right: 20px;
   bottom: calc(30px + env(safe-area-inset-bottom, 0px));
-  width: var(--export-button-expanded-width, 7.6rem);
-  min-width: 7rem;
-  height: 2.25rem;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.95);
-  color: #18a85f;
-  border: 1.5px solid #18a85f;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 14px;
+  z-index: 40;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+  transition: opacity 0.24s ease-in-out, transform 0.24s ease-in-out;
+}
+
+body[data-page="site-detail"] .site-detail-fab-stack.is-scroll-hidden {
+  opacity: 0;
+  transform: translateY(12px) scale(0.96);
+  pointer-events: none;
+}
+
+body[data-page="site-detail"] .site-detail-fab-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+body[data-page="site-detail"] .site-detail-fab-label {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
-  padding-inline: 0.95rem;
-  font-size: 0.84rem;
+  min-height: 30px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  background: #fff;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.16);
+  font-size: 13px;
   font-weight: 600;
-  box-shadow: 0 4px 10px rgba(8, 112, 62, 0.08);
-  z-index: 40;
-  overflow: hidden;
-  will-change: transform, width;
-  transition: width 0.25s ease, opacity 0.2s ease, transform 0.2s ease;
-}
-
-body[data-page="site-detail"] .fab--export__icon {
-  width: 18px;
-  height: 18px;
-  flex-shrink: 0;
-}
-
-body[data-page="site-detail"] .fab--export__label {
-  display: inline-block;
+  line-height: 1;
   white-space: nowrap;
-  opacity: 1;
-  transform: translateX(0);
-  max-width: 10ch;
-  transition: opacity 0.2s ease, transform 0.2s ease, max-width 0.2s ease;
 }
 
-body[data-page="site-detail"] .fab--export.is-scrolling {
-  width: 2.25rem;
-  min-width: 2.25rem;
-  padding-inline: 0;
-  gap: 0;
-  transform: scale(0.95);
+body[data-page="site-detail"] .site-detail-fab-label--create {
+  color: var(--detail-primary);
 }
 
-body[data-page="site-detail"] .fab--export.is-scrolling .fab--export__label {
-  opacity: 0;
-  transform: translateX(6px);
-  max-width: 0;
+body[data-page="site-detail"] .site-detail-fab-label--export {
+  color: #18a85f;
 }
 
-body[data-page="site-detail"] .fab--export:hover {
-  background: rgba(24, 168, 95, 0.12);
-  box-shadow: 0 6px 12px rgba(8, 112, 62, 0.12);
-}
-
-body[data-page="site-detail"] .fab--export:active {
-  background: rgba(24, 168, 95, 0.18);
-  transform: scale(0.97);
-}
-
+body[data-page="site-detail"] .fab--export,
 body[data-page="site-detail"] .fab-add,
 body[data-page="site-detail"] #openCreateItem {
-  position: fixed;
-  right: 20px;
+  position: relative;
+  right: auto;
   left: auto;
-  bottom: calc(88px + env(safe-area-inset-bottom, 0px));
+  bottom: auto;
   width: 56px;
   height: 56px;
   border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: 0;
+  box-shadow: 0 10px 22px var(--detail-primary-shadow);
+  z-index: 1;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+body[data-page="site-detail"] .fab--export {
+  background: #18a85f;
+  color: #fff;
+  padding: 0;
+}
+
+body[data-page="site-detail"] .fab--export__icon {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+body[data-page="site-detail"] .fab--export:hover {
+  background: #159451;
+  box-shadow: 0 12px 24px rgba(8, 112, 62, 0.24);
+}
+
+body[data-page="site-detail"] .fab--export:active {
+  transform: scale(0.95);
+}
+
+body[data-page="site-detail"] .fab-add,
+body[data-page="site-detail"] #openCreateItem {
   background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   color: #fff;
-  border: 0;
   font-size: 28px;
-  box-shadow: 0 10px 22px var(--detail-primary-shadow);
-  z-index: 40;
-  transition: all 0.2s ease;
 }
 
 body[data-page="site-detail"] .fab-add:hover,
@@ -2967,7 +2980,8 @@ body[data-page="site-detail"] #openCreateItem:hover {
 
 body[data-page="site-detail"] .fab-add:focus-visible,
 body[data-page="site-detail"] #openCreateItem:focus-visible,
-body[data-page="site-detail"] .filter-chip:focus-visible {
+body[data-page="site-detail"] .filter-chip:focus-visible,
+body[data-page="site-detail"] .fab--export:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--detail-primary-focus);
 }

--- a/js/app.js
+++ b/js/app.js
@@ -2291,6 +2291,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
+    const siteDetailFabStack = document.querySelector('body[data-page="site-detail"] .site-detail-fab-stack');
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -2303,6 +2304,10 @@ import { firebaseAuth } from './firebase-core.js';
       const isAuthenticated = isFirebaseUserAuthenticated(user);
       openCreateItem.hidden = !isAuthenticated;
       openCreateItem.style.display = isAuthenticated ? 'inline-flex' : 'none';
+      const createButtonRow = openCreateItem.closest('[data-fab-row="create"]');
+      if (createButtonRow) {
+        createButtonRow.hidden = !isAuthenticated;
+      }
     }
 
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
@@ -2376,37 +2381,26 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
-    const siteDetailScrollContainer = document.querySelector('body[data-page="site-detail"] .page-content');
-    if (openExportItems && siteDetailScrollContainer) {
-      let exportButtonScrollTimerId = null;
-      const SCROLL_IDLE_DELAY_MS = 400;
+    if (siteDetailFabStack) {
+      let siteDetailScrollTimerId = null;
+      const SCROLL_IDLE_DELAY_MS = 180;
 
-      const syncExportButtonExpandedWidth = () => {
-        openExportItems.classList.remove('is-scrolling');
-        const measuredWidth = openExportItems.scrollWidth;
-        if (measuredWidth > 0) {
-          openExportItems.style.setProperty('--export-button-expanded-width', `${measuredWidth}px`);
-        }
-      };
-
-      const setExportButtonScrollingState = (isScrolling) => {
-        openExportItems.classList.toggle('is-scrolling', isScrolling);
+      const setFabStackScrollingState = (isScrolling) => {
+        siteDetailFabStack.classList.toggle('is-scroll-hidden', isScrolling);
       };
 
       const handleSiteDetailScroll = () => {
-        setExportButtonScrollingState(true);
-        if (exportButtonScrollTimerId) {
-          window.clearTimeout(exportButtonScrollTimerId);
+        setFabStackScrollingState(true);
+        if (siteDetailScrollTimerId) {
+          window.clearTimeout(siteDetailScrollTimerId);
         }
-        exportButtonScrollTimerId = window.setTimeout(() => {
-          setExportButtonScrollingState(false);
-          exportButtonScrollTimerId = null;
+        siteDetailScrollTimerId = window.setTimeout(() => {
+          setFabStackScrollingState(false);
+          siteDetailScrollTimerId = null;
         }, SCROLL_IDLE_DELAY_MS);
       };
 
-      syncExportButtonExpandedWidth();
-      window.addEventListener('resize', syncExportButtonExpandedWidth);
-      siteDetailScrollContainer.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
+      window.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
     }
 
     itemSearchInput.addEventListener('input', () => {

--- a/page2.html
+++ b/page2.html
@@ -60,11 +60,18 @@
         <section id="itemList" class="list-grid" aria-live="polite"></section>
       </main>
 
-      <button type="button" id="openExportItems" class="fab fab--export" aria-label="Exporter">
-        <img src="Icon/Exporter.png" alt="" aria-hidden="true" class="fab--export__icon" />
-        <span class="fab--export__label">Exporter</span>
-      </button>
-      <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>
+      <div class="site-detail-fab-stack" aria-hidden="false">
+        <div class="site-detail-fab-row" data-fab-row="create">
+          <span class="site-detail-fab-label site-detail-fab-label--create">Créé</span>
+          <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>
+        </div>
+        <div class="site-detail-fab-row" data-fab-row="export">
+          <span class="site-detail-fab-label site-detail-fab-label--export">Exporter</span>
+          <button type="button" id="openExportItems" class="fab fab--export" aria-label="Exporter">
+            <img src="Icon/Exporter.png" alt="" aria-hidden="true" class="fab--export__icon" />
+          </button>
+        </div>
+      </div>
 
       <dialog id="itemDialog" class="modal-card">
         <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="itemForm">


### PR DESCRIPTION
### Motivation
- Replace the single floating export/create FAB layout with a stacked, labeled layout to improve clarity and mobile behavior.
- Simplify and modernize the FAB styling and hover/active states and make the stack hide on scroll for less visual clutter.
- Ensure create/export buttons respect authentication state and that the visibility toggles correctly during scrolling.

### Description
- HTML: Replaced standalone `#openExportItems` and `#openCreateItem` buttons with a `.site-detail-fab-stack` containing two `.site-detail-fab-row` blocks and labeled spans for create/export in `page2.html`.
- CSS: Reworked `css/style.css` to introduce `.site-detail-fab-stack`, `.site-detail-fab-row`, and `.site-detail-fab-label` with new positioning, sizing, shadows, hover/active states, and a `.is-scroll-hidden` state to animate hiding on scroll; removed the old expanded-width export button behavior.
- JS: Updated `js/app.js` to query `.site-detail-fab-stack`, replaced the old export-button width sync and container-scroll listener with a window scroll listener and a shorter idle delay (180ms), and added `setFabStackScrollingState` to toggle `.is-scroll-hidden` on the stack.
- Auth visibility: `updateCreateItemButtonVisibility` now also hides the create button row by locating the nearest `[data-fab-row="create"]` and toggling its `hidden` state.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc0f792a4832a8f034acb4ce5e2ea)