### PR TITLE
Améliore le modal « Ajouter une donnée » (page 3) — compteurs et animation bouton

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2075,16 +2075,47 @@ body[data-page="item-detail"] #detailCreateSubmitButton .btn-label-loading {
   display: none;
 }
 
+body[data-page="item-detail"] #detailCreateSubmitButton .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
 body[data-page="item-detail"] #detailCreateSubmitButton.is-loading {
   filter: saturate(0.95);
+  gap: 0.45rem;
 }
 
 body[data-page="item-detail"] #detailCreateSubmitButton.is-loading .btn-label-default {
   display: none;
 }
 
+body[data-page="item-detail"] #detailCreateSubmitButton.is-loading .btn-loading-spinner {
+  display: inline-flex;
+}
+
 body[data-page="item-detail"] #detailCreateSubmitButton.is-loading .btn-label-loading {
   display: inline-flex;
+}
+
+body[data-page="item-detail"] .detail-input-feedback-row {
+  width: 100%;
+  margin-top: 0.24rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+body[data-page="item-detail"] .detail-input-feedback-row .input-char-counter {
+  width: auto;
+  text-align: right;
+  margin-top: 0;
+  flex-shrink: 0;
 }
 
 body[data-page="item-detail"] .detail-form-row--qte-unit {

--- a/js/app.js
+++ b/js/app.js
@@ -2661,7 +2661,9 @@ import { firebaseAuth } from './firebase-core.js';
     const detailExportSubmitButton = requireElement('detailExportSubmitButton');
     const detailExportCancelButton = requireElement('detailExportCancelButton');
     const codeInput = requireElement('codeInput');
+    const codeInputCounter = requireElement('codeInputCounter');
     const designationInput = requireElement('designationInput');
+    const designationInputCounter = requireElement('designationInputCounter');
     const codeSuggestions = requireElement('codeSuggestions');
     const isAuthenticatedUser = Boolean(firebaseAuth.currentUser);
     const canEditDetails = permissions.canEdit && isAuthenticatedUser;
@@ -2698,6 +2700,11 @@ import { firebaseAuth } from './firebase-core.js';
       if (!detailFormModal || !permissions.canCreate || permissions.isLecture) {
         return;
       }
+      detailForm.reset();
+      requireElement('uniteInput').value = 'm';
+      setDetailFormSavingState(false);
+      detailFormError.textContent = '';
+      updateDetailInputCounters();
       detailFormModal.showModal();
       setDetailModalOpenState(true);
       window.setTimeout(() => {
@@ -2711,6 +2718,77 @@ import { firebaseAuth } from './firebase-core.js';
       }
       detailCreateSubmitButton.disabled = isSaving;
       detailCreateSubmitButton.classList.toggle('is-loading', isSaving);
+    }
+
+    function getInputMaxLength(input) {
+      return input?.maxLength > 0 ? input.maxLength : null;
+    }
+
+    function updateInputCharCounter(input, counter) {
+      if (!input || !counter) {
+        return;
+      }
+      const maxLength = getInputMaxLength(input);
+      const currentLength = input.value.length;
+      counter.textContent = `${currentLength} / ${maxLength ?? currentLength}`;
+      counter.classList.remove('is-warning', 'is-limit');
+      if (!maxLength || maxLength <= 0) {
+        return;
+      }
+      const ratio = currentLength / maxLength;
+      if (ratio >= 1) {
+        counter.classList.add('is-limit');
+      } else if (ratio >= 0.8) {
+        counter.classList.add('is-warning');
+      }
+    }
+
+    function enforceMaxLengthOnBeforeInput(event, input) {
+      const maxLength = getInputMaxLength(input);
+      if (!input || !maxLength || event.inputType.startsWith('delete')) {
+        return;
+      }
+      const selectionStart = input.selectionStart ?? input.value.length;
+      const selectionEnd = input.selectionEnd ?? input.value.length;
+      const selectedLength = Math.max(0, selectionEnd - selectionStart);
+      const nextAllowedLength = maxLength - (input.value.length - selectedLength);
+      if (nextAllowedLength <= 0) {
+        event.preventDefault();
+      }
+    }
+
+    function enforceMaxLengthOnPaste(event, input, counter) {
+      if (!input) {
+        return;
+      }
+      const maxLength = getInputMaxLength(input);
+      if (!maxLength) {
+        return;
+      }
+      const clipboardText = event.clipboardData?.getData('text') ?? '';
+      event.preventDefault();
+
+      const selectionStart = input.selectionStart ?? input.value.length;
+      const selectionEnd = input.selectionEnd ?? input.value.length;
+      const prefix = input.value.slice(0, selectionStart);
+      const suffix = input.value.slice(selectionEnd);
+      const remainingLength = maxLength - (prefix.length + suffix.length);
+      if (remainingLength <= 0) {
+        updateInputCharCounter(input, counter);
+        return;
+      }
+
+      const insertedText = clipboardText.slice(0, remainingLength);
+      const nextValue = `${prefix}${insertedText}${suffix}`;
+      input.value = nextValue.slice(0, maxLength);
+      const caretPosition = prefix.length + insertedText.length;
+      input.setSelectionRange(caretPosition, caretPosition);
+      updateInputCharCounter(input, counter);
+    }
+
+    function updateDetailInputCounters() {
+      updateInputCharCounter(codeInput, codeInputCounter);
+      updateInputCharCounter(designationInput, designationInputCounter);
     }
 
     function buildCodeSuggestionSource(details) {
@@ -2806,6 +2884,7 @@ import { firebaseAuth } from './firebase-core.js';
       }
       codeInput.value = entry.code;
       designationInput.value = entry.designation || '';
+      updateDetailInputCounters();
       hideCodeSuggestions();
     }
 
@@ -3098,6 +3177,7 @@ import { firebaseAuth } from './firebase-core.js';
         }
         detailForm.reset();
         requireElement('uniteInput').value = 'm';
