### PR TITLE
Améliore les skeletons shimmer globaux pour les 3 pages principales

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4735,3 +4735,78 @@ body[data-page="home"] .app-header--home > h1 {
     min-width: 70rem;
   }
 }
+
+/* Global skeleton shimmer layouts */
+body.is-loading .page-content > :not(.global-skeleton),
+body.app-content-loading .page-content > :not(.global-skeleton) {
+  opacity: 0;
+  pointer-events: none;
+}
+
+body.is-loading .global-skeleton,
+body.app-content-loading .global-skeleton {
+  display: grid;
+}
+
+body:not(.is-loading):not(.app-content-loading) .global-skeleton {
+  display: none;
+}
+
+body.is-loading .fab,
+body.is-loading .fab-add,
+body.is-loading .fab--export,
+body.is-loading .site-detail-fab-stack,
+body.is-loading .item-detail-fab-row,
+body.is-loading #exportDetailsButton,
+body.is-loading dialog[open],
+body.is-loading .header-menu__panel {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+.global-skeleton {
+  gap: 0.75rem;
+  padding-top: 0.1rem;
+}
+
+.global-skeleton .skeleton-line,
+.global-skeleton .skeleton-pill,
+.global-skeleton .skeleton-chip,
+.global-skeleton .skeleton-divider,
+.global-skeleton .skeleton-button,
+.global-skeleton .skeleton-table-head,
+.global-skeleton .skeleton-index,
+.global-skeleton .skeleton-cell {
+  display: block;
+  border-radius: 12px;
+  background: linear-gradient(90deg, #ebf1f7 15%, #f7fafd 50%, #ebf1f7 85%);
+  background-size: 220% 100%;
+  animation: inline-loader-shimmer 1.1s ease-in-out infinite;
+}
+
+.skeleton-card { background: #fff; border-radius: 20px; border: 1px solid rgba(216,226,236,.7); box-shadow: var(--shadow); padding: 14px; display: grid; gap: 10px; }
+.skeleton-card--search { min-height: 74px; align-items: center; }
+.skeleton-card--list { min-height: 170px; }
+.skeleton-line--input { height: 44px; border-radius: 14px; }
+.skeleton-heading-row { display:flex; align-items:center; justify-content:space-between; padding: 2px 2px 0; }
+.skeleton-line--heading { width: 42%; height: 20px; }
+.skeleton-pill { width: 38px; height: 28px; border-radius: 999px; }
+.skeleton-line--title { width: 62%; height: 22px; }
+.skeleton-line--meta { width: 78%; height: 15px; }
+.skeleton-divider { width: 100%; height: 1px; border-radius: 1px; }
+.skeleton-line--lock { width: 54%; height: 16px; }
+
+.skeleton-chip-row { display:flex; gap:8px; flex-wrap:wrap; }
+.skeleton-chip { width: 74px; height: 32px; border-radius: 999px; }
+.skeleton-separator { display:grid; place-items:center; margin: 4px 0; }
+.skeleton-line--separator { width: 110px; height: 22px; border-radius: 999px; }
+
+.skeleton-card--table-wrap { gap: 14px; }
+.skeleton-table-header { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
+.skeleton-line--table-title { width: 170px; height: 24px; margin-bottom: 8px; }
+.skeleton-button { width: 110px; height: 40px; border-radius: 12px; }
+.skeleton-card--search-inline { background: transparent; box-shadow:none; border:none; padding:0; }
+.skeleton-table-head { height: 34px; border-radius: 10px; }
+.skeleton-table-row { display:grid; grid-template-columns: 30px 1fr 1fr; gap:8px; align-items:center; }
+.skeleton-index { width: 26px; height: 26px; border-radius: 999px; }
+.skeleton-cell { height: 20px; }

--- a/js/ui.js
+++ b/js/ui.js
@@ -9,6 +9,7 @@
   const CONTENT_PENDING_CLASS = "app-content-pending";
   const CONTENT_LOADING_CLASS = "app-content-loading";
   const CONTENT_READY_CLASS = "app-content-ready";
+  const LEGACY_LOADING_CLASS = "is-loading";
   const INLINE_LOADER_ID = "pageInlineLoader";
   const CONTENT_LOADING_DELAY_MS = 120;
   let hideTimerId = null;
@@ -22,7 +23,7 @@
   function showGlobalLoader() {
     ensureInlineLoader();
     document.body.classList.remove(CONTENT_READY_CLASS);
-    document.body.classList.add(CONTENT_LOADING_CLASS);
+    document.body.classList.add(CONTENT_LOADING_CLASS, LEGACY_LOADING_CLASS);
   }
 
   function hideGlobalLoader() {
@@ -42,20 +43,56 @@
 
     inlineLoader = document.createElement("div");
     inlineLoader.id = INLINE_LOADER_ID;
-    inlineLoader.className = "page-inline-loader";
+    inlineLoader.className = "page-inline-loader global-skeleton";
     inlineLoader.setAttribute("aria-hidden", "true");
-    inlineLoader.innerHTML = `
-      <div class="page-inline-loader__block page-inline-loader__block--title"></div>
-      <div class="page-inline-loader__block"></div>
-      <div class="page-inline-loader__block"></div>
-      <div class="page-inline-loader__block page-inline-loader__block--short"></div>
-    `;
+
+    const pageName = document.body?.dataset?.page || "";
+    const skeletonByPage = {
+      home: `
+        <div class="skeleton-card skeleton-card--search"><span class="skeleton-line skeleton-line--input"></span></div>
+        <div class="skeleton-heading-row">
+          <span class="skeleton-line skeleton-line--heading"></span>
+          <span class="skeleton-pill"></span>
+        </div>
+        <div class="skeleton-card skeleton-card--list">
+          <span class="skeleton-line skeleton-line--title"></span>
+          <span class="skeleton-line skeleton-line--meta"></span>
+          <span class="skeleton-line skeleton-line--meta"></span>
+          <span class="skeleton-line skeleton-line--meta"></span>
+          <span class="skeleton-divider"></span>
+          <span class="skeleton-line skeleton-line--lock"></span>
+        </div>
+      `,
+      "site-detail": `
+        <div class="skeleton-card skeleton-card--search"><span class="skeleton-line skeleton-line--input"></span></div>
+        <div class="skeleton-chip-row">
+          <span class="skeleton-chip"></span><span class="skeleton-chip"></span><span class="skeleton-chip"></span><span class="skeleton-chip"></span>
+        </div>
+        <div class="skeleton-separator"><span class="skeleton-line skeleton-line--separator"></span></div>
+        <div class="skeleton-card skeleton-card--list"><span class="skeleton-line skeleton-line--title"></span><span class="skeleton-line skeleton-line--meta"></span><span class="skeleton-line skeleton-line--meta"></span><span class="skeleton-line skeleton-line--meta"></span></div>
+        <div class="skeleton-card skeleton-card--list"><span class="skeleton-line skeleton-line--title"></span><span class="skeleton-line skeleton-line--meta"></span><span class="skeleton-line skeleton-line--meta"></span><span class="skeleton-line skeleton-line--meta"></span></div>
+      `,
+      "item-detail": `
+        <div class="skeleton-card skeleton-card--table-wrap">
+          <div class="skeleton-table-header">
+            <div><span class="skeleton-line skeleton-line--table-title"></span><span class="skeleton-line skeleton-line--meta"></span><span class="skeleton-line skeleton-line--meta"></span></div>
+            <span class="skeleton-button"></span>
+          </div>
+          <div class="skeleton-card skeleton-card--search-inline"><span class="skeleton-line skeleton-line--input"></span></div>
+          <div class="skeleton-table-head"></div>
+          <div class="skeleton-table-row"><span class="skeleton-index"></span><span class="skeleton-cell"></span><span class="skeleton-cell"></span></div>
+          <div class="skeleton-table-row"><span class="skeleton-index"></span><span class="skeleton-cell"></span><span class="skeleton-cell"></span></div>
+          <div class="skeleton-table-row"><span class="skeleton-index"></span><span class="skeleton-cell"></span><span class="skeleton-cell"></span></div>
+        </div>
+      `,
+    };
+    inlineLoader.innerHTML = skeletonByPage[pageName] || `<div class="page-inline-loader__block page-inline-loader__block--title"></div>`;
     pageContent.prepend(inlineLoader);
     return inlineLoader;
   }
 
   function startContentLoadingState() {
-    document.body.classList.add(CONTENT_PENDING_CLASS);
+    document.body.classList.add(CONTENT_PENDING_CLASS, LEGACY_LOADING_CLASS);
     document.body.classList.remove(CONTENT_LOADING_CLASS, CONTENT_READY_CLASS);
 
     inlineLoaderTimerId = window.setTimeout(() => {
@@ -63,7 +100,7 @@
         return;
       }
       ensureInlineLoader();
-      document.body.classList.add(CONTENT_LOADING_CLASS);
+      document.body.classList.add(CONTENT_LOADING_CLASS, LEGACY_LOADING_CLASS);
     }, CONTENT_LOADING_DELAY_MS);
   }
 
@@ -72,7 +109,7 @@
       window.clearTimeout(inlineLoaderTimerId);
       inlineLoaderTimerId = null;
     }
-    document.body.classList.remove(CONTENT_PENDING_CLASS, CONTENT_LOADING_CLASS);
+    document.body.classList.remove(CONTENT_PENDING_CLASS, CONTENT_LOADING_CLASS, LEGACY_LOADING_CLASS);
     document.body.classList.add(CONTENT_READY_CLASS);
   }
 


### PR DESCRIPTION
### Motivation
- Rendre le loading global plus réaliste en affichant un skeleton qui reproduit la structure visuelle de chaque page (home, liste OUT, tableau de données) pendant les transitions.
- Garder le header réel visible et s’assurer que tout le contenu réel et les actions flottantes soient masqués pendant le loading.
- Préserver l’animation shimmer existante et ne modifier que l’affichage du loading, sans toucher aux données, routes ou logique Firebase.

### Description
- Généré dynamiquement un skeleton page-specific dans `js/ui.js` en injectant une `global-skeleton` adaptée aux pages `home`, `site-detail` et `item-detail` sous le header.
- Ajouté la compatibilité avec `body.is-loading` (en plus de l’existant `app-content-loading`) pour contrôler l’affichage du skeleton depuis le code de chargement global.
- Ajouté des règles CSS dans `css/style.css` pour masquer le contenu réel pendant le loading, afficher les blocs skeleton (cartes, chips, en-têtes, lignes/tableau, index ronds) et maintenir l’animation shimmer.
- Masqué explicitement les FABs, labels flottants, boutons Exporter, dialogues/panneaux et autres overlays pendant le loading pour éviter toute fuite visuelle.

### Testing
- Aucun test automatisé n'a été ajouté ou exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24709af70832ab303c0dc07498fee)