### PR TITLE
Afficher l’utilisateur (email) dans le statut verrouillé/déverrouillé de la page 1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3929,6 +3929,11 @@ body[data-page="home"] .list-card__status {
   font-weight: 700;
 }
 
+body[data-page="home"] .list-card__status-actor {
+  opacity: 0.8;
+  font-weight: 600;
+}
+
 body[data-page="home"] .list-card__status-icon {
   width: 16px;
   height: 16px;

--- a/js/app.js
+++ b/js/app.js
@@ -1716,7 +1716,12 @@ import { firebaseAuth } from './firebase-core.js';
           const createdDateTime = buildDateAndTimeLabel(site?.dateCreation);
           const createdBy = resolveActorLabel(site?.createdBy, userNamesById, site?.createdByName);
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
-          const lockLabel = isSiteLocked(site) ? 'Verrouillé' : 'Déverrouillé';
+          const lockActorEmail = isSiteLocked(site)
+            ? String(site?.lockedBy || '').trim()
+            : String(site?.unlockedBy || '').trim();
+          const lockLabel = isSiteLocked(site)
+            ? `🔒 Verrouillé${lockActorEmail ? ' par' : ''}`
+            : `🔓 Déverrouillé${lockActorEmail ? ' par' : ''}`;
           const canShowSiteActions = isAuthenticated;
           return `
             <article class="list-card">
@@ -1740,7 +1745,10 @@ import { firebaseAuth } from './firebase-core.js';
                 <span class="list-card__divider" aria-hidden="true"></span>
                 <span class="list-card__status ${isSiteLocked(site) ? 'list-card__status--locked' : 'list-card__status--unlocked'}">
                   <img src="${lockIconSrc}" alt="" aria-hidden="true" class="list-card__status-icon" />
-                  <span>${lockLabel}</span>
+                  <span>
+                    ${escapeHtml(lockLabel)}
+                    ${lockActorEmail ? `<span class="list-card__status-actor"> ${escapeHtml(lockActorEmail)}</span>` : ''}
+                  </span>
                 </span>
               </button>
             </article>

--- a/js/storage.js
+++ b/js/storage.js
@@ -597,6 +597,10 @@ async function resolveCurrentUserName() {
   return sanitizeText(rawName, false) || 'Utilisateur';
 }
 
+function resolveCurrentUserEmail() {
+  return String(state.authUser?.email || firebaseAuth.currentUser?.email || '').trim();
+}
+
 function uid() {
   return `local_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
 }
@@ -1025,11 +1029,14 @@ async function setSiteLock(siteId, lockPayload) {
 
   const timestamp = nowIso();
   const lockerName = (await resolveCurrentUserName()) || 'Utilisateur';
+  const lockerEmail = resolveCurrentUserEmail();
   const nextLockState = {
     isLocked: true,
     passwordHash: sanitizeText(lockPayload?.passwordHash, false),
     lockedAt: timestamp,
+    lockedBy: lockerEmail,
     lockedByName: lockerName,
+    unlockedBy: deleteField(),
     dateModification: timestamp,
   };
 
@@ -1060,11 +1067,14 @@ async function clearSiteLock(siteId) {
   }
 
   const timestamp = nowIso();
+  const unlockerEmail = resolveCurrentUserEmail();
   const nextLockState = {
     isLocked: false,
     passwordHash: deleteField(),
     lockedAt: deleteField(),
     lockedByName: deleteField(),
+    lockedBy: deleteField(),
+    unlockedBy: unlockerEmail,
     dateModification: timestamp,
   };
 
@@ -1079,7 +1089,9 @@ async function clearSiteLock(siteId) {
     isLocked: false,
     passwordHash: '',
     lockedAt: null,
+    lockedBy: '',
     lockedByName: '',
+    unlockedBy: unlockerEmail,
     dateModification: timestamp,
   };
   sortState();


### PR DESCRIPTION
### Motivation
- Afficher sur la page d’accueil qui a verrouillé ou déverrouillé un site en utilisant l’email de l’utilisateur connecté (Firebase Auth).
- Conserver le comportement et le style existants (couleurs rouge/vert, même ligne) tout en ajoutant un fallback lisible si l’email est absent.

### Description
- Ajout de `resolveCurrentUserEmail()` dans `js/storage.js` et écriture de `lockedBy` lors de `setSiteLock` et `unlockedBy` lors de `clearSiteLock`, en nettoyant l’autre champ via `deleteField()` pour la collection `pages/page1/items`.
- Mise à jour du rendu sur la page d’accueil (`js/app.js`) pour composer les libellés `🔒 Verrouillé par (email)` ou `🔓 Déverrouillé par (email)` et afficher `🔒 Verrouillé` / `🔓 Déverrouillé` quand l’email est vide.
- Ajout d’une classe CSS `.list-card__status-actor` dans `css/style.css` pour atténuer légèrement l’affichage de l’email (`opacity: 0.8`) et garder les couleurs existantes.
- Les modifications sont limitées à la logique et à l’affichage de la page 1 (home) et n’altèrent pas les autres pages.

### Testing
- Vérification de syntaxe JavaScript effectuée avec `node --check js/app.js js/storage.js` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec807e7088832a9a83362086b74a67)