### PR TITLE
Ajout du champ « Magasin » pour les OUT (pages 2 & 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2246,6 +2246,9 @@ import { firebaseAuth } from './firebase-core.js';
     const itemDialog = requireElement('itemDialog');
     const itemForm = requireElement('itemForm');
     const itemNumberInput = requireElement('itemNumberInput');
+    const itemStoreSelect = requireElement('itemStoreSelect');
+    const itemStoreOtherGroup = requireElement('itemStoreOtherGroup');
+    const itemStoreOtherInput = requireElement('itemStoreOtherInput');
     const itemNumberCounter = requireElement('itemNumberCounter');
     const itemFormError = requireElement('itemFormError');
     const itemCreateSubmitButton = requireElement('itemCreateSubmitButton');
@@ -2754,6 +2757,29 @@ import { firebaseAuth } from './firebase-core.js';
       return digitsOnly.slice(0, maxLength);
     }
 
+    function updateItemStoreOtherVisibility() {
+      if (!itemStoreSelect || !itemStoreOtherGroup) {
+        return;
+      }
+      const shouldShowOtherField = itemStoreSelect.value === 'Autre à préciser';
+      itemStoreOtherGroup.hidden = !shouldShowOtherField;
+      if (!shouldShowOtherField && itemStoreOtherInput) {
+        itemStoreOtherInput.value = '';
+      }
+    }
+
+    function resolveItemStoreValue() {
+      const selectedValue = String(itemStoreSelect?.value || '').trim();
+      if (!selectedValue) {
+        return 'None';
+      }
+      if (selectedValue === 'Autre à préciser') {
+        const customStore = String(itemStoreOtherInput?.value || '').trim();
+        return customStore || 'None';
+      }
+      return selectedValue;
+    }
+
     function updateItemNumberCounter() {
       const maxLength = getItemNumberMaxLength();
       const currentLength = itemNumberInput.value.length;
@@ -2817,8 +2843,13 @@ import { firebaseAuth } from './firebase-core.js';
       itemCreateSubmitButton.disabled = false;
       itemCreateSubmitButton.classList.remove('is-loading');
       updateItemNumberCounter();
+      updateItemStoreOtherVisibility();
       itemDialog.showModal();
       itemNumberInput.focus();
+    });
+
+    itemStoreSelect?.addEventListener('change', () => {
+      updateItemStoreOtherVisibility();
     });
 
     itemNumberInput.addEventListener('beforeinput', (event) => {
@@ -2875,6 +2906,7 @@ import { firebaseAuth } from './firebase-core.js';
       itemCreateSubmitButton.classList.remove('is-loading');
       itemCreateSubmitButton.disabled = false;
       updateItemNumberCounter();
+      updateItemStoreOtherVisibility();
     });
 
     if (openExportItems) {
@@ -3012,7 +3044,7 @@ import { firebaseAuth } from './firebase-core.js';
       itemCreateSubmitButton.disabled = true;
       itemCreateSubmitButton.classList.add('is-loading');
       try {
-        const result = await StorageService.createItem(siteId, value);
+        const result = await StorageService.createItem(siteId, value, { magasin: resolveItemStoreValue() });
         if (!result?.ok) {
           showItemFormError(
             result?.reason === 'duplicate_out'
@@ -3106,6 +3138,7 @@ import { firebaseAuth } from './firebase-core.js';
     const cancelDetailFormButton = requireElement('cancelDetailFormButton');
     const detailCreateSubmitButton = requireElement('detailCreateSubmitButton');
     const detailCount = requireElement('detailCount');
+    const detailStore = requireElement('detailStore');
     const detailTableBody = requireElement('detailTableBody');
     const detailSearchInput = requireElement('detailSearchInput');
     const exportButton = requireElement('exportDetailsButton');
@@ -3563,6 +3596,15 @@ import { firebaseAuth } from './firebase-core.js';
       secondaryLine.className = 'header-title__line header-title__line--secondary';
       secondaryLine.textContent = currentItem.numero;
       itemTitle.append(primaryLine, secondaryLine);
+    }
+
+    function renderStoreLabel() {
+      if (!detailStore) {
+        return;
+      }
+      const storeValue = String(currentItem?.magasin || '').trim();
+      const hasDefinedStore = Boolean(storeValue) && storeValue !== 'None';
+      detailStore.textContent = hasDefinedStore ? `Magasin : ${storeValue}` : 'Magasin : Non défini';
     }
 
     function getSearchQuery() {
@@ -4105,6 +4147,7 @@ import { firebaseAuth } from './firebase-core.js';
         return;
       }
       renderTitle();
+      renderStoreLabel();
     });
 
     StorageService.subscribeDetails(
@@ -4127,6 +4170,7 @@ import { firebaseAuth } from './firebase-core.js';
     );
 
     renderTitle();
+    renderStoreLabel();
     updateDetailInputCounters();
     refreshCodeSuggestionSource();
   }

