### PR TITLE
Refine Page 3 header layout and store badge structure

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2309,24 +2309,38 @@ body[data-page="item-detail"] .auth-required-card--embedded {
   margin-bottom: 20px;
 }
 
-body[data-page="item-detail"] #detailStore {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  flex-wrap: wrap;
+body[data-page="item-detail"] .section-heading--table {
+  display: block;
 }
 
-body[data-page="item-detail"] .section-heading--table {
+body[data-page="item-detail"] .header-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-body[data-page="item-detail"] .section-heading--table .section-heading__text-block {
-  display: flex;
-  flex-direction: column;
+body[data-page="item-detail"] .title-block {
   min-width: 0;
+}
+
+body[data-page="item-detail"] .title-block .section-title {
+  margin: 0;
+  font-size: 18px;
+}
+
+body[data-page="item-detail"] .count {
+  margin: 0.2rem 0 0;
+  font-size: 13px;
+  color: #888;
+}
+
+body[data-page="item-detail"] .magasin-block {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 body[data-page="item-detail"] .detail-store-label {
@@ -2342,6 +2356,12 @@ body[data-page="item-detail"] .detail-store-badge {
   color: #1d4ed8;
   font-weight: 600;
   line-height: 1.25;
+}
+
+body[data-page="item-detail"] .badge {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 13px;
 }
 
 body[data-page="item-detail"] .detail-store-badge--tit-i {

--- a/js/app.js
+++ b/js/app.js
@@ -3716,7 +3716,7 @@ import { firebaseAuth } from './firebase-core.js';
       storeLabel.className = 'detail-store-label';
       storeLabel.textContent = 'Magasin :';
       const storeBadge = document.createElement('span');
-      storeBadge.className = `detail-store-badge ${badgeVariantClass}`;
+      storeBadge.className = `detail-store-badge badge ${badgeVariantClass}`;
       storeBadge.textContent = displayValue;
       detailStore.append(storeLabel, storeBadge);
     }

--- a/page3.html
+++ b/page3.html
@@ -24,16 +24,18 @@
       <main class="page-content page-content--wide">
         <section class="surface-card table-card section">
           <div class="section-heading section-heading--table">
-            <div class="section-heading__text-block">
-              <h2 class="section-title">Tableau des données</h2>
-              <p id="detailCount">0 OUT</p>
-              <p id="detailStore">Magasin : Non défini</p>
+            <div class="header-top">
+              <div class="title-block">
+                <h2 class="section-title">Tableau des données</h2>
+                <p id="detailCount" class="count">0 OUT</p>
+              </div>
+              <button type="button" id="exportDetailsButton" class="btn btn-success export-details-button">
+                <img src="Icon/Exporter.png" alt="" class="export-details-button__icon" aria-hidden="true" />
+                <span>Exporter</span>
+              </button>
             </div>
-            <button type="button" id="exportDetailsButton" class="btn btn-success export-details-button">
-              <img src="Icon/Exporter.png" alt="" class="export-details-button__icon" aria-hidden="true" />
-              <span>Exporter</span>
-            </button>
           </div>
+          <div id="detailStore" class="magasin-block">Magasin : Non défini</div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">
               <span class="search-input__icon-wrap" aria-hidden="true">


### PR DESCRIPTION
### Motivation
- Rendre la Page 3 plus professionnelle et structurée en alignant le bouton "Exporter" sur la même ligne que le titre et en séparant le bloc "Magasin" pour améliorer la hiérarchie visuelle et la lisibilité.

### Description
- Restructuration HTML : ajouté un conteneur `header-top` avec `title-block` (titre + compteur) et positionné le bouton `Exporter` à droite, puis déplacé le bloc magasin dans `div#detailStore.magasin-block` sous le header (file `page3.html`).
- Styles ciblés : implémenté les règles demandées sous le scope `body[data-page="item-detail"]` avec `.header-top`, `.title-block`, `.count` et `.magasin-block` pour respecter l'alignement, la typographie et l'espacement (file `css/style.css`).
- Badge réutilisable : ajouté la classe `badge` au badge magasin généré côté client (`storeBadge.className = \`detail-store-badge badge ${badgeVariantClass}\``) afin d'appliquer le style de badge demandé sans modifier les variantes de couleurs existantes (file `js/app.js`).
- Non modifié : le bouton flottant `+`, le tableau et le champ recherche n'ont pas été touchés.

### Testing
- Aucune suite de tests automatisés n'a été exécutée pour cette PR; les modifications sont limitées à HTML/CSS/JS ciblés et peuvent être validées visuellement en page (scope `body[data-page="item-detail"]`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24f3952b8832aae7eb2965a2ab66a)