+        updateDetailInputCounters();
         hideCodeSuggestions();
         closeDetailModal();
         UiService.showToast('Article ajoutée .');
@@ -3141,6 +3221,16 @@ import { firebaseAuth } from './firebase-core.js';
       });
 
       codeInput.addEventListener('input', () => {
+        updateInputCharCounter(codeInput, codeInputCounter);
+        renderCodeSuggestions(codeInput.value);
+      });
+
+      codeInput.addEventListener('beforeinput', (event) => {
+        enforceMaxLengthOnBeforeInput(event, codeInput);
+      });
+
+      codeInput.addEventListener('paste', (event) => {
+        enforceMaxLengthOnPaste(event, codeInput, codeInputCounter);
         renderCodeSuggestions(codeInput.value);
       });
 
@@ -3189,6 +3279,18 @@ import { firebaseAuth } from './firebase-core.js';
         }
         const suggestion = visibleCodeSuggestions[Number(option.dataset.typeaheadIndex)];
         applyCodeSuggestion(suggestion);
+      });
+    }
+
+    if (designationInput) {
+      designationInput.addEventListener('input', () => {
+        updateInputCharCounter(designationInput, designationInputCounter);
+      });
+      designationInput.addEventListener('beforeinput', (event) => {
+        enforceMaxLengthOnBeforeInput(event, designationInput);
+      });
+      designationInput.addEventListener('paste', (event) => {
+        enforceMaxLengthOnPaste(event, designationInput, designationInputCounter);
       });
     }
 
@@ -3308,6 +3410,7 @@ import { firebaseAuth } from './firebase-core.js';
     );
 
     renderTitle();
+    updateDetailInputCounters();
     refreshCodeSuggestionSource();
   }
 

--- a/page3.html
+++ b/page3.html
@@ -116,10 +116,16 @@
                   <input id="codeInput" name="code" type="text" maxlength="40" aria-label="Code" autocomplete="off" />
                   <div id="codeSuggestions" class="typeahead__menu" role="listbox" aria-label="Suggestions de code" hidden></div>
                 </div>
+                <div class="detail-input-feedback-row">
+                  <span id="codeInputCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
+                </div>
               </label>
               <label class="input-group input-group--wide">
                 <span>Désignation</span>
                 <input id="designationInput" name="designation" type="text" maxlength="120" required />
+                <div class="detail-input-feedback-row">
+                  <span id="designationInputCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
+                </div>
               </label>
               <div class="detail-form-row detail-form-row--qte-unit">
                 <label class="input-group detail-form-field detail-form-field--qte">
@@ -140,6 +146,7 @@
                   <button type="button" class="btn" id="cancelDetailFormButton">Annuler</button>
                   <button type="submit" class="btn btn-success" id="detailCreateSubmitButton">
                     <span class="btn-label-default">Enregistrer</span>
+                    <span class="btn-loading-spinner" aria-hidden="true"></span>
                     <span class="btn-label-loading" aria-hidden="true">Enregistrement...</span>
                   </button>
                 </div>


### PR DESCRIPTION
### Motivation
- Harmoniser l’expérience du modal “Ajouter une donnée” (page 3) avec le modal “Nouveau numéro OUT” (page 2) en ajoutant compteur de caractères et animation du bouton.
- Fournir un retour visuel clair lors de la saisie pour les champs `Code` et `Désignation` en s’appuyant sur les `maxlength` existants.
- Empêcher les saisies/collages au-delà de la limite et éviter les clics multiples sur `Enregistrer` sans modifier la logique d’enregistrement existante.

### Description
- Ajout des compteurs sous `#codeInput` et `#designationInput` et insertion d’un élément spinner dans `#detailCreateSubmitButton` dans `page3.html`.
- Ajout des styles dans `css/style.css` pour la rangée de feedback des compteurs, le rendu `is-loading` et le spinner (même pattern visuel que page 2).
- Ajout dans `js/app.js` de helpers et logique UI : `getInputMaxLength`, `updateInputCharCounter`, `enforceMaxLengthOnBeforeInput`, `enforceMaxLengthOnPaste`, `updateDetailInputCounters`, et liaison des événements `input`, `beforeinput` et `paste` sur les champs concernés.
- Réinitialisation et mise à jour des compteurs à l’ouverture du modal, après autocomplétion et après soumission, tout en conservant l’appel et la gestion d’erreur de `StorageService.createDetail` sans modification de sa logique métier.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` réussie.
- Exécution de la vérification d’espace blanc/format avec `git diff --check` sans erreur.
- Contrôle de l’état du dépôt avec `git status --short` pour confirmer les fichiers modifiés.
- Aucune suite de tests UI automatisés lancée et pas de capture visuelle effectuée dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3127dfa8832abab8b7f7b33df6e9)