### PR TITLE
Refonte globale du toast/undo en composant unique modernisé

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2856,36 +2856,106 @@ body[data-page="item-detail"] #designationInput.is-shaking {
 }
 
 .toast {
+  --toast-accent: #2563eb;
+  --toast-bg: #ffffff;
+  --toast-text: #0f172a;
   position: fixed;
   left: 50%;
-  bottom: 1rem;
-  transform: translate(-50%, 110%);
-  background: #111827;
-  color: #fff;
-  padding: 0.8rem 1rem;
-  border-radius: 999px;
+  bottom: max(16px, calc(env(safe-area-inset-bottom) + 12px));
+  width: calc(100% - 32px);
+  max-width: 480px;
+  transform: translate(-50%, 22px);
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: var(--toast-bg);
+  color: var(--toast-text);
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.16), 0 4px 12px rgba(15, 23, 42, 0.08);
+  padding: 14px 16px;
   opacity: 0;
-  transition: transform 0.25s ease, opacity 0.25s ease;
-  display: inline-flex;
+  pointer-events: none;
+  transition: transform 0.28s ease, opacity 0.28s ease;
+  display: flex;
   align-items: center;
-  gap: 0.75rem;
-  width: auto;
-  height: auto;
-  max-width: calc(100vw - 2rem);
-  z-index: 30;
+  justify-content: space-between;
+  gap: 12px;
+  z-index: 1200;
+}
+
+.toast::before {
+  content: "";
+  width: 4px;
+  height: calc(100% - 18px);
+  border-radius: 999px;
+  background: var(--toast-accent);
+  align-self: center;
+}
+
+.toast[data-type="success"] {
+  --toast-accent: #16a34a;
+}
+
+.toast[data-type="error"] {
+  --toast-accent: #dc2626;
+}
+
+.toast[data-type="warning"] {
+  --toast-accent: #ea580c;
+}
+
+.toast[data-type="info"] {
+  --toast-accent: #2563eb;
 }
 
 .toast--visible {
   opacity: 1;
+  pointer-events: auto;
   transform: translate(-50%, 0);
+}
+
+.toast__content {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+}
+
+.toast__icon {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--toast-accent);
+  background: color-mix(in srgb, var(--toast-accent) 14%, white);
+}
+
+.toast__message {
+  font-size: 0.95rem;
+  line-height: 1.35;
+  font-weight: 500;
+  overflow-wrap: anywhere;
 }
 
 .toast__action {
   border: 0;
-  background: transparent;
-  color: #93c5fd;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--toast-accent) 15%, white);
+  color: var(--toast-accent);
   font-weight: 700;
-  padding: 0.25rem 0.35rem;
+  font-size: 0.83rem;
+  padding: 7px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.toast__action:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--toast-accent) 35%, #0f172a);
+  outline-offset: 1px;
 }
 
 /* Unified premium header system */

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,6 +1,8 @@
 (function () {
   const TOAST_VISIBLE_CLASS = "toast--visible";
-  const DEFAULT_TOAST_DURATION = 3000;
+  const TOAST_WITH_ACTION_CLASS = "toast--with-action";
+  const TOAST_TYPES = new Set(["success", "error", "warning", "info"]);
+  const DEFAULT_TOAST_DURATION = 2800;
   const DEFAULT_SNACKBAR_DURATION = 5000;
   const GLOBAL_LOADER_ID = "globalPageLoader";
   const GLOBAL_LOADER_HIDDEN_CLASS = "global-loader-overlay--hidden";
@@ -157,8 +159,69 @@
     return new URLSearchParams(window.location.search);
   }
 
+  function createTypeIcon(type) {
+    const icon = document.createElement("span");
+    icon.className = "toast__icon";
+    icon.setAttribute("aria-hidden", "true");
+
+    const iconByType = {
+      success: "✓",
+      error: "⚠",
+      warning: "!",
+      info: "i",
+    };
+
+    icon.textContent = iconByType[type] || iconByType.info;
+    return icon;
+  }
+
+  function inferToastType(message) {
+    const normalizedMessage = String(message ?? "").toLowerCase();
+    if (/(impossible|erreur|échec|invalide|indisponible)/.test(normalizedMessage)) {
+      return "error";
+    }
+    if (/(attention|avertissement|verrouillé)/.test(normalizedMessage)) {
+      return "warning";
+    }
+    if (/(succès|succ[eé]d|supprim|ajout|mis [àa] jour|import|export|lanc[ée])/.test(normalizedMessage)) {
+      return "success";
+    }
+    return "info";
+  }
+
+  function normalizeToastOptions(messageOrOptions, maybeOptions = {}) {
+    if (typeof messageOrOptions === "object" && messageOrOptions !== null) {
+      const options = { ...messageOrOptions };
+      options.message = String(options.message ?? "");
+      const safeType = TOAST_TYPES.has(options.type) ? options.type : inferToastType(options.message);
+      options.type = safeType;
+      options.duration = Number.isFinite(options.duration) ? Number(options.duration) : DEFAULT_TOAST_DURATION;
+      return options;
+    }
+
+    const message = String(messageOrOptions ?? "");
+    const options = { ...maybeOptions, message };
+    const safeType = TOAST_TYPES.has(options.type) ? options.type : inferToastType(message);
+    options.type = safeType;
+    options.duration = Number.isFinite(options.duration) ? Number(options.duration) : DEFAULT_TOAST_DURATION;
+    return options;
+  }
+
   function getToastElement() {
-    return document.getElementById("toast");
+    let toast = document.getElementById("toast");
+    if (toast) {
+      toast.classList.add("toast");
+      return toast;
+    }
+
+    toast = document.createElement("div");
+    toast.id = "toast";
+    toast.className = "toast";
+    toast.setAttribute("role", "status");
+    toast.setAttribute("aria-live", "polite");
+    toast.setAttribute("aria-atomic", "true");
+    document.body.appendChild(toast);
+    return toast;
   }
 
   function hideToast() {
@@ -166,12 +229,13 @@
     if (!toast) {
       return;
     }
-    toast.classList.remove(TOAST_VISIBLE_CLASS);
+    toast.classList.remove(TOAST_VISIBLE_CLASS, TOAST_WITH_ACTION_CLASS);
+    toast.removeAttribute("data-type");
     window.setTimeout(() => {
       if (!toast.classList.contains(TOAST_VISIBLE_CLASS)) {
         toast.textContent = "";
       }
-    }, 250);
+    }, 260);
   }
 
   function scheduleHide(delay = DEFAULT_TOAST_DURATION) {
@@ -184,36 +248,46 @@
     }, delay);
   }
 
