### PR TITLE
Page 2: transformer les libellés flottants en chips non-cliquables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3822,14 +3822,16 @@ body[data-page="site-detail"] .site-detail-fab-label {
   align-items: center;
   justify-content: center;
   min-height: 30px;
-  padding: 6px 12px;
-  border-radius: 20px;
-  background: #fff;
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.16);
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(43, 125, 233, 0.12);
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(4px);
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 500;
   line-height: 1;
   white-space: nowrap;
+  pointer-events: none;
 }
 
 body[data-page="site-detail"] .site-detail-fab-label--create {


### PR DESCRIPTION
### Motivation
- Rendre les libellés flottants « Créer un OUT » et « Exporter » sur la page 2 visibles mais sans apparence ni comportement de boutons cliquables tout en conservant leur position, alignement et animations existantes.

### Description
- Mise à jour de la règle `body[data-page="site-detail"] .site-detail-fab-label` dans `css/style.css` pour remplacer le fond blanc et l’ombre par `background: rgba(255, 255, 255, 0.55)`, `border: 1px solid rgba(43, 125, 233, 0.12)`, `border-radius: 999px`, `padding: 5px 10px`, `font-size: 13px`, `font-weight: 500`, `backdrop-filter: blur(4px)` et `pointer-events: none` afin d’empêcher le clic sur les libellés tout en conservant les couleurs texte existantes pour les variantes `--create` et `--export`.

### Testing
- Aucun test automatisé n’a été exécuté car le dépôt ne fournit pas de suite de tests automatisés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfc55432c832ab057190e88741025)