### PR TITLE
Aligner verticalement le bouton “Exporter” avec le bloc texte (page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2314,6 +2314,19 @@ body[data-page="item-detail"] #detailStore {
   flex-wrap: wrap;
 }
 
+body[data-page="item-detail"] .section-heading--table {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+body[data-page="item-detail"] .section-heading--table .section-heading__text-block {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
 body[data-page="item-detail"] .detail-store-label {
   color: var(--text-muted);
 }

--- a/page3.html
+++ b/page3.html
@@ -24,7 +24,7 @@
       <main class="page-content page-content--wide">
         <section class="surface-card table-card section">
           <div class="section-heading section-heading--table">
-            <div>
+            <div class="section-heading__text-block">
               <h2 class="section-title">Tableau des données</h2>
               <p id="detailCount">0 OUT</p>
               <p id="detailStore">Magasin : Non défini</p>


### PR DESCRIPTION
### Motivation
- Corriger l’alignement vertical entre le bouton `Exporter` et le bloc texte dans la carte « Tableau des données » de la page 3 pour un rendu professionnel et équilibré.

### Description
- Ajout d’un conteneur `div` avec la classe `section-heading__text-block` autour du titre, du compteur et du libellé magasin dans `page3.html` pour regrouper ces éléments en colonne.
- Ajout de styles scoped à la page détail (`body[data-page="item-detail"]`) dans `css/style.css` pour forcer la ligne du haut en `display: flex`, `justify-content: space-between`, `align-items: center` et un `gap` pour espacer proprement texte et bouton.
- Mise en colonne du bloc texte via `flex-direction: column` sans modifier la taille, le style, les couleurs ni la logique du bouton `Exporter`.

### Testing
- Recherches et vérifications de fichiers avec `rg -n "Tableau des données|Exporter|7 Article|Magasin"` ont trouvé les occurrences attendues et confirmé la page affectée (succès).
- Inspection du diff avec `git -C /workspace/Album diff -- page3.html css/style.css` a montré uniquement les modifications prévues (succès).
- Ajout et commit avec `git -C /workspace/Album add page3.html css/style.css && git -C /workspace/Album commit -m "Align export button with data table header text on page 3"` ont réussi (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed058adbc8832a91d92204a9b78181)