### PR TITLE
Ajuste la taille et l’alignement de l’icône œil dans le modal de création du mot de passe

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1386,17 +1386,17 @@ body[data-page="home"] #siteLockDialog .password-wrap--site-lock {
 }
 
 body[data-page="home"] #siteLockDialog .password-wrap--site-lock input {
-  padding-right: 3.1rem;
+  padding-right: 2.8rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 body[data-page="home"] #siteLockDialog .password-toggle--site-lock {
   position: absolute;
   top: 50%;
-  right: 0.45rem;
+  right: 0.4rem;
   transform: translateY(-50%);
-  width: 2.1rem;
-  height: 2.1rem;
+  width: 2.125rem;
+  height: 2.125rem;
   padding: 0;
   border: 0;
   border-radius: 999px;
@@ -1407,9 +1407,16 @@ body[data-page="home"] #siteLockDialog .password-toggle--site-lock {
 }
 
 body[data-page="home"] #siteLockDialog .password-toggle--site-lock img {
-  width: 1.45rem;
-  height: 1.45rem;
+  width: 1.3125rem;
+  height: 1.3125rem;
   object-fit: contain;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+body[data-page="home"] #siteLockDialog .password-toggle--site-lock:hover img,
+body[data-page="home"] #siteLockDialog .password-toggle--site-lock:focus-visible img {
+  opacity: 1;
 }
 
 body[data-page="home"] #siteLockDialog .form-error--field {


### PR DESCRIPTION
### Motivation
- Rendre l’icône Eye_ON / Eye_OFF visuellement proportionnée dans le modal `Créer un mot de passe` tout en conservant une zone cliquable confortable et sans toucher à la logique ou aux assets.

### Description
- Réduit le `padding-right` de l’input dans `#siteLockDialog .password-wrap--site-lock` de `3.1rem` à `2.8rem` pour éviter que le texte passe sous l’icône.
- Ajuste la position du toggle `right` de `0.45rem` à `0.4rem` et la taille du bouton toggle de `2.1rem` à `2.125rem` pour maintenir une zone cliquable autour de 34px.
- Diminue la taille de l’image de l’icône de `1.45rem` à `1.3125rem` pour obtenir ~20–22px visuels et ajoute `opacity: 0.8` avec une transition et retour à `opacity: 1` au `:hover` et `:focus-visible`.
- Aucune modification des fichiers d’images ni de la logique ON/OFF, uniquement des règles CSS dans `css/style.css`.

### Testing
- Exécuté `git diff --check` et la vérification a réussi.
- Modifications validées localement via inspection du fichier `css/style.css` (diff et visual review des règles appliquées).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4f77d7b8832a9261f830611a1fd4)