### PR TITLE
Add consistent error styling to edit site name modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3663,6 +3663,15 @@ body[data-page="home"] #siteEditNameDialog #siteEditNameCounter.is-limit {
   opacity: 1;
 }
 
+body[data-page="home"] #siteEditNameDialog #siteEditNameInput.input-error,
+body[data-page="home"] #siteEditNameDialog #siteEditNameInput.input-error:focus {
+  border: 2px solid #ef4444 !important;
+}
+
+body[data-page="home"] #siteEditNameDialog #siteEditNameInput.is-shaking {
+  animation: site-name-input-shake 300ms ease-in-out 1;
+}
+
 body[data-page="home"] #siteDialog #siteNameInput {
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -1096,7 +1096,7 @@ import { firebaseAuth } from './firebase-core.js';
         window.clearTimeout(siteNameEditErrorClearTimer);
         siteNameEditErrorClearTimer = null;
       }
-      siteEditNameInput?.classList.remove('is-error', 'is-shaking');
+      siteEditNameInput?.classList.remove('input-error', 'is-error', 'is-shaking');
     }
 
     function showSiteEditNameError(message, durationMs = 2300) {
@@ -1104,7 +1104,7 @@ import { firebaseAuth } from './firebase-core.js';
       showTransientError(siteEditNameError, message);
       siteEditNameInput?.classList.remove('is-shaking');
       void siteEditNameInput?.offsetWidth;
-      siteEditNameInput?.classList.add('is-error', 'is-shaking');
+      siteEditNameInput?.classList.add('input-error', 'is-error', 'is-shaking');
       siteNameEditErrorClearTimer = window.setTimeout(() => {
         clearSiteEditNameErrorState();
       }, durationMs);


### PR DESCRIPTION
### Motivation
- Improve visual consistency by adding the same red error border and existing shake effect to the "Modifier le nom du site" modal input without changing layout or duplicating CSS.
- Reuse existing project animation and classes so the error state matches other forms and modals exactly.

### Description
- Added CSS rules in `css/style.css` to apply a `2px solid #ef4444` red border via the `input-error` class scoped to `#siteEditNameDialog` and to reuse the existing `site-name-input-shake` animation when the input has `is-shaking`.
- Updated `js/app.js` to add/remove the new `input-error` class alongside the existing `is-error` and `is-shaking` classes in `showSiteEditNameError` and `clearSiteEditNameErrorState` so JS triggers the same shake animation and the red border.
- Did not add new `@keyframes` or create any new animations, and did not change any layout/position/margins or other modals.
- Files changed: `css/style.css`, `js/app.js`.

### Testing
- Ran project searches with `rg` to confirm existing shake animations and to ensure no duplicate keyframes were introduced, and the searches completed successfully.
- Verified changes with `git diff -- css/style.css js/app.js` which showed the added CSS and JS updates and succeeded.
- Committed the changes with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36277aa60832ab467f49504fb65e3)