### PR TITLE
Améliorer l’affichage verrouillé/déverrouillé sur la page 1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3927,11 +3927,28 @@ body[data-page="home"] .list-card__status {
   gap: 0.42rem;
   font-size: 0.88rem;
   font-weight: 700;
+  min-width: 0;
+}
+
+body[data-page="home"] .list-card__status-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: nowrap;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+body[data-page="home"] .list-card__status-main {
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 body[data-page="home"] .list-card__status-actor {
+  color: #6b7280;
   opacity: 0.8;
-  font-weight: 600;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 body[data-page="home"] .list-card__status-icon {

--- a/js/app.js
+++ b/js/app.js
@@ -1719,9 +1719,8 @@ import { firebaseAuth } from './firebase-core.js';
           const lockActorEmail = isSiteLocked(site)
             ? String(site?.lockedBy || '').trim()
             : String(site?.unlockedBy || '').trim();
-          const lockLabel = isSiteLocked(site)
-            ? `🔒 Verrouillé${lockActorEmail ? ' par' : ''}`
-            : `🔓 Déverrouillé${lockActorEmail ? ' par' : ''}`;
+          const lockLabel = isSiteLocked(site) ? 'Verrouillé' : 'Déverrouillé';
+          const lockLabelWithActor = lockActorEmail ? `${lockLabel} par` : lockLabel;
           const canShowSiteActions = isAuthenticated;
           return `
             <article class="list-card">
@@ -1745,9 +1744,9 @@ import { firebaseAuth } from './firebase-core.js';
                 <span class="list-card__divider" aria-hidden="true"></span>
                 <span class="list-card__status ${isSiteLocked(site) ? 'list-card__status--locked' : 'list-card__status--unlocked'}">
                   <img src="${lockIconSrc}" alt="" aria-hidden="true" class="list-card__status-icon" />
-                  <span>
-                    ${escapeHtml(lockLabel)}
-                    ${lockActorEmail ? `<span class="list-card__status-actor"> ${escapeHtml(lockActorEmail)}</span>` : ''}
+                  <span class="list-card__status-text">
+                    <span class="list-card__status-main">${escapeHtml(lockLabelWithActor)}</span>
+                    ${lockActorEmail ? `<span class="list-card__status-actor">${escapeHtml(lockActorEmail)}</span>` : ''}
                   </span>
                 </span>
               </button>


### PR DESCRIPTION
### Motivation
- Rendre le statut de verrouillage sur la page d’accueil (page 1) plus propre, lisible et professionnel sans toucher à la logique de verrouillage ni à Firebase.
- Supprimer les emojis cadenas dans le texte et garder uniquement l’icône visuelle à gauche pour indiquer l’état fermé/ouvert.
- Présenter le libellé sur une seule ligne avec un affichage conditionnel de l’email (`Verrouillé par email` / `Déverrouillé par email`) et un fallback sans email (`Verrouillé` / `Déverrouillé`).

### Description
- Remplacement du libellé textuel dans `js/app.js` pour supprimer les emojis et construire `lockLabel` et `lockLabelWithActor` afin d’ajouter `par` seulement si un email existe.
- Restructuration du HTML généré dans `js/app.js` pour séparer l’icône, le texte principal et l’email dans des spans dédiés (`.list-card__status-text`, `.list-card__status-main`, `.list-card__status-actor`) garantissant un alignement horizontal propre.
- Ajout et ajustement de styles dans `css/style.css` pour forcer le rendu sur une seule ligne (`white-space: nowrap`), appliquer la couleur d’email `#6b7280` avec `opacity: 0.8` et une graisse plus légère (`font-weight: 500`), et garantir un espacement/alignement cohérent entre icône, texte et email.
- Conservation des classes de couleur existantes pour les états `list-card__status--locked` et `list-card__status--unlocked` et absence de modifications hors de la page d’accueil ou de la logique métier.

### Testing
- Exécution de la vérification de syntaxe JS avec `node --check js/app.js` réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8a4fb114832a85691956aa5dd2ba)