### PR TITLE
Improve “Site verrouillé” modal UX on home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1380,6 +1380,67 @@ body[data-page="history"] .list-grid {
   margin-top: 0.35rem;
 }
 
+body[data-page="home"] #siteUnlockDialog .input-group--site-unlock {
+  gap: 0.65rem;
+}
+
+body[data-page="home"] #siteUnlockDialog .password-wrap--site-unlock {
+  position: relative;
+  width: 100%;
+}
+
+body[data-page="home"] #siteUnlockDialog .password-wrap--site-unlock input {
+  padding-right: 2.8rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="home"] #siteUnlockDialog .password-toggle--site-unlock {
+  position: absolute;
+  top: 50%;
+  right: 0.4rem;
+  transform: translateY(-50%);
+  width: 2.125rem;
+  height: 2.125rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body[data-page="home"] #siteUnlockDialog .password-toggle--site-unlock img {
+  width: 1.3125rem;
+  height: 1.3125rem;
+  object-fit: contain;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+body[data-page="home"] #siteUnlockDialog .password-toggle--site-unlock:hover img,
+body[data-page="home"] #siteUnlockDialog .password-toggle--site-unlock:focus-visible img {
+  opacity: 1;
+}
+
+body[data-page="home"] #siteUnlockDialog .form-error--field {
+  margin-top: 0.1rem;
+  min-height: 1rem;
+  text-align: left;
+  color: #c95e68;
+  font-size: 0.82rem;
+}
+
+body[data-page="home"] #siteUnlockDialog #siteUnlockPasswordInput.is-error,
+body[data-page="home"] #siteUnlockDialog #siteUnlockPasswordInput.is-error:focus {
+  border-color: #e57373;
+  box-shadow: 0 0 0 3px rgba(229, 115, 115, 0.16);
+}
+
+body[data-page="home"] #siteUnlockDialog #siteUnlockPasswordInput.is-shaking {
+  animation: site-lock-input-shake 300ms ease-in-out 1;
+}
+
 body[data-page="home"] #siteLockDialog .password-wrap--site-lock {
   position: relative;
   width: 100%;
@@ -1586,6 +1647,40 @@ body[data-page="home"] #siteLockDialog #siteLockConfirmPasswordInput.is-shaking 
 }
 
 #siteCreateSubmitButton.is-loading .btn-label-loading {
+  display: inline-flex;
+}
+
+#siteUnlockSubmitButton {
+  position: relative;
+}
+
+#siteUnlockSubmitButton .btn-label-loading {
+  display: none;
+}
+
+#siteUnlockSubmitButton .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
+#siteUnlockSubmitButton.is-loading {
+  filter: saturate(0.95);
+}
+
+#siteUnlockSubmitButton.is-loading .btn-label-default {
+  display: none;
+}
+
+#siteUnlockSubmitButton.is-loading .btn-loading-spinner {
+  display: inline-flex;
+}
+
+#siteUnlockSubmitButton.is-loading .btn-label-loading {
   display: inline-flex;
 }
 

--- a/index.html
+++ b/index.html
@@ -181,14 +181,28 @@
           <div class="modal-header">
             <h2>Site verrouillé</h2>
           </div>
-          <label class="input-group">
+          <label class="input-group input-group--site-unlock">
             <span>Mot de passe</span>
-            <input id="siteUnlockPasswordInput" type="password" autocomplete="current-password" />
+            <div class="password-wrap password-wrap--site-unlock">
+              <input id="siteUnlockPasswordInput" type="password" autocomplete="current-password" />
+              <button
+                id="siteUnlockPasswordToggle"
+                class="password-toggle password-toggle--site-unlock"
+                type="button"
+                aria-label="Afficher le mot de passe"
+              >
+                <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
+              </button>
+            </div>
+            <p id="siteUnlockError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
-          <p id="siteUnlockError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--password">
             <button type="button" class="btn" data-close-dialog>Annuler</button>
-            <button type="submit" class="btn btn-success">Valider</button>
+            <button id="siteUnlockSubmitButton" type="submit" class="btn btn-success">
+              <span class="btn-label-default">Valider</span>
+              <span class="btn-loading-spinner" aria-hidden="true"></span>
+              <span class="btn-label-loading" aria-hidden="true">Validation...</span>
+            </button>
           </div>
         </form>
       </dialog>

--- a/js/app.js
+++ b/js/app.js
@@ -917,6 +917,8 @@ import { firebaseAuth } from './firebase-core.js';
     const siteUnlockDialog = requireElement('siteUnlockDialog');
     const siteUnlockForm = requireElement('siteUnlockForm');
     const siteUnlockPasswordInput = requireElement('siteUnlockPasswordInput');
