### PR TITLE
Fix character counter styling in site name edit modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3622,6 +3622,47 @@ body[data-page="home"] #siteDialog #siteNameCounter {
   opacity: 1;
 }
 
+
+body[data-page="home"] #siteEditNameDialog .input-group--site-create {
+  position: relative;
+}
+
+body[data-page="home"] #siteEditNameDialog .site-input-feedback-row {
+  width: 100%;
+  margin-top: 0.24rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+body[data-page="home"] #siteEditNameDialog #siteEditNameError {
+  width: auto;
+  margin-top: 0;
+  text-align: left;
+  color: #c95e68;
+  font-size: 0.82rem;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+body[data-page="home"] #siteEditNameDialog #siteEditNameCounter,
+body[data-page="home"] #siteEditNameDialog #siteEditNameCounter.is-warning,
+body[data-page="home"] #siteEditNameDialog #siteEditNameCounter.is-limit {
+  display: block;
+  width: auto;
+  text-align: right;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 0;
+  flex-shrink: 0;
+  font-size: 12px;
+  line-height: 1.2;
+  color: #9e9e9e;
+  font-weight: 400;
+  opacity: 1;
+}
+
 body[data-page="home"] #siteDialog #siteNameInput {
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }


### PR DESCRIPTION
### Motivation
- The character counter in the “Modifier le nom du site” modal was visually inconsistent with the reference modal and needed a scoped CSS fix so only that modal is affected.

### Description
- Added scoped CSS rules under `body[data-page="home"] #siteEditNameDialog` to set the wrapper to `position: relative` and align the feedback row layout to match other modals.
- Overrode the counter styles for `#siteEditNameCounter` (and its `.is-warning`/`.is-limit` variants) to be small, muted gray, right-aligned, and with compact spacing so it matches the `Nouveau numéro OUT` counter.
- Ensured the change is local to the edit modal and does not touch other counters, JS logic, validation, or buttons.

### Testing
- Searched for relevant selectors with `rg` to confirm impacted files and scope of selectors and inspected the updated `css/style.css` content to verify the inserted block contains the new rules for `#siteEditNameDialog` and `#siteEditNameCounter`.
- Printed relevant file sections with `nl`/`sed` to confirm line-level placement and that the counter styles match the reference appearance.
- Verified the repository reflects the saved CSS change and no JavaScript or validation files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35c1e46f8832aabecb225f2ffd429)