### PR TITLE
Adjust Page 2 header subtitle balance

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3174,12 +3174,29 @@ body[data-page="item-detail"] #designationInput.is-shaking {
 
 .site-detail-subtitle {
   margin: 0;
+  margin-top: 6px;
   width: 100%;
   text-align: center;
-  font-size: var(--header-subtitle-size);
+  font-size: 14px;
   font-weight: 500;
   line-height: 1.2;
   color: rgba(255, 255, 255, 0.9);
+}
+
+.app-header--detail .app-header__center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.site-detail-subtitle .outs-number {
+  color: #43a047;
+  font-weight: 700;
+}
+
+.site-detail-subtitle .outs-label {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .app-header .back-button,


### PR DESCRIPTION
### Motivation
- The OUTS count in the Page 2 header visually competed with the main title after a style change, causing poor spacing, hierarchy and dominance issues.

### Description
- Added a top margin to the Page 2 subtitle by updating `.site-detail-subtitle` with `margin-top: 6px` to separate it from the title.
- Reduced the subtitle prominence by setting `font-size: 14px` and `font-weight: 500` on `.site-detail-subtitle`.
- Improved OUTS visual hierarchy by styling `.site-detail-subtitle .outs-number` with `color: #43a047` and stronger weight and `.site-detail-subtitle .outs-label` with `color: rgba(255,255,255,0.85)`, and added vertical centering for the detail header via `.app-header--detail .app-header__center` flex rules.

### Testing
- Located selector usage across the codebase with `rg` to ensure the change targets only the detail view, and the search succeeded.
- Applied an automated script to update `css/style.css` and verified the updated file contents with `sed`/`nl`, and these checks succeeded.
- Inspected the workspace to confirm only `css/style.css` was modified and no markup changes were made to Page 1 or Page 3, and the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25e9ee79c832aaafb34f94472e1ff)