### PR TITLE
Move Page 2 export action to header and align FAB with Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3956,12 +3956,10 @@ body[data-page="site-detail"] .outs-label {
 body[data-page="site-detail"] .site-detail-fab-stack {
   position: fixed;
   right: 20px;
-  bottom: calc(30px + env(safe-area-inset-bottom, 0px));
+  bottom: calc(20px + env(safe-area-inset-bottom, 0px));
   display: inline-flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 14px;
-  z-index: 40;
+  align-items: center;
+  z-index: 45;
   opacity: 1;
   transform: translateY(0) scale(1);
   pointer-events: auto;
@@ -3982,9 +3980,13 @@ body[data-page="site-detail"].app-content-pending .site-detail-fab-stack {
 }
 
 body[data-page="site-detail"] .site-detail-fab-row {
+  position: fixed;
+  right: 20px;
+  bottom: calc(20px + env(safe-area-inset-bottom, 0px));
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  z-index: 45;
 }
 
 body[data-page="site-detail"] .site-detail-fab-label {
@@ -4008,19 +4010,15 @@ body[data-page="site-detail"] .site-detail-fab-label--create {
   color: var(--detail-primary);
 }
 
-body[data-page="site-detail"] .site-detail-fab-label--export {
-  color: #18a85f;
-}
-
-body[data-page="site-detail"] .fab--export,
 body[data-page="site-detail"] .fab-add,
-body[data-page="site-detail"] #openCreateItem {
+body[data-page="site-detail"] #openCreateItem,
+body[data-page="site-detail"] .fab-add--item-detail {
   position: relative;
   right: auto;
   left: auto;
   bottom: auto;
-  width: 56px;
-  height: 56px;
+  width: 58px;
+  height: 58px;
   border-radius: 50%;
   display: inline-flex;
   align-items: center;
@@ -4029,28 +4027,6 @@ body[data-page="site-detail"] #openCreateItem {
   box-shadow: 0 10px 22px var(--detail-primary-shadow);
   z-index: 1;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-body[data-page="site-detail"] .fab--export {
-  background: #18a85f;
-  color: #fff;
-  padding: 0;
-}
-
-body[data-page="site-detail"] .fab--export__icon {
-  width: 22px;
-  height: 22px;
-  object-fit: contain;
-  flex-shrink: 0;
-}
-
-body[data-page="site-detail"] .fab--export:hover {
-  background: #159451;
-  box-shadow: 0 12px 24px rgba(8, 112, 62, 0.24);
-}
-
-body[data-page="site-detail"] .fab--export:active {
-  transform: scale(0.95);
 }
 
 body[data-page="site-detail"] .fab-add,
@@ -4067,8 +4043,7 @@ body[data-page="site-detail"] #openCreateItem:hover {
 
 body[data-page="site-detail"] .fab-add:focus-visible,
 body[data-page="site-detail"] #openCreateItem:focus-visible,
-body[data-page="site-detail"] .filter-chip:focus-visible,
-body[data-page="site-detail"] .fab--export:focus-visible {
+body[data-page="site-detail"] .filter-chip:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--detail-primary-focus);
 }
@@ -4931,6 +4906,29 @@ body[data-page="site-detail"] .page2-header .app-header__side {
   width: 56px;
   justify-content: center;
 }
+body[data-page="site-detail"] .btn-export-header {
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+body[data-page="site-detail"] .btn-export-header img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+}
+
+body[data-page="site-detail"] .btn-export-header:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--detail-primary-focus);
+}
+
 
 body[data-page="site-detail"] .page2-header-center {
   min-width: 0;

--- a/page2.html
+++ b/page2.html
@@ -16,7 +16,11 @@
           <h1 id="siteTitle" class="page2-title">Chargement...</h1>
           <div id="itemCount" class="site-detail-subtitle outs-count page2-header-subtitle"><span class="outs-number">0</span><span class="outs-label">OUTS</span></div>
         </div>
-        <div class="app-header__side app-header__side--right page2-header-spacer" aria-hidden="true"></div>
+        <div class="app-header__side app-header__side--right">
+          <button class="btn-export-header" type="button" id="openExportItems" aria-label="Exporter">
+            <img src="Icon/Exporter.png" alt="" aria-hidden="true" />
+          </button>
+        </div>
       </header>
 
       <main class="page-content">
@@ -61,13 +65,7 @@
       <div class="site-detail-fab-stack" aria-hidden="false">
         <div class="site-detail-fab-row" data-fab-row="create">
           <span class="site-detail-fab-label site-detail-fab-label--create">Créer un OUT</span>
-          <button id="openCreateItem" class="fab fab-add" type="button" aria-label="Ajouter un numéro OUT">+</button>
-        </div>
-        <div class="site-detail-fab-row" data-fab-row="export">
-          <span class="site-detail-fab-label site-detail-fab-label--export">Exporter</span>
-          <button type="button" id="openExportItems" class="fab fab--export" aria-label="Exporter">
-            <img src="Icon/Exporter.png" alt="" aria-hidden="true" class="fab--export__icon" />
-          </button>
+          <button id="openCreateItem" class="fab fab-add fab-add--item-detail" type="button" aria-label="Ajouter un numéro OUT">+</button>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Reduce visual clutter on Page 2 by removing the floating green Export FAB and exposing the same export action in the header while keeping existing JS logic intact.
- Make the Page 2 floating add (`+`) button visually and behaviorally identical to Page 3 for consistent UX.

### Description
- Removed the floating Export FAB and its label from `page2.html` while preserving the `id="openExportItems"` trigger.
- Added a header export button in the Page 2 right header column: a `button.btn-export-header` with `id="openExportItems"` that reuses the existing export handler.
- Updated `page2.html` add-FAB markup to include the `fab-add--item-detail` class to match Page 3 styling.
- Modified `css/style.css` to align Page 2 FAB sizing/positioning and add styles for `.btn-export-header` (44×44 header button, 22×22 icon, circular translucent background) without changing header sticky/top/z-index/height or any JS export/create logic.

### Testing
- Ran `rg` searches to confirm `openExportItems` is present only in the Page 2 header and the floating export row was removed, and the checks succeeded.
- Inspected the diffs for `page2.html` and `css/style.css` to verify only the intended markup and style changes were introduced and the output matched expectations.
- No automated unit test suite is present in the repository, so no unit tests were run; repository checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d97e3ac4832a96a3109886955001)