### PR TITLE
Amélioration de la séparation visuelle sur la Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2343,7 +2343,7 @@ body[data-page="item-detail"] .title-block .section-title,
 }
 
 .page3 .page3-sub-info {
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 .page3 .article-count,


### PR DESCRIPTION
### Motivation
- Améliorer la hiérarchie visuelle entre le bloc (Titre + Exporter) et le bloc (Nombre d’articles + Magasin) uniquement sur la Page 3 en conservant un design minimaliste sans ligne épaisse ni couleur foncée.

### Description
- Mise à jour de `css/style.css` : la règle `margin-top` de ` .page3 .page3-sub-info` est passée de `12px` à `14px`, la modification étant strictement limitée à la Page 3 et sans toucher aux Pages 1/2, au tableau, au bouton Exporter ou aux données.

### Testing
- Aucune suite de tests automatisés n'était nécessaire pour ce changement CSS ciblé et la modification a été vérifiée en inspectant le fichier `css/style.css` pour confirmer la portée du sélecteur et la valeur modifiée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cc4df53c832a9de4f0ebdcbdfcb6)