### PR TITLE
Améliorer le modal « Gestion de l’accès sécurisé » (page 1)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1541,6 +1541,70 @@ body[data-page="home"] #siteLockDialog #siteLockConfirmPasswordInput.is-shaking 
   margin-top: 16px;
 }
 
+body[data-page="home"] #siteLockManageDialog .input-group--site-lock-manage {
+  gap: 0.65rem;
+}
+
+body[data-page="home"] #siteLockManageDialog .password-wrap--site-lock-manage {
+  position: relative;
+  width: 100%;
+}
+
+body[data-page="home"] #siteLockManageDialog .password-wrap--site-lock-manage input {
+  padding-right: 2.8rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="home"] #siteLockManageDialog .password-toggle--site-lock-manage {
+  position: absolute;
+  top: 50%;
+  right: 0.4rem;
+  transform: translateY(-50%);
+  width: 2.125rem;
+  height: 2.125rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body[data-page="home"] #siteLockManageDialog .password-toggle--site-lock-manage img {
+  width: 1.3125rem;
+  height: 1.3125rem;
+  object-fit: contain;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+body[data-page="home"] #siteLockManageDialog .password-toggle--site-lock-manage:hover img,
+body[data-page="home"] #siteLockManageDialog .password-toggle--site-lock-manage:focus-visible img {
+  opacity: 1;
+}
+
+body[data-page="home"] #siteLockManageDialog .form-error--field {
+  margin-top: 0.1rem;
+  min-height: 1rem;
+  text-align: left;
+  color: #c95e68;
+  font-size: 0.82rem;
+}
+
+body[data-page="home"] #siteLockManageDialog #siteLockCurrentPasswordInput.is-error,
+body[data-page="home"] #siteLockManageDialog #siteLockCurrentPasswordInput.is-error:focus,
+body[data-page="home"] #siteLockManageDialog #siteLockNewPasswordInput.is-error,
+body[data-page="home"] #siteLockManageDialog #siteLockNewPasswordInput.is-error:focus {
+  border-color: #e57373;
+  box-shadow: 0 0 0 3px rgba(229, 115, 115, 0.16);
+}
+
+body[data-page="home"] #siteLockManageDialog #siteLockCurrentPasswordInput.is-shaking,
+body[data-page="home"] #siteLockManageDialog #siteLockNewPasswordInput.is-shaking {
+  animation: site-lock-input-shake 300ms ease-in-out 1;
+}
+
 .modal-header {
   display: flex;
   align-items: center;
@@ -1650,15 +1714,21 @@ body[data-page="home"] #siteLockDialog #siteLockConfirmPasswordInput.is-shaking 
   display: inline-flex;
 }
 
-#siteUnlockSubmitButton {
+#siteUnlockSubmitButton,
+#siteLockManageUpdateButton,
+#siteLockManageUnlockButton {
   position: relative;
 }
 
-#siteUnlockSubmitButton .btn-label-loading {
+#siteUnlockSubmitButton .btn-label-loading,
+#siteLockManageUpdateButton .btn-label-loading,
+#siteLockManageUnlockButton .btn-label-loading {
   display: none;
 }
 
-#siteUnlockSubmitButton .btn-loading-spinner {
+#siteUnlockSubmitButton .btn-loading-spinner,
+#siteLockManageUpdateButton .btn-loading-spinner,
+#siteLockManageUnlockButton .btn-loading-spinner {
   width: 0.95rem;
   height: 0.95rem;
   border-radius: 50%;
@@ -1668,19 +1738,27 @@ body[data-page="home"] #siteLockDialog #siteLockConfirmPasswordInput.is-shaking 
   animation: btn-spinner-rotate 0.7s linear infinite;
 }
 
-#siteUnlockSubmitButton.is-loading {
+#siteUnlockSubmitButton.is-loading,
+#siteLockManageUpdateButton.is-loading,
+#siteLockManageUnlockButton.is-loading {
   filter: saturate(0.95);
 }
 
-#siteUnlockSubmitButton.is-loading .btn-label-default {
+#siteUnlockSubmitButton.is-loading .btn-label-default,
+#siteLockManageUpdateButton.is-loading .btn-label-default,
+#siteLockManageUnlockButton.is-loading .btn-label-default {
   display: none;
 }
 
