### PR TITLE
Ajouter modal de confirmation avant suppression des lignes (page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2399,6 +2399,109 @@ body[data-page="item-detail"] #detailCreateSubmitButton.is-loading .btn-label-lo
   display: inline-flex;
 }
 
+body[data-page="item-detail"] .detail-delete-confirm-overlay {
+  z-index: 1260;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-overlay.is-open {
+  opacity: 1;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-card {
+  width: min(92vw, 24rem);
+  border-radius: 22px;
+  border: 1px solid #d7e0ee;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  padding: 1.25rem 1rem 1rem;
+  transform: translateY(8px) scale(0.985);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-overlay.is-open .detail-delete-confirm-card {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-card h3 {
+  margin: 0;
+  font-size: 1.16rem;
+  font-weight: 800;
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+  text-align: center;
+  color: #111827;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-card p {
+  margin-top: 0.82rem;
+  font-size: 0.94rem;
+  line-height: 1.45;
+  font-weight: 500;
+  text-align: center;
+  color: #4b5563;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-actions {
+  margin-top: 1.1rem;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-actions .item-delete-confirm-button {
+  flex: 1 1 50%;
+  width: 50%;
+  min-height: 3.35rem;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  padding: 0.72rem 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-actions .item-delete-confirm-button--cancel {
+  background: #eceff3;
+  color: #1f2937;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-actions .item-delete-confirm-button--danger {
+  background: #dc2626;
+  color: #fff;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-submit .btn-label-loading,
+body[data-page="item-detail"] .detail-delete-confirm-submit .btn-loading-spinner {
+  display: none;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-submit .btn-loading-spinner {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-submit.is-loading {
+  gap: 0.45rem;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-submit.is-loading .btn-label-default {
+  display: none;
+}
+
+body[data-page="item-detail"] .detail-delete-confirm-submit.is-loading .btn-loading-spinner,
+body[data-page="item-detail"] .detail-delete-confirm-submit.is-loading .btn-label-loading {
+  display: inline-flex;
+}
+
 body[data-page="item-detail"] .detail-input-feedback-row {
   width: 100%;
   margin-top: 0.24rem;

--- a/js/app.js
+++ b/js/app.js
@@ -3612,6 +3612,121 @@ import { firebaseAuth } from './firebase-core.js';
       }, 40);
     }
 
+    function ensureDetailDeleteConfirmationDialog() {
+      let overlay = document.getElementById('detailDeleteConfirmOverlay');
+      if (overlay) {
+        return overlay;
+      }
+
+      overlay = document.createElement('div');
+      overlay.id = 'detailDeleteConfirmOverlay';
+      overlay.className = 'maintenance-overlay item-delete-confirm-overlay detail-delete-confirm-overlay';
+      overlay.hidden = true;
+      overlay.innerHTML = `
+        <article class="maintenance-card item-delete-confirm-card detail-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="detailDeleteConfirmTitle">
+          <h3 id="detailDeleteConfirmTitle">Supprimer cette donnée ?</h3>
+          <p id="detailDeleteConfirmText">Cette action est définitive.</p>
+          <div class="modal-actions item-delete-confirm-actions detail-delete-confirm-actions">
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--cancel" id="detailDeleteCancelButton">Annuler</button>
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--danger detail-delete-confirm-submit" id="detailDeleteConfirmButton">
+              <span class="btn-label-default">Supprimer</span>
+              <span class="btn-loading-spinner" aria-hidden="true"></span>
+              <span class="btn-label-loading" aria-hidden="true">Suppression...</span>
+            </button>
+          </div>
+        </article>
+      `;
+      document.body.appendChild(overlay);
+      return overlay;
+    }
+
+    function askDetailDeleteConfirmation(detailId) {
+      const overlay = ensureDetailDeleteConfirmationDialog();
+      const cancelButton = overlay.querySelector('#detailDeleteCancelButton');
+      const confirmButton = overlay.querySelector('#detailDeleteConfirmButton');
+      if (!cancelButton || !confirmButton) {
+        return Promise.resolve();
+      }
+
+      return new Promise((resolve) => {
+        const closeAnimationDurationMs = 170;
+        let closeAnimationTimer = null;
+        let isClosing = false;
+        let isDeleting = false;
+
+        const setLoadingState = (isLoading) => {
+          confirmButton.disabled = isLoading;
+          confirmButton.classList.toggle('is-loading', isLoading);
+          cancelButton.disabled = isLoading;
+        };
+
+        const cleanup = () => {
+          if (closeAnimationTimer) {
+            window.clearTimeout(closeAnimationTimer);
+            closeAnimationTimer = null;
+          }
+          setLoadingState(false);
+          overlay.hidden = true;
+          overlay.classList.remove('is-open');
+          overlay.onclick = null;
+          cancelButton.onclick = null;
+          confirmButton.onclick = null;
+          document.removeEventListener('keydown', handleKeyDown);
+        };
+
+        const close = () => {
+          if (isClosing) {
+            return;
+          }
+          isClosing = true;
+          overlay.classList.remove('is-open');
+          closeAnimationTimer = window.setTimeout(() => {
+            cleanup();
+            resolve();
+          }, closeAnimationDurationMs);
+        };
+
+        const handleKeyDown = (event) => {
+          if (event.key === 'Escape' && !isDeleting) {
+            close();
+          }
+        };
+
+        cancelButton.onclick = () => {
+          if (!isDeleting) {
+            close();
+          }
+        };
+
+        confirmButton.onclick = async () => {
+          if (isDeleting) {
+            return;
+          }
+          isDeleting = true;
+          setLoadingState(true);
+          const removed = await StorageService.removeDetail(siteId, itemId, detailId);
+          UiService.showToast(removed ? 'Article supprimée.' : 'Suppression impossible.');
+          if (removed) {
+            close();
+            return;
+          }
+          isDeleting = false;
+          setLoadingState(false);
+        };
+
+        overlay.onclick = (event) => {
+          if (event.target === overlay && !isDeleting) {
+            close();
+          }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        overlay.hidden = false;
+        window.requestAnimationFrame(() => {
+          overlay.classList.add('is-open');
+        });
+      });
+    }
+
     function renderTable() {
       if (!currentItem) {
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
@@ -3691,8 +3806,7 @@ import { firebaseAuth } from './firebase-core.js';
 
       detailTableBody.querySelectorAll('[data-detail-delete]').forEach((button) => {
         button.addEventListener('click', async () => {
-          const removed = await StorageService.removeDetail(siteId, itemId, button.dataset.detailDelete);
-          UiService.showToast(removed ? 'Article supprimée.' : 'Suppression impossible.');
+          await askDetailDeleteConfirmation(button.dataset.detailDelete);
         });
       });
     }


### PR DESCRIPTION
### Motivation
- Empêcher la suppression immédiate d’une ligne depuis la colonne « Action » sur la page 3 et demander une confirmation utilisateur avant d’appeler la logique de suppression existante.

### Description
- Ajout de `ensureDetailDeleteConfirmationDialog()` et `askDetailDeleteConfirmation()` dans `js/app.js` pour afficher un modal de confirmation spécifique à la page détail (item-detail) et gérer l’état de chargement/désactivation des boutons pendant la suppression.
- Remplacement du traitement direct du clic sur l’icône poubelle dans `renderTable()` par l’appel à `askDetailDeleteConfirmation()` afin d’ouvrir le modal au lieu de supprimer immédiatement.
- Ajout de styles scoped à la page 3 dans `css/style.css` (`body[data-page="item-detail"] .detail-delete-confirm-*`) pour reproduire exactement le design, la largeur, le border-radius, le padding, l’alignement, l’espacement, l’overlay et les animations des autres modals, et inclure le spinner et le texte `Suppression...` pendant l’action.
- La logique de suppression existante (`StorageService.removeDetail(...)`) n’a pas été modifiée et est invoquée depuis le bouton « Supprimer » du modal, en conservant les toasts/undo existants.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7460dee0832a918251f9f8137e55)