### PR TITLE
Améliorer l’animation du menu « trois points » (page d'accueil)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -286,8 +286,37 @@ button {
   z-index: 10;
 }
 
+body[data-page="home"] .header-menu__panel {
+  opacity: 0;
+  transform: translateY(-0.35rem) scale(0.96);
+  transform-origin: top right;
+  pointer-events: none;
+  transition:
+    opacity 220ms cubic-bezier(0.2, 0, 0, 1),
+    transform 220ms cubic-bezier(0.2, 0, 0, 1);
+  will-change: opacity, transform;
+}
+
+body[data-page="home"] .header-menu__panel.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+body[data-page="home"] .header-menu__panel.is-closing {
+  opacity: 0;
+  transform: translateY(-0.35rem) scale(0.96);
+  pointer-events: none;
+}
+
 .header-menu__panel[hidden] {
   display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-page="home"] .header-menu__panel {
+    transition-duration: 1ms;
+  }
 }
 
 .header-menu__option {

--- a/js/app.js
+++ b/js/app.js
@@ -1029,19 +1029,63 @@ import { firebaseAuth } from './firebase-core.js';
       return `Exporter.${datePart}.su`;
     }
 
+    const HOME_MENU_TRANSITION_MS = 220;
+    let homeMenuCloseTimer = null;
+
+    function finalizeHomeMenuClose() {
+      if (!homeMenuPanel) {
+        return;
+      }
+      homeMenuPanel.hidden = true;
+      homeMenuPanel.classList.remove('is-open', 'is-closing');
+    }
+
     function closeHomeMenu() {
       if (!homeMenuPanel || !homeMenuButton) {
         return;
       }
-      homeMenuPanel.hidden = true;
+      if (homeMenuCloseTimer) {
+        window.clearTimeout(homeMenuCloseTimer);
+        homeMenuCloseTimer = null;
+      }
       homeMenuButton.setAttribute('aria-expanded', 'false');
+      if (homeMenuPanel.hidden || homeMenuPanel.classList.contains('is-closing')) {
+        finalizeHomeMenuClose();
+        return;
+      }
+
+      homeMenuPanel.classList.remove('is-open');
+      homeMenuPanel.classList.add('is-closing');
+      const onTransitionEnd = (event) => {
+        if (event.target !== homeMenuPanel) {
+          return;
+        }
+        finalizeHomeMenuClose();
+      };
+      homeMenuPanel.addEventListener('transitionend', onTransitionEnd, { once: true });
+      homeMenuCloseTimer = window.setTimeout(() => {
+        homeMenuPanel.removeEventListener('transitionend', onTransitionEnd);
+        finalizeHomeMenuClose();
+        homeMenuCloseTimer = null;
+      }, HOME_MENU_TRANSITION_MS + 50);
     }
 
     function openHomeMenu() {
       if (!homeMenuPanel || !homeMenuButton) {
         return;
       }
+      if (homeMenuCloseTimer) {
+        window.clearTimeout(homeMenuCloseTimer);
+        homeMenuCloseTimer = null;
+      }
       homeMenuPanel.hidden = false;
+      homeMenuPanel.classList.remove('is-closing');
+      window.requestAnimationFrame(() => {
+        if (homeMenuPanel.hidden) {
+          return;
+        }
+        homeMenuPanel.classList.add('is-open');
+      });
       homeMenuButton.setAttribute('aria-expanded', 'true');
     }
 
@@ -1554,6 +1598,7 @@ import { firebaseAuth } from './firebase-core.js';
 
     if (importDataButton) {
       importDataButton.addEventListener('click', () => {
+        closeHomeMenu();
         openImportFilePicker();
       });
     }


### PR DESCRIPTION
### Motivation
- Éviter l’apparition/disparition brutale du menu contextuel de la page d’accueil en ajoutant une animation d’ouverture/fermeture douce (fade + léger slide + scale) tout en conservant le design et le comportement existants.
- Scoper la modification uniquement à la page 1 (`body[data-page="home"]`) pour ne pas impacter les autres pages.

### Description
- Ajout de styles CSS scoped dans `css/style.css` pour animer le panneau avec `opacity`, `translateY(-0.35rem)` et `scale(0.96)` → `translateY(0)` et `scale(1)` en `220ms` avec `cubic-bezier(0.2, 0, 0, 1)` et gestion `prefers-reduced-motion` via `transition-duration: 1ms`.
- Introduction de classes d’état `is-open` et `is-closing` et de sélecteurs `body[data-page="home"] .header-menu__panel` pour limiter l’effet au home et préserver le rendu mobile.
- JS: modification de `js/app.js` pour retarder le `hidden` du panneau jusqu’à la fin de la transition en écoutant `transitionend` avec un timer de secours (`HOME_MENU_TRANSITION_MS`) et en fournissant la fonction `finalizeHomeMenuClose` pour nettoyer les classes d’état.
- Harmonisation des chemins de fermeture (clic extérieur, re-clic sur le bouton, clic sur un item) et uniformisation du comportement pour l’action `Importer les données` sans toucher aux actions métier ni à Firebase.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3d7433fc832ab2d24b3c208b58b1)