-#siteUnlockSubmitButton.is-loading .btn-loading-spinner {
+#siteUnlockSubmitButton.is-loading .btn-loading-spinner,
+#siteLockManageUpdateButton.is-loading .btn-loading-spinner,
+#siteLockManageUnlockButton.is-loading .btn-loading-spinner {
   display: inline-flex;
 }
 
-#siteUnlockSubmitButton.is-loading .btn-label-loading {
+#siteUnlockSubmitButton.is-loading .btn-label-loading,
+#siteLockManageUpdateButton.is-loading .btn-label-loading,
+#siteLockManageUnlockButton.is-loading .btn-label-loading {
   display: inline-flex;
 }
 

--- a/index.html
+++ b/index.html
@@ -155,22 +155,51 @@
             <h2>Gestion de l’accès sécurisé</h2>
           </div>
           <p class="modal-helper-text">Ce site est actuellement protégé par un mot de passe.</p>
-          <label class="input-group">
+          <label class="input-group input-group--site-lock-manage">
             <span>Mot de passe actuel</span>
-            <input id="siteLockCurrentPasswordInput" type="password" autocomplete="current-password" />
+            <div class="password-wrap password-wrap--site-lock-manage">
+              <input id="siteLockCurrentPasswordInput" type="password" autocomplete="current-password" />
+              <button
+                id="siteLockCurrentPasswordToggle"
+                class="password-toggle password-toggle--site-lock-manage"
+                type="button"
+                aria-label="Afficher le mot de passe"
+              >
+                <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
+              </button>
+            </div>
+            <p id="siteLockCurrentPasswordError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
-          <label class="input-group">
+          <label class="input-group input-group--site-lock-manage">
             <span>Nouveau mot de passe</span>
-            <input id="siteLockNewPasswordInput" type="password" autocomplete="new-password" />
+            <div class="password-wrap password-wrap--site-lock-manage">
+              <input id="siteLockNewPasswordInput" type="password" autocomplete="new-password" />
+              <button
+                id="siteLockNewPasswordToggle"
+                class="password-toggle password-toggle--site-lock-manage"
+                type="button"
+                aria-label="Afficher le mot de passe"
+              >
+                <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
+              </button>
+            </div>
+            <p id="siteLockNewPasswordError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
-          <p id="siteLockManageError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--password modal-actions--password-manage">
             <div class="modal-actions__row modal-actions__row--pair">
               <button type="button" class="btn" data-close-dialog>Annuler</button>
-              <button type="submit" class="btn btn-success" data-lock-manage-action="update">Mettre à jour</button>
+              <button id="siteLockManageUpdateButton" type="submit" class="btn btn-success" data-lock-manage-action="update">
+                <span class="btn-label-default">Mettre à jour</span>
+                <span class="btn-loading-spinner" aria-hidden="true"></span>
+                <span class="btn-label-loading" aria-hidden="true">Mise à jour...</span>
+              </button>
             </div>
             <div class="modal-actions__row modal-actions__row--single">
-              <button type="submit" class="btn btn-danger" data-lock-manage-action="unlock">Déverrouiller</button>
+              <button id="siteLockManageUnlockButton" type="submit" class="btn btn-danger" data-lock-manage-action="unlock">
+                <span class="btn-label-default">Déverrouiller</span>
+                <span class="btn-loading-spinner" aria-hidden="true"></span>
+                <span class="btn-label-loading" aria-hidden="true">Déverrouillage...</span>
+              </button>
             </div>
           </div>
         </form>

--- a/js/app.js
+++ b/js/app.js
@@ -924,7 +924,12 @@ import { firebaseAuth } from './firebase-core.js';
     const siteLockManageForm = requireElement('siteLockManageForm');
     const siteLockCurrentPasswordInput = requireElement('siteLockCurrentPasswordInput');
     const siteLockNewPasswordInput = requireElement('siteLockNewPasswordInput');
-    const siteLockManageError = requireElement('siteLockManageError');
+    const siteLockCurrentPasswordError = requireElement('siteLockCurrentPasswordError');
+    const siteLockNewPasswordError = requireElement('siteLockNewPasswordError');
+    const siteLockCurrentPasswordToggle = requireElement('siteLockCurrentPasswordToggle');
+    const siteLockNewPasswordToggle = requireElement('siteLockNewPasswordToggle');
+    const siteLockManageUpdateButton = requireElement('siteLockManageUpdateButton');
+    const siteLockManageUnlockButton = requireElement('siteLockManageUnlockButton');
 
     let currentSites = [];
     let itemCountsBySite = {};
