### PR TITLE
Fix Page 2 floating '+' button position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4996,3 +4996,36 @@ body[data-page="site-detail"] .page2-header-subtitle .outs-label {
   color: rgba(255, 255, 255, 0.85);
   font-weight: 500;
 }
+
+
+/* Page 2 FAB alignment fix */
+.page2 .fab-add,
+.page2 .floating-add-btn,
+.page2 #addOutBtn,
+.page2 #openCreateItem {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  z-index: 1000;
+}
+
+.page2 .fab-label,
+.page2 .floating-label,
+.page2 .site-detail-fab-label {
+  position: fixed;
+  right: 96px;
+  bottom: 34px;
+  z-index: 999;
+}
+
+.page2 .site-detail-fab-row .fab-add,
+.page2 .site-detail-fab-row .fab-add--item-detail,
+.page2 .site-detail-fab-row #openCreateItem,
+.page2 .site-detail-fab-row .fab-label,
+.page2 .site-detail-fab-row .site-detail-fab-label {
+  margin-bottom: 0;
+  transform: none;
+}

--- a/page2.html
+++ b/page2.html
@@ -6,7 +6,7 @@
     <title>Détail liste - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
   </head>
-  <body data-page="site-detail">
+  <body data-page="site-detail" class="page2">
     <div class="app-shell">
       <header class="app-header app-header--detail page2-header">
         <div class="app-header__side app-header__side--left">


### PR DESCRIPTION
### Motivation
- Page 2's floating add button was positioned too low and partially off-screen, unlike Page 1 and Page 3. 
- The fix must target only Page 2 without touching Page 1, Page 3, the header, the export button, OUT cards, or JS logic. 
- The goal is to keep the `+` button fully visible and aligned bottom-right as on the other pages.

### Description
- Added a `page2` class to the `<body>` in `page2.html` to scope CSS adjustments to Page 2 only. 
- Appended Page 2-only CSS rules in `css/style.css` to force the FAB to `position: fixed` and `right: 24px; bottom: 24px; width: 64px; height: 64px; border-radius: 50%; z-index: 1000`. 
- Added Page 2-only CSS for the label to `position: fixed` with `right: 96px; bottom: 34px; z-index: 999` to correct the “Créer un OUT” placement. 
- Neutralized legacy offsets on Page 2 (`margin-bottom: 0; transform: none;`) for the FAB row to remove older rules that pushed the button off-screen.

### Testing
- Ran a scoped search with `rg -n "page2|fab-add|floating-add-btn|addOutBtn|fab-label|floating-label|translateY|margin-bottom|sticky|absolute|OUT"` to verify selectors and scope, and the search completed successfully. 
- Inspected the relevant CSS ranges with `sed -n` and verified the new Page 2 rules appear in `css/style.css`, and the check completed successfully. 
- Verified `page2.html` contains `class="page2"` on the body with `nl -ba` to ensure the scoping change was applied, and the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e70e74e4832a9a829a91db68fbe4)