### PR TITLE
Corrige l’alignement message d’erreur / compteur dans le modal "Nouveau numéro OUT" (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2633,17 +2633,29 @@ body[data-page="site-detail"] #itemDialog .input-group--item-create input:focus 
 }
 
 body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-counter {
-  width: 100%;
+  width: auto;
   text-align: right;
-  margin-top: 0.3rem;
+  margin-top: 0;
+  flex-shrink: 0;
+}
+
+body[data-page="site-detail"] #itemDialog .item-input-feedback-row {
+  width: 100%;
+  margin-top: 0.24rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 body[data-page="site-detail"] #itemDialog #itemFormError {
-  width: 100%;
-  margin-top: 0.24rem;
-  text-align: right;
+  width: auto;
+  margin-top: 0;
+  text-align: left;
   color: #c95e68;
   font-size: 0.82rem;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 body[data-page="site-detail"] #itemDialog .modal-actions--item-create {

--- a/page2.html
+++ b/page2.html
@@ -90,9 +90,11 @@
               minlength="4"
               placeholder="Exemple : 26050200"
             />
-            <span id="itemNumberCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
+            <div class="item-input-feedback-row">
+              <p id="itemFormError" class="form-error" aria-live="polite"></p>
+              <span id="itemNumberCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
+            </div>
           </label>
-          <p id="itemFormError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
             <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
             <button id="itemCreateSubmitButton" type="submit" class="btn btn-success">


### PR DESCRIPTION
### Motivation
- Corriger l’alignement du message d’erreur et du compteur dans le modal « Nouveau numéro OUT » sur la page 2 pour que le message d’erreur soit à gauche et le compteur à droite sur la même ligne, sans toucher à la logique existante.

### Description
- Déplacé le paragraphe d’erreur et le compteur dans une nouvelle ligne de feedback `div.item-input-feedback-row` directement sous l’input dans `page2.html` afin qu’ils puissent être mis en page côte à côte.
- Ajouté des styles spécifiques à `body[data-page="site-detail"] #itemDialog` dans `css/style.css` pour utiliser `display: flex`, `justify-content: space-between` et `align-items: center`, et ajusté `.input-char-counter` et `#itemFormError` pour conserver les alignements demandés.
- Les modifications sont strictement visuelles et limitées à la modal ciblée (aucun changement JS, aucune modification des boutons, du compteur ou de la logique d’erreur temporaire).

### Testing
- Exécuté des recherches pour vérifier la présence et le placement des sélecteurs avec `rg -n "id=\"itemFormError\"|item-input-feedback-row|id=\"itemNumberCounter\"" page2.html css/style.css` et tous les chemins attendus ont été trouvés avec succès.
- Vérifié le commit et le diff avec `git show --stat --oneline HEAD` et la commande de commit s’est exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2e1b712c832a9d948390e6b66973)