+    const siteUnlockPasswordToggle = requireElement('siteUnlockPasswordToggle');
+    const siteUnlockSubmitButton = requireElement('siteUnlockSubmitButton');
     const siteUnlockError = requireElement('siteUnlockError');
     const siteLockManageDialog = requireElement('siteLockManageDialog');
     const siteLockManageForm = requireElement('siteLockManageForm');
@@ -944,6 +946,7 @@ import { firebaseAuth } from './firebase-core.js';
     let isSiteCreationPending = false;
     let siteNameErrorClearTimer = null;
     const siteLockFieldStateTimers = new WeakMap();
+    let isSiteUnlockPending = false;
 
     function setSiteCreateLoadingState(isLoading) {
       isSiteCreationPending = Boolean(isLoading);
@@ -957,6 +960,16 @@ import { firebaseAuth } from './firebase-core.js';
 
     function getSiteNameMaxLength() {
       return siteNameInput.maxLength > 0 ? siteNameInput.maxLength : null;
+    }
+
+    function setSiteUnlockLoadingState(isLoading) {
+      isSiteUnlockPending = Boolean(isLoading);
+      if (!siteUnlockSubmitButton) {
+        return;
+      }
+      siteUnlockSubmitButton.disabled = isSiteUnlockPending;
+      siteUnlockSubmitButton.classList.toggle('is-loading', isSiteUnlockPending);
+      siteUnlockSubmitButton.setAttribute('aria-busy', String(isSiteUnlockPending));
     }
 
     function enforceSiteNameMaxLength() {
@@ -1060,6 +1073,35 @@ import { firebaseAuth } from './firebase-core.js';
         siteLockFieldStateTimers.delete(inputElement);
       }, durationMs);
       siteLockFieldStateTimers.set(inputElement, timer);
+    }
+
+    function clearSiteUnlockFieldErrorState() {
+      if (!siteUnlockPasswordInput || !siteUnlockError) {
+        return;
+      }
+      clearTransientError(siteUnlockError);
+      const timer = siteLockFieldStateTimers.get(siteUnlockPasswordInput);
+      if (timer) {
+        window.clearTimeout(timer);
+        siteLockFieldStateTimers.delete(siteUnlockPasswordInput);
+      }
+      siteUnlockPasswordInput.classList.remove('is-error', 'is-shaking');
+    }
+
+    function showSiteUnlockFieldError(message, durationMs = 2300) {
+      if (!siteUnlockPasswordInput || !siteUnlockError) {
+        return;
+      }
+      clearSiteUnlockFieldErrorState();
+      showTransientError(siteUnlockError, message);
+      siteUnlockPasswordInput.classList.remove('is-shaking');
+      void siteUnlockPasswordInput.offsetWidth;
+      siteUnlockPasswordInput.classList.add('is-error', 'is-shaking');
+      const timer = window.setTimeout(() => {
+        siteUnlockPasswordInput.classList.remove('is-error', 'is-shaking');
+        siteLockFieldStateTimers.delete(siteUnlockPasswordInput);
+      }, durationMs);
+      siteLockFieldStateTimers.set(siteUnlockPasswordInput, timer);
     }
 
     function setPasswordVisibility(inputElement, toggleButton, isVisible) {
@@ -1635,7 +1677,9 @@ import { firebaseAuth } from './firebase-core.js';
           }
           siteIdPendingUnlock = siteId;
           siteUnlockPasswordInput.value = '';
-          clearTransientError(siteUnlockError);
+          clearSiteUnlockFieldErrorState();
+          setPasswordVisibility(siteUnlockPasswordInput, siteUnlockPasswordToggle, false);
+          setSiteUnlockLoadingState(false);
           siteUnlockDialog.showModal();
           siteUnlockPasswordInput.focus();
         });
@@ -1881,30 +1925,43 @@ import { firebaseAuth } from './firebase-core.js';
       setPasswordVisibility(siteLockConfirmPasswordInput, siteLockConfirmPasswordToggle, nextIsVisible);
     });
 
