### PR TITLE
Fix Page 2 floating add button safe-area positioning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5003,22 +5003,28 @@ body[data-page="site-detail"] .page2-header-subtitle .outs-label {
 .page2 .floating-add-btn,
 .page2 #addOutBtn,
 .page2 #openCreateItem {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  z-index: 1000;
+  position: fixed !important;
+  right: 24px !important;
+  bottom: calc(24px + env(safe-area-inset-bottom)) !important;
+  top: auto !important;
+  width: 64px !important;
+  height: 64px !important;
+  border-radius: 50% !important;
+  margin-bottom: 0 !important;
+  transform: none !important;
+  z-index: 1000 !important;
 }
 
 .page2 .fab-label,
 .page2 .floating-label,
 .page2 .site-detail-fab-label {
-  position: fixed;
-  right: 96px;
-  bottom: 34px;
-  z-index: 999;
+  position: fixed !important;
+  right: 96px !important;
+  bottom: calc(34px + env(safe-area-inset-bottom)) !important;
+  top: auto !important;
+  margin-bottom: 0 !important;
+  transform: none !important;
+  z-index: 999 !important;
 }
 
 .page2 .site-detail-fab-row .fab-add,
@@ -5026,6 +5032,6 @@ body[data-page="site-detail"] .page2-header-subtitle .outs-label {
 .page2 .site-detail-fab-row #openCreateItem,
 .page2 .site-detail-fab-row .fab-label,
 .page2 .site-detail-fab-row .site-detail-fab-label {
-  margin-bottom: 0;
-  transform: none;
+  margin-bottom: 0 !important;
+  transform: none !important;
 }


### PR DESCRIPTION
### Motivation
- Page 2’s floating "+" button was being cut off at the bottom on some devices due to conflicting placement rules and lack of safe-area handling. 
- The goal is to fix only Page 2 layout so the FAB and its label are fully visible at bottom-right without touching other pages, header, cards, or JS.

### Description
- Updated the Page 2 scoped FAB override block in `css/style.css` to target `.page2 .fab-add`, `.page2 #openCreateItem`, `.page2 .fab-label` and related selectors. 
- Enforced `position: fixed !important`, `right: 24px !important`, and `bottom: calc(... + env(safe-area-inset-bottom)) !important` and set `top: auto`, `margin-bottom: 0`, and `transform: none` to avoid inherited conflicts. 
- Applied `!important` and explicit sizing (`width: 64px`, `height: 64px`, `border-radius: 50%`) for the FAB and adjusted the label to `right: 96px` / `bottom: calc(34px + env(safe-area-inset-bottom))`. 
- Change is strictly scoped to Page 2 and does not modify Page 1, Page 3, header export button, OUT cards, or JavaScript logic.

### Testing
- Verified presence of the Page 2 button and parent structure by inspecting `page2.html` (`#openCreateItem`, `.fab`, `.site-detail-fab-row`).
- Confirmed selectors and new rules exist with `rg -n "fab|floating|addOut|openCreateItem|site-detail-fab|page2" css/style.css page2.html` and inspected the rule block with `nl -ba css/style.css | sed -n '4996,5045p'` which succeeded. 
- Confirmed the FAB rule lines in `css/style.css` reference `env(safe-area-inset-bottom)` and include the `!important` overrides expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ec717ed8832aabf3ac40fe791463)