### PR TITLE
Simplifier le modal « Créer un mot de passe » et ajouter un indicateur de force

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1447,37 +1447,63 @@ body[data-page="home"] #siteLockDialog .password-wrap--site-lock {
 }
 
 body[data-page="home"] #siteLockDialog .password-wrap--site-lock input {
-  padding-right: 2.8rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-body[data-page="home"] #siteLockDialog .password-toggle--site-lock {
-  position: absolute;
-  top: 50%;
-  right: 0.4rem;
-  transform: translateY(-50%);
-  width: 2.125rem;
-  height: 2.125rem;
-  padding: 0;
-  border: 0;
+body[data-page="home"] #siteLockDialog .password-strength {
+  margin-top: 0.55rem;
+}
+
+body[data-page="home"] #siteLockDialog .password-strength__track {
+  width: 100%;
+  height: 0.35rem;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.08);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  background: rgba(15, 23, 42, 0.1);
+  overflow: hidden;
 }
 
-body[data-page="home"] #siteLockDialog .password-toggle--site-lock img {
-  width: 1.3125rem;
-  height: 1.3125rem;
-  object-fit: contain;
-  opacity: 0.8;
-  transition: opacity 0.2s ease;
+body[data-page="home"] #siteLockDialog .password-strength__bar {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: #e53935;
+  transition: width 220ms ease, background-color 220ms ease;
 }
 
-body[data-page="home"] #siteLockDialog .password-toggle--site-lock:hover img,
-body[data-page="home"] #siteLockDialog .password-toggle--site-lock:focus-visible img {
-  opacity: 1;
+body[data-page="home"] #siteLockDialog .password-strength__text {
+  margin: 0.38rem 0 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: left;
+  transition: color 220ms ease;
+}
+
+body[data-page="home"] #siteLockDialog .password-strength[data-strength='weak'] .password-strength__bar {
+  width: 30%;
+  background: #e53935;
+}
+
+body[data-page="home"] #siteLockDialog .password-strength[data-strength='medium'] .password-strength__bar {
+  width: 60%;
+  background: #fb8c00;
+}
+
+body[data-page="home"] #siteLockDialog .password-strength[data-strength='strong'] .password-strength__bar {
+  width: 100%;
+  background: #43a047;
+}
+
+body[data-page="home"] #siteLockDialog .password-strength[data-strength='weak'] .password-strength__text {
+  color: #e53935;
+}
+
+body[data-page="home"] #siteLockDialog .password-strength[data-strength='medium'] .password-strength__text {
+  color: #fb8c00;
+}
+
+body[data-page="home"] #siteLockDialog .password-strength[data-strength='strong'] .password-strength__text {
+  color: #43a047;
 }
 
 body[data-page="home"] #siteLockDialog .form-error--field {

--- a/index.html
+++ b/index.html
@@ -115,30 +115,20 @@
           <label class="input-group input-group--site-lock-create">
             <span>Entrer un mot de passe</span>
             <div class="password-wrap password-wrap--site-lock">
-              <input id="siteLockPasswordInput" type="password" autocomplete="new-password" />
-              <button
-                id="siteLockPasswordToggle"
-                class="password-toggle password-toggle--site-lock"
-                type="button"
-                aria-label="Afficher le mot de passe"
-              >
-                <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
-              </button>
+              <input id="siteLockPasswordInput" type="text" autocomplete="new-password" />
+            </div>
+            <div id="siteLockStrengthIndicator" class="password-strength" hidden>
+              <div class="password-strength__track" aria-hidden="true">
+                <span id="siteLockStrengthBar" class="password-strength__bar"></span>
+              </div>
+              <p id="siteLockStrengthLabel" class="password-strength__text">Mot de passe faible</p>
             </div>
             <p id="siteLockPasswordError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
           <label class="input-group input-group--site-lock-create">
             <span>Confirmer le mot de passe</span>
             <div class="password-wrap password-wrap--site-lock">
-              <input id="siteLockConfirmPasswordInput" type="password" autocomplete="new-password" />
-              <button
-                id="siteLockConfirmPasswordToggle"
-                class="password-toggle password-toggle--site-lock"
-                type="button"
-                aria-label="Afficher le mot de passe"
-              >
-                <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
-              </button>
+              <input id="siteLockConfirmPasswordInput" type="text" autocomplete="new-password" />
             </div>
             <p id="siteLockConfirmPasswordError" class="form-error form-error--field" aria-live="polite"></p>
           </label>

--- a/js/app.js
+++ b/js/app.js
@@ -912,8 +912,8 @@ import { firebaseAuth } from './firebase-core.js';
     const siteLockConfirmPasswordInput = requireElement('siteLockConfirmPasswordInput');
     const siteLockPasswordError = requireElement('siteLockPasswordError');
     const siteLockConfirmPasswordError = requireElement('siteLockConfirmPasswordError');
-    const siteLockPasswordToggle = requireElement('siteLockPasswordToggle');
-    const siteLockConfirmPasswordToggle = requireElement('siteLockConfirmPasswordToggle');
+    const siteLockStrengthIndicator = requireElement('siteLockStrengthIndicator');
+    const siteLockStrengthLabel = requireElement('siteLockStrengthLabel');
     const siteUnlockDialog = requireElement('siteUnlockDialog');
     const siteUnlockForm = requireElement('siteUnlockForm');
     const siteUnlockPasswordInput = requireElement('siteUnlockPasswordInput');
