### PR TITLE
Emphasize article count on Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2329,10 +2329,27 @@ body[data-page="item-detail"] .title-block .section-title {
   font-size: 18px;
 }
 
-body[data-page="item-detail"] .count {
-  margin: 0.2rem 0 0;
+.page3 .article-count {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.page3 .count-number {
+  font-size: 22px;
+  font-weight: 700;
+  color: #2e7d32;
+  line-height: 1;
+  background: #e6f4ea;
+  padding: 2px 10px;
+  border-radius: 10px;
+}
+
+.page3 .count-label {
   font-size: 13px;
   color: #888;
+  font-weight: 500;
 }
 
 body[data-page="item-detail"] .magasin-block {

--- a/js/app.js
+++ b/js/app.js
@@ -3734,11 +3734,18 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     function updateCount(filteredCount, totalCount) {
-      if (filteredCount === totalCount) {
-        setCountText(detailCount, totalCount, 'Article', 'Article');
+      const countNumber = detailCount?.querySelector('.count-number');
+      const countLabel = detailCount?.querySelector('.count-label');
+      if (!countNumber || !countLabel) {
         return;
       }
-      detailCount.textContent = `${filteredCount} Article${filteredCount > 1 ? 's' : ''} affichée${filteredCount > 1 ? 's' : ''} / ${totalCount}`;
+
+      countNumber.textContent = String(filteredCount);
+      if (filteredCount === totalCount) {
+        countLabel.textContent = filteredCount > 1 ? 'Articles' : 'Article';
+        return;
+      }
+      countLabel.textContent = `${filteredCount > 1 ? 'Articles' : 'Article'} affiché${filteredCount > 1 ? 's' : ''} / ${totalCount}`;
     }
 
     function exportDetails(fileNameOverride) {

--- a/page3.html
+++ b/page3.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
-  <body data-page="item-detail">
+  <body data-page="item-detail" class="page3">
     <div class="app-shell app-shell--wide">
       <header class="app-header app-header--detail">
         <div class="app-header__side app-header__side--left">
@@ -27,7 +27,10 @@
             <div class="header-top">
               <div class="title-block">
                 <h2 class="section-title">Tableau des données</h2>
-                <p id="detailCount" class="count">0 OUT</p>
+                <div id="detailCount" class="article-count">
+                  <span class="count-number">0</span>
+                  <span class="count-label">Articles</span>
+                </div>
               </div>
               <button type="button" id="exportDetailsButton" class="btn btn-success export-details-button">
                 <img src="Icon/Exporter.png" alt="" class="export-details-button__icon" aria-hidden="true" />


### PR DESCRIPTION
### Motivation
- Rendre le nombre d'articles sur la Page 3 beaucoup plus visible que le libellé « Articles » pour une lecture rapide et un style moderne.
- Appliquer l'effet « premium » optionnel autour du nombre sans impacter Page 1, Page 2, le bouton Exporter, le bloc Magasin ni le tableau.

### Description
- HTML: sur `page3.html` la balise du compteur a été remplacée par un wrapper scindé en `div.article-count` contenant `span.count-number` et `span.count-label`, et la `body` reçoit la classe `page3` pour scoper les styles.
- CSS: ajout de règles `.page3 .article-count`, `.page3 .count-number` et `.page3 .count-label` dans `css/style.css` pour agrandir le chiffre, styliser le badge premium autour du nombre et rendre le label secondaire; le scope est limité à `.page3`.
- JS: adaptation de la fonction `updateCount` dans `js/app.js` pour mettre à jour séparément la `count-number` et la `count-label` en conservant le message de comptage filtré.
- Portée: modifications strictement limitées à la Page 3 et à l'affichage du compteur sans toucher aux autres éléments requis (Page 1/2, Exporter, Magasin, tableau).

### Testing
- Recherche dans le projet avec `rg -n "3 Article|count"` a été exécutée pour localiser les occurrences et a réussi.
- Inspection des fichiers modifiés via `nl`/`sed` et revue du diff avec `git diff -- page3.html css/style.css js/app.js` a confirmé les changements attendus et a réussi.
- Les fichiers modifiés ont été ajoutés et committés (`git add` + `git commit`) sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f252290f7c832abbc8241e30cef8ed)