### PR TITLE
Adjust Page 2 floating add button bottom offset

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5005,7 +5005,7 @@ body[data-page="site-detail"] .page2-header-subtitle .outs-label {
 .page2 #openCreateItem {
   position: fixed !important;
   right: 24px !important;
-  bottom: calc(24px + env(safe-area-inset-bottom)) !important;
+  bottom: calc(42px + env(safe-area-inset-bottom)) !important;
   top: auto !important;
   width: 64px !important;
   height: 64px !important;


### PR DESCRIPTION
### Motivation
- Le bouton flottant "+" de la Page 2 était légèrement trop bas et partiellement masqué, il faut le remonter pour qu'il soit entièrement visible et aligné visuellement avec Page 1 et Page 3.

### Description
- Modifié uniquement la règle CSS ciblant Page 2 dans `css/style.css` en remplaçant `bottom: calc(24px + env(safe-area-inset-bottom))` par `bottom: calc(42px + env(safe-area-inset-bottom))` pour les sélecteurs `.page2 .fab-add`, `.page2 .floating-add-btn`, `.page2 #addOutBtn` et `.page2 #openCreateItem`.

### Testing
- Aucune suite de tests automatisés n'a été exécutée; la modification a été vérifiée par inspection ciblée du fichier `css/style.css` pour confirmer la nouvelle valeur `calc(42px + env(safe-area-inset-bottom))`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ee9b6d68832a93ebe1b0b350b365)