### PR TITLE
Align FAB (+) position on Page 2 and Page 3 with Page 1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2589,10 +2589,15 @@ body[data-page="item-detail"] .item-detail-fab-row {
 }
 
 body[data-page="item-detail"] .item-detail-fab-row .fab-add--item-detail {
-  position: relative;
-  right: auto;
-  left: auto;
-  bottom: auto;
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  z-index: 1000;
+  box-shadow: 0 10px 22px var(--detail-primary-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 body[data-page="item-detail"] .site-detail-fab-label {
@@ -4018,6 +4023,20 @@ body[data-page="item-detail"] .item-detail-fab-row .site-detail-fab-label {
   right: 96px;
   bottom: 34px;
   z-index: 999;
+}
+
+body[data-page="site-detail"] .site-detail-fab-row .fab-add,
+body[data-page="site-detail"] .site-detail-fab-row .fab-add--item-detail,
+body[data-page="item-detail"] .item-detail-fab-row .fab-add--item-detail {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  z-index: 1000;
+  box-shadow: 0 10px 22px var(--detail-primary-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 body[data-page="site-detail"] .fab-add,


### PR DESCRIPTION
### Motivation
- Fix visual inconsistency where the floating "+" FAB on Page 2 (`site-detail`) and Page 3 (`item-detail`) was mis-positioned compared to Page 1, using Page 1 as the authoritative reference.

### Description
- Replace the relative/inline positioning for the Page 3 FAB with the same fixed geometry and anchoring used by Page 1, adding `position: fixed`, `right: 24px`, `bottom: 24px`, `width: 64px`, `height: 64px`, `border-radius: 50%`, `z-index: 1000`, `box-shadow`, and `transition` in `css/style.css` for `.fab-add--item-detail`.
- Add a shared rule for Page 2 (`site-detail`) and Page 3 selectors to ensure `.fab-add` and `.fab-add--item-detail` use the same fixed placement and sizing as Page 1.
- Keep the FAB labels ("Créer un OUT" / "Ajouter un article") coordinates intact so they remain aligned with the FAB, and do not modify Page 1, headers, cards, export button, JS logic, or sticky behavior.

### Testing
- Verified the CSS changes by searching and inspecting relevant selectors with `rg` and `sed` to confirm the new fixed rules are present in `css/style.css` and no other files were modified, and the inspections succeeded.
- Confirmed the previous relative positioning rules for Page 3 were neutralized and replaced by the fixed rules via file diff inspection, and the verification succeeded.
- Performed local validation that only `css/style.css` contains the updates and that the updated selectors match the Page 1 reference values, and these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e3ea96ec832a8b4ca3c105c41559)