### PR TITLE
Refonte UI du système global de toast et undo bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2856,9 +2856,9 @@ body[data-page="item-detail"] #designationInput.is-shaking {
 }
 
 .toast {
-  --toast-accent: #2563eb;
-  --toast-bg: #ffffff;
-  --toast-text: #0f172a;
+  --toast-bg: #3b82f6;
+  --toast-text: #ffffff;
+  --toast-border: rgba(255, 255, 255, 0.2);
   position: fixed;
   left: 50%;
   bottom: max(16px, calc(env(safe-area-inset-bottom) + 12px));
@@ -2866,14 +2866,14 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   max-width: 480px;
   transform: translate(-50%, 22px);
   border-radius: 18px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid var(--toast-border);
   background: var(--toast-bg);
   color: var(--toast-text);
-  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.16), 0 4px 12px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.25), 0 6px 14px rgba(15, 23, 42, 0.16);
   padding: 14px 16px;
   opacity: 0;
   pointer-events: none;
-  transition: transform 0.28s ease, opacity 0.28s ease;
+  transition: transform 0.2s ease, opacity 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2881,29 +2881,20 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   z-index: 1200;
 }
 
-.toast::before {
-  content: "";
-  width: 4px;
-  height: calc(100% - 18px);
-  border-radius: 999px;
-  background: var(--toast-accent);
-  align-self: center;
-}
-
 .toast[data-type="success"] {
-  --toast-accent: #16a34a;
+  --toast-bg: #22c55e;
 }
 
 .toast[data-type="error"] {
-  --toast-accent: #dc2626;
+  --toast-bg: #ef4444;
 }
 
 .toast[data-type="warning"] {
-  --toast-accent: #ea580c;
+  --toast-bg: #f59e0b;
 }
 
 .toast[data-type="info"] {
-  --toast-accent: #2563eb;
+  --toast-bg: #3b82f6;
 }
 
 .toast--visible {
@@ -2921,22 +2912,22 @@ body[data-page="item-detail"] #designationInput.is-shaking {
 }
 
 .toast__icon {
-  width: 22px;
-  height: 22px;
-  min-width: 22px;
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
   border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   font-weight: 700;
-  color: var(--toast-accent);
-  background: color-mix(in srgb, var(--toast-accent) 14%, white);
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .toast__message {
   font-size: 0.95rem;
-  line-height: 1.35;
+  line-height: 1.4;
   font-weight: 500;
   overflow-wrap: anywhere;
 }
@@ -2944,17 +2935,17 @@ body[data-page="item-detail"] #designationInput.is-shaking {
 .toast__action {
   border: 0;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--toast-accent) 15%, white);
-  color: var(--toast-accent);
-  font-weight: 700;
-  font-size: 0.83rem;
-  padding: 7px 12px;
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+  font-weight: 500;
+  font-size: 0.85rem;
+  padding: 6px 12px;
   cursor: pointer;
   white-space: nowrap;
 }
 
 .toast__action:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--toast-accent) 35%, #0f172a);
+  outline: 2px solid rgba(255, 255, 255, 0.9);
   outline-offset: 1px;
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -4,6 +4,7 @@
   const TOAST_TYPES = new Set(["success", "error", "warning", "info"]);
   const DEFAULT_TOAST_DURATION = 2800;
   const DEFAULT_SNACKBAR_DURATION = 5000;
+  const TOAST_HIDE_ANIMATION_DURATION = 220;
   const GLOBAL_LOADER_ID = "globalPageLoader";
   const GLOBAL_LOADER_HIDDEN_CLASS = "global-loader-overlay--hidden";
   const APP_LOADED_STORAGE_KEY = "albumAppHasLoadedOnce";
@@ -13,6 +14,9 @@
   const INLINE_LOADER_ID = "pageInlineLoader";
   const CONTENT_LOADING_DELAY_MS = 120;
   let hideTimerId = null;