-  function showToast(message) {
+  function renderToast(options) {
     const toast = getToastElement();
     if (!toast) {
       return;
     }
-    toast.textContent = String(message ?? "");
-    toast.classList.add(TOAST_VISIBLE_CLASS);
-    scheduleHide(DEFAULT_TOAST_DURATION);
-  }
 
-  function showUndoSnackbar(message, onUndo, actionLabel = "Annuler") {
-    const toast = getToastElement();
-    if (!toast) {
-      return;
-    }
+    const { message, type = "info", actionLabel, onAction } = options;
+    const hasAction = typeof onAction === "function";
 
     toast.textContent = "";
-    const messageNode = document.createElement("span");
-    messageNode.textContent = String(message ?? "");
-    toast.appendChild(messageNode);
+    toast.classList.toggle(TOAST_WITH_ACTION_CLASS, hasAction);
+    toast.dataset.type = type;
+    toast.setAttribute("role", "status");
+    toast.setAttribute("aria-live", type === "error" ? "assertive" : "polite");
 
-    if (typeof onUndo === "function") {
+    const content = document.createElement("div");
+    content.className = "toast__content";
+
+    content.appendChild(createTypeIcon(type));
+
+    const messageNode = document.createElement("span");
+    messageNode.className = "toast__message";
+    messageNode.textContent = String(message ?? "");
+    content.appendChild(messageNode);
+
+    toast.appendChild(content);
+
+    if (hasAction) {
       const actionButton = document.createElement("button");
       actionButton.type = "button";
       actionButton.className = "toast__action";
-      actionButton.textContent = actionLabel;
+      actionButton.textContent = actionLabel || "Annuler";
       actionButton.addEventListener(
         "click",
         () => {
-          onUndo();
+          onAction();
+          if (hideTimerId) {
+            window.clearTimeout(hideTimerId);
+            hideTimerId = null;
+          }
           hideToast();
         },
         { once: true },
@@ -222,7 +296,22 @@
     }
 
     toast.classList.add(TOAST_VISIBLE_CLASS);
-    scheduleHide(DEFAULT_SNACKBAR_DURATION);
+    scheduleHide(options.duration);
+  }
+
+  function showToast(messageOrOptions, maybeOptions = {}) {
+    const options = normalizeToastOptions(messageOrOptions, maybeOptions);
+    renderToast(options);
+  }
+
+  function showUndoSnackbar(message, onUndo, actionLabel = "Annuler") {
+    const options = normalizeToastOptions(message, {
+      type: "warning",
+      duration: DEFAULT_SNACKBAR_DURATION,
+      actionLabel,
+      onAction: onUndo,
+    });
+    renderToast(options);
   }
 
   function renderEmptyState(container, message) {


### PR DESCRIPTION
### Motivation
- Unifier l’ancien toast et la barre d’undo en un composant global unique réutilisable et moderne pour toutes les pages. 
- Fournir des toasts typés (`success`, `error`, `warning`, `info`) avec design mobile-first et animations fluides sans casser les appels existants. 
- Transformer la barre d’undo en un toast actionnable conservant la logique d’annulation/délai existante. 

### Description
- Réécriture du rendu toast dans `js/ui.js` avec un renderer central `renderToast` et une API compatible legacy via `showToast(message)` ou en passant un objet d’options à `showToast` (type, duration, action). 
- Ajout de l’inférence de type et de la normalisation d’options via `normalizeToastOptions`, plus la création d’icônes par `createTypeIcon` pour chaque type de toast. 
- `showUndoSnackbar` devient un simple wrapper autour de `renderToast` (action `Annuler` qui exécute la fonction `onUndo` et conserve le timeout), et les attributs d’accessibilité sont améliorés (`role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece206fb74832ab51ebeac677194bd)