### PR TITLE
Améliore les couleurs du badge magasin sur la page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2329,7 +2329,27 @@ body[data-page="item-detail"] .detail-store-badge {
   line-height: 1.25;
 }
 
-body[data-page="item-detail"] .detail-store-badge--muted {
+body[data-page="item-detail"] .detail-store-badge--tit-i {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+body[data-page="item-detail"] .detail-store-badge--hag-36 {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+body[data-page="item-detail"] .detail-store-badge--by-pass {
+  background: #ffedd5;
+  color: #ea580c;
+}
+
+body[data-page="item-detail"] .detail-store-badge--custom {
+  background: #f3e8ff;
+  color: #9333ea;
+}
+
+body[data-page="item-detail"] .detail-store-badge--undefined {
   background: #f1f5f9;
   color: #64748b;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -3632,15 +3632,31 @@ import { firebaseAuth } from './firebase-core.js';
       if (!detailStore) {
         return;
       }
-      const storeValue = String(currentItem?.magasin || '').trim();
-      const hasDefinedStore = Boolean(storeValue) && storeValue !== 'None';
-      const displayValue = hasDefinedStore ? storeValue : 'Non défini';
+      const rawStoreValue = String(currentItem?.magasin || '').trim();
+      const normalizedStoreValue = rawStoreValue.toLowerCase();
+      let displayValue = rawStoreValue;
+      let badgeVariantClass = 'detail-store-badge--custom';
+
+      if (!rawStoreValue || normalizedStoreValue === 'none' || normalizedStoreValue === 'null') {
+        displayValue = 'Non défini';
+        badgeVariantClass = 'detail-store-badge--undefined';
+      } else if (normalizedStoreValue === 'tit i') {
+        displayValue = 'TIT I';
+        badgeVariantClass = 'detail-store-badge--tit-i';
+      } else if (normalizedStoreValue === 'hag 36') {
+        displayValue = 'HAG 36';
+        badgeVariantClass = 'detail-store-badge--hag-36';
+      } else if (normalizedStoreValue === 'by pass') {
+        displayValue = 'BY Pass';
+        badgeVariantClass = 'detail-store-badge--by-pass';
+      }
+
       detailStore.textContent = '';
       const storeLabel = document.createElement('span');
       storeLabel.className = 'detail-store-label';
       storeLabel.textContent = 'Magasin :';
       const storeBadge = document.createElement('span');
-      storeBadge.className = `detail-store-badge${hasDefinedStore ? '' : ' detail-store-badge--muted'}`;
+      storeBadge.className = `detail-store-badge ${badgeVariantClass}`;
       storeBadge.textContent = displayValue;
       detailStore.append(storeLabel, storeBadge);
     }


### PR DESCRIPTION
### Motivation
- Améliorer l’identification visuelle du champ `Magasin` sur la page 3 (détail) en appliquant une couleur de badge différente selon la valeur saisie. 
- Permettre une lecture rapide des magasins (`TIT I`, `HAG 36`, `BY Pass`, autres) tout en affichant clairement les cas non définis.
- Limiter le changement à l’affichage (UI) sur la page détail sans toucher à la logique Firebase ni à la page 2.

### Description
- `js/app.js`: mise à jour de `renderStoreLabel()` pour normaliser la valeur `magasin`, déterminer le libellé affiché et sélectionner dynamiquement une classe de variante de badge (`--tit-i`, `--hag-36`, `--by-pass`, `--custom`, `--undefined`).
- `css/style.css`: ajout de classes scoped `body[data-page="item-detail"] .detail-store-badge--*` avec couleurs demandées (bleu clair/bleu, vert clair/vert, orange clair/orange, violet clair/violet, gris clair/gris) pour chaque variante.
- Comportement implémenté: `TIT I`, `HAG 36`, `BY Pass` → classes dédiées; `None`/vide/`null` → affiche `Non défini` avec badge gris; toute autre valeur → badge violet (autre magasin).
- Les modifications sont limitées au rendu du badge sur la page détail et n’affectent ni Firebase ni d’autres pages.

### Testing
- Recherche et inspection des fichiers impactés via `rg --files` et `rg -n "detailStore|magasin|badge"` ont confirmé l’isolation des changements et ont réussi. 
- Vérification du diff avec `git diff -- js/app.js css/style.css` a montré les modifications attendues et a réussi. 
- Commit réalisé avec `git commit -m "Améliore le badge magasin sur la page détail"` pour enregistrer les changements avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdae68580832aa04c120990e5898f)