+  let toastClearTimerId = null;
+  const toastQueue = [];
+  let activeToast = null;
   let globalLoader = null;
   let hasWindowLoaded = document.readyState === "complete";
   let isAppReady = false;
@@ -229,13 +233,26 @@
     if (!toast) {
       return;
     }
+
+    if (hideTimerId) {
+      window.clearTimeout(hideTimerId);
+      hideTimerId = null;
+    }
+    if (toastClearTimerId) {
+      window.clearTimeout(toastClearTimerId);
+      toastClearTimerId = null;
+    }
+
     toast.classList.remove(TOAST_VISIBLE_CLASS, TOAST_WITH_ACTION_CLASS);
     toast.removeAttribute("data-type");
-    window.setTimeout(() => {
+    toastClearTimerId = window.setTimeout(() => {
       if (!toast.classList.contains(TOAST_VISIBLE_CLASS)) {
         toast.textContent = "";
       }
-    }, 260);
+      activeToast = null;
+      toastClearTimerId = null;
+      processToastQueue();
+    }, TOAST_HIDE_ANIMATION_DURATION);
   }
 
   function scheduleHide(delay = DEFAULT_TOAST_DURATION) {
@@ -246,6 +263,14 @@
       hideTimerId = null;
       hideToast();
     }, delay);
+  }
+
+  function processToastQueue() {
+    if (activeToast || toastQueue.length === 0) {
+      return;
+    }
+    activeToast = toastQueue.shift();
+    renderToast(activeToast);
   }
 
   function renderToast(options) {
@@ -284,10 +309,6 @@
         "click",
         () => {
           onAction();
-          if (hideTimerId) {
-            window.clearTimeout(hideTimerId);
-            hideTimerId = null;
-          }
           hideToast();
         },
         { once: true },
@@ -301,7 +322,8 @@
 
   function showToast(messageOrOptions, maybeOptions = {}) {
     const options = normalizeToastOptions(messageOrOptions, maybeOptions);
-    renderToast(options);
+    toastQueue.push(options);
+    processToastQueue();
   }
 
   function showUndoSnackbar(message, onUndo, actionLabel = "Annuler") {
@@ -311,7 +333,8 @@
       actionLabel,
       onAction: onUndo,
     });
-    renderToast(options);
+    toastQueue.push(options);
+    processToastQueue();
   }
 
   function renderEmptyState(container, message) {


### PR DESCRIPTION
### Motivation
- Remplacer les toasts et l’undo bar dispersés par un composant global unique, moderne et mobile-first pour une visibilité optimale sur fond blanc.
- Uniformiser le rendu visuel entre toast simple et undo bar tout en conservant la logique et les textes existants.
- Fournir des couleurs contextuelles obligatoires (success/error/warning/info) et une animation fluide pour une expérience premium.

### Description
- Ajout d’une file d’attente et d’un enchaînement automatique dans `js/ui.js` (`toastQueue`, `activeToast`, `processToastQueue`) pour éviter l’écrasement des notifications simultanées.
- Gestion des timers et durée d’animation centralisée (`TOAST_HIDE_ANIMATION_DURATION`) et nettoyage contrôlé du DOM pour éviter des suppressions brutales.
- `showToast` et `showUndoSnackbar` poussent maintenant les options dans la même file et utilisent le même rendu/flux d’affichage pour garantir l’uniformité et appeler le callback `onAction` pour l’undo.
- Refonte CSS (`css/style.css`) : suppression du fond blanc, application des couleurs demandées par type (success `#22c55e`, error `#ef4444`, warning `#f59e0b`, info `#3b82f6`), texte blanc, icône et bouton action pill translucide, bord-radius 18px, ombre douce, largeur responsive et transitions `opacity + translateY` ≈200ms.

### Testing
- `node --check js/ui.js` — succès (pas d’erreurs de syntaxe détectées).
- `git status --short` — vérification d’état du dépôt effectuée (aucun fichier non enregistré signalé après les modifications).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece5641dc0832a938b9c15396a6835)