### PR TITLE
style: bouton Exporter (Page 2) — style premium bordure verte

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5032,3 +5032,29 @@ body[data-page="site-detail"] .page2-header-subtitle .outs-label {
   margin-bottom: 0 !important;
   transform: none !important;
 }
+
+/* Page 2 export button premium style */
+.page2 .export-btn,
+.page2 .btn-export,
+.page2 #exportBtn,
+.page2 #siteExportSubmitButton {
+  background: #ffffff !important;
+  border: 1.5px solid #22c55e !important;
+  color: #22c55e !important;
+  border-radius: 999px !important;
+  padding: 10px 16px !important;
+  font-size: 14px !important;
+  font-weight: 600 !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05) !important;
+}
+
+.page2 .export-btn:active,
+.page2 .btn-export:active,
+.page2 #exportBtn:active,
+.page2 #siteExportSubmitButton:active {
+  transform: scale(0.97) !important;
+  background: #f0fdf4 !important;
+}


### PR DESCRIPTION
### Motivation
- Mettre à jour le rendu du bouton "Exporter" sur Page 2 pour un aspect premium (fond blanc, bordure verte fine, texte vert, forme arrondie et retour tactile) sans toucher à la logique ni aux autres pages/éléments.

### Description
- Ajout d'un bloc CSS dans `css/style.css` ciblant `.page2 .export-btn, .page2 .btn-export, .page2 #exportBtn, .page2 #siteExportSubmitButton` pour appliquer fond blanc, bordure 1.5px #22c55e, texte vert, radius pill, padding, typographie et ombre légère.
- Ajout d'un état `:active` pour l'effet tactile (`transform: scale(0.97)` et `background: #f0fdf4`).
- Les sélecteurs sont strictement scoped à `.page2` et incluent l'ID du bouton d'export de la modale afin de ne pas impacter Page 1, Page 3, le header, d'autres boutons ou la logique JS.

### Testing
- Aucun test automatisé exécuté (modification CSS uniquement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f314a4072c832a913c05a1524f5764)