### PR TITLE
Add dynamic character counter to Numéro OUT input (page 2 modal)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1327,6 +1327,22 @@ body[data-page="history"] .list-grid {
   margin-bottom: 0.3rem;
 }
 
+.input-char-counter {
+  align-self: flex-end;
+  margin-top: 0.2rem;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.2;
+}
+
+.input-char-counter.is-warning {
+  color: #d17a00;
+}
+
+.input-char-counter.is-limit {
+  color: var(--danger);
+}
+
 .input-group--site-lock-create {
   gap: 0.65rem;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -1818,6 +1818,7 @@ import { firebaseAuth } from './firebase-core.js';
     const itemDialog = requireElement('itemDialog');
     const itemForm = requireElement('itemForm');
     const itemNumberInput = requireElement('itemNumberInput');
+    const itemNumberCounter = requireElement('itemNumberCounter');
     const itemFormError = requireElement('itemFormError');
     const itemCreateSubmitButton = requireElement('itemCreateSubmitButton');
     const openExportItems = requireElement('openExportItems');
@@ -2310,6 +2311,37 @@ import { firebaseAuth } from './firebase-core.js';
       }
     }
 
+    function getItemNumberMaxLength() {
+      return itemNumberInput.maxLength > 0 ? itemNumberInput.maxLength : null;
+    }
+
+    function normalizeItemNumberInput(rawValue) {
+      const digitsOnly = String(rawValue || '').replace(/\D/g, '');
+      const maxLength = getItemNumberMaxLength();
+      if (!maxLength) {
+        return digitsOnly;
+      }
+      return digitsOnly.slice(0, maxLength);
+    }
+
+    function updateItemNumberCounter() {
+      const maxLength = getItemNumberMaxLength();
+      const currentLength = itemNumberInput.value.length;
+      itemNumberCounter.textContent = `${currentLength} / ${maxLength ?? currentLength}`;
+
+      itemNumberCounter.classList.remove('is-warning', 'is-limit');
+      if (!maxLength || maxLength <= 0) {
+        return;
+      }
+
+      const ratio = currentLength / maxLength;
+      if (ratio >= 1) {
+        itemNumberCounter.classList.add('is-limit');
+      } else if (ratio >= 0.8) {
+        itemNumberCounter.classList.add('is-warning');
+      }
+    }
+
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
     onAuthStateChanged(firebaseAuth, (user) => {
       updateCreateItemButtonVisibility(user || null);
@@ -2320,16 +2352,56 @@ import { firebaseAuth } from './firebase-core.js';
       itemFormError.textContent = '';
       itemCreateSubmitButton.disabled = false;
       itemCreateSubmitButton.classList.remove('is-loading');
+      updateItemNumberCounter();
       itemDialog.showModal();
       itemNumberInput.focus();
     });
 
-    itemNumberInput.addEventListener('input', () => {
-      const digitsOnly = itemNumberInput.value.replace(/\D/g, '');
-      if (itemNumberInput.value !== digitsOnly) {
-        itemNumberInput.value = digitsOnly;
+    itemNumberInput.addEventListener('beforeinput', (event) => {
+      const maxLength = getItemNumberMaxLength();
+      if (!maxLength || event.inputType.startsWith('delete')) {
+        return;
+      }
+
+      const selectionStart = itemNumberInput.selectionStart ?? itemNumberInput.value.length;
+      const selectionEnd = itemNumberInput.selectionEnd ?? itemNumberInput.value.length;
+      const selectedLength = Math.max(0, selectionEnd - selectionStart);
+      const nextAllowedLength = maxLength - (itemNumberInput.value.length - selectedLength);
+      if (nextAllowedLength <= 0) {
+        event.preventDefault();
       }
     });
+
+    itemNumberInput.addEventListener('paste', (event) => {
+      const clipboardText = event.clipboardData?.getData('text') ?? '';
+      const sanitizedClipboardText = String(clipboardText).replace(/\D/g, '');
+      if (!sanitizedClipboardText) {
+        event.preventDefault();
+        updateItemNumberCounter();
+        return;
+      }
+
+      event.preventDefault();
+      const maxLength = getItemNumberMaxLength();
+      const selectionStart = itemNumberInput.selectionStart ?? itemNumberInput.value.length;
+      const selectionEnd = itemNumberInput.selectionEnd ?? itemNumberInput.value.length;
+      const selectedLength = Math.max(0, selectionEnd - selectionStart);
+      const remainingLength = maxLength
+        ? Math.max(0, maxLength - (itemNumberInput.value.length - selectedLength))
+        : sanitizedClipboardText.length;
+      const insertedValue = sanitizedClipboardText.slice(0, remainingLength);
+      itemNumberInput.setRangeText(insertedValue, selectionStart, selectionEnd, 'end');
+      updateItemNumberCounter();
+    });
+
+    itemNumberInput.addEventListener('input', () => {
+      const normalizedValue = normalizeItemNumberInput(itemNumberInput.value);
+      if (itemNumberInput.value !== normalizedValue) {
+        itemNumberInput.value = normalizedValue;
+      }
+      updateItemNumberCounter();
+    });
+    updateItemNumberCounter();
 
     if (openExportItems) {
       openExportItems.addEventListener('click', openSiteExportDialog);

--- a/page2.html
+++ b/page2.html
@@ -90,6 +90,7 @@
               minlength="4"
               placeholder="OUT-123456"
             />
+            <span id="itemNumberCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
           </label>
           <p id="itemFormError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">


### PR DESCRIPTION
### Motivation
- Provide a live character counter for the `Numéro OUT` field in the create-item modal on page 2 that reads the max length dynamically and prevents overflow. 
- Improve UX by giving immediate visual feedback and preventing accidental paste/typing beyond the allowed length.

### Description
- Added a new counter element `#itemNumberCounter` below the `#itemNumberInput` in `page2.html` and styled it with `.input-char-counter` in `css/style.css`. 
- Implemented dynamic logic in `js/app.js` to read the max value from `itemNumberInput.maxLength`, compute `current / max`, and update the counter text and visual state (`.is-warning` at >= 80% and `.is-limit` at 100%).
- Enforced strict digit-only input and hard length limits using `beforeinput` (blocks extra typing), `paste` (sanitizes and truncates clipboard text), and `input` (normalizes and synchronizes the counter). 
- Scoped changes to only the `Numéro OUT` field and ensured no Firebase or "Créer" button logic was modified.

### Testing
- Ran a JavaScript syntax check with `node --check js/app.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebca5dd778832abea07a87090dc41f)