### PR TITLE
Harmonize page 2 character counter style with page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2671,6 +2671,10 @@ body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-
   text-align: right;
   margin-top: 0;
   flex-shrink: 0;
+  font-size: 12px;
+  color: #9e9e9e;
+  font-weight: 400;
+  opacity: 1;
 }
 
 body[data-page="site-detail"] #itemDialog .item-input-feedback-row {


### PR DESCRIPTION
### Motivation
- Uniformiser le rendu visuel du compteur de caractères dans le modal « Nouveau numéro OUT » de la page 2 pour qu’il soit strictement identique à celui de la page 3.

### Description
- Ajustement CSS uniquement dans `css/style.css` pour la règle `body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-counter` en appliquant `font-size: 12px`, `color: #9e9e9e`, `font-weight: 400` et `opacity: 1` sans toucher à la logique, aux messages d’erreur, aux boutons ou à d’autres éléments.

### Testing
- Exécuté les vérifications locales `git diff --check` et `git -C /workspace/Album status --short` qui ont abouti sans erreurs de style/whitespace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec36c39c88832a9ae095d44a1a8149)