### PR TITLE
Harmonize Page 3 label typography for Articles and Magasin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2367,8 +2367,9 @@ body[data-page="item-detail"] .title-block .section-title,
 
 .page3 .count-label,
 .page3 .page3-count-label {
-  font-size: 13px;
-  color: #888;
+  font-size: 14px;
+  font-weight: 500;
+  color: #6b7280;
 }
 
 .page3 .store-info,
@@ -2391,7 +2392,7 @@ body[data-page="item-detail"] .title-block .section-title,
 
 body[data-page="item-detail"] .detail-store-label,
 .page3 .page3-info-label {
-  font-size: 16px;
+  font-size: 14px;
   color: #6b7280;
   font-weight: 500;
 }


### PR DESCRIPTION
### Motivation
- Harmoniser la taille et le style des libellés « Articles » et « Magasin » uniquement sur la Page 3 pour une cohérence visuelle tout en gardant le nombre d’articles plus visible.
- Respecter les contraintes existantes en ne touchant pas Page 1/2, le bouton Exporter, le tableau, les positions ni la responsivité mobile.

### Description
- Modifié `css/style.css` pour mettre `.page3 .count-label` et `.page3 .page3-count-label` à `font-size: 14px`, `font-weight: 500`, `color: #6b7280`.
- Ajusté `body[data-page="item-detail"] .detail-store-label` et `.page3 .page3-info-label` à `font-size: 14px` pour aligner le libellé « Magasin » sur le même style.
- Conservé le style de `.page3 .count-number` (18px, 700) pour que le nombre reste visuellement dominant.
- Les changements sont limités à des sélecteurs Page 3 / item-detail et n’affectent pas d’autres composants.

### Testing
- Local verification with `rg` et `sed` pour valider les sélecteurs et valeurs modifiées — vérification réussie.
- VCS checks with `git status --short` et `git add css/style.css && git commit -m "Harmonize Page 3 labels for Articles and Magasin"` — commit réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d3db437c832a815a2b7992b12352)