### PR TITLE
Fix page 2 floating buttons hide/show on content scroll

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2382,6 +2382,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     if (siteDetailFabStack) {
+      const siteDetailScrollContainer = document.querySelector('body[data-page="site-detail"] .page-content');
       let siteDetailScrollTimerId = null;
       const SCROLL_IDLE_DELAY_MS = 180;
 
@@ -2400,7 +2401,7 @@ import { firebaseAuth } from './firebase-core.js';
         }, SCROLL_IDLE_DELAY_MS);
       };
 
-      window.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
+      siteDetailScrollContainer?.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
     }
 
     itemSearchInput.addEventListener('input', () => {


### PR DESCRIPTION
### Motivation
- Ensure the floating action buttons and their labels on page 2 (site detail) hide immediately when the user scrolls the page content and reappear after a short idle delay, since the page uses an internal scroll container and the previous `window` listener did not fire reliably.

### Description
- Changed the scroll listener scope in `js/app.js` to attach to `body[data-page="site-detail"] .page-content` instead of `window`, keeping the existing `is-scroll-hidden` class and animation/pointer behavior unchanged.

### Testing
- Ran `node --check js/app.js` to validate the updated script syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc458725c832a81334f0a1a3c6215)