### PR TITLE
Fix locked-site bottom sheet actions on Page 1

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1693,6 +1693,10 @@ import { firebaseAuth } from './firebase-core.js';
         const siteIsLocked = isSiteLocked(latestSite);
         const canDeleteSite = isAuthenticated && currentPermissions.canDelete && !siteIsLocked;
         lockToggleLabel.textContent = siteIsLocked ? 'Déverrouiller' : 'Verrouiller';
+        const canEditSiteName = !siteIsLocked;
+        editNameButton.hidden = !canEditSiteName;
+        editNameButton.style.display = canEditSiteName ? 'inline-flex' : 'none';
+        editNameButton.disabled = !canEditSiteName;
         deleteButton.hidden = !canDeleteSite;
         deleteButton.style.display = canDeleteSite ? 'inline-flex' : 'none';
         deleteButton.disabled = !canDeleteSite;
@@ -1761,8 +1765,13 @@ import { firebaseAuth } from './firebase-core.js';
         openSiteLockActionDialog(siteId);
       };
       editNameButton.onclick = async () => {
-        await closeSheet();
         const targetSite = getLatestSiteState(siteId);
+        if (isSiteLocked(targetSite)) {
+          UiService.showToast('Impossible de modifier le nom tant que le site est verrouillé.');
+          refreshSiteActionSheetContent();
+          return;
+        }
+        await closeSheet();
         if (!targetSite || !siteEditNameDialog || !siteEditNameInput) {
           return;
         }
@@ -2147,6 +2156,11 @@ import { firebaseAuth } from './firebase-core.js';
       const targetSite = getLatestSiteState(siteId);
       if (!siteId || !targetSite) {
         siteEditNameDialog?.close();
+        return;
+      }
+      if (isSiteLocked(targetSite)) {
+        siteEditNameDialog?.close();
+        UiService.showToast('Impossible de modifier le nom tant que le site est verrouillé.');
         return;
       }
       const currentName = String(targetSite.nom || '').trim();


### PR DESCRIPTION
### Motivation
- The site action bottom sheet allowed the "Modifier le nom" action even when a site was locked, which contradicts the intended lock UX/rules. 
- The change enforces the rule that locked sites must show an unlock action and hide/disable sensitive actions like renaming. 

### Description
- Updated `refreshSiteActionSheetContent` in `js/app.js` to compute `canEditSiteName = !siteIsLocked` and hide/disable the `siteActionEditNameButton` when the site is locked. 
- Added a runtime guard in the `editNameButton.onclick` handler to show a toast and abort if `isSiteLocked(targetSite)` is true, preventing the bottom-sheet from opening the rename modal. 
- Added a submit-time guard in the `siteEditNameForm` handler to block rename attempts if the target site is locked and to close the dialog with a toast. 
- Only `js/app.js` (Page 1 behavior) was modified and Page 2 and Page 3 files were left unchanged. 

### Testing
- Located and reviewed the modified code with `rg -n` and inspected relevant ranges using `sed -n '1460,1775p' js/app.js` and `sed -n '2128,2188p' js/app.js`, confirming the new branches were present and correct. 
- Verified the updated lines and context using `nl -ba js/app.js | sed -n '1688,1778p'` and `nl -ba js/app.js | sed -n '2140,2175p'` to ensure the visibility and guard logic were injected in the expected places. 
- No unit test suite exists for this code path; static inspections completed successfully and there were no syntax issues reported by the file inspections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f373f90c08832a85b5fb44174a528a)