### PR TITLE
Adjust Page 2 header OUTS number color for visual consistency

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4962,7 +4962,7 @@ body[data-page="site-detail"] .page2-header-subtitle {
 }
 
 body[data-page="site-detail"] .page2-header-subtitle .outs-number {
-  color: #2e7d32;
+  color: #ffffff;
   font-weight: 700;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the OUTS count in the Page 2 header is white for better contrast against the blue header while keeping the number more prominent than its label.

### Description
- Updated `css/style.css` by changing `body[data-page="site-detail"] .page2-header-subtitle .outs-number` color to `#ffffff` and preserving `font-weight: 700`, leaving `.outs-label` styling unchanged.

### Testing
- Ran `rg` to locate affected selectors and verify the change, which found the updated rule in `css/style.css` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f298154ec0832a9d5dea7b784a7334)