### PR TITLE
Améliorer l'affichage du champ Magasin sur la page détail

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2307,6 +2307,33 @@ body[data-page="item-detail"] .auth-required-card--embedded {
   margin-bottom: 20px;
 }
 
+body[data-page="item-detail"] #detailStore {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+body[data-page="item-detail"] .detail-store-label {
+  color: var(--text-muted);
+}
+
+body[data-page="item-detail"] .detail-store-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.16rem 0.62rem;
+  border-radius: 999px;
+  background: #e8f3ff;
+  color: #1d4ed8;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+body[data-page="item-detail"] .detail-store-badge--muted {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
 body[data-page="item-detail"] .table-container input,
 body[data-page="item-detail"] .table-container select,
 body[data-page="item-detail"] .table-container button,

--- a/js/app.js
+++ b/js/app.js
@@ -3634,7 +3634,15 @@ import { firebaseAuth } from './firebase-core.js';
       }
       const storeValue = String(currentItem?.magasin || '').trim();
       const hasDefinedStore = Boolean(storeValue) && storeValue !== 'None';
-      detailStore.textContent = hasDefinedStore ? `Magasin : ${storeValue}` : 'Magasin : Non défini';
+      const displayValue = hasDefinedStore ? storeValue : 'Non défini';
+      detailStore.textContent = '';
+      const storeLabel = document.createElement('span');
+      storeLabel.className = 'detail-store-label';
+      storeLabel.textContent = 'Magasin :';
+      const storeBadge = document.createElement('span');
+      storeBadge.className = `detail-store-badge${hasDefinedStore ? '' : ' detail-store-badge--muted'}`;
+      storeBadge.textContent = displayValue;
+      detailStore.append(storeLabel, storeBadge);
     }
 
     function getSearchQuery() {


### PR DESCRIPTION
### Motivation

- Rendre la valeur du champ « Magasin » plus visible et professionnelle sur la page de détail (page 3) sans modifier la logique existante ni casser l’alignement ou l’espacement.

### Description

- `renderStoreLabel` crée désormais deux éléments `span`: un label `detail-store-label` et un badge `detail-store-badge` contenant la valeur affichée, en conservant la logique existante de détermination de la valeur (gestion de `None`).
- Lorsque la valeur vaut `None`, le texte affiché devient `Non défini` et le badge reçoit la classe `detail-store-badge--muted` pour un style grisé moins attractif.
- Ajout de règles CSS ciblées dans le scope `body[data-page="item-detail"]` pour le badge (fond bleu clair, texte bleu, bord arrondi « pill », padding) et pour la variante atténuée, afin de n’impacter aucune autre page.
- Aucun changement fonctionnel ou logique côté stockage/traitement des données n’a été effectué; seule la présentation a été modifiée.

### Testing

- Validation par inspection/diff du dépôt confirmant que seules les modifications sur `js/app.js` et `css/style.css` ont été appliquées et que les fichiers se sont mis à jour proprement (vérification de l’état et du diff) — OK.
- Aucun framework de tests automatisés détecté dans le projet (pas de `package.json`/test runner), donc aucun test unitaire automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd8b052e4832ab9d6551fe7bb6940)