### PR TITLE
Masquer les libellés FAB sur Page 2 et Page 3 (CSS uniquement)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5017,14 +5017,11 @@ body[data-page="site-detail"] .page2-header-subtitle .outs-label {
 
 .page2 .fab-label,
 .page2 .floating-label,
-.page2 .site-detail-fab-label {
-  position: fixed !important;
-  right: 96px !important;
-  bottom: calc(60px + env(safe-area-inset-bottom)) !important;
-  top: auto !important;
-  margin-bottom: 0 !important;
-  transform: none !important;
-  z-index: 999 !important;
+.page2 .site-detail-fab-label,
+.page3 .fab-label,
+.page3 .floating-label,
+.page3 .site-detail-fab-label {
+  display: none !important;
 }
 
 .page2 .site-detail-fab-row .fab-add,


### PR DESCRIPTION
### Motivation
- Masquer visuellement les libellés du bouton flottant (+) sur les pages 2 et 3 tout en conservant intact le bouton lui‑même, le HTML et la logique JavaScript.

### Description
- Mise à jour de `css/style.css` : le bloc ciblant `.page2 .fab-label`, `.page2 .floating-label`, `.page2 .site-detail-fab-label` a été remplacé et étendu pour inclure également `.page3 .fab-label`, `.page3 .floating-label`, `.page3 .site-detail-fab-label` et appliquer `display: none !important;` afin de masquer uniquement les libellés.

### Testing
- Vérification automatisée par recherche et inspection du fichier avec `rg` et `sed`, exécution du script de remplacement (retour `patched`) et inspection du diff qui confirme que seul `css/style.css` a été modifié et que la règle `display: none !important;` est présente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30dd80df8832a80fe960512681ad0)