### PR TITLE
Améliore le comportement dynamique du champ “Magasin” dans le modal OUT (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3262,6 +3262,26 @@ body[data-page="site-detail"] #itemDialog .input-group--item-create input:focus 
   box-shadow: 0 0 0 3px var(--detail-primary-focus);
 }
 
+body[data-page="site-detail"] #itemDialog #itemStoreOtherGroup {
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+body[data-page="site-detail"] #itemDialog #itemStoreOtherGroup[hidden] {
+  display: none;
+}
+
+body[data-page="site-detail"] #itemDialog #itemStoreOtherGroup.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+body[data-page="site-detail"] #itemDialog #itemStoreOtherGroup.is-hiding {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
 body[data-page="site-detail"] #itemDialog #itemNumberInput {
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -2726,6 +2726,8 @@ import { firebaseAuth } from './firebase-core.js';
     const siteDetailFabStack = document.querySelector('body[data-page="site-detail"] .site-detail-fab-stack');
     let itemFormErrorTimeoutId = null;
     let itemNumberErrorClearTimer = null;
+    let itemStoreOtherHideTimer = null;
+    const itemStoreOtherTransitionDurationMs = 200;
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -2757,15 +2759,43 @@ import { firebaseAuth } from './firebase-core.js';
       return digitsOnly.slice(0, maxLength);
     }
 
-    function updateItemStoreOtherVisibility() {
+    function updateItemStoreOtherVisibility(options = {}) {
       if (!itemStoreSelect || !itemStoreOtherGroup) {
         return;
       }
+      const immediate = Boolean(options.immediate);
       const shouldShowOtherField = itemStoreSelect.value === 'Autre à préciser';
-      itemStoreOtherGroup.hidden = !shouldShowOtherField;
-      if (!shouldShowOtherField && itemStoreOtherInput) {
+      if (itemStoreOtherHideTimer) {
+        window.clearTimeout(itemStoreOtherHideTimer);
+        itemStoreOtherHideTimer = null;
+      }
+
+      if (shouldShowOtherField) {
+        itemStoreOtherGroup.hidden = false;
+        itemStoreOtherGroup.classList.remove('is-hiding');
+        window.requestAnimationFrame(() => {
+          itemStoreOtherGroup.classList.add('is-visible');
+        });
+        return;
+      }
+
+      if (itemStoreOtherInput) {
         itemStoreOtherInput.value = '';
       }
+
+      if (immediate || itemStoreOtherGroup.hidden) {
+        itemStoreOtherGroup.classList.remove('is-visible', 'is-hiding');
+        itemStoreOtherGroup.hidden = true;
+        return;
+      }
+
+      itemStoreOtherGroup.classList.remove('is-visible');
+      itemStoreOtherGroup.classList.add('is-hiding');
+      itemStoreOtherHideTimer = window.setTimeout(() => {
+        itemStoreOtherGroup.hidden = true;
+        itemStoreOtherGroup.classList.remove('is-hiding');
+        itemStoreOtherHideTimer = null;
+      }, itemStoreOtherTransitionDurationMs);
     }
 
     function resolveItemStoreValue() {
@@ -2843,7 +2873,7 @@ import { firebaseAuth } from './firebase-core.js';
       itemCreateSubmitButton.disabled = false;
       itemCreateSubmitButton.classList.remove('is-loading');
       updateItemNumberCounter();
-      updateItemStoreOtherVisibility();
+      updateItemStoreOtherVisibility({ immediate: true });
       itemDialog.showModal();
       itemNumberInput.focus();
     });
@@ -2906,7 +2936,7 @@ import { firebaseAuth } from './firebase-core.js';
       itemCreateSubmitButton.classList.remove('is-loading');
       itemCreateSubmitButton.disabled = false;
       updateItemNumberCounter();
-      updateItemStoreOtherVisibility();
+      updateItemStoreOtherVisibility({ immediate: true });
     });
 
     if (openExportItems) {


### PR DESCRIPTION
### Motivation
- Rendre le champ secondaire “Préciser le magasin” masqué par défaut et ne l’afficher que lorsque l’utilisateur choisit `Autre à préciser` depuis le `select` Magasin.
- Garantir que la valeur du champ secondaire n’est pas prise en compte quand il est caché et qu’elle est vidée automatiquement lors du masquage.
- Ajouter une apparition/disparition fluide (opacity + translateY ~200ms) pour éviter toute apparition brutale tout en conservant le design existant.

### Description
- Refactorise `updateItemStoreOtherVisibility` dans `js/app.js` pour gérer l’affichage animé, le masquage animé, la vidange de la valeur et un mode `immediate` pour les resets d’ouverture/fermeture du modal via `{ immediate: true }`.
- Ajoute un timer d’animation `itemStoreOtherHideTimer` et une constante `itemStoreOtherTransitionDurationMs` pour synchroniser le masquage DOM après la transition (~200ms).
- Assure un masquage immédiat lors de l’ouverture et de la fermeture du modal en appelant `updateItemStoreOtherVisibility({ immediate: true })` depuis les handlers d’ouverture/fermeture du modal.
- Ajoute les styles ciblés dans `css/style.css` pour `#itemStoreOtherGroup` (`.is-visible` / `.is-hiding`) avec `opacity + translateY` transition et `display: none` quand l’attribut `hidden` est présent, en conservant le style visuel des autres champs.

### Testing
- Exécution de `node --check js/app.js` pour vérifier l’absence d’erreurs de syntaxe JavaScript : succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd0c5ebac832a8be6d12ec7659cb6)