### PR TITLE
Adjust Page 3 sub-info spacing for subtle header separation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2342,6 +2342,10 @@ body[data-page="item-detail"] .title-block .section-title,
   gap: 12px;
 }
 
+.page3 .page3-sub-info {
+  margin-top: 12px;
+}
+
 .page3 .article-count,
 .page3 .page3-article-count {
   display: flex;


### PR DESCRIPTION
### Motivation
- Improve visual separation between the title and the row containing article count and store on Page 3 using a light, modern, minimalist change without affecting Pages 1 and 2.

### Description
- Added a Page‑3 scoped CSS override ` .page3 .page3-sub-info { margin-top: 12px; }` in `css/style.css` to create a subtle, non‑intrusive separation (no thick lines or dark colors).

### Testing
- Inspected the `css/style.css` diff to confirm only the Page‑3 scoped rule was added and no other files were modified, and note that no automated test suite applies to this static styling change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f259c71c3c832a989ca18e17e00907)