### PR TITLE
Align modal de création (page 1) avec UX pages 2/3 — compteur & erreurs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1453,12 +1453,26 @@ body[data-page="history"] .list-grid {
   display: none;
 }
 
+#siteCreateSubmitButton .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
 #siteCreateSubmitButton.is-loading {
   filter: saturate(0.95);
 }
 
 #siteCreateSubmitButton.is-loading .btn-label-default {
   display: none;
+}
+
+#siteCreateSubmitButton.is-loading .btn-loading-spinner {
+  display: inline-flex;
 }
 
 #siteCreateSubmitButton.is-loading .btn-label-loading {
@@ -2701,6 +2715,40 @@ body[data-page="site-detail"] #itemDialog .modal-actions--item-create {
 }
 
 body[data-page="site-detail"] #itemDialog #itemCreateSubmitButton.is-loading {
+  gap: 0.45rem;
+}
+
+body[data-page="home"] #siteDialog .site-input-feedback-row {
+  width: 100%;
+  margin-top: 0.24rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+body[data-page="home"] #siteDialog #siteFormError {
+  width: auto;
+  margin-top: 0;
+  text-align: left;
+  color: #c95e68;
+  font-size: 0.82rem;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+body[data-page="home"] #siteDialog #siteNameCounter {
+  width: auto;
+  text-align: right;
+  margin-top: 0;
+  flex-shrink: 0;
+  font-size: 12px;
+  color: #9e9e9e;
+  font-weight: 400;
+  opacity: 1;
+}
+
+body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   gap: 0.45rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -91,12 +91,16 @@
           <label class="input-group input-group--site-create">
             <span>Nom du site</span>
             <input id="siteNameInput" name="siteName" type="text" maxlength="20" />
+            <div class="site-input-feedback-row">
+              <p id="siteFormError" class="form-error" aria-live="polite"></p>
+              <span id="siteNameCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
+            </div>
           </label>
-          <p id="siteFormError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
             <button id="siteCreateSubmitButton" type="submit" class="btn btn-success">
               <span class="btn-label-default">Créer</span>
+              <span class="btn-loading-spinner" aria-hidden="true"></span>
               <span class="btn-label-loading" aria-hidden="true">Création...</span>
             </button>
           </div>

--- a/js/app.js
+++ b/js/app.js
@@ -897,6 +897,7 @@ import { firebaseAuth } from './firebase-core.js';
     const siteDialog = requireElement('siteDialog');
     const siteForm = requireElement('siteForm');
     const siteNameInput = requireElement('siteNameInput');
+    const siteNameCounter = requireElement('siteNameCounter');
     const siteFormError = requireElement('siteFormError');
     const siteCreateSubmitButton = requireElement('siteCreateSubmitButton');
     const homeMenuButton = requireElement('homeMenuButton');
@@ -947,6 +948,28 @@ import { firebaseAuth } from './firebase-core.js';
       siteCreateSubmitButton.disabled = isSiteCreationPending;
       siteCreateSubmitButton.classList.toggle('is-loading', isSiteCreationPending);
       siteCreateSubmitButton.setAttribute('aria-busy', String(isSiteCreationPending));
+    }
+
+    function getSiteNameMaxLength() {
+      return siteNameInput.maxLength > 0 ? siteNameInput.maxLength : null;
+    }
+
+    function updateSiteNameCounter() {
+      const maxLength = getSiteNameMaxLength();
+      const currentLength = siteNameInput.value.length;
+      siteNameCounter.textContent = `${currentLength} / ${maxLength ?? currentLength}`;
+
+      siteNameCounter.classList.remove('is-warning', 'is-limit');
+      if (!maxLength || maxLength <= 0) {
+        return;
+      }
+
+      const ratio = currentLength / maxLength;
+      if (ratio >= 1) {
+        siteNameCounter.classList.add('is-limit');
+      } else if (ratio >= 0.8) {
+        siteNameCounter.classList.add('is-warning');
+      }
     }
 
     function clearTransientError(errorElement) {
@@ -1586,13 +1609,40 @@ import { firebaseAuth } from './firebase-core.js';
         return;
       }
       siteForm.reset();
-      siteFormError.textContent = '';
+      clearTransientError(siteFormError);
       setSiteCreateLoadingState(false);
