### PR TITLE
Page 3 : bouton “Exporter” en style secondaire (outline)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2559,7 +2559,15 @@ body[data-page="item-detail"] #exportDetailsButton.export-details-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
+  gap: 0.45rem;
+  background: #ffffff;
+  border: 2px solid #22c55e;
+  color: #22c55e;
+  font-weight: 600;
+}
+
+body[data-page="item-detail"] #exportDetailsButton.export-details-button:hover {
+  background: rgba(34, 197, 94, 0.08);
 }
 
 body[data-page="item-detail"] .export-details-button__icon {


### PR DESCRIPTION
### Motivation
- Rendre le bouton “Exporter” de la page détail (page 3) visuellement secondaire sans toucher à sa logique ni à sa position.

### Description
- Mise à jour des règles CSS ciblées de `body[data-page="item-detail"] #exportDetailsButton.export-details-button` pour appliquer un fond blanc, une bordure verte `2px`, et une couleur de texte verte `#22c55e` avec `font-weight: 600`.
- Conservation de l'alignement horizontal via `inline-flex`, `align-items: center` et gestion de l'icône gauche avec `object-fit: contain` (taille inchangée, ~16px).
- Ajout d'un état `:hover` léger avec `background: rgba(34,197,94,0.08)` et ajustement mineur du `gap` pour un espacement propre.

### Testing
- Vérification ciblée du fichier modifié avec une recherche par sélecteur via `rg` pour confirmer la présence de la règle CSS mise à jour.
- Inspection du fichier `css/style.css` pour valider l'ajout des propriétés `background`, `border`, `color`, `font-weight` et du sélecteur `:hover`.
- Validation locale que seul le sélecteur `body[data-page="item-detail"] #exportDetailsButton.export-details-button` a été modifié et qu'aucune autre règle de page n'a été touchée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecff4819a4832a8e33eca03a8c46ca)