### PR TITLE
Refine Page 3 data table header visual hierarchy

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2313,65 +2313,91 @@ body[data-page="item-detail"] .section-heading--table {
   display: block;
 }
 
-body[data-page="item-detail"] .header-top {
+body[data-page="item-detail"] .header-top,
+.page3 .page3-summary-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
+  align-items: flex-start;
+  gap: 12px;
 }
 
-body[data-page="item-detail"] .title-block {
+body[data-page="item-detail"] .title-block,
+.page3 .page3-title-block {
   min-width: 0;
 }
 
-body[data-page="item-detail"] .title-block .section-title {
+body[data-page="item-detail"] .title-block .section-title,
+.page3 .page3-title-block h2 {
   margin: 0;
-  font-size: 18px;
-}
-
-.page3 .article-count {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  margin-top: 4px;
-}
-
-.page3 .count-number {
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 700;
-  color: #2e7d32;
-  line-height: 1;
-  background: #e6f4ea;
-  padding: 2px 10px;
-  border-radius: 10px;
+  color: #1f2937;
 }
 
-.page3 .count-label {
-  font-size: 13px;
-  color: #888;
-  font-weight: 500;
-}
-
-body[data-page="item-detail"] .magasin-block {
-  margin-top: 10px;
+.page3 .article-count,
+.page3 .page3-article-count {
+  margin-top: 6px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
+}
+
+.page3 .count-number,
+.page3 .page3-count-number {
+  min-width: 34px;
+  height: 34px;
+  padding: 0 9px;
+  border-radius: 12px;
+  background: #eaf7ef;
+  color: #2e7d32;
+  font-size: 21px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.page3 .count-label,
+.page3 .page3-count-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #6b7280;
+}
+
+body[data-page="item-detail"] .magasin-block,
+.page3 .page3-info-row {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  display: flex;
+  align-items: center;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
-body[data-page="item-detail"] .detail-store-label {
-  color: var(--text-muted);
+
+.page3 .page3-info-row + .search-panel {
+  margin-top: 18px;
 }
 
-body[data-page="item-detail"] .detail-store-badge {
+body[data-page="item-detail"] .detail-store-label,
+.page3 .page3-info-label {
+  font-size: 16px;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+body[data-page="item-detail"] .detail-store-badge,
+.page3 .page3-store-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.16rem 0.62rem;
-  border-radius: 999px;
-  background: #e8f3ff;
-  color: #1d4ed8;
-  font-weight: 600;
+  background: #e8f1ff;
+  color: #2563eb;
+  padding: 5px 12px;
+  border-radius: 14px;
+  font-size: 14px;
+  font-weight: 700;
   line-height: 1.25;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -3713,10 +3713,10 @@ import { firebaseAuth } from './firebase-core.js';
 
       detailStore.textContent = '';
       const storeLabel = document.createElement('span');
-      storeLabel.className = 'detail-store-label';
+      storeLabel.className = 'detail-store-label page3-info-label';
       storeLabel.textContent = 'Magasin :';
       const storeBadge = document.createElement('span');
-      storeBadge.className = `detail-store-badge badge ${badgeVariantClass}`;
+      storeBadge.className = `detail-store-badge page3-store-badge badge ${badgeVariantClass}`;
       storeBadge.textContent = displayValue;
       detailStore.append(storeLabel, storeBadge);
     }

--- a/page3.html
+++ b/page3.html
@@ -24,21 +24,21 @@
       <main class="page-content page-content--wide">
         <section class="surface-card table-card section">
           <div class="section-heading section-heading--table">
-            <div class="header-top">
-              <div class="title-block">
+            <div class="header-top page3-summary-header">
+              <div class="title-block page3-title-block">
                 <h2 class="section-title">Tableau des données</h2>
-                <div id="detailCount" class="article-count">
-                  <span class="count-number">0</span>
-                  <span class="count-label">Articles</span>
+                <div id="detailCount" class="article-count page3-article-count">
+                  <span class="count-number page3-count-number">0</span>
+                  <span class="count-label page3-count-label">Articles</span>
                 </div>
               </div>
-              <button type="button" id="exportDetailsButton" class="btn btn-success export-details-button">
+              <button type="button" id="exportDetailsButton" class="btn btn-success export-details-button btn-export">
                 <img src="Icon/Exporter.png" alt="" class="export-details-button__icon" aria-hidden="true" />
                 <span>Exporter</span>
               </button>
             </div>
           </div>
-          <div id="detailStore" class="magasin-block">Magasin : Non défini</div>
+          <div id="detailStore" class="magasin-block page3-info-row">Magasin : Non défini</div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">
               <span class="search-input__icon-wrap" aria-hidden="true">


### PR DESCRIPTION
### Motivation
- Improve the visual hierarchy of the "Tableau des données" block on Page 3 so the title, count, export button and store information read clearer and more professional.
- Reduce visual weight of the article count badge so it remains visible but secondary to the title.
- Separate the store information visually from the count and keep the search input positioned under the store block without increasing the card height significantly.

### Description
- Updated `page3.html` to add Page‑3 specific structure and classes: `page3-summary-header`, `page3-title-block`, `page3-article-count`, `page3-count-number`, `page3-count-label`, `btn-export`, and `page3-info-row` on the existing elements while preserving existing IDs (`detailCount`, `detailStore`).
- Adjusted `css/style.css` to add styling for the new `page3-*` classes including header alignment, reduced count badge emphasis, separated store row with `border-top` and ~18px spacing before the search panel, and minor typography tweaks to match the requested design.
- Modified `js/app.js` to append the new styling hooks to dynamically generated store elements by adding `page3-info-label` to the store label and `page3-store-badge` to the store badge while preserving all existing dynamic logic and behavior.
- Changed only Page 3 files and styles and did not modify Page 1, Page 2, the data table structure, export logic, floating "+" button, or dynamic data generation.

### Testing
- No automated tests were run because this is a UI/CSS-only change; changes were inspected via diffs and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25453ea8c832a8f9239806cef02b8)