### PR TITLE
Ajout de l’icône au bouton Exporter de la page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2555,6 +2555,20 @@ body[data-page="item-detail"] .detail-form-actions .btn {
   justify-content: center;
 }
 
+body[data-page="item-detail"] #exportDetailsButton.export-details-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+body[data-page="item-detail"] .export-details-button__icon {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
 body[data-page="item-detail"] #detailCreateSubmitButton .btn-label-loading {
   display: none;
 }

--- a/page3.html
+++ b/page3.html
@@ -29,7 +29,10 @@
               <p id="detailCount">0 OUT</p>
               <p id="detailStore">Magasin : Non défini</p>
             </div>
-            <button type="button" id="exportDetailsButton" class="btn btn-success">Exporter</button>
+            <button type="button" id="exportDetailsButton" class="btn btn-success export-details-button">
+              <img src="Icon/Exporter.png" alt="" class="export-details-button__icon" aria-hidden="true" />
+              <span>Exporter</span>
+            </button>
           </div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">


### PR DESCRIPTION
### Motivation
- Améliorer visuellement le bouton `Exporter` de la page de détail en utilisant l’icône existante `Icon/Exporter.png` sans toucher à la logique ni aux autres pages.

### Description
- Ajout de l’icône à gauche du texte dans `page3.html` et insertion de styles ciblés dans `css/style.css` pour un alignement propre (`display: inline-flex`, `align-items: center`, `gap: 0.4rem`) et une icône dimensionnée avec `width: 1rem`, `height: 1rem` et `object-fit: contain`.

### Testing
- Exécution de contrôles automatiques de diff et état: `git status --short`, `git diff -- page3.html css/style.css`, `nl -ba page3.html | sed -n '22,42p'` et `nl -ba css/style.css | sed -n '2548,2585p'`, tous réussis; `git commit` a également réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf41b3b44832ab6090499273f1df6)