### PR TITLE
Add "Modifier le nom" action and rename modal on Page 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,26 @@
         </form>
       </dialog>
 
+      <dialog id="siteEditNameDialog" class="modal-card">
+        <form class="modal-content modal-content--site-create" id="siteEditNameForm">
+          <div class="modal-header">
+            <h2>Modifier le nom du site</h2>
+          </div>
+          <label class="input-group input-group--site-create">
+            <span>Nom du site</span>
+            <input id="siteEditNameInput" name="siteEditName" type="text" maxlength="25" />
+            <div class="site-input-feedback-row">
+              <p id="siteEditNameError" class="form-error" aria-live="polite"></p>
+              <span id="siteEditNameCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
+            </div>
+          </label>
+          <div class="modal-actions modal-actions--split modal-actions--site-create">
+            <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
+            <button id="siteEditNameSubmitButton" type="submit" class="btn btn-success">Enregistrer</button>
+          </div>
+        </form>
+      </dialog>
+
       <dialog id="siteLockDialog" class="modal-card">
         <form class="modal-content" id="siteLockForm">
           <div class="modal-header">

--- a/js/app.js
+++ b/js/app.js
@@ -900,6 +900,12 @@ import { firebaseAuth } from './firebase-core.js';
     const siteNameCounter = requireElement('siteNameCounter');
     const siteFormError = requireElement('siteFormError');
     const siteCreateSubmitButton = requireElement('siteCreateSubmitButton');
+    const siteEditNameDialog = requireElement('siteEditNameDialog');
+    const siteEditNameForm = requireElement('siteEditNameForm');
+    const siteEditNameInput = requireElement('siteEditNameInput');
+    const siteEditNameCounter = requireElement('siteEditNameCounter');
+    const siteEditNameError = requireElement('siteEditNameError');
+    const siteEditNameSubmitButton = requireElement('siteEditNameSubmitButton');
     const homeMenuButton = requireElement('homeMenuButton');
     const homeMenuPanel = requireElement('homeMenuPanel');
     const importDataButton = requireElement('importDataButton');
@@ -950,6 +956,8 @@ import { firebaseAuth } from './firebase-core.js';
     const transientErrorTimers = new WeakMap();
     let isSiteCreationPending = false;
     let siteNameErrorClearTimer = null;
+    let siteNameEditErrorClearTimer = null;
+    let isSiteNameEditPending = false;
     const siteLockFieldStateTimers = new WeakMap();
     let isSiteUnlockPending = false;
     let isSiteLockManageUpdatePending = false;
@@ -967,6 +975,10 @@ import { firebaseAuth } from './firebase-core.js';
 
     function getSiteNameMaxLength() {
       return siteNameInput.maxLength > 0 ? siteNameInput.maxLength : null;
+    }
+
+    function getSiteEditNameMaxLength() {
+      return siteEditNameInput?.maxLength > 0 ? siteEditNameInput.maxLength : 25;
     }
 
     function setSiteUnlockLoadingState(isLoading) {
@@ -1028,6 +1040,25 @@ import { firebaseAuth } from './firebase-core.js';
       }
     }
 
