### PR TITLE
Fix desktop responsive width on pages 1-3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4511,3 +4511,70 @@ body[data-page="home"] .app-header--home > h1 {
   width: auto;
   padding-inline: 0;
 }
+
+/* Desktop fluid layout adjustments (pages 1, 2, 3) */
+@media (min-width: 992px) {
+  body[data-page="home"] .app-shell,
+  body[data-page="site-detail"] .app-shell,
+  body[data-page="item-detail"] .app-shell,
+  body[data-page="item-detail"] .app-shell.app-shell--wide {
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    box-sizing: border-box;
+  }
+
+  body[data-page="home"] .app-header,
+  body[data-page="site-detail"] .app-header,
+  body[data-page="item-detail"] .app-header {
+    width: 100%;
+    max-width: none;
+    padding-left: clamp(16px, 4vw, 48px);
+    padding-right: clamp(16px, 4vw, 48px);
+    box-sizing: border-box;
+  }
+
+  body[data-page="home"] .page-content,
+  body[data-page="site-detail"] .page-content,
+  body[data-page="item-detail"] .page-content,
+  body[data-page="item-detail"] .page-content--wide {
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    padding-left: clamp(16px, 4vw, 48px);
+    padding-right: clamp(16px, 4vw, 48px);
+    box-sizing: border-box;
+  }
+
+  body[data-page="home"] .search-panel,
+  body[data-page="home"] .section-heading--sticky,
+  body[data-page="home"] .list-grid,
+  body[data-page="site-detail"] .search-panel--site,
+  body[data-page="site-detail"] .list-grid,
+  body[data-page="site-detail"] .list-separator,
+  body[data-page="item-detail"] .surface-card,
+  body[data-page="item-detail"] .table-card,
+  body[data-page="item-detail"] .section,
+  body[data-page="item-detail"] .search-panel {
+    width: 100%;
+    max-width: none;
+    margin-left: 0;
+    margin-right: 0;
+    box-sizing: border-box;
+  }
+
+  body[data-page="item-detail"] .table-container,
+  body[data-page="item-detail"] .table-container--card,
+  body[data-page="item-detail"] .table-wrapper,
+  body[data-page="item-detail"] .table-wrapper--shared {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  body[data-page="item-detail"] .data-table {
+    width: 100%;
+    min-width: 70rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Corriger l’affichage desktop qui était trop étroit et trop centré en supprimant les max-width restrictifs sur les containers principaux.
- Permettre au contenu de s’adapter naturellement à la largeur de l’écran sur PC sans imposer une largeur fixe.
- Conserver le design mobile-first et ne pas modifier la logique JavaScript, Firebase ou les textes.

### Description
- Ajout d’un bloc CSS ciblé `@media (min-width: 992px)` qui force `width: 100%`, `max-width: none` et `box-sizing: border-box` sur les `.app-shell` des pages home, site-detail et item-detail.
- Application des mêmes principes au `header` et au `page-content` avec des marges latérales adaptatives via `padding-left/right: clamp(16px, 4vw, 48px)` afin d’éviter une largeur fixe trop restrictive.
- Suppression des contraintes de largeur sur éléments clés (search panels, sections principales, list-grid, cards) en desktop pour un rendu fluide et non centré de façon excessive.
- Pour la page 3 (tableau), élargissement des wrappers/container de table pour occuper la largeur disponible tout en conservant un `min-width` de tableau (`min-width: 70rem`) afin de préserver le scroll horizontal interne uniquement si nécessaire.

### Testing
- Le CSS et les fichiers HTML ont été inspectés avec `rg`/`sed` pour localiser les règles de largeur et vérifier la portée des modifications.
- Le diff a été revu avec `git diff -- css/style.css` pour confirmer que seules des règles de layout responsive ont été ajoutées.
- Le changement a été enregistré avec `git status --short` et `git commit -m "Fix desktop responsive width on pages 1-3"` ; aucun test visuel automatisé (capture d’écran) n’a été effectué dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec96b47924832ab067830ec99fef0c)