### PR TITLE
Afficher 'TITAN I' sur la page 2 et la page 3 (affichage uniquement)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3640,8 +3640,8 @@ import { firebaseAuth } from './firebase-core.js';
       if (!rawStoreValue || normalizedStoreValue === 'none' || normalizedStoreValue === 'null') {
         displayValue = 'Non défini';
         badgeVariantClass = 'detail-store-badge--undefined';
-      } else if (normalizedStoreValue === 'tit i') {
-        displayValue = 'TIT I';
+      } else if (normalizedStoreValue === 'tit i' || normalizedStoreValue === 'titan i') {
+        displayValue = 'TITAN I';
         badgeVariantClass = 'detail-store-badge--tit-i';
       } else if (normalizedStoreValue === 'hag 36') {
         displayValue = 'HAG 36';

--- a/page2.html
+++ b/page2.html
@@ -99,7 +99,7 @@
             <span>Magasin</span>
             <select id="itemStoreSelect" name="itemStore">
               <option value="">-- Sélectionner --</option>
-              <option value="TIT I">TIT I</option>
+              <option value="TIT I">TITAN I</option>
               <option value="HAG 36">HAG 36</option>
               <option value="BY Pass">BY Pass</option>
               <option value="Autre à préciser">Autre à préciser</option>


### PR DESCRIPTION
### Motivation
- Remplacer le libellé visible `TIT I` par `TITAN I` sur la page de création (page 2) et sur le détail (page 3) sans toucher à la structure des données ni à Firebase.

### Description
- Dans `page2.html` j’ai changé le texte de l’option de `<option value="TIT I">TIT I</option>` vers `<option value="TIT I">TITAN I</option>` pour ne modifier que l’affichage tout en conservant `value="TIT I"`.
- Dans `js/app.js` la fonction `renderStoreLabel` a été ajustée pour que les valeurs normalisées `'tit i'` ou `'titan i'` s’affichent comme `TITAN I` (conversion à l’affichage uniquement).
- Aucune autre option magasin, aucun schéma de données et aucun code Firebase n’ont été modifiés.

### Testing
- Exécution de `rg -n "TIT I|TITAN I" page2.html js/app.js` pour vérifier les occurrences mises à jour, commande réussie.
- Inspection du changement via `git diff -- page2.html js/app.js` et commit de la modification, opérations réussies.
- Aucun test automatique d’interface/visuel n’a été exécuté dans cet environnement (limite d’exécution).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdd7a0db8832aa9b7159da34550ff)