### PR TITLE
Refine Page 3 sub-info separator styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2345,7 +2345,10 @@ body[data-page="item-detail"] .title-block .section-title,
 .page3 .page3-sub-info {
   margin-top: 10px;
   padding-top: 10px;
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  width: 95%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .page3 .article-count,


### PR DESCRIPTION
### Motivation
- Improve the visual separation on Page 3 between the (Title + Exporter) block and the (Articles + Store) block by using a shorter, centered, and subtler divider to give a more premium look while preserving existing layout and behavior.

### Description
- Modified `.page3 .page3-sub-info` in `css/style.css` to set `border-top: 1px solid rgba(0, 0, 0, 0.06)`, `width: 95%`, and `margin-left: auto; margin-right: auto;`, keeping all JS, header, exporter button, table, search field, Page 1 and Page 2 unchanged.

### Testing
- No automated tests were run for this visual CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d1ae3fb4832ab6b2de3e661e8598)