### PR TITLE
Add subtle separator above Page 3 sub-info block

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2343,7 +2343,9 @@ body[data-page="item-detail"] .title-block .section-title,
 }
 
 .page3 .page3-sub-info {
-  margin-top: 14px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 .page3 .article-count,


### PR DESCRIPTION
### Motivation
- Ensure a visible but subtle divider between the title/export row and the articles/magasin block on Page 3 because the separator was previously not appearing due to CSS targeting/spacing issues.

### Description
- Update `css/style.css` to adjust the Page 3 rule for `.page3 .page3-sub-info` to `margin-top: 10px;`, `padding-top: 10px;` and `border-top: 1px solid rgba(0,0,0,0.08);`, leaving HTML structure, the table, and the Exporter untouched.

### Testing
- Verified presence of the container in `page3.html`, inspected and committed the CSS change (`git add css/style.css && git commit`), and validated the inserted lines with `nl`/`sed` and `rg`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cec35968832a87be25c44b57fcf9)