### PR TITLE
Uniformiser le bouton flottant + sur les 3 pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1309,6 +1309,23 @@ body[data-page="history"] .list-grid {
   transform: scale(0.95);
 }
 
+.fab-add {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  z-index: 1000;
+}
+
+.fab-label {
+  position: fixed;
+  right: 96px;
+  bottom: 34px;
+  z-index: 999;
+}
+
 .modal-card {
   width: min(92vw, 28rem);
   border: 0;
@@ -2551,12 +2568,6 @@ body[data-page="item-detail"].item-detail-modal-open {
 }
 
 body[data-page="item-detail"] .fab-add--item-detail {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
   border: 0;
   display: inline-flex;
   align-items: center;
@@ -2571,9 +2582,6 @@ body[data-page="item-detail"] .fab-add--item-detail {
 }
 
 body[data-page="item-detail"] .item-detail-fab-row {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -3954,9 +3962,6 @@ body[data-page="site-detail"] .outs-label {
 }
 
 body[data-page="site-detail"] .site-detail-fab-stack {
-  position: fixed;
-  right: 20px;
-  bottom: calc(20px + env(safe-area-inset-bottom, 0px));
   display: inline-flex;
   align-items: center;
   z-index: 45;
@@ -3980,9 +3985,6 @@ body[data-page="site-detail"].app-content-pending .site-detail-fab-stack {
 }
 
 body[data-page="site-detail"] .site-detail-fab-row {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -4021,13 +4023,6 @@ body[data-page="item-detail"] .item-detail-fab-row .site-detail-fab-label {
 body[data-page="site-detail"] .fab-add,
 body[data-page="site-detail"] #openCreateItem,
 body[data-page="site-detail"] .fab-add--item-detail {
-  position: relative;
-  right: auto;
-  left: auto;
-  bottom: auto;
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       </main>
 
 
-      <button id="openCreateSite" class="fab" type="button" aria-label="Créer un site">+</button>
+      <button id="openCreateSite" class="fab fab-add" type="button" aria-label="Créer un site">+</button>
 
       <dialog id="siteDialog" class="modal-card">
         <form class="modal-content modal-content--site-create" id="siteForm">

--- a/page2.html
+++ b/page2.html
@@ -64,7 +64,7 @@
 
       <div class="site-detail-fab-stack" aria-hidden="false">
         <div class="site-detail-fab-row" data-fab-row="create">
-          <span class="site-detail-fab-label site-detail-fab-label--create">Créer un OUT</span>
+          <span class="site-detail-fab-label fab-label site-detail-fab-label--create">Créer un OUT</span>
           <button id="openCreateItem" class="fab fab-add fab-add--item-detail" type="button" aria-label="Ajouter un numéro OUT">+</button>
         </div>
       </div>

--- a/page3.html
+++ b/page3.html
@@ -84,7 +84,7 @@
       </main>
 
       <div class="item-detail-fab-row site-detail-fab-row" data-fab-row="create">
-        <span id="itemDetailFabLabel" class="site-detail-fab-label site-detail-fab-label--create">Ajouter un article</span>
+        <span id="itemDetailFabLabel" class="site-detail-fab-label fab-label site-detail-fab-label--create">Ajouter un article</span>
         <button type="button" id="openDetailFormButton" class="fab-add fab-add--item-detail" aria-label="Ajouter une donnée">+</button>
       </div>
 


### PR DESCRIPTION
### Motivation
- Harmoniser la position et la taille du bouton flottant `+` sur Page 1, Page 2 et Page 3 en prenant la Page 3 comme référence visuelle exacte.
- Remplacer les règles locales divergentes par une classe réutilisable pour éviter les écarts sur `right`, `bottom`, `width`, `height`, `z-index`, `border-radius`, ombre et comportement responsive.
- Respecter les contraintes existantes en ne modifiant ni le header, ni les cards, ni la logique JavaScript, et en conservant les libellés `Exporter` aux emplacements actuels.

### Description
- Ajout d’une classe commune ` .fab-add ` dans `css/style.css` fournissant `position: fixed`, `right: 24px`, `bottom: 24px`, `width: 64px`, `height: 64px`, `border-radius: 50%` et `z-index: 1000` pour piloter le bouton `+`.
- Ajout d’une classe commune ` .fab-label ` dans `css/style.css` avec `position: fixed`, `right: 96px`, `bottom: 34px` et `z-index: 999` pour uniformiser les libellés associés.
- Application de `fab-add` au bouton `+` de Page 1 (`index.html`) et application de `fab-label` aux libellés de Page 2 et Page 3 (`page2.html`, `page3.html`).
- Neutralisation des règles CSS conflictuelles spécifiques à `site-detail` / `item-detail` (suppression des positions/offsets locaux tels que `position: fixed`, `right`, `bottom`, tailles et overrides) pour laisser la nouvelle classe commune contrôler l’emplacement sans toucher au header/cards/JS.

### Testing
- Recherches de vérification avec `rg -n "fab-add|fab-label|site-detail-fab-stack|item-detail-fab-row|openCreateSite" index.html page2.html page3.html css/style.css` exécutées avec succès.
- Inspection des modifications via `git diff -- index.html page2.html page3.html css/style.css` réalisée avec succès pour valider le delta attendu.
- Commit final `git commit -m "Unify floating add button placement across pages"` exécuté avec succès (output: `4 files changed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e0d3c274832a96bd05c90a346338)