+    function updateSiteEditNameCounter() {
+      if (!siteEditNameInput || !siteEditNameCounter) {
+        return;
+      }
+      const maxLength = getSiteEditNameMaxLength();
+      if (siteEditNameInput.value.length > maxLength) {
+        siteEditNameInput.value = siteEditNameInput.value.slice(0, maxLength);
+      }
+      const currentLength = siteEditNameInput.value.length;
+      siteEditNameCounter.textContent = `${currentLength} / ${maxLength}`;
+      siteEditNameCounter.classList.remove('is-warning', 'is-limit');
+      const ratio = currentLength / maxLength;
+      if (ratio >= 1) {
+        siteEditNameCounter.classList.add('is-limit');
+      } else if (ratio >= 0.8) {
+        siteEditNameCounter.classList.add('is-warning');
+      }
+    }
+
     function clearTransientError(errorElement) {
       if (!errorElement) {
         return;
@@ -1058,6 +1089,33 @@ import { firebaseAuth } from './firebase-core.js';
       siteNameErrorClearTimer = window.setTimeout(() => {
         clearSiteNameErrorState();
       }, durationMs);
+    }
+
+    function clearSiteEditNameErrorState() {
+      if (siteNameEditErrorClearTimer) {
+        window.clearTimeout(siteNameEditErrorClearTimer);
+        siteNameEditErrorClearTimer = null;
+      }
+      siteEditNameInput?.classList.remove('is-error', 'is-shaking');
+    }
+
+    function showSiteEditNameError(message, durationMs = 2300) {
+      clearSiteEditNameErrorState();
+      showTransientError(siteEditNameError, message);
+      siteEditNameInput?.classList.remove('is-shaking');
+      void siteEditNameInput?.offsetWidth;
+      siteEditNameInput?.classList.add('is-error', 'is-shaking');
+      siteNameEditErrorClearTimer = window.setTimeout(() => {
+        clearSiteEditNameErrorState();
+      }, durationMs);
+    }
+
+    function setSiteEditNameLoadingState(isLoading) {
+      isSiteNameEditPending = Boolean(isLoading);
+      if (!siteEditNameSubmitButton) {
+        return;
+      }
+      siteEditNameSubmitButton.disabled = isSiteNameEditPending;
     }
 
     function showTransientError(errorElement, message) {
@@ -1374,6 +1432,11 @@ import { firebaseAuth } from './firebase-core.js';
               <span id="siteActionLockToggleLabel">Verrouiller</span>
             </button>
             <div class="item-action-sheet__divider" aria-hidden="true"></div>
+            <button type="button" class="item-action-sheet__row" id="siteActionEditNameButton">
+              <img src="Icon/crayon-de-blog.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
+              <span>Modifier le nom</span>
+            </button>
+            <div class="item-action-sheet__divider" aria-hidden="true"></div>
             <button type="button" class="item-action-sheet__row item-action-sheet__row--danger" id="siteActionDeleteButton">
               <img src="Icon/poubelle.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
               <span>Supprimer</span>
@@ -1554,8 +1617,9 @@ import { firebaseAuth } from './firebase-core.js';
       const title = overlay.querySelector('#siteActionSheetTitle');
       const lockToggleButton = overlay.querySelector('#siteActionLockToggleButton');
       const lockToggleLabel = overlay.querySelector('#siteActionLockToggleLabel');
+      const editNameButton = overlay.querySelector('#siteActionEditNameButton');
       const deleteButton = overlay.querySelector('#siteActionDeleteButton');
-      if (!sheet || !title || !lockToggleButton || !lockToggleLabel || !deleteButton) {
+      if (!sheet || !title || !lockToggleButton || !lockToggleLabel || !editNameButton || !deleteButton) {
         return;
       }
       const closeTransitionDurationMs = 280;
@@ -1636,6 +1700,21 @@ import { firebaseAuth } from './firebase-core.js';
       lockToggleButton.onclick = async () => {
         await closeSheet();
         openSiteLockActionDialog(siteId);
+      };
+      editNameButton.onclick = async () => {
+        await closeSheet();
+        const targetSite = getLatestSiteState(siteId);
+        if (!targetSite || !siteEditNameDialog || !siteEditNameInput) {
+          return;
+        }
+        siteActionState.activeSiteId = siteId;
+        siteEditNameInput.value = String(targetSite.nom || '').trim();
+        clearTransientError(siteEditNameError);
+        clearSiteEditNameErrorState();
+        setSiteEditNameLoadingState(false);
+        updateSiteEditNameCounter();
+        siteEditNameDialog.showModal();
+        siteEditNameInput.focus();
       };
       deleteButton.onclick = async () => {
         const latestSiteState = getLatestSiteState(siteId);
@@ -1904,11 +1983,29 @@ import { firebaseAuth } from './firebase-core.js';
         event.preventDefault();
       }
     });
+    siteEditNameInput?.addEventListener('beforeinput', (event) => {
+      const maxLength = getSiteEditNameMaxLength();
+      if (!maxLength || event.inputType.startsWith('delete')) {
+        return;
+      }
+      const selectionStart = siteEditNameInput.selectionStart ?? siteEditNameInput.value.length;
+      const selectionEnd = siteEditNameInput.selectionEnd ?? siteEditNameInput.value.length;
+      const selectedLength = Math.max(0, selectionEnd - selectionStart);
+      const nextAllowedLength = maxLength - (siteEditNameInput.value.length - selectedLength);
+      if (nextAllowedLength <= 0) {
+        event.preventDefault();
+      }
+    });
 
     siteNameInput.addEventListener('input', () => {
       clearTransientError(siteFormError);
       clearSiteNameErrorState();
       updateSiteNameCounter();
+    });
+    siteEditNameInput?.addEventListener('input', () => {
+      clearTransientError(siteEditNameError);
+      clearSiteEditNameErrorState();
+      updateSiteEditNameCounter();
     });
 
     siteDialog.addEventListener('close', () => {
@@ -1916,6 +2013,12 @@ import { firebaseAuth } from './firebase-core.js';
       clearSiteNameErrorState();
       setSiteCreateLoadingState(false);
       updateSiteNameCounter();
+    });
+    siteEditNameDialog?.addEventListener('close', () => {
+      clearTransientError(siteEditNameError);
+      clearSiteEditNameErrorState();
+      setSiteEditNameLoadingState(false);
+      updateSiteEditNameCounter();
     });
 
     siteForm.addEventListener('submit', async (event) => {
@@ -1954,6 +2057,51 @@ import { firebaseAuth } from './firebase-core.js';
         console.error('Erreur lors de la création du site :', error);
         showSiteNameError("Impossible d'enregistrer le site. Vérifiez Firestore et réessayez.");
         setSiteCreateLoadingState(false);
+      }
+    });
+    siteEditNameForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (isSiteNameEditPending) {
+        return;
+      }
+      const siteId = siteActionState.activeSiteId;
+      const targetSite = getLatestSiteState(siteId);
+      if (!siteId || !targetSite) {
+        siteEditNameDialog?.close();
+        return;
+      }
+      const currentName = String(targetSite.nom || '').trim();
+      const nextName = String(siteEditNameInput?.value || '').trim();
+      if (!nextName) {
+        showSiteEditNameError('Veuillez entrer un nom de site.');
+        return;
+      }
+      if (nextName.length < 4) {
+        showSiteEditNameError('Le nom doit contenir au moins 4 caractères.');
+        return;
+      }
+      if (nextName.length > 25) {
+        showSiteEditNameError('Le nom doit contenir au maximum 25 caractères.');
+        return;
+      }
+      if (nextName === currentName) {
+        siteEditNameDialog?.close();
+        return;
+      }
+      try {
+        setSiteEditNameLoadingState(true);
+        const result = await StorageService.updateSiteName(siteId, nextName);
+        if (!result?.ok) {
+          showSiteEditNameError(result?.reason === 'duplicate_site' ? 'Ce nom de site existe déjà.' : 'Modification impossible.');
+          setSiteEditNameLoadingState(false);
+          return;
+        }
+        setSiteEditNameLoadingState(false);
+        siteEditNameDialog?.close();
+        UiService.showToast('Nom du site mis à jour.');
+      } catch (_error) {
+        showSiteEditNameError("Impossible d'enregistrer le nom du site.");
+        setSiteEditNameLoadingState(false);
       }
     });
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1021,6 +1021,42 @@ async function createSite(name) {
   return { ok: true, id: site.id };
 }
 
