### PR TITLE
Améliore le feedback d’erreur du champ « Nom du site » (page 1) avec bordure rouge et animation shake

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2777,6 +2777,41 @@ body[data-page="home"] #siteDialog #siteNameCounter {
   opacity: 1;
 }
 
+body[data-page="home"] #siteDialog #siteNameInput {
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="home"] #siteDialog #siteNameInput.is-error,
+body[data-page="home"] #siteDialog #siteNameInput.is-error:focus {
+  border-color: #e53935;
+  box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.14);
+}
+
+body[data-page="home"] #siteDialog #siteNameInput.is-shaking {
+  animation: site-name-input-shake 300ms ease-in-out 1;
+}
+
+@keyframes site-name-input-shake {
+  0% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-2px);
+  }
+  80% {
+    transform: translateX(2px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
 body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   gap: 0.45rem;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -939,6 +939,7 @@ import { firebaseAuth } from './firebase-core.js';
     };
     const transientErrorTimers = new WeakMap();
     let isSiteCreationPending = false;
+    let siteNameErrorClearTimer = null;
 
     function setSiteCreateLoadingState(isLoading) {
       isSiteCreationPending = Boolean(isLoading);
@@ -993,6 +994,26 @@ import { firebaseAuth } from './firebase-core.js';
         transientErrorTimers.delete(errorElement);
       }
       errorElement.textContent = '';
+    }
+
+    function clearSiteNameErrorState() {
+      if (siteNameErrorClearTimer) {
+        window.clearTimeout(siteNameErrorClearTimer);
+        siteNameErrorClearTimer = null;
+      }
+      siteNameInput.classList.remove('is-error', 'is-shaking');
+    }
+
+    function showSiteNameError(message, durationMs = 2300) {
+      clearSiteNameErrorState();
+      showTransientError(siteFormError, message);
+      siteNameInput.classList.remove('is-shaking');
+      // Force un reflow pour rejouer l'animation à chaque nouvelle erreur.
+      void siteNameInput.offsetWidth;
+      siteNameInput.classList.add('is-error', 'is-shaking');
+      siteNameErrorClearTimer = window.setTimeout(() => {
+        clearSiteNameErrorState();
+      }, durationMs);
     }
 
     function showTransientError(errorElement, message) {
@@ -1666,6 +1687,7 @@ import { firebaseAuth } from './firebase-core.js';
       }
       siteForm.reset();
       clearTransientError(siteFormError);
+      clearSiteNameErrorState();
       setSiteCreateLoadingState(false);
       updateSiteNameCounter();
       siteDialog.showModal();
@@ -1691,11 +1713,13 @@ import { firebaseAuth } from './firebase-core.js';
 
     siteNameInput.addEventListener('input', () => {
       clearTransientError(siteFormError);
+      clearSiteNameErrorState();
       updateSiteNameCounter();
     });
 
     siteDialog.addEventListener('close', () => {
       clearTransientError(siteFormError);
+      clearSiteNameErrorState();
       setSiteCreateLoadingState(false);
       updateSiteNameCounter();
     });
@@ -1707,12 +1731,12 @@ import { firebaseAuth } from './firebase-core.js';
       }
       const name = siteNameInput.value.trim();
       if (!name) {
-        showTransientError(siteFormError, 'Veuillez remplir ce champ');
+        showSiteNameError('Veuillez remplir ce champ');
         return;
       }
 
       if (!currentPermissions.canCreate) {
-        showTransientError(siteFormError, 'Action non autorisée.');
+        showSiteNameError('Action non autorisée.');
         return;
       }
 
@@ -1720,8 +1744,7 @@ import { firebaseAuth } from './firebase-core.js';
         setSiteCreateLoadingState(true);
         const result = await StorageService.createSite(name);
         if (!result?.ok) {
-          showTransientError(
-            siteFormError,
+          showSiteNameError(
             result?.reason === 'duplicate_site'
               ? 'Ce nom de site existe déjà.'
               : 'Création impossible. Vérifiez le nom du site.',
@@ -1735,7 +1758,7 @@ import { firebaseAuth } from './firebase-core.js';
         UiService.showToast('Site créé avec succés.');
       } catch (error) {
         console.error('Erreur lors de la création du site :', error);
-        showTransientError(siteFormError, "Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.");
+        showSiteNameError("Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.");
         setSiteCreateLoadingState(false);
       }
     });


### PR DESCRIPTION
### Motivation
- Rendre le retour d’erreur sur le modal de création de site (page 1) plus clair et moderne en ajoutant un état visuel complet sur le champ « Nom du site ». 
- Respecter la priorité d’état demandée (Erreur > Focus > Normal) et fournir une animation courte et non bouclée lors des erreurs. 
- Supprimer automatiquement l’état d’erreur après une durée courte et dès que l’utilisateur commence à saisir.

### Description
- Ajout de `clearSiteNameErrorState()` et `showSiteNameError()` dans `js/app.js` pour gérer localement l’état d’erreur, la classe `is-error`, la classe `is-shaking` et le timer d’effacement automatique. 
- Intégration de ces helpers dans le flux du modal : ouverture/reset, saisie (`input`), fermeture du dialog et branches de validation/soumission (`submit`). 
- Remplacement des appels ponctuels de `showTransientError()` par `showSiteNameError()` pour les erreurs liées à ce champ afin d’appliquer animation + bordure. 
- Ajout de règles CSS dans `css/style.css` scoped à la page d’accueil pour `#siteNameInput` : transition `0.2s`, bordure rouge `#e53935`, ombre rouge discrète, animation `site-name-input-shake` (~300ms) avec translation horizontale faible et exécutée une seule fois.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec41524e98832a8f7d876f69e0d1c4)