### PR TITLE
Améliorer l’UX du modal “Créer un mot de passe” (page 1)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1380,6 +1380,80 @@ body[data-page="history"] .list-grid {
   margin-top: 0.35rem;
 }
 
+body[data-page="home"] #siteLockDialog .password-wrap--site-lock {
+  position: relative;
+  width: 100%;
+}
+
+body[data-page="home"] #siteLockDialog .password-wrap--site-lock input {
+  padding-right: 3.1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="home"] #siteLockDialog .password-toggle--site-lock {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  transform: translateY(-50%);
+  width: 2.1rem;
+  height: 2.1rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body[data-page="home"] #siteLockDialog .password-toggle--site-lock img {
+  width: 1.45rem;
+  height: 1.45rem;
+  object-fit: contain;
+}
+
+body[data-page="home"] #siteLockDialog .form-error--field {
+  margin-top: 0.1rem;
+  min-height: 1rem;
+  text-align: left;
+  color: #c95e68;
+  font-size: 0.82rem;
+}
+
+body[data-page="home"] #siteLockDialog #siteLockPasswordInput.is-error,
+body[data-page="home"] #siteLockDialog #siteLockPasswordInput.is-error:focus,
+body[data-page="home"] #siteLockDialog #siteLockConfirmPasswordInput.is-error,
+body[data-page="home"] #siteLockDialog #siteLockConfirmPasswordInput.is-error:focus {
+  border-color: #e57373;
+  box-shadow: 0 0 0 3px rgba(229, 115, 115, 0.16);
+}
+
+body[data-page="home"] #siteLockDialog #siteLockPasswordInput.is-shaking,
+body[data-page="home"] #siteLockDialog #siteLockConfirmPasswordInput.is-shaking {
+  animation: site-lock-input-shake 300ms ease-in-out 1;
+}
+
+@keyframes site-lock-input-shake {
+  0% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-2px);
+  }
+  80% {
+    transform: translateX(2px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
 .modal-helper-text {
   margin: -0.2rem 0 0.9rem;
   color: var(--text-muted);

--- a/index.html
+++ b/index.html
@@ -114,13 +114,34 @@
           </div>
           <label class="input-group input-group--site-lock-create">
             <span>Entrer un mot de passe</span>
-            <input id="siteLockPasswordInput" type="password" autocomplete="new-password" />
+            <div class="password-wrap password-wrap--site-lock">
+              <input id="siteLockPasswordInput" type="password" autocomplete="new-password" />
+              <button
+                id="siteLockPasswordToggle"
+                class="password-toggle password-toggle--site-lock"
+                type="button"
+                aria-label="Afficher le mot de passe"
+              >
+                <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
+              </button>
+            </div>
+            <p id="siteLockPasswordError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
           <label class="input-group input-group--site-lock-create">
             <span>Confirmer le mot de passe</span>
-            <input id="siteLockConfirmPasswordInput" type="password" autocomplete="new-password" />
+            <div class="password-wrap password-wrap--site-lock">
+              <input id="siteLockConfirmPasswordInput" type="password" autocomplete="new-password" />
+              <button
+                id="siteLockConfirmPasswordToggle"
+                class="password-toggle password-toggle--site-lock"
+                type="button"
+                aria-label="Afficher le mot de passe"
+              >
+                <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
+              </button>
+            </div>
+            <p id="siteLockConfirmPasswordError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
-          <p id="siteLockError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--password">
             <button type="button" class="btn" data-close-dialog>Annuler</button>
             <button type="submit" class="btn btn-success">Enregistrer</button>

--- a/js/app.js
+++ b/js/app.js
@@ -910,7 +910,10 @@ import { firebaseAuth } from './firebase-core.js';
     const siteLockForm = requireElement('siteLockForm');
     const siteLockPasswordInput = requireElement('siteLockPasswordInput');
     const siteLockConfirmPasswordInput = requireElement('siteLockConfirmPasswordInput');
-    const siteLockError = requireElement('siteLockError');
+    const siteLockPasswordError = requireElement('siteLockPasswordError');
+    const siteLockConfirmPasswordError = requireElement('siteLockConfirmPasswordError');
+    const siteLockPasswordToggle = requireElement('siteLockPasswordToggle');
+    const siteLockConfirmPasswordToggle = requireElement('siteLockConfirmPasswordToggle');
     const siteUnlockDialog = requireElement('siteUnlockDialog');
     const siteUnlockForm = requireElement('siteUnlockForm');
     const siteUnlockPasswordInput = requireElement('siteUnlockPasswordInput');
@@ -940,6 +943,7 @@ import { firebaseAuth } from './firebase-core.js';
     const transientErrorTimers = new WeakMap();
     let isSiteCreationPending = false;
     let siteNameErrorClearTimer = null;
+    const siteLockFieldStateTimers = new WeakMap();
 
     function setSiteCreateLoadingState(isLoading) {
       isSiteCreationPending = Boolean(isLoading);
@@ -1027,6 +1031,47 @@ import { firebaseAuth } from './firebase-core.js';
         transientErrorTimers.delete(errorElement);
       }, 2000);
       transientErrorTimers.set(errorElement, hideTimer);
+    }
+
+    function clearSiteLockFieldErrorState(inputElement, errorElement) {
+      if (!inputElement || !errorElement) {
+        return;
+      }
+      clearTransientError(errorElement);
+      const timer = siteLockFieldStateTimers.get(inputElement);
+      if (timer) {
+        window.clearTimeout(timer);
+        siteLockFieldStateTimers.delete(inputElement);
+      }
+      inputElement.classList.remove('is-error', 'is-shaking');
+    }
+
+    function showSiteLockFieldError(inputElement, errorElement, message, durationMs = 2300) {
+      if (!inputElement || !errorElement) {
+        return;
+      }
+      clearSiteLockFieldErrorState(inputElement, errorElement);
+      showTransientError(errorElement, message);
+      inputElement.classList.remove('is-shaking');
+      void inputElement.offsetWidth;
+      inputElement.classList.add('is-error', 'is-shaking');
+      const timer = window.setTimeout(() => {
+        inputElement.classList.remove('is-error', 'is-shaking');
+        siteLockFieldStateTimers.delete(inputElement);
+      }, durationMs);
+      siteLockFieldStateTimers.set(inputElement, timer);
+    }
+
+    function setPasswordVisibility(inputElement, toggleButton, isVisible) {
+      if (!inputElement || !toggleButton) {
+        return;
+      }
+      const iconElement = toggleButton.querySelector('img');
+      inputElement.type = isVisible ? 'text' : 'password';
+      toggleButton.setAttribute('aria-label', isVisible ? 'Cacher le mot de passe' : 'Afficher le mot de passe');
+      if (iconElement) {
+        iconElement.src = isVisible ? 'Icon/Eye_ON.png' : 'Icon/Eye_OFF.png';
+      }
     }
 
     async function loadUserNames() {
@@ -1344,13 +1389,22 @@ import { firebaseAuth } from './firebase-core.js';
         return;
       }
 
-      if (!siteLockDialog || !siteLockPasswordInput || !siteLockConfirmPasswordInput || !siteLockError) {
+      if (
+        !siteLockDialog ||
+        !siteLockPasswordInput ||
+        !siteLockConfirmPasswordInput ||
+        !siteLockPasswordError ||
+        !siteLockConfirmPasswordError
+      ) {
         return;
       }
       siteIdPendingLock = siteId;
       siteLockPasswordInput.value = '';
       siteLockConfirmPasswordInput.value = '';
-      clearTransientError(siteLockError);
+      clearSiteLockFieldErrorState(siteLockPasswordInput, siteLockPasswordError);
+      clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
+      setPasswordVisibility(siteLockPasswordInput, siteLockPasswordToggle, false);
+      setPasswordVisibility(siteLockConfirmPasswordInput, siteLockConfirmPasswordToggle, false);
       siteLockDialog.showModal();
       siteLockPasswordInput.focus();
     }
@@ -1768,17 +1822,29 @@ import { firebaseAuth } from './firebase-core.js';
       if (!siteIdPendingLock) {
         return;
       }
-      clearTransientError(siteLockError);
+      clearSiteLockFieldErrorState(siteLockPasswordInput, siteLockPasswordError);
+      clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
       const passwordValue = siteLockPasswordInput?.value || '';
       const confirmValue = siteLockConfirmPasswordInput?.value || '';
 
-      if (!passwordValue.trim() || !confirmValue.trim()) {
-        showTransientError(siteLockError, 'Veuillez remplir tous les champs.');
+      const isPasswordMissing = !passwordValue.trim();
+      const isConfirmMissing = !confirmValue.trim();
+      if (isPasswordMissing || isConfirmMissing) {
+        if (isPasswordMissing) {
+          showSiteLockFieldError(siteLockPasswordInput, siteLockPasswordError, 'Veuillez remplir ce champ');
+        }
+        if (isConfirmMissing) {
+          showSiteLockFieldError(siteLockConfirmPasswordInput, siteLockConfirmPasswordError, 'Veuillez remplir ce champ');
+        }
         return;
       }
 
       if (passwordValue !== confirmValue) {
-        showTransientError(siteLockError, 'Les mots de passe ne correspondent pas.');
+        showSiteLockFieldError(
+          siteLockConfirmPasswordInput,
+          siteLockConfirmPasswordError,
+          'Les mots de passe ne correspondent pas.',
+        );
         return;
       }
 
@@ -1786,15 +1852,33 @@ import { firebaseAuth } from './firebase-core.js';
         const passwordHash = await hashPassword(passwordValue);
         const result = await StorageService.setSiteLock(siteIdPendingLock, { passwordHash });
         if (!result?.ok) {
-          showTransientError(siteLockError, 'Impossible de verrouiller ce site.');
+          showSiteLockFieldError(siteLockConfirmPasswordInput, siteLockConfirmPasswordError, 'Impossible de verrouiller ce site.');
           return;
         }
         siteLockDialog?.close();
         siteIdPendingLock = null;
         UiService.showToast('Site verrouillé.');
       } catch (_error) {
-        showTransientError(siteLockError, 'Erreur pendant le verrouillage.');
+        showSiteLockFieldError(siteLockConfirmPasswordInput, siteLockConfirmPasswordError, 'Erreur pendant le verrouillage.');
       }
+    });
+
+    siteLockPasswordInput?.addEventListener('input', () => {
+      clearSiteLockFieldErrorState(siteLockPasswordInput, siteLockPasswordError);
+    });
+
+    siteLockConfirmPasswordInput?.addEventListener('input', () => {
+      clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
+    });
+
+    siteLockPasswordToggle?.addEventListener('click', () => {
+      const nextIsVisible = siteLockPasswordInput?.type === 'password';
+      setPasswordVisibility(siteLockPasswordInput, siteLockPasswordToggle, nextIsVisible);
+    });
+
+    siteLockConfirmPasswordToggle?.addEventListener('click', () => {
+      const nextIsVisible = siteLockConfirmPasswordInput?.type === 'password';
+      setPasswordVisibility(siteLockConfirmPasswordInput, siteLockConfirmPasswordToggle, nextIsVisible);
     });
 
     siteUnlockForm?.addEventListener('submit', async (event) => {
@@ -1894,7 +1978,10 @@ import { firebaseAuth } from './firebase-core.js';
 
     siteLockDialog?.addEventListener('close', () => {
       siteIdPendingLock = null;
-      clearTransientError(siteLockError);
+      clearSiteLockFieldErrorState(siteLockPasswordInput, siteLockPasswordError);
+      clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
+      setPasswordVisibility(siteLockPasswordInput, siteLockPasswordToggle, false);
+      setPasswordVisibility(siteLockConfirmPasswordInput, siteLockConfirmPasswordToggle, false);
     });
 
     siteUnlockDialog?.addEventListener('close', () => {


### PR DESCRIPTION
### Motivation
- Harmoniser le modal “Créer un mot de passe” de la page d’accueil avec les autres modals en passant d’un message d’erreur global à des erreurs par champ, bordure rouge douce, animation "shake", messages temporaires et un contrôle oeil ON/OFF pour chaque champ.
- Améliorer la clarté des erreurs pour les champs `Entrer un mot de passe` et `Confirmer le mot de passe` afin que les erreurs de champ (vide / mismatch) s’affichent juste en dessous du champ concerné.
- Préserver la logique existante (pas de changement Firebase ni d’autres modals/pages) tout en ajoutant des comportements visuels cohérents et réactifs.

### Description
- Mise à jour de `index.html` pour envelopper chaque champ mot de passe dans un `div.password-wrap` contenant un bouton oeil (utilisant `Icon/Eye_OFF.png` / `Icon/Eye_ON.png`) et ajouter un paragraphe d’erreur par champ (`siteLockPasswordError` et `siteLockConfirmPasswordError`).
- Ajout de styles dans `css/style.css` scoped sur `#siteLockDialog` pour le positionnement de l’icône, `padding-right` des inputs, taille et alignement de l’icône, texte d’erreur aligné à gauche, bordure rouge douce et animation `site-lock-input-shake`.
- Ajout de logique dans `js/app.js` : helpers `clearSiteLockFieldErrorState`, `showSiteLockFieldError`, `setPasswordVisibility`, validation au `submit` qui affiche les erreurs par champ (champ vide / confirmation mismatch), effacement immédiat de l’erreur à la saisie, handlers pour toggler la visibilité oeil ON/OFF, et réinitialisation des états/visibilités à l’ouverture et à la fermeture du modal.

### Testing
- L’analyse statique rapide `node --check js/app.js` a été exécutée et a réussi sans erreurs.
- Aucun test automatisé UI n’a été exécuté dans cet environnement (vérification visuelle non automatisée).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4d864900832ab4562f42d2fbfc54)