### PR TITLE
Limiter les largeurs desktop et préserver le rendu mobile-first (CSS uniquement)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16,7 +16,9 @@
   --header-height: 5.75rem;
   --header-side-width: 3rem;
   --primary-color: #2e6ce5;
-  --content-max-width: 860px;
+  --content-max-width: 820px;
+  --content-max-width-wide: 980px;
+  --app-shell-max-width: var(--content-max-width);
 }
 
 /* Unified premium header system - final overrides */
@@ -186,13 +188,15 @@ button {
 
 .app-shell {
   height: 100vh;
+  width: min(100%, var(--app-shell-max-width));
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
 .app-shell--wide {
-  max-width: 1440px;
+  max-width: var(--content-max-width-wide);
   margin: 0 auto;
 }
 
@@ -476,6 +480,9 @@ body.app-content-loading #exportDetailsButton {
 }
 
 .page-content--wide {
+  width: 100%;
+  max-width: var(--content-max-width-wide);
+  margin-inline: auto;
   padding-bottom: 2rem;
 }
 
@@ -2032,7 +2039,7 @@ body[data-page="users-management"] {
 
 body[data-page="users-management"] .app-shell.app-shell--wide {
   min-height: 100dvh;
-  width: min(100%, 100vw);
+  width: min(100%, var(--content-max-width-wide));
 }
 
 body[data-page="users-management"] .page-content--wide {
@@ -2041,7 +2048,7 @@ body[data-page="users-management"] .page-content--wide {
   gap: 1.15rem;
   min-height: 0;
   flex: 1 1 auto;
-  padding-inline: clamp(0.9rem, 2vw, 1.5rem);
+  padding-inline: clamp(0.9rem, 2vw, 1.2rem);
   padding-bottom: clamp(0.75rem, 1.8vw, 1.25rem);
 }
 
@@ -2254,6 +2261,12 @@ body[data-page="item-detail"] .table-wrapper--shared {
   width: max-content;
   min-width: 100%;
   padding-bottom: 1.5rem;
+}
+
+body[data-page="item-detail"] .table-container--card {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 body[data-page="item-detail"] .search-panel .input-group {


### PR DESCRIPTION
### Motivation
- Éviter l’étirement du layout sur PC qui déforme l’apparence par rapport à la version mobile-first (cards trop larges, page 3 trop étirée, layout desktop/tablette spécifique indésirable). 
- Garder Android/mobile comme référence visuelle et faire en sorte que l’affichage PC conserve les proportions mobile plutôt que d’imposer un layout différent.

### Description
- Ajout et ajustement de variables CSS pour contrôler les largeurs globales (`--content-max-width`, `--content-max-width-wide`, `--app-shell-max-width`) afin de contraindre le rendu sur grands écrans dans `css/style.css`.
- Contrainte et centrage du shell applicatif avec `app-shell { width: min(100%, var(--app-shell-max-width)); margin: 0 auto; }` et limitation de `app-shell--wide` à `var(--content-max-width-wide)` pour éviter l’expansion excessive.
- Contention des zones « wide » via `.page-content--wide { max-width: var(--content-max-width-wide); margin-inline: auto; }` pour que page 1/2 restent proches du visuel mobile sur desktop.
- Ajustements spécifiques à la page utilisateurs pour limiter la largeur/padding desktop et éviter un changement visuel trop marqué (réduction du padding horizontal et du comportement d’extension).
- Empêchement du débordement horizontal global sur la page 3 en forçant le scroll horizontal localisé à l’intérieur de la carte du tableau (`.table-container--card { overflow-x: auto; overflow-y: hidden; }`).
- Aucun autre fichier modifié; pas de modification de Firebase, logique métier ou textes (CSS uniquement, fichier modifié: `css/style.css`).

### Testing
- Recherches automatisées des media queries et règles responsables avec `rg -n "@media \(min-width|@media \(max-width|@media" css/style.css` ont confirmé qu’aucune nouvelle media-query desktop intrusive n’a été ajoutée, et ont réussi.
- Inspection ciblée des sections modifiées de `css/style.css` via `sed -n` a confirmé les ajouts/ajustements attendus et l’absence de changements fonctionnels hors CSS, et a réussi.
- Vérification que seule la feuille `css/style.css` a été modifiée dans la revue des fichiers affectés a été réalisée et est conforme.
- Aucun test visuel automatisé dans un navigateur n’a été exécuté dans cet environnement (captures/screenshots non disponibles).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec92f38a9c832aa06269d6033aaaed)