### PR TITLE
Sort page 2 Excel export rows by designation (A→Z)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2343,8 +2343,48 @@ import { firebaseAuth } from './firebase-core.js';
         return;
       }
 
+      const sortedRows = [...rows].sort((a, b) => {
+        const designationA = String(a?.designation || '').trim();
+        const designationB = String(b?.designation || '').trim();
+
+        if (!designationA && !designationB) {
+          return 0;
+        }
+        if (!designationA) {
+          return 1;
+        }
+        if (!designationB) {
+          return -1;
+        }
+
+        const byDesignation = designationA.localeCompare(designationB, 'fr', {
+          sensitivity: 'base',
+          numeric: true,
+        });
+        if (byDesignation !== 0) {
+          return byDesignation;
+        }
+
+        const outA = String(a?.out || '').trim();
+        const outB = String(b?.out || '').trim();
+        const byOut = outA.localeCompare(outB, 'fr', {
+          sensitivity: 'base',
+          numeric: true,
+        });
+        if (byOut !== 0) {
+          return byOut;
+        }
+
+        const codeA = String(a?.code || '').trim();
+        const codeB = String(b?.code || '').trim();
+        return codeA.localeCompare(codeB, 'fr', {
+          sensitivity: 'base',
+          numeric: true,
+        });
+      });
+
       const title = `SUIVI MATERIEL . ${currentSite.nom}`;
-      const workbook = buildSiteExcelContent(title, rows);
+      const workbook = buildSiteExcelContent(title, sortedRows);
       const fileBaseName = normalizeExportBaseName(fileNameOverride || title, title);
       downloadExcelFile(`${fileBaseName}.xls`, 'Export Excel', workbook);
       saveExportFileNameToHistory(fileBaseName);


### PR DESCRIPTION
### Motivation
- Garantir que le fichier Excel exporté depuis la page détail (page2) soit trié automatiquement par la colonne « Désignation » sans modifier l’affichage, les boutons, les filtres, le design ou les données source.

### Description
- Ajout d’une copie triée `sortedRows = [...rows].sort(...)` dans la fonction `exportItems(...)` de `js/app.js` juste avant la génération du workbook.
- Tri principal par `designation` A→Z insensible à la casse et gestion des accents via `localeCompare(..., 'fr', { sensitivity: 'base', numeric: true })` avec les désignations vides placées en fin.
- Critères secondaires déterministes en cas d’égalité : d’abord `OUT`, puis `Code` pour conserver l’ordre attendu entre lignes identiques en désignation.
- L’export Excel utilise uniquement `sortedRows` pour générer le fichier, sans toucher au format existant (titres, colonnes, largeurs, bordures, styles, nom du fichier) ni à l’ordre d’affichage de la page web.

### Testing
- `node --check js/app.js` a été exécuté et a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2432c9b1c832aa41e799e6cb74d34)