### PR TITLE
Amélioration UX/UI du modal "Nouveau numéro OUT" (page 2 uniquement)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1419,12 +1419,26 @@ body[data-page="history"] .list-grid {
   display: none;
 }
 
+#itemCreateSubmitButton .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
 #itemCreateSubmitButton.is-loading {
   filter: saturate(0.95);
 }
 
 #itemCreateSubmitButton.is-loading .btn-label-default {
   display: none;
+}
+
+#itemCreateSubmitButton.is-loading .btn-loading-spinner {
+  display: inline-flex;
 }
 
 #itemCreateSubmitButton.is-loading .btn-label-loading {
@@ -2516,6 +2530,12 @@ body[data-page="home"] .app-header--home > h1 {
   }
 }
 
+@keyframes btn-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Site detail page modern UI overrides */
 body[data-page="site-detail"] {
   background: #f3f6fa;
@@ -2604,6 +2624,34 @@ body[data-page="site-detail"] #itemSearchInput:focus {
   outline: none;
   border: 2px solid var(--detail-primary);
   box-shadow: 0 0 0 4px rgba(39, 141, 218, 0.12);
+}
+
+body[data-page="site-detail"] #itemDialog .input-group--item-create input:focus {
+  outline: none;
+  border-color: var(--detail-primary);
+  box-shadow: 0 0 0 3px var(--detail-primary-focus);
+}
+
+body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-counter {
+  width: 100%;
+  text-align: right;
+  margin-top: 0.3rem;
+}
+
+body[data-page="site-detail"] #itemDialog #itemFormError {
+  width: 100%;
+  margin-top: 0.24rem;
+  text-align: right;
+  color: #c95e68;
+  font-size: 0.82rem;
+}
+
+body[data-page="site-detail"] #itemDialog .modal-actions--item-create {
+  margin-top: 0.62rem;
+}
+
+body[data-page="site-detail"] #itemDialog #itemCreateSubmitButton.is-loading {
+  gap: 0.45rem;
 }
 
 body[data-page="site-detail"] .filter-chip-group {

--- a/js/app.js
+++ b/js/app.js
@@ -2293,6 +2293,7 @@ import { firebaseAuth } from './firebase-core.js';
 
     const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
     const siteDetailFabStack = document.querySelector('body[data-page="site-detail"] .site-detail-fab-stack');
+    let itemFormErrorTimeoutId = null;
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -2342,6 +2343,23 @@ import { firebaseAuth } from './firebase-core.js';
       }
     }
 
