### PR TITLE
Split numeric count and label and style numbers on Page 1 & Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3910,6 +3910,26 @@ body[data-page="site-detail"] .list-card__meta-item--article {
   font-weight: 600;
 }
 
+body[data-page="home"] .outs-count,
+body[data-page="site-detail"] .outs-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 15px;
+}
+
+body[data-page="home"] .outs-number,
+body[data-page="site-detail"] .outs-number {
+  color: #2e7d32;
+  font-weight: 700;
+}
+
+body[data-page="home"] .outs-label,
+body[data-page="site-detail"] .outs-label {
+  color: #6b7280;
+  font-weight: 500;
+}
+
 body[data-page="site-detail"] .site-detail-fab-stack {
   position: fixed;
   right: 20px;

--- a/js/app.js
+++ b/js/app.js
@@ -1730,7 +1730,7 @@ import { firebaseAuth } from './firebase-core.js';
                 <div class="list-card__meta">
                   <span class="list-card__meta-item list-card__meta-item--outs">
                     <img src="Icon/OUT.png" alt="" aria-hidden="true" class="icon" />
-                    <span>${outCount} OUT${outCount > 1 ? 'S' : ''}</span>
+                    <span class="outs-count"><span class="outs-number">${outCount}</span><span class="outs-label">OUT${outCount > 1 ? 'S' : ''}</span></span>
                   </span>
                   <span class="list-card__meta-item">
                     <img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" />
@@ -2708,7 +2708,7 @@ import { firebaseAuth } from './firebase-core.js';
         return itemDesignations.some((designation) => String(designation || '').toUpperCase().includes(query));
       });
 
-      itemCount.textContent = `${filteredItems.length} OUT${filteredItems.length > 1 ? 'S' : ''}`;
+      itemCount.innerHTML = `<span class="outs-number">${filteredItems.length}</span><span class="outs-label">OUT${filteredItems.length > 1 ? 'S' : ''}</span>`;
 
       if (!filteredItems.length) {
         UiService.renderEmptyState(
@@ -2738,7 +2738,7 @@ import { firebaseAuth } from './firebase-core.js';
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
-                  <span class="list-card__meta-item list-card__meta-item--article"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>${detailCountsByItem[item.id] || 0} Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span></span>
+                  <span class="list-card__meta-item list-card__meta-item--article"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span class="outs-count"><span class="outs-number">${detailCountsByItem[item.id] || 0}</span><span class="outs-label">Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span></span></span>
                   <span class="list-card__meta-item"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Créé le ${escapeHtml(createdLabel)}</span></span>
                   <span class="list-card__meta-item"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>${escapeHtml(createdBy)}</span></span>
                 </div>

--- a/page2.html
+++ b/page2.html
@@ -15,7 +15,7 @@
         <div class="app-header__center">
           <div class="header-title header-title--stacked">
             <h1 id="siteTitle">Chargement...</h1>
-            <p id="itemCount" class="site-detail-subtitle">0 OUTS</p>
+            <p id="itemCount" class="site-detail-subtitle outs-count"><span class="outs-number">0</span><span class="outs-label">OUTS</span></p>
           </div>
         </div>
         <div class="app-header__side app-header__side--right" aria-hidden="true"></div>


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité en mettant en évidence uniquement le nombre (ex. `72`) pour les compteurs sur Page 1 et Page 2 tout en laissant le libellé (`OUTS` / `Articles`) neutre.
- Appliquer un style ciblé sans modifier la mise en page, la taille globale du texte, ni toucher à Page 3.

### Description
- Modifié le markup de la sous-en-tête de Page 2 dans `page2.html` pour séparer le nombre et le libellé en `<span class="outs-number">` et `<span class="outs-label">` à l'intérieur d'une `outs-count`.
- Mis à jour `js/app.js` pour rendre dynamiquement les compteurs en tant que `outs-count` (sites `OUT/OUTS`, header Page 2 `OUT/OUTS`, et `Article/Articles` dans les cartes d'items) au lieu d'une chaîne texte unique.
- Ajouté des règles CSS ciblées dans `css/style.css` (scopées à `body[data-page="home"]` et `body[data-page="site-detail"]`) pour afficher `outs-count` en `inline-flex`, colorer `outs-number` en vert `#2e7d32` et `outs-label` en gris `#6b7280`, tout en conservant l'alignement et le responsive.
- Aucun changement effectué sur Page 3 ou sur la logique fonctionnelle existante au-delà du rendu/markup et du style visuel.

### Testing
- Aucun test automatisé n'a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25c588180832abc5a69b5521e3b12)