+async function updateSiteName(siteId, name) {
+  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
+  if (siteIndex === -1) {
+    return { ok: false, reason: 'site_not_found' };
+  }
+
+  const siteName = sanitizeText(name, true);
+  if (!siteName) {
+    return { ok: false, reason: 'invalid_name' };
+  }
+
+  const hasDuplicate = state.sites.some(
+    (site, index) => index !== siteIndex && sanitizeText(site.nom, true) === siteName,
+  );
+  if (hasDuplicate) {
+    return { ok: false, reason: 'duplicate_site' };
+  }
+
+  const timestamp = nowIso();
+  await setDoc(
+    doc(state.db, 'pages', 'page1', 'items', siteId),
+    { nom: siteName, dateModification: timestamp },
+    { merge: true },
+  );
+
+  state.sites[siteIndex] = {
+    ...state.sites[siteIndex],
+    nom: siteName,
+    dateModification: timestamp,
+  };
+  sortState();
+  persistOfflineState();
+  emitAll();
+  return { ok: true };
+}
+
 async function setSiteLock(siteId, lockPayload) {
   const siteIndex = state.sites.findIndex((site) => site.id === siteId);
   if (siteIndex === -1) {
@@ -1613,6 +1649,7 @@ window.StorageService = {
   getDetailRowsBySite,
   getAllDetails,
   createSite,
+  updateSiteName,
   setSiteLock,
   clearSiteLock,
   removeSite,


### PR DESCRIPTION
### Motivation
- Permettre la modification du nom d’un site depuis le bottom sheet de la Page 1 en réutilisant les composants existants et sans ajouter de nouveau CSS modal. 
- Assurer une expérience cohérente avec les autres actions du sheet (Verrouiller / Supprimer) et une mise à jour immédiate des données affichées.

### Description
- Ajout du modal de renommage dans `index.html` avec la même structure et classes que les modals existants (`#siteEditNameDialog`, champ `#siteEditNameInput`, compteur `#siteEditNameCounter`, erreur `#siteEditNameError`).
- Ajout du bouton `Modifier le nom` dans le bottom sheet de Page 1 en réutilisant l’icône existante `Icon/crayon-de-blog.png` et les classes visuelles existantes pour garantir un rendu identique aux autres lignes du sheet (`js/app.js`).
- Implémentation du flux client dans `js/app.js` incluant pré-remplissage du nom courant, compteur dynamique (max 25), enforcement `beforeinput`, validation (`trim()`, requis, min 4, max 25), affichage d’erreurs via le système existant (`is-error` / `is-shaking`), et fermeture sans modification si le nom est inchangé.
- Ajout de la méthode `updateSiteName(siteId, name)` dans `js/storage.js` qui vérifie les doublons, met à jour Firestore sur `pages/page1/items/{siteId}`, met à jour l’état local et émet les changements pour un rafraîchissement immédiat.

### Testing
- Vérification statique des fichiers modifiés avec `node --check js/app.js` qui a réussi.
- Vérification statique des fichiers modifiés avec `node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3255e23ac832a9b60377f2720df5a)