+    function clearItemFormError() {
+      if (itemFormErrorTimeoutId) {
+        window.clearTimeout(itemFormErrorTimeoutId);
+        itemFormErrorTimeoutId = null;
+      }
+      itemFormError.textContent = '';
+    }
+
+    function showItemFormError(message) {
+      clearItemFormError();
+      itemFormError.textContent = message;
+      itemFormErrorTimeoutId = window.setTimeout(() => {
+        itemFormError.textContent = '';
+        itemFormErrorTimeoutId = null;
+      }, 2600);
+    }
+
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
     onAuthStateChanged(firebaseAuth, (user) => {
       updateCreateItemButtonVisibility(user || null);
@@ -2349,7 +2367,7 @@ import { firebaseAuth } from './firebase-core.js';
 
     openCreateItem?.addEventListener('click', () => {
       itemForm.reset();
-      itemFormError.textContent = '';
+      clearItemFormError();
       itemCreateSubmitButton.disabled = false;
       itemCreateSubmitButton.classList.remove('is-loading');
       updateItemNumberCounter();
@@ -2399,6 +2417,7 @@ import { firebaseAuth } from './firebase-core.js';
       if (itemNumberInput.value !== normalizedValue) {
         itemNumberInput.value = normalizedValue;
       }
+      clearItemFormError();
       updateItemNumberCounter();
     });
     updateItemNumberCounter();
@@ -2520,19 +2539,19 @@ import { firebaseAuth } from './firebase-core.js';
       }
       const value = itemNumberInput.value.trim();
       if (!value) {
-        itemFormError.textContent = 'Veuillez remplir ce champ';
+        showItemFormError('Veuillez remplir ce champ');
         return;
       }
       if (!/^\d+$/.test(value)) {
-        itemFormError.textContent = 'Veuillez saisir des chiffres uniquement.';
+        showItemFormError('Veuillez saisir des chiffres uniquement.');
         return;
       }
       if (value.length < 4) {
-        itemFormError.textContent = 'Veuillez saisir au moins 4 chiffres.';
+        showItemFormError('Veuillez saisir au moins 4 chiffres.');
         return;
       }
       if (!permissions.canCreate) {
-        itemFormError.textContent = 'Action non autorisée.';
+        showItemFormError('Action non autorisée.');
         return;
       }
       itemCreateSubmitButton.disabled = true;
@@ -2540,12 +2559,14 @@ import { firebaseAuth } from './firebase-core.js';
       try {
         const result = await StorageService.createItem(siteId, value);
         if (!result?.ok) {
-          itemFormError.textContent =
+          showItemFormError(
             result?.reason === 'duplicate_out'
               ? 'Ce N° OUT existe déjà pour ce site.'
-              : 'Veuillez saisir au moins 4 chiffres.';
+              : 'Veuillez saisir au moins 4 chiffres.',
+          );
           return;
         }
+        clearItemFormError();
         itemCreateSubmitButton.classList.remove('is-loading');
         itemCreateSubmitButton.disabled = false;
         itemDialog.close();

--- a/page2.html
+++ b/page2.html
@@ -76,7 +76,7 @@
       <dialog id="itemDialog" class="modal-card">
         <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="itemForm">
           <div class="modal-header">
-            <h2>Créer un numéro OUT</h2>
+            <h2>Nouveau numéro OUT</h2>
           </div>
           <label class="input-group input-group--site-create input-group--item-create">
             <span>Numéro OUT</span>
@@ -97,6 +97,7 @@
             <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
             <button id="itemCreateSubmitButton" type="submit" class="btn btn-success">
               <span class="btn-label-default">Créer</span>
+              <span class="btn-loading-spinner" aria-hidden="true"></span>
               <span class="btn-label-loading" aria-hidden="true">Création...</span>
             </button>
           </div>


### PR DESCRIPTION
### Motivation
- Rendre le modal de création d’un N° OUT sur la page 2 plus professionnel, propre et agréable sans modifier la logique métier existante.
- Respecter les contraintes : toucher uniquement le modal création OUT sur la page 2, ne pas modifier Firebase ni les autres pages ou boutons flottants.

### Description
- Titre modifié dans le modal : `Créer un numéro OUT` → `Nouveau numéro OUT` (fichier `page2.html`).
- UI/CSS : ajout d’un style de focus pour le champ `Numéro OUT` (bordure bleue + glow discret), alignement du compteur de caractères à droite, style du message d’erreur atténué et taille réduite, espacement ajouté entre l’erreur et les boutons, et animation/spinner pour le bouton `Créer` (fichier `css/style.css`).
- JS : ajout de `showItemFormError` et `clearItemFormError` pour afficher les erreurs seulement en cas d’erreur, disparition automatique après ~2.6s et suppression immédiate si l’utilisateur corrige la saisie, tout en conservant la logique de validation et création (fichier `js/app.js`).
- Ajout d’un élément DOM pour un petit spinner dans le bouton `Créer` et liaison visuelle via la classe `.is-loading` sans changer la logique de désactivation/envoi.

### Testing
- Lint/syntax check exécuté : `node --check js/app.js` — succès.
- Validation de l’état du dépôt après changement : `git status --short` et commit effectué — succès.
- Aucun test automatisé d’interface visuelle exécuté dans cet environnement, et aucune capture d’écran fournie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2af3ed54832a8b05b4c0488c5964)