+      updateSiteNameCounter();
       siteDialog.showModal();
       siteNameInput.focus();
     });
 
     searchInput.addEventListener('input', renderSites);
+
+    siteNameInput.addEventListener('beforeinput', (event) => {
+      const maxLength = getSiteNameMaxLength();
+      if (!maxLength || event.inputType.startsWith('delete')) {
+        return;
+      }
+
+      const selectionStart = siteNameInput.selectionStart ?? siteNameInput.value.length;
+      const selectionEnd = siteNameInput.selectionEnd ?? siteNameInput.value.length;
+      const selectedLength = Math.max(0, selectionEnd - selectionStart);
+      const nextAllowedLength = maxLength - (siteNameInput.value.length - selectedLength);
+      if (nextAllowedLength <= 0) {
+        event.preventDefault();
+      }
+    });
+
+    siteNameInput.addEventListener('input', () => {
+      clearTransientError(siteFormError);
+      updateSiteNameCounter();
+    });
+
+    siteDialog.addEventListener('close', () => {
+      clearTransientError(siteFormError);
+      setSiteCreateLoadingState(false);
+      updateSiteNameCounter();
+    });
 
     siteForm.addEventListener('submit', async (event) => {
       event.preventDefault();
@@ -1601,12 +1651,12 @@ import { firebaseAuth } from './firebase-core.js';
       }
       const name = siteNameInput.value.trim();
       if (!name) {
-        siteFormError.textContent = 'Veuillez remplir ce champ';
+        showTransientError(siteFormError, 'Veuillez remplir ce champ');
         return;
       }
 
       if (!currentPermissions.canCreate) {
-        siteFormError.textContent = 'Action non autorisée.';
+        showTransientError(siteFormError, 'Action non autorisée.');
         return;
       }
 
@@ -1614,10 +1664,12 @@ import { firebaseAuth } from './firebase-core.js';
         setSiteCreateLoadingState(true);
         const result = await StorageService.createSite(name);
         if (!result?.ok) {
-          siteFormError.textContent =
+          showTransientError(
+            siteFormError,
             result?.reason === 'duplicate_site'
               ? 'Ce nom de site existe déjà.'
-              : 'Création impossible. Vérifiez le nom du site.';
+              : 'Création impossible. Vérifiez le nom du site.',
+          );
           setSiteCreateLoadingState(false);
           return;
         }
@@ -1627,7 +1679,7 @@ import { firebaseAuth } from './firebase-core.js';
         UiService.showToast('Site créé avec succés.');
       } catch (error) {
         console.error('Erreur lors de la création du site :', error);
-        siteFormError.textContent = "Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.";
+        showTransientError(siteFormError, "Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.");
         setSiteCreateLoadingState(false);
       }
     });


### PR DESCRIPTION
### Motivation
- Harmoniser l’expérience du modal “Entrer nom du site” sur la page 1 avec le comportement visuel et fonctionnel déjà présent sur les pages 2 et 3 (compteur, message d’erreur transitoire, comportement du bouton Créer). 

### Description
- Ajout d’une ligne de feedback sous le champ `siteNameInput` avec le message d’erreur à gauche et un compteur dynamique `siteNameCounter` à droite dans `index.html`. 
- Réutilisation automatique du `maxlength` du champ dans `js/app.js`, mise à jour en temps réel du compteur, blocage de la saisie via `beforeinput` quand la limite est atteinte, et suppression immédiate du message d’erreur lors de la correction. 
- Implémentation d’erreurs transitoires via `showTransientError` (apparition seulement en cas d’erreur, disparition auto après ~2s) et intégration de cet affichage dans le flux de validation du formulaire existant (page 1). 
- Ajout d’un petit spinner et d’un état `is-loading` pour le bouton `siteCreateSubmitButton` sur la page 1, et adaptation du CSS (`css/style.css`) pour correspondre au style déjà utilisé sur les pages 2/3; modifications limitées à `index.html`, `js/app.js`, `css/style.css`.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` : succès. 
- Inspection du diff des fichiers modifiés (`index.html`, `css/style.css`, `js/app.js`) : modifications conformes à la portée demandée et limitées au modal de création de site sur la page 1 (vérification manuelle via `git diff`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec38c56ccc832aa01d9601ca90c4e0)