### PR TITLE
Page 2: Edit OUT modal — strip `OUT-` prefix, enforce maxlength and validation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2975,7 +2975,8 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     function normalizeItemNumberInput(rawValue) {
-      const digitsOnly = String(rawValue || '').replace(/\D/g, '');
+      const normalizedRawValue = String(rawValue || '').trim().replace(/^out-/i, '');
+      const digitsOnly = normalizedRawValue.replace(/\D/g, '');
       const maxLength = getItemNumberMaxLength();
       if (!maxLength) {
         return digitsOnly;
@@ -3104,10 +3105,10 @@ import { firebaseAuth } from './firebase-core.js';
         loadingLabel.textContent = itemDialogMode === ITEM_DIALOG_MODE_EDIT ? 'Enregistrement...' : 'Création...';
       }
       if (itemDialogMode === ITEM_DIALOG_MODE_EDIT) {
-        itemNumberInput.removeAttribute('inputmode');
-        itemNumberInput.removeAttribute('pattern');
-        itemNumberInput.placeholder = 'Exemple : OUT-26050200';
-        itemNumberInput.value = String(targetItem?.numero || '').trim();
+        itemNumberInput.setAttribute('inputmode', 'numeric');
+        itemNumberInput.setAttribute('pattern', '[0-9]*');
+        itemNumberInput.placeholder = 'Exemple : 26050200';
+        itemNumberInput.value = normalizeItemNumberInput(targetItem?.numero || '');
       } else {
         itemNumberInput.setAttribute('inputmode', 'numeric');
         itemNumberInput.setAttribute('pattern', '[0-9]*');
@@ -3177,11 +3178,9 @@ import { firebaseAuth } from './firebase-core.js';
     });
 
     itemNumberInput.addEventListener('input', () => {
-      if (itemDialogMode === ITEM_DIALOG_MODE_CREATE) {
-        const normalizedValue = normalizeItemNumberInput(itemNumberInput.value);
-        if (itemNumberInput.value !== normalizedValue) {
-          itemNumberInput.value = normalizedValue;
-        }
+      const normalizedValue = normalizeItemNumberInput(itemNumberInput.value);
+      if (itemNumberInput.value !== normalizedValue) {
+        itemNumberInput.value = normalizedValue;
       }
       clearItemFormError();
       clearItemNumberErrorState();
@@ -3315,7 +3314,9 @@ import { firebaseAuth } from './firebase-core.js';
       if (itemCreateSubmitButton.disabled) {
         return;
       }
-      const value = itemNumberInput.value.trim();
+      const value = normalizeItemNumberInput(itemNumberInput.value.trim());
+      itemNumberInput.value = value;
+      const maxLength = getItemNumberMaxLength();
       if (itemDialogMode === ITEM_DIALOG_MODE_EDIT) {
         if (!value) {
           showItemFormError('Veuillez entrer un nom OUT.');
@@ -3323,6 +3324,10 @@ import { firebaseAuth } from './firebase-core.js';
         }
         if (value.length < 4) {
           showItemFormError('Le nom doit contenir au moins 4 caractères.');
+          return;
+        }
+        if (maxLength && value.length > maxLength) {
+          showItemFormError(`Le nom OUT ne peut pas dépasser ${maxLength} caractères.`);
           return;
         }
       } else {


### PR DESCRIPTION
### Motivation
- Make the Page 2 modal “Modifier le nom OUT” show only the numeric portion of an OUT (`OUT-` removed) while keeping the final stored/displayed format with the `OUT-` prefix.
- Reuse existing input blocking/counter behavior (no new counter/CSS/design changes) and ensure user input is automatically cleaned when they type or paste `OUT-`.
- Enforce the project validation rules for this field: required, trimmed, digits-only, minimum 4 and maximum 10 characters.

### Description
- Updated `js/app.js` to change `normalizeItemNumberInput` so it strips a leading `OUT-` (case-insensitive), keeps digits only, and applies the `maxlength` truncation.
- In `setItemDialogMode` the edit path now pre-fills `itemNumberInput.value` with the normalized numeric part instead of the full `OUT-xxxx` string.
- Normalization is applied on every `input` and before `submit`; the submit handler now sets `itemNumberInput.value` to the normalized value and enforces the max length check before calling `StorageService`.
- Left existing `beforeinput`, `paste` handlers and the dynamic counter (`maxlength` = 10) intact so the input blocks at the limit and the counter shows `current / 10`, and storage still reconstructs `OUT-` as required (no CSS/design/button changes, only `js/app.js` modified).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36a4b14b4832abc5cca43fc1482e6)