@@ -1159,6 +1159,46 @@ import { firebaseAuth } from './firebase-core.js';
       if (iconElement) {
         iconElement.src = isVisible ? 'Icon/Eye_ON.png' : 'Icon/Eye_OFF.png';
       }
+    }
+
+    function getPasswordStrength(passwordValue) {
+      const value = String(passwordValue || '');
+      const length = value.length;
+      if (!length) {
+        return null;
+      }
+      const bonusCount = [/[A-Z]/.test(value), /\d/.test(value), /[^A-Za-z0-9]/.test(value)].filter(Boolean).length;
+      if (length < 6) {
+        return 'weak';
+      }
+      if (length >= 10 && bonusCount >= 2) {
+        return 'strong';
+      }
+      if ((length >= 6 && length <= 9) || bonusCount >= 1) {
+        return 'medium';
+      }
+      return 'weak';
+    }
+
+    function updateSiteLockStrengthIndicator() {
+      if (!siteLockStrengthIndicator || !siteLockStrengthLabel) {
+        return;
+      }
+      const passwordValue = siteLockPasswordInput?.value || '';
+      const strength = getPasswordStrength(passwordValue);
+      if (!strength) {
+        siteLockStrengthIndicator.hidden = true;
+        siteLockStrengthIndicator.removeAttribute('data-strength');
+        return;
+      }
+      const strengthLabelByKey = {
+        weak: 'Mot de passe faible',
+        medium: 'Mot de passe moyen',
+        strong: 'Mot de passe fort',
+      };
+      siteLockStrengthIndicator.hidden = false;
+      siteLockStrengthIndicator.dataset.strength = strength;
+      siteLockStrengthLabel.textContent = strengthLabelByKey[strength] || strengthLabelByKey.weak;
     }
 
     async function loadUserNames() {
@@ -1495,8 +1535,7 @@ import { firebaseAuth } from './firebase-core.js';
       siteLockConfirmPasswordInput.value = '';
       clearSiteLockFieldErrorState(siteLockPasswordInput, siteLockPasswordError);
       clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
-      setPasswordVisibility(siteLockPasswordInput, siteLockPasswordToggle, false);
-      setPasswordVisibility(siteLockConfirmPasswordInput, siteLockConfirmPasswordToggle, false);
+      updateSiteLockStrengthIndicator();
       siteLockDialog.showModal();
       siteLockPasswordInput.focus();
     }
@@ -1959,20 +1998,11 @@ import { firebaseAuth } from './firebase-core.js';
 
     siteLockPasswordInput?.addEventListener('input', () => {
       clearSiteLockFieldErrorState(siteLockPasswordInput, siteLockPasswordError);
+      updateSiteLockStrengthIndicator();
     });
 
     siteLockConfirmPasswordInput?.addEventListener('input', () => {
       clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
-    });
-
-    siteLockPasswordToggle?.addEventListener('click', () => {
-      const nextIsVisible = siteLockPasswordInput?.type === 'password';
-      setPasswordVisibility(siteLockPasswordInput, siteLockPasswordToggle, nextIsVisible);
-    });
-
-    siteLockConfirmPasswordToggle?.addEventListener('click', () => {
-      const nextIsVisible = siteLockConfirmPasswordInput?.type === 'password';
-      setPasswordVisibility(siteLockConfirmPasswordInput, siteLockConfirmPasswordToggle, nextIsVisible);
     });
 
     siteUnlockPasswordInput?.addEventListener('input', () => {
@@ -2149,8 +2179,7 @@ import { firebaseAuth } from './firebase-core.js';
       siteIdPendingLock = null;
       clearSiteLockFieldErrorState(siteLockPasswordInput, siteLockPasswordError);
       clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
-      setPasswordVisibility(siteLockPasswordInput, siteLockPasswordToggle, false);
-      setPasswordVisibility(siteLockConfirmPasswordInput, siteLockConfirmPasswordToggle, false);
+      updateSiteLockStrengthIndicator();
     });
 
     siteUnlockDialog?.addEventListener('close', () => {


### PR DESCRIPTION
### Motivation
- Rendre la création de mot de passe plus simple et visible en retirant le toggle œil et en affichant la force du mot de passe de façon professionnelle. 

### Description
- Dans `index.html` le modal `Créer un mot de passe` a été modifié pour remplacer les deux champs `type="password"` par `type="text"` et supprimer les boutons/icônes Eye_ON/Eye_OFF sur les champs de création. 
- Un indicateur de force a été ajouté sous le champ `siteLockPasswordInput` avec une barre (`.password-strength__bar`) et un label (`siteLockStrengthLabel`), initialement caché quand le champ est vide. 
- Dans `js/app.js` une fonction `getPasswordStrength` a été ajoutée pour calculer `weak|medium|strong` selon la longueur et les critères bonus (majuscule, chiffre, caractère spécial) et une fonction `updateSiteLockStrengthIndicator` met à jour l'UI sur `input` et lors de l'ouverture/fermeture du modal. 
- Dans `css/style.css` sont ajoutés des styles scoped pour l'indicateur avec transition douce et les valeurs demandées : faible 30% `#e53935`, moyen 60% `#fb8c00`, fort 100% `#43a047`, tout en conservant un rendu discret/professionnel et en retirant le padding droit prévu pour l'icône. 

### Testing
- Exécution de `node --check js/app.js` pour vérifier la validité du bundle JavaScript: réussite. 
- Vérification de l'état des fichiers modifiés via `git status --short` pour confirmer l'ensemble des changements locaux: réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7cf35304832a8575e16160aea3d7)