### PR TITLE
Hide Magasin field in edit OUT modal only

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3588,6 +3588,10 @@ body[data-page="site-detail"] #itemDialog .modal-actions--item-create {
   margin-top: 0.62rem;
 }
 
+body[data-page="site-detail"] #itemDialog.edit-out-modal .magasin-group {
+  display: none !important;
+}
+
 body[data-page="site-detail"] #itemDialog #itemCreateSubmitButton.is-loading {
   gap: 0.45rem;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -3088,6 +3088,7 @@ import { firebaseAuth } from './firebase-core.js';
     function setItemDialogMode(mode, targetItem = null) {
       itemDialogMode = mode === ITEM_DIALOG_MODE_EDIT ? ITEM_DIALOG_MODE_EDIT : ITEM_DIALOG_MODE_CREATE;
       editingItemId = itemDialogMode === ITEM_DIALOG_MODE_EDIT ? targetItem?.id || null : null;
+      itemDialog.classList.toggle('edit-out-modal', itemDialogMode === ITEM_DIALOG_MODE_EDIT);
       if (itemDialogTitle) {
         itemDialogTitle.textContent = itemDialogMode === ITEM_DIALOG_MODE_EDIT ? 'Modifier le nom OUT' : 'Nouveau numéro OUT';
       }

--- a/page2.html
+++ b/page2.html
@@ -91,8 +91,8 @@
               <span id="itemNumberCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
             </div>
           </label>
-          <label class="input-group input-group--site-create input-group--item-create">
-            <span>Magasin</span>
+          <label class="input-group input-group--site-create input-group--item-create magasin-group">
+            <span class="magasin-label">Magasin</span>
             <select id="itemStoreSelect" name="itemStore">
               <option value="">-- Sélectionner --</option>
               <option value="TIT I">TITAN I</option>


### PR DESCRIPTION
### Motivation
- Simplifier l’UI du modal « Modifier le nom OUT » en masquant le champ `Magasin` et son libellé sans supprimer le champ du DOM ni impacter le modal de création.
- Cibler uniquement le modal d’édition pour éviter tout effet secondaire global ou espace vide dans le layout.

### Description
- Ajout de la classe structurelle `magasin-group` sur le bloc Magasin et `magasin-label` sur le label dans `page2.html` pour pouvoir le cibler proprement.
- Ajout d’une règle CSS scoped `body[data-page="site-detail"] #itemDialog.edit-out-modal .magasin-group { display: none !important; }` dans `css/style.css` pour masquer le groupe uniquement en mode édition.
- Application d’une classe d’état `edit-out-modal` sur le dialog via `itemDialog.classList.toggle('edit-out-modal', ...)` dans `js/app.js` depuis la fonction `setItemDialogMode` pour activer le comportement en mode `ITEM_DIALOG_MODE_EDIT`.
- Le champ `Magasin` reste présent dans le DOM et le comportement du modal de création reste inchangé.

### Testing
- Exécution des patchs via les outils d’application de patch (`apply_patch`) a réussi et les fichiers `page2.html`, `css/style.css` et `js/app.js` ont été modifiés comme prévu.
- Vérification du contenu avec `rg`/`sed` pour localiser les modifications et visualiser les blocs a réussi et a confirmé les changements ciblés.
- Ajout et commit des fichiers avec `git add` + `git commit` ont réussi et ont produit un commit contenant les modifications décrites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3678fced4832a901842960fd59956)