### PR TITLE
Améliore l’UX des champs Code/Désignation du modal d’ajout (page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2149,9 +2149,26 @@ body[data-page="item-detail"] .detail-input-feedback-row {
   width: 100%;
   margin-top: 0.24rem;
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   gap: 0.5rem;
+}
+
+body[data-page="item-detail"] .required-asterisk {
+  color: #d65f68;
+  font-size: 0.88em;
+  margin-left: 0.18rem;
+  vertical-align: baseline;
+}
+
+body[data-page="item-detail"] .detail-field-error {
+  width: auto;
+  margin-top: 0;
+  text-align: left;
+  color: #c95e68;
+  font-size: 0.82rem;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 body[data-page="item-detail"] .detail-input-feedback-row .input-char-counter {
@@ -2186,6 +2203,45 @@ body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field--uni
 body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > input,
 body[data-page="item-detail"] .detail-form-row--qte-unit .detail-form-field > select {
   height: 100%;
+}
+
+body[data-page="item-detail"] #codeInput,
+body[data-page="item-detail"] #designationInput {
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="item-detail"] #codeInput.is-error,
+body[data-page="item-detail"] #designationInput.is-error,
+body[data-page="item-detail"] #codeInput.is-error:focus,
+body[data-page="item-detail"] #designationInput.is-error:focus {
+  border-color: #e53935;
+  box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.14);
+}
+
+body[data-page="item-detail"] #codeInput.is-shaking,
+body[data-page="item-detail"] #designationInput.is-shaking {
+  animation: detail-required-input-shake 300ms ease-in-out 1;
+}
+
+@keyframes detail-required-input-shake {
+  0% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-2px);
+  }
+  80% {
+    transform: translateX(2px);
+  }
+  100% {
+    transform: translateX(0);
+  }
 }
 
 @keyframes detailModalIn {

--- a/js/app.js
+++ b/js/app.js
@@ -2820,8 +2820,10 @@ import { firebaseAuth } from './firebase-core.js';
     const detailExportCancelButton = requireElement('detailExportCancelButton');
     const codeInput = requireElement('codeInput');
     const codeInputCounter = requireElement('codeInputCounter');
+    const codeInputError = requireElement('codeInputError');
     const designationInput = requireElement('designationInput');
     const designationInputCounter = requireElement('designationInputCounter');
+    const designationInputError = requireElement('designationInputError');
     const codeSuggestions = requireElement('codeSuggestions');
     const isAuthenticatedUser = Boolean(firebaseAuth.currentUser);
     const canEditDetails = permissions.canEdit && isAuthenticatedUser;
@@ -2839,6 +2841,10 @@ import { firebaseAuth } from './firebase-core.js';
     let visibleCodeSuggestions = [];
     let activeSuggestionIndex = -1;
     let detailFormErrorTimeoutId = null;
+    let codeInputErrorTimeoutId = null;
+    let designationInputErrorTimeoutId = null;
+    let codeInputErrorStateTimeoutId = null;
+    let designationInputErrorStateTimeoutId = null;
 
     function setDetailModalOpenState(isOpen) {
       document.body.classList.toggle('item-detail-modal-open', isOpen);
@@ -2853,6 +2859,7 @@ import { firebaseAuth } from './firebase-core.js';
       setDetailModalOpenState(false);
       hideCodeSuggestions();
       clearDetailFormError();
+      clearDetailRequiredFieldErrors();
     }
 
     function openDetailModal() {
@@ -2863,6 +2870,7 @@ import { firebaseAuth } from './firebase-core.js';
       requireElement('uniteInput').value = 'm';
       setDetailFormSavingState(false);
       clearDetailFormError();
+      clearDetailRequiredFieldErrors();
       updateDetailInputCounters();
       detailFormModal.showModal();
       setDetailModalOpenState(true);
@@ -2970,6 +2978,94 @@ import { firebaseAuth } from './firebase-core.js';
         detailFormErrorTimeoutId = null;
       }
       detailFormError.textContent = '';
+    }
+
+    function getDetailFieldElements(fieldName) {
+      if (fieldName === 'code') {
+        return { input: codeInput, error: codeInputError };
+      }
+      if (fieldName === 'designation') {
+        return { input: designationInput, error: designationInputError };
+      }
+      return { input: null, error: null };
+    }
+
+    function clearDetailFieldErrorTimeout(fieldName) {
+      if (fieldName === 'code' && codeInputErrorTimeoutId) {
+        window.clearTimeout(codeInputErrorTimeoutId);
+        codeInputErrorTimeoutId = null;
+      }
+      if (fieldName === 'designation' && designationInputErrorTimeoutId) {
+        window.clearTimeout(designationInputErrorTimeoutId);
+        designationInputErrorTimeoutId = null;
+      }
+    }
+
+    function clearDetailFieldErrorStateTimeout(fieldName) {
+      if (fieldName === 'code' && codeInputErrorStateTimeoutId) {
+        window.clearTimeout(codeInputErrorStateTimeoutId);
+        codeInputErrorStateTimeoutId = null;
+      }
+      if (fieldName === 'designation' && designationInputErrorStateTimeoutId) {
+        window.clearTimeout(designationInputErrorStateTimeoutId);
+        designationInputErrorStateTimeoutId = null;
+      }
+    }
+
+    function clearDetailFieldErrorState(fieldName) {
+      const { input, error } = getDetailFieldElements(fieldName);
+      clearDetailFieldErrorTimeout(fieldName);
+      clearDetailFieldErrorStateTimeout(fieldName);
+      if (error) {
+        error.textContent = '';
+      }
+      if (input) {
+        input.classList.remove('is-error', 'is-shaking');
+      }
+    }
+
+    function showDetailFieldError(fieldName, message, durationMs = 2400) {
+      const { input, error } = getDetailFieldElements(fieldName);
+      if (!input || !error) {
+        return;
+      }
+      clearDetailFieldErrorState(fieldName);
+      clearDetailFormError();
+      error.textContent = message;
+      input.classList.remove('is-shaking');
+      void input.offsetWidth;
+      input.classList.add('is-error', 'is-shaking');
+
+      const errorTimeoutId = window.setTimeout(() => {
+        error.textContent = '';
+        if (fieldName === 'code') {
+          codeInputErrorTimeoutId = null;
+        } else if (fieldName === 'designation') {
+          designationInputErrorTimeoutId = null;
+        }
+      }, durationMs);
+
+      const errorStateTimeoutId = window.setTimeout(() => {
+        input.classList.remove('is-error', 'is-shaking');
+        if (fieldName === 'code') {
+          codeInputErrorStateTimeoutId = null;
+        } else if (fieldName === 'designation') {
+          designationInputErrorStateTimeoutId = null;
+        }
+      }, durationMs);
+
+      if (fieldName === 'code') {
+        codeInputErrorTimeoutId = errorTimeoutId;
+        codeInputErrorStateTimeoutId = errorStateTimeoutId;
+      } else if (fieldName === 'designation') {
+        designationInputErrorTimeoutId = errorTimeoutId;
+        designationInputErrorStateTimeoutId = errorStateTimeoutId;
+      }
+    }
+
+    function clearDetailRequiredFieldErrors() {
+      clearDetailFieldErrorState('code');
+      clearDetailFieldErrorState('designation');
     }
 
     function showDetailFormError(message) {
@@ -3344,8 +3440,16 @@ import { firebaseAuth } from './firebase-core.js';
     detailForm.addEventListener('submit', async (event) => {
       event.preventDefault();
       clearDetailFormError();
-      if (!designationInput.value.trim()) {
-        showDetailFormError('Veuillez remplir le champ.');
+      let hasFieldError = false;
+      if (!String(codeInput.value || '').trim()) {
+        showDetailFieldError('code', 'Veuillez remplir ce champ');
+        hasFieldError = true;
+      }
+      if (!String(designationInput.value || '').trim()) {
+        showDetailFieldError('designation', 'Veuillez remplir ce champ');
+        hasFieldError = true;
+      }
+      if (hasFieldError) {
         return;
       }
       if (!permissions.canCreate) {
@@ -3417,6 +3521,7 @@ import { firebaseAuth } from './firebase-core.js';
 
       codeInput.addEventListener('input', () => {
         clearDetailFormError();
+        clearDetailFieldErrorState('code');
         updateInputCharCounter(codeInput, codeInputCounter);
         renderCodeSuggestions(codeInput.value);
       });
@@ -3481,6 +3586,7 @@ import { firebaseAuth } from './firebase-core.js';
     if (designationInput) {
       designationInput.addEventListener('input', () => {
         clearDetailFormError();
+        clearDetailFieldErrorState('designation');
         updateInputCharCounter(designationInput, designationInputCounter);
       });
       designationInput.addEventListener('beforeinput', (event) => {

--- a/page3.html
+++ b/page3.html
@@ -111,19 +111,21 @@
           <section id="detailFormSection" class="surface-card form-card section detail-form-modal__section">
             <form id="detailForm" class="responsive-form" novalidate>
               <label class="input-group">
-                <span>Code</span>
+                <span>Code <span class="required-asterisk" aria-hidden="true">*</span></span>
                 <div class="typeahead" id="codeTypeahead">
                   <input id="codeInput" name="code" type="text" maxlength="40" aria-label="Code" autocomplete="off" />
                   <div id="codeSuggestions" class="typeahead__menu" role="listbox" aria-label="Suggestions de code" hidden></div>
                 </div>
                 <div class="detail-input-feedback-row">
+                  <p id="codeInputError" class="form-error detail-field-error" aria-live="polite"></p>
                   <span id="codeInputCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
                 </div>
               </label>
               <label class="input-group input-group--wide">
-                <span>Désignation</span>
+                <span>Désignation <span class="required-asterisk" aria-hidden="true">*</span></span>
                 <input id="designationInput" name="designation" type="text" maxlength="120" required />
                 <div class="detail-input-feedback-row">
+                  <p id="designationInputError" class="form-error detail-field-error" aria-live="polite"></p>
                   <span id="designationInputCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
                 </div>
               </label>


### PR DESCRIPTION
### Motivation
- Harmoniser l’expérience du modal « Ajouter une donnée » de la page 3 avec le comportement UX existant sur les pages 1 et 2 pour les champs obligatoires "Code" et "Désignation".
- Rendre les erreurs de saisie plus claires et temporisées tout en gardant la logique d’enregistrement inchangée.

### Description
- Page modifiée : `page3.html` — ajout d’une petite étoile rouge sur les labels `Code` et `Désignation` et insertion d’une zone d’aide/erreur dédiée sous chaque champ (`codeInputError`, `designationInputError`) à gauche et du compteur à droite.
- Feuilles de styles : `css/style.css` — `detail-input-feedback-row` passe en `space-between`, ajout du style pour l’astérisque (`.required-asterisk`), style d’erreur local (`.detail-field-error`), états `is-error`/`is-shaking` pour les inputs et keyframes de shake pour reproduire l’animation courte existante.
- Comportement JS : `js/app.js` — gestion d’erreur par champ (timers pour affichage temporaire ≈ 2.4s), fonctions utilitaires `showDetailFieldError` / `clearDetailFieldErrorState`, validation sur `submit` pour exiger `code` et `designation`, suppression immédiate de l’erreur quand l’utilisateur recommence à taper, et réinitialisation des erreurs à l’ouverture/fermeture du modal; la logique d’appel à `StorageService.createDetail(...)` n’a pas été modifiée.

### Testing
- Exécution de la vérification syntaxique JS avec `node --check js/app.js`, qui a réussi without errors.
- Aucune modification des appels Firebase ni des routines de persistance n’a été effectuée, et les validations côté front ont été testées manuellement via les handlers ajoutés (erreur affichée, disparition automatique et effacement immédiat à la saisie).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4956a9cc832a9b613b7e08985e16)