### PR TITLE
Fix Page 2 header centering (title + subtitle)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4913,3 +4913,60 @@ body.is-loading .header-menu__panel {
 .skeleton-table-row { display:grid; grid-template-columns: 30px 1fr 1fr; gap:8px; align-items:center; }
 .skeleton-index { width: 26px; height: 26px; border-radius: 999px; }
 .skeleton-cell { height: 20px; }
+
+/* Page 2 header centering hard-fix */
+body[data-page="site-detail"] .page2-header {
+  display: grid;
+  grid-template-columns: 56px 1fr 56px;
+  align-items: center;
+}
+
+body[data-page="site-detail"] .page2-header .app-header__side {
+  width: 56px;
+  justify-content: center;
+}
+
+body[data-page="site-detail"] .page2-header-center {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+body[data-page="site-detail"] .page2-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: #ffffff;
+  text-align: center;
+}
+
+body[data-page="site-detail"] .page2-header-subtitle {
+  margin-top: 4px;
+  margin-left: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  position: static;
+  left: auto;
+  transform: none;
+  align-self: center;
+  float: none;
+  width: auto;
+}
+
+body[data-page="site-detail"] .page2-header-subtitle .outs-number {
+  color: #2e7d32;
+  font-weight: 700;
+}
+
+body[data-page="site-detail"] .page2-header-subtitle .outs-label {
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 500;
+}

--- a/page2.html
+++ b/page2.html
@@ -8,17 +8,15 @@
   </head>
   <body data-page="site-detail">
     <div class="app-shell">
-      <header class="app-header app-header--detail">
+      <header class="app-header app-header--detail page2-header">
         <div class="app-header__side app-header__side--left">
-          <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
+          <button class="back-button back-btn" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
         </div>
-        <div class="app-header__center">
-          <div class="header-title header-title--stacked">
-            <h1 id="siteTitle">Chargement...</h1>
-            <p id="itemCount" class="site-detail-subtitle outs-count"><span class="outs-number">0</span><span class="outs-label">OUTS</span></p>
-          </div>
+        <div class="app-header__center page2-header-center">
+          <h1 id="siteTitle" class="page2-title">Chargement...</h1>
+          <div id="itemCount" class="site-detail-subtitle outs-count page2-header-subtitle"><span class="outs-number">0</span><span class="outs-label">OUTS</span></div>
         </div>
-        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
+        <div class="app-header__side app-header__side--right page2-header-spacer" aria-hidden="true"></div>
       </header>
 
       <main class="page-content">


### PR DESCRIPTION
### Motivation
- Corriger l’alignement du header sur la Page 2 pour que le titre et le sous-titre (ex: `72 OUTS`) soient parfaitement centrés dans un même bloc. 
- Neutraliser les règles CSS qui causaient le décalage (positionnement absolu, transforms, marges/left, float, width fixe) sans toucher au comportement sticky ni à la hauteur/background du header. 
- Conserver le bouton retour à gauche et un espace vide à droite pour équilibrer visuellement le header.

### Description
- Restructuration du header de la Page 2 en ajoutant la classe `page2-header` et en regroupant titre et sous-titre dans le bloc central `page2-header-center` (modifications dans `page2.html`).
- Ajout des classes `page2-title`, `page2-header-subtitle` et `page2-header-spacer` et maintien des IDs existants (`siteTitle`, `itemCount`) pour ne pas casser la logique JS.
- Ajout d’un CSS scoped à la page (`body[data-page="site-detail"]`) dans `css/style.css` qui impose une grille 3 zones `56px 1fr 56px`, centre verticalement et horizontalement le bloc central, et stylise la partie compteur (`outs-number` en vert, `outs-label` en clair).
- Neutralisation explicite des propriétés problématiques sur le sous-titre (`position`, `left`, `transform`, `float`, `width`, `align-self`, etc.) sans modifier `position: sticky`, `top`, `z-index`, la hauteur du header ou son background.

### Testing
- Aucun test automatisé n'a été exécuté pour cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f261d0de54832aae406649c96a0fb3)