### PR TITLE
Ajouter le libellé "Ajouter un article" à côté du FAB sur la page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -474,7 +474,9 @@ body.app-content-loading .fab-add--item-detail,
 body.app-content-pending .fab--export,
 body.app-content-loading .fab--export,
 body.app-content-pending #exportDetailsButton,
-body.app-content-loading #exportDetailsButton {
+body.app-content-loading #exportDetailsButton,
+body.app-content-pending .item-detail-fab-row,
+body.app-content-loading .item-detail-fab-row {
   opacity: 0;
   pointer-events: none;
 }
@@ -2494,6 +2496,44 @@ body[data-page="item-detail"] .fab-add--item-detail {
   box-shadow: 0 10px 22px var(--detail-primary-shadow);
   z-index: 45;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+body[data-page="item-detail"] .item-detail-fab-row {
+  position: fixed;
+  right: 20px;
+  bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 45;
+}
+
+body[data-page="item-detail"] .item-detail-fab-row .fab-add--item-detail {
+  position: relative;
+  right: auto;
+  left: auto;
+  bottom: auto;
+}
+
+body[data-page="item-detail"] .site-detail-fab-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(43, 125, 233, 0.12);
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(4px);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+body[data-page="item-detail"] .site-detail-fab-label--create {
+  color: var(--detail-primary);
 }
 
 body[data-page="item-detail"] .fab-add--item-detail:hover {

--- a/js/app.js
+++ b/js/app.js
@@ -3175,6 +3175,8 @@ import { firebaseAuth } from './firebase-core.js';
     const detailFormError = requireElement('detailFormError');
     const detailFormModal = requireElement('detailFormModal');
     const openDetailFormButton = requireElement('openDetailFormButton');
+    const itemDetailFabLabel = document.querySelector('body[data-page="item-detail"] #itemDetailFabLabel');
+    const itemDetailFabRow = openDetailFormButton?.closest('[data-fab-row="create"]');
     const cancelDetailFormButton = requireElement('cancelDetailFormButton');
     const detailCreateSubmitButton = requireElement('detailCreateSubmitButton');
     const detailCount = requireElement('detailCount');
@@ -3609,6 +3611,14 @@ import { firebaseAuth } from './firebase-core.js';
       const isAuthenticated = isFirebaseUserAuthenticated(user);
       openDetailFormButton.hidden = !isAuthenticated;
       openDetailFormButton.style.display = isAuthenticated ? 'inline-flex' : 'none';
+      if (itemDetailFabLabel) {
+        itemDetailFabLabel.hidden = !isAuthenticated;
+        itemDetailFabLabel.style.display = isAuthenticated ? '' : 'none';
+      }
+      if (itemDetailFabRow) {
+        itemDetailFabRow.hidden = !isAuthenticated;
+        itemDetailFabRow.style.display = isAuthenticated ? '' : 'none';
+      }
     }
 
     if (!permissions.canCreate || permissions.isLecture) {

--- a/page3.html
+++ b/page3.html
@@ -75,7 +75,10 @@
         </section>
       </main>
 
-      <button type="button" id="openDetailFormButton" class="fab-add fab-add--item-detail" aria-label="Ajouter une donnée">+</button>
+      <div class="item-detail-fab-row site-detail-fab-row" data-fab-row="create">
+        <span id="itemDetailFabLabel" class="site-detail-fab-label site-detail-fab-label--create">Ajouter un article</span>
+        <button type="button" id="openDetailFormButton" class="fab-add fab-add--item-detail" aria-label="Ajouter une donnée">+</button>
+      </div>
 
       <dialog id="detailFormModal" class="modal-card detail-form-modal">
         <div class="modal-content detail-form-modal__content">


### PR DESCRIPTION
### Motivation
- Rendre explicite l’action du FAB « + » sur la page détail (page 3) en ajoutant un libellé identique visuellement à celui utilisé sur la page 2 pour conserver la cohérence de l’application.
- Le libellé doit être non interactif et suivre exactement la même logique de visibilité que le bouton « + » (authentification, scroll/chargement, etc.).

### Description
- Ajout du markup sur `page3.html`: une nouvelle ligne FAB `<div class="item-detail-fab-row site-detail-fab-row" data-fab-row="create">` contenant `<span id="itemDetailFabLabel" class="site-detail-fab-label site-detail-fab-label--create">Ajouter un article</span>` à gauche du bouton `#openDetailFormButton`.
- Réutilisation du style existant en `css/style.css` en exposant les règles `site-detail-fab-label` pour `body[data-page="item-detail"]` et en ajoutant une règle `item-detail-fab-row` pour positionner le label sans modifier l’apparence du bouton `fab-add--item-detail`.
- Synchronisation dynamique en `js/app.js`: sélection de `#itemDetailFabLabel` et de la ligne FAB, et mise à jour de `updateDetailCreateButtonVisibility` pour que le label et la ligne héritent de la même visibilité que le bouton (authentifié / non authentifié); le masquage pendant les états `app-content-loading` / `app-content-pending` est également couvert par CSS.
- Contrainte respectée: le libellé est non cliquable (`pointer-events: none` via la classe existante) et aucune logique métier existante du bouton ou des autres pages n’a été modifiée.

### Testing
- Vérification de la syntaxe JavaScript avec `node --check js/app.js` qui a réussi sans erreur.
- Exécution de contrôles rapides sur les fichiers modifiés (`git status` / commits) pour s’assurer que les changements ont été appliqués; les modifications ont été engagées avec succès.
- Aucun test automatisé additionnel disponible dans le dépôt; changement limité à la page 3, CSS et synchronisation JS, et les vérifications automatisées réalisées ont passé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0b19dbcc832aaeca5d51d5dc8638)