### PR TITLE
Masquer les actions flottantes (page 2) pendant le chargement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2896,6 +2896,13 @@ body[data-page="site-detail"] .site-detail-fab-stack.is-scroll-hidden {
   pointer-events: none;
 }
 
+body[data-page="site-detail"].app-content-loading .site-detail-fab-stack,
+body[data-page="site-detail"].app-content-pending .site-detail-fab-stack {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(12px);
+}
+
 body[data-page="site-detail"] .site-detail-fab-row {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Pendant le skeleton loading les libellés flottants (« Créé », « Exporter ») et les boutons restaient visibles sur la page 2; il faut les cacher pendant le loading sans toucher à la logique des boutons ni au header.

### Description
- Ajout de règles CSS dans `css/style.css` pour cibler `body[data-page="site-detail"]` et masquer `.site-detail-fab-stack` lorsque la page a les classes `app-content-loading` ou `app-content-pending`, ce qui cache le bouton `+`, le bouton `Exporter` et leurs libellés sans modifier le JavaScript ni d’autres pages.

### Testing
- Exécutés et réussis : `git -C /workspace/Album diff -- css/style.css`, `git -C /workspace/Album commit -m "Hide page 2 floating actions during loading"`, et `git -C /workspace/Album status --short`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc7a45ce0832aaa2ab7cf8deb4ce4)