--- a/js/storage.js
+++ b/js/storage.js
@@ -1126,7 +1126,7 @@ async function removeSite(siteId) {
   return { site: clone(site), items, details };
 }
 
-async function createItem(siteId, numberValue) {
+async function createItem(siteId, numberValue, options = {}) {
   const cleanNumber = sanitizeDigits(sanitizeText(numberValue, true).replace(/^OUT-/, ''));
   if (cleanNumber.length < 4) {
     return { ok: false, reason: 'invalid_out' };
@@ -1141,6 +1141,7 @@ async function createItem(siteId, numberValue) {
   const itemPayload = {
     siteId,
     numero,
+    magasin: sanitizeText(options?.magasin || 'None', true) || 'None',
     ownerId: state.userId,
     createdBy: state.userId,
     createdByName: creatorName,

--- a/page2.html
+++ b/page2.html
@@ -95,6 +95,20 @@
               <span id="itemNumberCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
             </div>
           </label>
+          <label class="input-group input-group--site-create input-group--item-create">
+            <span>Magasin</span>
+            <select id="itemStoreSelect" name="itemStore">
+              <option value="">-- Sélectionner --</option>
+              <option value="TIT I">TIT I</option>
+              <option value="HAG 36">HAG 36</option>
+              <option value="BY Pass">BY Pass</option>
+              <option value="Autre à préciser">Autre à préciser</option>
+            </select>
+          </label>
+          <label id="itemStoreOtherGroup" class="input-group input-group--site-create input-group--item-create" hidden>
+            <span>Préciser le magasin</span>
+            <input id="itemStoreOtherInput" name="itemStoreOther" type="text" placeholder="Ex : Dépôt secondaire" />
+          </label>
           <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
             <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
             <button id="itemCreateSubmitButton" type="submit" class="btn btn-success">

--- a/page3.html
+++ b/page3.html
@@ -27,6 +27,7 @@
             <div>
               <h2 class="section-title">Tableau des données</h2>
               <p id="detailCount">0 OUT</p>
+              <p id="detailStore">Magasin : Non défini</p>
             </div>
             <button type="button" id="exportDetailsButton" class="btn btn-success">Exporter</button>
           </div>


### PR DESCRIPTION
### Motivation
- Permettre d’enregistrer un magasin pour chaque OUT depuis le modal de création (page 2) et d’afficher cette information sur la page détail (page 3). 
- Respecter les règles métier : champ optionnel, valeur par défaut `None`, prise en charge de l’option « Autre à préciser » sans stocker la chaîne brute.

### Description
- page2.html : ajout d’un `select` `#itemStoreSelect` avec les choix demandés et d’un champ texte conditionnel `#itemStoreOtherInput` affiché uniquement si « Autre à préciser » est choisi.
- js/app.js : gestion UI pour afficher/cacher le champ « Préciser le magasin », résolution de la valeur finale via `resolveItemStoreValue()` et transmission de `magasin` à `StorageService.createItem(...)` lors de la création d’un OUT.
- js/storage.js : signature de `createItem` étendue à `createItem(siteId, numberValue, options = {})` et persistance du champ `magasin` dans le payload (normalisé, fallback `'None'`).
- page3.html + js/app.js : ajout d’un élément `#detailStore` dans la carte « Tableau des données » et rendu via `renderStoreLabel()` qui affiche « Magasin : Non défini » si la valeur est `None`.

### Testing
- Vérification syntaxique JavaScript : `node --check js/app.js` — réussi.
- Vérification syntaxique JavaScript : `node --check js/storage.js` — réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecccf79cc8832ab724731ee673eb9b)