+    siteUnlockPasswordInput?.addEventListener('input', () => {
+      clearSiteUnlockFieldErrorState();
+    });
+
+    siteUnlockPasswordToggle?.addEventListener('click', () => {
+      const nextIsVisible = siteUnlockPasswordInput?.type === 'password';
+      setPasswordVisibility(siteUnlockPasswordInput, siteUnlockPasswordToggle, nextIsVisible);
+    });
+
     siteUnlockForm?.addEventListener('submit', async (event) => {
       event.preventDefault();
-      if (!siteIdPendingUnlock) {
+      if (!siteIdPendingUnlock || isSiteUnlockPending) {
         return;
       }
-      clearTransientError(siteUnlockError);
+      clearSiteUnlockFieldErrorState();
       const passwordValue = siteUnlockPasswordInput?.value || '';
       if (!passwordValue.trim()) {
-        showTransientError(siteUnlockError, 'Veuillez entrer le mot de passe.');
+        showSiteUnlockFieldError('Veuillez entrer le mot de passe.');
         return;
       }
 
       const targetSite = getLatestSiteState(siteIdPendingUnlock);
       if (!isSiteLocked(targetSite)) {
+        setSiteUnlockLoadingState(true);
         siteUnlockDialog?.close();
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteIdPendingUnlock)}`);
         siteIdPendingUnlock = null;
+        setSiteUnlockLoadingState(false);
         return;
       }
 
       try {
+        setSiteUnlockLoadingState(true);
         const passwordHash = await hashPassword(passwordValue);
         if (passwordHash !== targetSite.passwordHash) {
-          showTransientError(siteUnlockError, 'Mot de passe incorrect.');
+          showSiteUnlockFieldError('Mot de passe incorrect.');
+          setSiteUnlockLoadingState(false);
           return;
         }
         const openSiteId = siteIdPendingUnlock;
@@ -1912,7 +1969,8 @@ import { firebaseAuth } from './firebase-core.js';
         siteIdPendingUnlock = null;
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(openSiteId)}`);
       } catch (_error) {
-        showTransientError(siteUnlockError, 'Erreur pendant la vérification.');
+        showSiteUnlockFieldError('Erreur pendant la vérification.');
+        setSiteUnlockLoadingState(false);
       }
     });
 
@@ -1986,7 +2044,9 @@ import { firebaseAuth } from './firebase-core.js';
 
     siteUnlockDialog?.addEventListener('close', () => {
       siteIdPendingUnlock = null;
-      clearTransientError(siteUnlockError);
+      clearSiteUnlockFieldErrorState();
+      setPasswordVisibility(siteUnlockPasswordInput, siteUnlockPasswordToggle, false);
+      setSiteUnlockLoadingState(false);
     });
 
     siteLockManageDialog?.addEventListener('close', () => {


### PR DESCRIPTION
### Motivation
- Harmoniser l’UX du modal « Site verrouillé » avec les autres modals de mot de passe en adoptant le même comportement (œil ON/OFF, erreur au niveau du champ, bordure rouge + shake, état loading sur le bouton Valider). 
- Améliorer l’accessibilité et l’interaction mobile en réutilisant uniquement les icônes existantes `Icon/Eye_ON.png` / `Icon/Eye_OFF.png` et en gardant la logique métier intacte.

### Description
- Ajout de la structure du champ mot de passe dans `index.html` : wrapper `password-wrap--site-unlock`, bouton toggle `siteUnlockPasswordToggle` avec image `Icon/Eye_OFF.png`, paragraphe d’erreur `siteUnlockError` et bouton submit `siteUnlockSubmitButton` avec labels/spinner pour l’état loading.
- Ajout de styles dédiés dans `css/style.css` pour le modal d’unlock : taille et zone cliquable de l’icône, padding-right de l’input, centrage vertical de l’icône, style d’erreur discret (rouge doux), animation de shake réutilisée et styles d’état loading pour le bouton submit.
- Mise à jour de `js/app.js` : nouveaux sélecteurs pour le toggle et le bouton submit, fonctions `setSiteUnlockLoadingState`, `clearSiteUnlockFieldErrorState` et `showSiteUnlockFieldError`, gestion du toggle (swap `Icon/Eye_ON.png` / `Icon/Eye_OFF.png`), effacement immédiat de l’erreur à la saisie, protection contre double submission et réinitialisation de l’état (visibilité/erreur/loading) à l’ouverture/fermeture du modal.
- Les changes sont strictement limités au modal « Site verrouillé » (page d’accueil) et n’altèrent aucune logique Firebase ou la logique de verrouillage/déverrouillage existante.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` : succeeded.
- Aucun test automatique d’IU n’a été exécuté dans cet environnement, changements validés par revue de code et vérification que les assets `Icon/Eye_ON.png` / `Icon/Eye_OFF.png` sont réutilisés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec51a699d4832ab37b640ec430d3d9)