### PR TITLE
Page 3 — Ajuste le style du compteur et rend l’erreur du modal “Ajouter une donnée” transitoire

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2116,6 +2116,9 @@ body[data-page="item-detail"] .detail-input-feedback-row .input-char-counter {
   text-align: right;
   margin-top: 0;
   flex-shrink: 0;
+  font-size: 12px;
+  color: #9e9e9e;
+  font-weight: 400;
 }
 
 body[data-page="item-detail"] .detail-form-row--qte-unit {

--- a/js/app.js
+++ b/js/app.js
@@ -2680,6 +2680,7 @@ import { firebaseAuth } from './firebase-core.js';
     let codeSuggestionSource = [];
     let visibleCodeSuggestions = [];
     let activeSuggestionIndex = -1;
+    let detailFormErrorTimeoutId = null;
 
     function setDetailModalOpenState(isOpen) {
       document.body.classList.toggle('item-detail-modal-open', isOpen);
@@ -2693,7 +2694,7 @@ import { firebaseAuth } from './firebase-core.js';
       detailFormModal.close();
       setDetailModalOpenState(false);
       hideCodeSuggestions();
-      detailFormError.textContent = '';
+      clearDetailFormError();
     }
 
     function openDetailModal() {
@@ -2703,7 +2704,7 @@ import { firebaseAuth } from './firebase-core.js';
       detailForm.reset();
       requireElement('uniteInput').value = 'm';
       setDetailFormSavingState(false);
-      detailFormError.textContent = '';
+      clearDetailFormError();
       updateDetailInputCounters();
       detailFormModal.showModal();
       setDetailModalOpenState(true);
@@ -2789,6 +2790,29 @@ import { firebaseAuth } from './firebase-core.js';
     function updateDetailInputCounters() {
       updateInputCharCounter(codeInput, codeInputCounter);
       updateInputCharCounter(designationInput, designationInputCounter);
+    }
+
+    function clearDetailFormError() {
+      if (!detailFormError) {
+        return;
+      }
+      if (detailFormErrorTimeoutId) {
+        window.clearTimeout(detailFormErrorTimeoutId);
+        detailFormErrorTimeoutId = null;
+      }
+      detailFormError.textContent = '';
+    }
+
+    function showDetailFormError(message) {
+      if (!detailFormError) {
+        return;
+      }
+      clearDetailFormError();
+      detailFormError.textContent = message;
+      detailFormErrorTimeoutId = window.setTimeout(() => {
+        detailFormError.textContent = '';
+        detailFormErrorTimeoutId = null;
+      }, 2600);
     }
 
     function buildCodeSuggestionSource(details) {
@@ -3150,13 +3174,13 @@ import { firebaseAuth } from './firebase-core.js';
 
     detailForm.addEventListener('submit', async (event) => {
       event.preventDefault();
-      detailFormError.textContent = '';
+      clearDetailFormError();
       if (!designationInput.value.trim()) {
-        detailFormError.textContent = 'Veuillez remplir le champ.';
+        showDetailFormError('Veuillez remplir le champ.');
         return;
       }
       if (!permissions.canCreate) {
-        detailFormError.textContent = 'Action non autorisée.';
+        showDetailFormError('Action non autorisée.');
         return;
       }
 
@@ -3169,16 +3193,18 @@ import { firebaseAuth } from './firebase-core.js';
           unite: requireElement('uniteInput').value,
         });
         if (!result?.ok) {
-          detailFormError.textContent =
+          showDetailFormError(
             result?.reason === 'duplicate_designation'
               ? 'Cette désignation existe déjà pour ce N° OUT.'
-              : 'Création impossible. Vérifiez la désignation.';
+              : 'Création impossible. Vérifiez la désignation.',
+          );
           return;
         }
         detailForm.reset();
         requireElement('uniteInput').value = 'm';
         updateDetailInputCounters();
         hideCodeSuggestions();
+        clearDetailFormError();
         closeDetailModal();
         UiService.showToast('Article ajoutée .');
       } finally {
@@ -3221,6 +3247,7 @@ import { firebaseAuth } from './firebase-core.js';
       });
 
       codeInput.addEventListener('input', () => {
+        clearDetailFormError();
         updateInputCharCounter(codeInput, codeInputCounter);
         renderCodeSuggestions(codeInput.value);
       });
@@ -3284,6 +3311,7 @@ import { firebaseAuth } from './firebase-core.js';
 
     if (designationInput) {
       designationInput.addEventListener('input', () => {
+        clearDetailFormError();
         updateInputCharCounter(designationInput, designationInputCounter);
       });
       designationInput.addEventListener('beforeinput', (event) => {
@@ -3293,6 +3321,9 @@ import { firebaseAuth } from './firebase-core.js';
         enforceMaxLengthOnPaste(event, designationInput, designationInputCounter);
       });
     }
+
+    requireElement('qteSortieInput')?.addEventListener('input', clearDetailFormError);
+    requireElement('uniteInput')?.addEventListener('change', clearDetailFormError);
 
     if (detailSearchInput) {
       detailSearchInput.addEventListener('input', renderTable);


### PR DESCRIPTION
### Motivation
- Harmoniser le comportement du modal “Ajouter une donnée” (page 3) avec le modal “Nouveau numéro OUT” (page 2) en rendant le message d’erreur transitoire et en améliorant la lisibilité du compteur de caractères.

### Description
- Ajuste le style du compteur Code/Désignation uniquement pour la page 3 (`body[data-page="item-detail"]`) en réduisant la taille à `12px`, couleur `#9e9e9e`, `font-weight: 400` et conserve l’alignement à droite en ne touchant pas la logique du compteur (`css/style.css`).
- Introduit une gestion transitoire des erreurs pour le modal “Ajouter une donnée” en ajoutant `showDetailFormError(message)` et `clearDetailFormError()` avec un timer d’auto-disparition (`2600` ms) et en effaçant immédiatement l’erreur dès que l’utilisateur modifie les champs concernés (`js/app.js`).
- Remplace les affectations directes à `detailFormError.textContent` par les nouvelles fonctions pour s’assurer que le message d’erreur n’est affiché que lorsqu’il y a une erreur et qu’il disparaît automatiquement; la logique d’enregistrement (`StorageService.createDetail`), Firebase et les boutons restent inchangés.
- Lie la suppression immédiate de l’erreur aux événements d’entrée sur `codeInput`, `designationInput`, `qteSortieInput` et au changement de `uniteInput`, et utilise la transition d’opacité existante pour un effacement en douceur (`.form-error { transition: opacity 0.25s ease; }`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` qui a réussi.
- Validation rapide d’état avec `git status --short` et commit local effectué; aucun test automatisé supplémentaire n’était présent dans le dépôt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec34a3ee4c832a9af2649d74b36ea3)