@@ -947,6 +952,8 @@ import { firebaseAuth } from './firebase-core.js';
     let siteNameErrorClearTimer = null;
     const siteLockFieldStateTimers = new WeakMap();
     let isSiteUnlockPending = false;
+    let isSiteLockManageUpdatePending = false;
+    let isSiteLockManageUnlockPending = false;
 
     function setSiteCreateLoadingState(isLoading) {
       isSiteCreationPending = Boolean(isLoading);
@@ -970,6 +977,26 @@ import { firebaseAuth } from './firebase-core.js';
       siteUnlockSubmitButton.disabled = isSiteUnlockPending;
       siteUnlockSubmitButton.classList.toggle('is-loading', isSiteUnlockPending);
       siteUnlockSubmitButton.setAttribute('aria-busy', String(isSiteUnlockPending));
+    }
+
+    function setSiteLockManageActionLoadingState(action, isLoading) {
+      if (action === 'unlock') {
+        isSiteLockManageUnlockPending = Boolean(isLoading);
+        if (!siteLockManageUnlockButton) {
+          return;
+        }
+        siteLockManageUnlockButton.disabled = isSiteLockManageUnlockPending;
+        siteLockManageUnlockButton.classList.toggle('is-loading', isSiteLockManageUnlockPending);
+        siteLockManageUnlockButton.setAttribute('aria-busy', String(isSiteLockManageUnlockPending));
+        return;
+      }
+      isSiteLockManageUpdatePending = Boolean(isLoading);
+      if (!siteLockManageUpdateButton) {
+        return;
+      }
+      siteLockManageUpdateButton.disabled = isSiteLockManageUpdatePending;
+      siteLockManageUpdateButton.classList.toggle('is-loading', isSiteLockManageUpdatePending);
+      siteLockManageUpdateButton.setAttribute('aria-busy', String(isSiteLockManageUpdatePending));
     }
 
     function enforceSiteNameMaxLength() {
@@ -1073,6 +1100,24 @@ import { firebaseAuth } from './firebase-core.js';
         siteLockFieldStateTimers.delete(inputElement);
       }, durationMs);
       siteLockFieldStateTimers.set(inputElement, timer);
+    }
+
+    function clearSiteLockManageFieldErrorState(inputElement, errorElement) {
+      clearSiteLockFieldErrorState(inputElement, errorElement);
+    }
+
+    function showSiteLockManageFieldError(inputElement, errorElement, message, durationMs = 2300) {
+      showSiteLockFieldError(inputElement, errorElement, message, durationMs);
+    }
+
+    function clearSiteLockManageErrors() {
+      clearSiteLockManageFieldErrorState(siteLockCurrentPasswordInput, siteLockCurrentPasswordError);
+      clearSiteLockManageFieldErrorState(siteLockNewPasswordInput, siteLockNewPasswordError);
+    }
+
+    function clearSiteLockManageLoadingStates() {
+      setSiteLockManageActionLoadingState('update', false);
+      setSiteLockManageActionLoadingState('unlock', false);
     }
 
     function clearSiteUnlockFieldErrorState() {
@@ -1418,14 +1463,18 @@ import { firebaseAuth } from './firebase-core.js';
           !siteLockManageDialog ||
           !siteLockCurrentPasswordInput ||
           !siteLockNewPasswordInput ||
-          !siteLockManageError
+          !siteLockCurrentPasswordError ||
+          !siteLockNewPasswordError
         ) {
           return;
         }
         siteIdPendingLockManage = siteId;
         siteLockCurrentPasswordInput.value = '';
         siteLockNewPasswordInput.value = '';
-        clearTransientError(siteLockManageError);
+        clearSiteLockManageErrors();
+        clearSiteLockManageLoadingStates();
+        setPasswordVisibility(siteLockCurrentPasswordInput, siteLockCurrentPasswordToggle, false);
+        setPasswordVisibility(siteLockNewPasswordInput, siteLockNewPasswordToggle, false);
         siteLockManageDialog.showModal();
         siteLockCurrentPasswordInput.focus();
         return;
