### PR TITLE
Enforce maxlength for char counters on home and detail forms

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -954,7 +954,18 @@ import { firebaseAuth } from './firebase-core.js';
       return siteNameInput.maxLength > 0 ? siteNameInput.maxLength : null;
     }
 
+    function enforceSiteNameMaxLength() {
+      const maxLength = getSiteNameMaxLength();
+      if (!maxLength || maxLength <= 0) {
+        return;
+      }
+      if (siteNameInput.value.length > maxLength) {
+        siteNameInput.value = siteNameInput.value.slice(0, maxLength);
+      }
+    }
+
     function updateSiteNameCounter() {
+      enforceSiteNameMaxLength();
       const maxLength = getSiteNameMaxLength();
       const currentLength = siteNameInput.value.length;
       siteNameCounter.textContent = `${currentLength} / ${maxLength ?? currentLength}`;
@@ -2777,10 +2788,21 @@ import { firebaseAuth } from './firebase-core.js';
       return input?.maxLength > 0 ? input.maxLength : null;
     }
 
+    function enforceInputMaxLength(input) {
+      const maxLength = getInputMaxLength(input);
+      if (!input || !maxLength || maxLength <= 0) {
+        return;
+      }
+      if (input.value.length > maxLength) {
+        input.value = input.value.slice(0, maxLength);
+      }
+    }
+
     function updateInputCharCounter(input, counter) {
       if (!input || !counter) {
         return;
       }
+      enforceInputMaxLength(input);
       const maxLength = getInputMaxLength(input);
       const currentLength = input.value.length;
       counter.textContent = `${currentLength} / ${maxLength ?? currentLength}`;


### PR DESCRIPTION
### Motivation
- Corriger un bug où les compteurs de caractères pouvaient afficher une longueur supérieure à la limite (ex. `28 / 20`) en garantissant que la saisie et le collage soient bloqués et tronqués à `maxlength`.

### Description
- Ajout de `enforceSiteNameMaxLength()` et appel depuis `updateSiteNameCounter()` pour tronquer `siteNameInput` (page 1) avant mise à jour du compteur.
- Ajout d’une fonction générique `enforceInputMaxLength(input)` et appel depuis `updateInputCharCounter()` pour garantir que `Code` et `Désignation` (page 3) sont tronqués à `maxlength` avant que le compteur ne soit recalculé.
- Aucune modification du design, de Firebase, de la logique d’enregistrement, des autres pages ou champs ; seul le blocage de saisie et la cohérence des compteurs ont été ajustés dans `js/app.js`.

### Testing
- Exécution de `node --check js/app.js` qui a réussi et n’a signalé aucune erreur de syntaxe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3b09bf18832aa4037d575b5d652c)