### PR TITLE
Hide page 2 "Créer un OUT" label for signed-out users

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2723,6 +2723,9 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
+    const createItemLabel = document.querySelector(
+      'body[data-page="site-detail"] .site-detail-fab-label--create',
+    );
     const siteDetailFabStack = document.querySelector('body[data-page="site-detail"] .site-detail-fab-stack');
     let itemFormErrorTimeoutId = null;
     let itemNumberErrorClearTimer = null;
@@ -2734,15 +2737,22 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     function updateCreateItemButtonVisibility(user) {
-      if (!openCreateItem) {
+      if (!openCreateItem && !createItemLabel) {
         return;
       }
       const isAuthenticated = isFirebaseUserAuthenticated(user);
-      openCreateItem.hidden = !isAuthenticated;
-      openCreateItem.style.display = isAuthenticated ? 'inline-flex' : 'none';
-      const createButtonRow = openCreateItem.closest('[data-fab-row="create"]');
+      if (openCreateItem) {
+        openCreateItem.hidden = !isAuthenticated;
+        openCreateItem.style.display = isAuthenticated ? 'inline-flex' : 'none';
+      }
+      if (createItemLabel) {
+        createItemLabel.hidden = !isAuthenticated;
+        createItemLabel.style.display = isAuthenticated ? '' : 'none';
+      }
+      const createButtonRow = openCreateItem?.closest('[data-fab-row="create"]');
       if (createButtonRow) {
         createButtonRow.hidden = !isAuthenticated;
+        createButtonRow.style.display = isAuthenticated ? '' : 'none';
       }
     }
 


### PR DESCRIPTION
### Motivation
- Harmoniser le comportement des éléments d’action sur la page 2 en garantissant que le libellé « Créer un OUT » suit le même affichage/masquage en temps réel que le bouton flottant `+` pour éviter tout espace vide ou possibilité d’ajout quand l’utilisateur est non connecté.

### Description
- Ajout d’une sélection du libellé avec `const createItemLabel = document.querySelector('body[data-page="site-detail"] .site-detail-fab-label--create')` dans `js/app.js`.
- Mise à jour de `updateCreateItemButtonVisibility` pour piloter à la fois le bouton `#openCreateItem`, le `createItemLabel` et leur conteneur, en appliquant `hidden` et `style.display = 'none'` lorsqu’utilisateur non authentifié et en restaurant l’affichage pour l’utilisateur connecté.
- Utilisation d’un test de présence (`if (!openCreateItem && !createItemLabel) return;`) et d’optional chaining pour éviter les erreurs si un élément manque.

### Testing
- Executed `node --check js/app.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf8794a38832aa24197fb5d93da4c)