@@ -1934,6 +1983,24 @@ import { firebaseAuth } from './firebase-core.js';
       setPasswordVisibility(siteUnlockPasswordInput, siteUnlockPasswordToggle, nextIsVisible);
     });
 
+    siteLockCurrentPasswordInput?.addEventListener('input', () => {
+      clearSiteLockManageFieldErrorState(siteLockCurrentPasswordInput, siteLockCurrentPasswordError);
+    });
+
+    siteLockNewPasswordInput?.addEventListener('input', () => {
+      clearSiteLockManageFieldErrorState(siteLockNewPasswordInput, siteLockNewPasswordError);
+    });
+
+    siteLockCurrentPasswordToggle?.addEventListener('click', () => {
+      const nextIsVisible = siteLockCurrentPasswordInput?.type === 'password';
+      setPasswordVisibility(siteLockCurrentPasswordInput, siteLockCurrentPasswordToggle, nextIsVisible);
+    });
+
+    siteLockNewPasswordToggle?.addEventListener('click', () => {
+      const nextIsVisible = siteLockNewPasswordInput?.type === 'password';
+      setPasswordVisibility(siteLockNewPasswordInput, siteLockNewPasswordToggle, nextIsVisible);
+    });
+
     siteUnlockForm?.addEventListener('submit', async (event) => {
       event.preventDefault();
       if (!siteIdPendingUnlock || isSiteUnlockPending) {
@@ -1979,34 +2046,63 @@ import { firebaseAuth } from './firebase-core.js';
       if (!siteIdPendingLockManage) {
         return;
       }
-      clearTransientError(siteLockManageError);
 
-      const submittedAction = event.submitter?.dataset?.lockManageAction;
+      const submittedAction = event.submitter?.dataset?.lockManageAction === 'unlock' ? 'unlock' : 'update';
+      if (
+        (submittedAction === 'unlock' && isSiteLockManageUnlockPending) ||
+        (submittedAction === 'update' && isSiteLockManageUpdatePending)
+      ) {
+        return;
+      }
+
+      clearSiteLockManageErrors();
+
       const currentPasswordValue = siteLockCurrentPasswordInput?.value || '';
       const newPasswordValue = siteLockNewPasswordInput?.value || '';
       const targetSite = getLatestSiteState(siteIdPendingLockManage);
       if (!isSiteLocked(targetSite)) {
+        clearSiteLockManageLoadingStates();
         siteLockManageDialog?.close();
         siteIdPendingLockManage = null;
         return;
       }
 
       if (!currentPasswordValue.trim()) {
-        showTransientError(siteLockManageError, 'Mot de passe actuel incorrect.');
+        showSiteLockManageFieldError(
+          siteLockCurrentPasswordInput,
+          siteLockCurrentPasswordError,
+          'Veuillez remplir ce champ',
+        );
+        return;
+      }
+
+      if (submittedAction === 'update' && !newPasswordValue.trim()) {
+        showSiteLockManageFieldError(siteLockNewPasswordInput, siteLockNewPasswordError, 'Veuillez remplir ce champ');
         return;
       }
 
       try {
+        setSiteLockManageActionLoadingState(submittedAction, true);
         const currentPasswordHash = await hashPassword(currentPasswordValue);
         if (currentPasswordHash !== targetSite.passwordHash) {
-          showTransientError(siteLockManageError, 'Mot de passe actuel incorrect.');
+          showSiteLockManageFieldError(
+            siteLockCurrentPasswordInput,
+            siteLockCurrentPasswordError,
+            'Mot de passe actuel incorrect.',
+          );
+          setSiteLockManageActionLoadingState(submittedAction, false);
           return;
         }
 
         if (submittedAction === 'unlock') {
           const result = await StorageService.clearSiteLock(siteIdPendingLockManage);
           if (!result?.ok) {
-            showTransientError(siteLockManageError, 'Impossible de retirer le verrouillage.');
+            showSiteLockManageFieldError(
+              siteLockCurrentPasswordInput,
+              siteLockCurrentPasswordError,
+              'Impossible de retirer le verrouillage.',
+            );
+            setSiteLockManageActionLoadingState('unlock', false);
             return;
           }
           siteLockManageDialog?.close();
@@ -2015,22 +2111,36 @@ import { firebaseAuth } from './firebase-core.js';
           return;
         }
 
-        if (!newPasswordValue.trim()) {
-          showTransientError(siteLockManageError, 'Veuillez saisir un nouveau mot de passe.');
-          return;
-        }
-
         const nextPasswordHash = await hashPassword(newPasswordValue);
         const result = await StorageService.setSiteLock(siteIdPendingLockManage, { passwordHash: nextPasswordHash });
         if (!result?.ok) {
-          showTransientError(siteLockManageError, 'Impossible de mettre à jour le mot de passe.');
+          showSiteLockManageFieldError(
+            siteLockNewPasswordInput,
+            siteLockNewPasswordError,
+            'Impossible de mettre à jour le mot de passe.',
+          );
+          setSiteLockManageActionLoadingState('update', false);
           return;
         }
         siteLockManageDialog?.close();
         siteIdPendingLockManage = null;
         UiService.showToast('Le mot de passe a été mis à jour avec succès.');
       } catch (_error) {
-        showTransientError(siteLockManageError, 'Erreur pendant la gestion du mot de passe.');
+        if (submittedAction === 'unlock') {
+          showSiteLockManageFieldError(
+            siteLockCurrentPasswordInput,
+            siteLockCurrentPasswordError,
+            'Erreur pendant la gestion du mot de passe.',
+          );
+          setSiteLockManageActionLoadingState('unlock', false);
+          return;
+        }
+        showSiteLockManageFieldError(
+          siteLockNewPasswordInput,
+          siteLockNewPasswordError,
+          'Erreur pendant la gestion du mot de passe.',
+        );
+        setSiteLockManageActionLoadingState('update', false);
       }
     });
 
@@ -2051,7 +2161,10 @@ import { firebaseAuth } from './firebase-core.js';
 
     siteLockManageDialog?.addEventListener('close', () => {
       siteIdPendingLockManage = null;
-      clearTransientError(siteLockManageError);
+      clearSiteLockManageErrors();
+      clearSiteLockManageLoadingStates();
+      setPasswordVisibility(siteLockCurrentPasswordInput, siteLockCurrentPasswordToggle, false);
+      setPasswordVisibility(siteLockNewPasswordInput, siteLockNewPasswordToggle, false);
     });
 
     StorageService.subscribeSites(


### PR DESCRIPTION
### Motivation
- Harmoniser l’UX du modal “Gestion de l’accès sécurisé” avec les autres modals corrigés en ajoutant erreurs par champ, bordure rouge, animation shake, disparition automatique, icônes œil ON/OFF et loading sur les boutons. 
- Conserver intacte la logique de verrouillage/déverrouillage et ne pas toucher à Firebase ni aux autres pages/modals.

### Description
- `index.html` : remplacement des inputs du modal par des blocs `password-wrap` avec boutons toggle contenant `Icon/Eye_OFF.png` par défaut et conteneurs d’erreur par champ (`siteLockCurrentPasswordError`, `siteLockNewPasswordError`), et ajout des boutons d’action `siteLockManageUpdateButton` et `siteLockManageUnlockButton` avec structure spinner/labels. 
- `css/style.css` : ajout des règles pour positionner les toggles œil, `padding-right` des inputs, styles d’erreur (texte discret rouge aligné à gauche), bordure rouge + `is-shaking` (animation `site-lock-input-shake`) et styles `is-loading` pour les boutons `update`/`unlock`. 
- `js/app.js` : ajout des références DOM pour les toggles, erreurs et boutons, implémentation des fonctions de visibilité (`setPasswordVisibility`), erreurs par champ (`showSiteLockManageFieldError`, `clearSiteLockManageFieldErrorState`), timers de disparition automatique, états de loading indépendants (`setSiteLockManageActionLoadingState`) et intégration de ces états dans les handlers `open`, `input`, `submit` et `close` du modal sans modifier la logique métier de lock/unlock. 
- Réinitialisation complète des états (erreurs, visibilité, loading) à l’ouverture/fermeture du modal et prévention des doubles clics lors des actions réseau via des flags `isSiteLockManageUpdatePending` / `isSiteLockManageUnlockPending`.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js`, qui a réussi. 
- Vérification manuelle des fichiers modifiés et cohérence des sélecteurs/ID utilisés par le code (contrôles statiques réalisés pendant la mise à jour).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6cf5fe18832a93211169afdbc9fc)