### PR TITLE
Améliore l’UX du formulaire de connexion (erreurs transitoires, icône œil, état chargement)

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -53,20 +53,37 @@ body {
   transform: translateY(-1px);
 }
 .password-wrap { position: relative; }
-.password-wrap input { padding-right: 3rem; }
+.password-wrap input { padding-right: 3.1rem; }
 .password-toggle {
   position: absolute;
   top: 50%;
   right: .45rem;
   transform: translateY(-50%);
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 2.125rem;
+  height: 2.125rem;
   border: 0;
-  border-radius: 50%;
+  border-radius: 999px;
   background: rgba(15, 23, 42, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
-.password-toggle img { width: 1.2rem; height: 1.2rem; object-fit: contain; }
-.field-error { min-height: 1.1rem; color: #ffe4e6; font-size: .8rem; }
+.password-toggle img { width: 1.3125rem; height: 1.3125rem; object-fit: contain; }
+.field-error {
+  min-height: 1rem;
+  margin-top: .1rem;
+  text-align: left;
+  color: #ffe4e6;
+  font-size: .82rem;
+}
+.field-group input.is-error,
+.field-group input.is-error:focus {
+  border-color: #e57373;
+  box-shadow: 0 0 0 3px rgba(229, 115, 115, 0.16);
+}
+.field-group input.is-shaking {
+  animation: login-input-shake 300ms ease-in-out 1;
+}
 .btn {
   border: 0;
   border-radius: .85rem;
@@ -97,3 +114,11 @@ body {
 .btn.is-loading .btn__loader { display: inline-block; }
 .btn.is-loading .btn__label { opacity: .7; }
 @keyframes spin { to { transform: rotate(360deg);} }
+@keyframes login-input-shake {
+  0% { transform: translateX(0); }
+  20% { transform: translateX(-4px); }
+  40% { transform: translateX(4px); }
+  60% { transform: translateX(-3px); }
+  80% { transform: translateX(3px); }
+  100% { transform: translateX(0); }
+}

--- a/js/login.js
+++ b/js/login.js
@@ -64,6 +64,8 @@ if (inAppBrowserWarning) {
 
 let lastEmailCheckId = 0;
 let isAuthInProgress = false;
+const fieldErrorTimers = new Map();
+const fieldStateTimers = new Map();
 
 function redirectToHome() {
   window.location.replace('index.html');
@@ -94,6 +96,18 @@ function setLoading(isLoading, sourceButton = emailLoginButton) {
   emailLoginButton.setAttribute('aria-busy', String(isLoading));
   googleLoginButton.setAttribute('aria-busy', String(isLoading));
   sourceButton?.classList.toggle('is-loading', isLoading);
+  if (sourceButton) {
+    const labelElement = sourceButton.querySelector('.btn__label');
+    if (labelElement) {
+      const defaultLabel = sourceButton.dataset.defaultLabel || labelElement.textContent || '';
+      sourceButton.dataset.defaultLabel = defaultLabel;
+      if (isLoading && sourceButton === emailLoginButton) {
+        labelElement.textContent = 'Connexion…';
+      } else {
+        labelElement.textContent = defaultLabel;
+      }
+    }
+  }
 }
 
 async function startGoogleSignIn() {
@@ -141,14 +155,13 @@ function isEmailFormatValid(email) {
 
 async function validateEmailRealtime() {
   const email = emailInput.value.trim();
-  emailError.textContent = '';
 
   if (!email) {
-    emailError.textContent = 'Email vide.';
+    showFieldError(emailInput, emailError, 'Email requis.');
     return false;
   }
   if (!isEmailFormatValid(email)) {
-    emailError.textContent = 'Format email invalide.';
+    showFieldError(emailInput, emailError, 'Format email invalide.');
     return false;
   }
 
@@ -159,11 +172,11 @@ async function validateEmailRealtime() {
       return false;
     }
     if (!methods.length) {
-      emailError.textContent = 'Email inexistant.';
+      showFieldError(emailInput, emailError, 'Email inexistant.');
       return false;
     }
   } catch (_error) {
-    emailError.textContent = 'Vérification email indisponible.';
+    showFieldError(emailInput, emailError, 'Vérification email indisponible.');
     return false;
   }
   return true;
@@ -171,27 +184,64 @@ async function validateEmailRealtime() {
 
 function validatePasswordRealtime() {
   const password = passwordInput.value;
-  passwordError.textContent = '';
   if (!password) {
-    passwordError.textContent = 'Mot de passe requis.';
+    showFieldError(passwordInput, passwordError, 'Mot de passe requis.');
     return false;
   }
   if (password.length < 6) {
-    passwordError.textContent = 'Mot de passe trop court (minimum 6 caractères).';
+    showFieldError(passwordInput, passwordError, 'Mot de passe trop court (minimum 6 caractères).');
     return false;
   }
   return true;
+}
+
+function clearFieldError(errorElement) {
+  const timer = fieldErrorTimers.get(errorElement);
+  if (timer) {
+    window.clearTimeout(timer);
+    fieldErrorTimers.delete(errorElement);
+  }
+  errorElement.textContent = '';
+}
+
+function clearFieldState(inputElement, errorElement) {
+  clearFieldError(errorElement);
+  const timer = fieldStateTimers.get(inputElement);
+  if (timer) {
+    window.clearTimeout(timer);
+    fieldStateTimers.delete(inputElement);
+  }
+  inputElement.classList.remove('is-error', 'is-shaking');
+}
+
+function showFieldError(inputElement, errorElement, message, durationMs = 2300) {
+  clearFieldState(inputElement, errorElement);
+  errorElement.textContent = message;
+  const errorTimer = window.setTimeout(() => {
+    errorElement.textContent = '';
+    fieldErrorTimers.delete(errorElement);
+  }, durationMs);
+  fieldErrorTimers.set(errorElement, errorTimer);
+
+  inputElement.classList.remove('is-shaking');
+  void inputElement.offsetWidth;
+  inputElement.classList.add('is-error', 'is-shaking');
+  const stateTimer = window.setTimeout(() => {
+    inputElement.classList.remove('is-error', 'is-shaking');
+    fieldStateTimers.delete(inputElement);
+  }, durationMs);
+  fieldStateTimers.set(inputElement, stateTimer);
 }
 
 emailInput.addEventListener('focus', applyMemoIfAny);
 passwordInput.addEventListener('focus', applyMemoIfAny);
 emailInput.addEventListener('input', () => {
   globalError.textContent = '';
-  validateEmailRealtime();
+  clearFieldState(emailInput, emailError);
 });
 passwordInput.addEventListener('input', () => {
   globalError.textContent = '';
-  validatePasswordRealtime();
+  clearFieldState(passwordInput, passwordError);
 });
 
 togglePasswordButton.addEventListener('click', () => {
@@ -206,11 +256,13 @@ form.addEventListener('submit', async (event) => {
   if (isAuthInProgress) {
     return;
   }
+  isAuthInProgress = true;
   globalError.textContent = '';
 
   const isEmailValid = await validateEmailRealtime();
   const isPasswordValid = validatePasswordRealtime();
   if (!isEmailValid || !isPasswordValid) {
+    isAuthInProgress = false;
     return;
   }
 
@@ -222,13 +274,14 @@ form.addEventListener('submit', async (event) => {
   } catch (error) {
     const code = String(error?.code || '');
     if (code.includes('wrong-password') || code.includes('invalid-credential')) {
-      passwordError.textContent = 'Mot de passe incorrect.';
+      showFieldError(passwordInput, passwordError, 'Mot de passe incorrect.');
     } else if (code.includes('user-not-found')) {
-      emailError.textContent = 'Email inexistant.';
+      showFieldError(emailInput, emailError, 'Email inexistant.');
     } else {
       globalError.textContent = 'Connexion impossible. Veuillez réessayer.';
     }
   } finally {
+    isAuthInProgress = false;
     setLoading(false, emailLoginButton);
   }
 });


### PR DESCRIPTION
### Motivation
- Harmoniser le comportement UX de la page de connexion avec les autres modals en affichant des erreurs par champ de façon transitoire et discrète.
- Fournir un retour visuel clair (bordure rouge douce + léger shake) quand un champ est invalide ou vide, tout en masquant l’erreur dès que l’utilisateur saisit.
- Garder l’utilisation des icônes existantes pour le mot de passe et empêcher les doubles soumissions via le bouton « Se connecter ». 

### Description
- Ajout de timers et fonctions de gestion des erreurs par champ (`fieldErrorTimers`, `fieldStateTimers`, `showFieldError`, `clearFieldState`) dans `js/login.js` pour afficher un message sous le champ et l’effacer automatiquement après ~2300ms.
- Remplacement des assignations directes de `textContent` par `showFieldError(...)` dans les validations email/password et dans le traitement des erreurs Firebase, et nettoyage immédiat de l’erreur quand l’utilisateur tape dans le champ concerné.
- Ajout d’un verrou `isAuthInProgress` et amélioration de `setLoading(...)` pour empêcher les doubles clics, activer la classe `.is-loading` et remplacer temporairement le label du bouton par `Connexion…` pendant la requête.
- Ajustements CSS dans `css/login.css` : padding-right du champ mot de passe, taille visuelle de l’icône œil (~21px) et zone cliquable (~34px), styles `.field-error` alignés à gauche, styles `.is-error` + `.is-shaking` et animation `login-input-shake` pour reproduire la même UX que les modals existants.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/login.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6fde9798832a9a06b1ac042b49a8)