### PR TITLE
Replace global page spinner with existing skeleton loader

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3220,54 +3220,6 @@ body[data-page="home"] .app-header--home > h1 {
   display: none;
 }
 
-.global-loader-overlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(255, 255, 255, 0.6);
-  z-index: 10000;
-  -webkit-backdrop-filter: blur(7px);
-  backdrop-filter: blur(7px);
-  opacity: 1;
-  visibility: visible;
-  transition: opacity 0.25s ease, visibility 0.25s ease;
-}
-
-@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
-  .global-loader-overlay {
-    background: rgba(255, 255, 255, 0.82);
-  }
-}
-
-.global-loader-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.global-loader-overlay--hidden {
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-}
-
-.global-loader-spinner {
-  width: 52px;
-  height: 52px;
-  border: 4px solid rgba(39, 141, 218, 0.2);
-  border-top-color: var(--primary-dark);
-  border-radius: 50%;
-  animation: global-spinner-rotate 0.9s linear infinite;
-}
-
-@keyframes global-spinner-rotate {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 @keyframes btn-spinner-rotate {
   to {
     transform: rotate(360deg);

--- a/js/ui.js
+++ b/js/ui.js
@@ -5,8 +5,6 @@
   const DEFAULT_TOAST_DURATION = 2800;
   const DEFAULT_SNACKBAR_DURATION = 5000;
   const TOAST_HIDE_ANIMATION_DURATION = 220;
-  const GLOBAL_LOADER_ID = "globalPageLoader";
-  const GLOBAL_LOADER_HIDDEN_CLASS = "global-loader-overlay--hidden";
   const APP_LOADED_STORAGE_KEY = "albumAppHasLoadedOnce";
   const CONTENT_PENDING_CLASS = "app-content-pending";
   const CONTENT_LOADING_CLASS = "app-content-loading";
@@ -17,53 +15,18 @@
   let toastClearTimerId = null;
   const toastQueue = [];
   let activeToast = null;
-  let globalLoader = null;
   let hasWindowLoaded = document.readyState === "complete";
   let isAppReady = false;
-  let shouldUseGlobalLoader = false;
   let inlineLoaderTimerId = null;
 
-  function ensureGlobalLoader() {
-    if (globalLoader) {
-      return globalLoader;
-    }
-
-    globalLoader = document.getElementById(GLOBAL_LOADER_ID);
-    if (globalLoader) {
-      return globalLoader;
-    }
-
-    const overlay = document.createElement("div");
-    overlay.id = GLOBAL_LOADER_ID;
-    overlay.className = "global-loader-overlay";
-    overlay.setAttribute("role", "status");
-    overlay.setAttribute("aria-live", "polite");
-    overlay.setAttribute("aria-label", "Chargement en cours");
-
-    const loaderContent = document.createElement("div");
-    loaderContent.className = "global-loader-content";
-
-    const spinner = document.createElement("div");
-    spinner.className = "global-loader-spinner";
-    spinner.setAttribute("aria-hidden", "true");
-    loaderContent.appendChild(spinner);
-
-    overlay.appendChild(loaderContent);
-
-    document.body.appendChild(overlay);
-    globalLoader = overlay;
-    return globalLoader;
-  }
-
   function showGlobalLoader() {
-    ensureGlobalLoader().classList.remove(GLOBAL_LOADER_HIDDEN_CLASS);
+    ensureInlineLoader();
+    document.body.classList.remove(CONTENT_READY_CLASS);
+    document.body.classList.add(CONTENT_LOADING_CLASS);
   }
 
   function hideGlobalLoader() {
-    if (!globalLoader) {
-      return;
-    }
-    globalLoader.classList.add(GLOBAL_LOADER_HIDDEN_CLASS);
+    stopContentLoadingState();
   }
 
   function ensureInlineLoader() {
@@ -356,22 +319,12 @@
   }
 
   try {
-    shouldUseGlobalLoader = sessionStorage.getItem(APP_LOADED_STORAGE_KEY) !== "1";
+    sessionStorage.getItem(APP_LOADED_STORAGE_KEY);
   } catch (_error) {
-    shouldUseGlobalLoader = true;
-  }
-
-  if (shouldUseGlobalLoader) {
-    ensureGlobalLoader();
-    showGlobalLoader();
+    // Ignore storage restrictions.
   }
   startContentLoadingState();
 
-  window.addEventListener("beforeunload", () => {
-    if (shouldUseGlobalLoader) {
-      showGlobalLoader();
-    }
-  });
   window.addEventListener("load", () => {
     hasWindowLoaded = true;
     maybeHideGlobalLoader();


### PR DESCRIPTION
### Motivation
- Remplacer le spinner overlay global par la skeleton animation déjà existante pour le chargement global de page afin d’uniformiser l’expérience de chargement.
- Ne modifier que le système de chargement global sans impacter les animations de boutons, d’enregistrement, ni les transitions de modals/toasts.

### Description
- Supprimé la création et le DOM du overlay spinner global dans `js/ui.js` et retiré les règles CSS associées `.global-loader-*` dans `css/style.css`.
- `showGlobalLoader()` affiche désormais l’inline skeleton en appelant `ensureInlineLoader()` et en ajoutant la classe `app-content-loading`, et `hideGlobalLoader()` délègue à `stopContentLoadingState()` pour masquer le skeleton.
- Enlevé la logique qui gérait l’affichage conditionnel du spinner via `sessionStorage` et le handler `beforeunload`, tout en conservant la logique existante de `startContentLoadingState()` et du skeleton inline.
- Conservé intactes les animations et classes liées aux boutons, enregistrements, toasts et autres transitions.

### Testing
- Executed `node --check js/ui.js` which succeeded with no syntax errors.
- Searched codebase for remaining global spinner selectors via ripgrep (`rg`) and verified there are no occurrences in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecea960728832aaa862ae08cf55420)