### PR TITLE
Améliorer la disposition du header de la Page 3 pour meilleure lisibilité

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2317,7 +2317,7 @@ body[data-page="item-detail"] .header-top,
 .page3 .page3-summary-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 12px;
 }
 
@@ -2334,51 +2334,50 @@ body[data-page="item-detail"] .title-block .section-title,
   color: #1f2937;
 }
 
+.page3-sub-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  gap: 12px;
+}
+
 .page3 .article-count,
 .page3 .page3-article-count {
-  margin-top: 6px;
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 6px;
 }
 
 .page3 .count-number,
 .page3 .page3-count-number {
-  min-width: 34px;
-  height: 34px;
-  padding: 0 9px;
-  border-radius: 12px;
-  background: #eaf7ef;
-  color: #2e7d32;
-  font-size: 21px;
+  font-size: 18px;
   font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
+  color: #2e7d32;
 }
 
 .page3 .count-label,
 .page3 .page3-count-label {
-  font-size: 14px;
-  font-weight: 500;
-  color: #6b7280;
+  font-size: 13px;
+  color: #888;
 }
 
-body[data-page="item-detail"] .magasin-block,
+.page3 .store-info,
 .page3 .page3-info-row {
-  margin-top: 16px;
-  padding-top: 14px;
-  border-top: 1px solid rgba(0, 0, 0, 0.06);
   display: flex;
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
 }
 
+.page3 .page3-info-row {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
 
 .page3 .page3-info-row + .search-panel {
-  margin-top: 18px;
+  margin-top: 12px;
 }
 
 body[data-page="item-detail"] .detail-store-label,

--- a/page3.html
+++ b/page3.html
@@ -27,10 +27,6 @@
             <div class="header-top page3-summary-header">
               <div class="title-block page3-title-block">
                 <h2 class="section-title">Tableau des données</h2>
-                <div id="detailCount" class="article-count page3-article-count">
-                  <span class="count-number page3-count-number">0</span>
-                  <span class="count-label page3-count-label">Articles</span>
-                </div>
               </div>
               <button type="button" id="exportDetailsButton" class="btn btn-success export-details-button btn-export">
                 <img src="Icon/Exporter.png" alt="" class="export-details-button__icon" aria-hidden="true" />
@@ -38,7 +34,14 @@
               </button>
             </div>
           </div>
-          <div id="detailStore" class="magasin-block page3-info-row">Magasin : Non défini</div>
+          <div class="page3-sub-info">
+            <div id="detailCount" class="article-count page3-article-count">
+              <span class="count-number page3-count-number">0</span>
+              <span class="count-label page3-count-label">Articles</span>
+            </div>
+
+            <div id="detailStore" class="store-info magasin-block page3-info-row">Magasin : Non défini</div>
+          </div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">
               <span class="search-input__icon-wrap" aria-hidden="true">


### PR DESCRIPTION
### Motivation
- Rendre la lecture de la section "Tableau des données" plus claire en séparant le titre/button d'export de la méta-infos (nombre d’articles et magasin). 
- Garder le titre et le bouton `Exporter` sur la même ligne tout en plaçant le nombre d’articles à gauche et le magasin à droite sur une ligne secondaire. 
- Satisfaire aux contraintes existantes: ne pas déplacer le compteur sous le champ recherche, ne pas inverser les priorités et ne pas modifier Page 1 et Page 2.

### Description
- Déplacement du bloc `#detailCount` dans un nouveau conteneur secondaire `.page3-sub-info` placé directement sous la ligne titre/`Exporter` dans `page3.html`.
- Ajout de la classe `store-info` sur `#detailStore` et regroupement du compteur et du magasin dans la nouvelle structure HTML (`page3.html`).
- Ajout et ajustement de règles CSS ciblées (`css/style.css`) pour `.page3-sub-info`, `.article-count`, `.count-number`, `.count-label` et `.store-info`, et réglage de `align-items` de la ligne principale pour centrer verticalement sans impacter les autres pages.
- Portée limitée aux sélecteurs Page 3 afin d'éviter toute régression sur Page 1 et Page 2 (modifications dans `page3.html` et `css/style.css`).

### Testing
- Exécution de recherches/inspection de fichiers avec `rg` et `nl` pour vérifier les emplacements modifiés, et ces vérifications ont réussi.
- Vérification de l'état Git avec `git status --short` qui a retourné les fichiers modifiés avec succès.
- Validation de l'enregistrement des modifications via `git add page3.html css/style.css && git commit -m "Refine Page 3 header meta layout for readability"` qui a été exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f257c99294832aa795e41752946d96)