### PR TITLE
Reorganize Page 1 header: move 3-dot button left, avatar right, convert menu to left drawer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5112,3 +5112,70 @@ body[data-page="site-detail"] .page2-header-subtitle .outs-label {
   transform: scale(0.97) !important;
   background: #f0fdf4 !important;
 }
+
+/* Home header reorganization: actions left + avatar right + drawer */
+body[data-page="home"] .app-header__side--right {
+  gap: 0.45rem;
+}
+
+.avatar-button--with-arrow {
+  position: relative;
+  padding-right: 0.78rem;
+}
+
+.avatar-button__chevron {
+  position: absolute;
+  right: 0.18rem;
+  bottom: 0.18rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2a37;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.55rem;
+  line-height: 1;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.home-menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background: rgba(15, 23, 42, 0);
+  pointer-events: none;
+  transition: background 220ms ease;
+}
+
+.home-menu-overlay.is-open {
+  background: rgba(15, 23, 42, 0.42);
+  pointer-events: auto;
+}
+
+.header-menu__drawer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: auto;
+  width: min(280px, 80vw);
+  height: 100%;
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding: 1rem 0.55rem;
+  display: grid;
+  align-content: start;
+  gap: 0.35rem;
+  transform: translateX(-102%);
+  opacity: 1;
+  transition: transform 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.home-menu-overlay.is-open .header-menu__drawer {
+  transform: translateX(0);
+}
+
+body[data-page="home"] .header-menu__panel.is-closing {
+  opacity: 1;
+  transform: translateX(-102%);
+}

--- a/index.html
+++ b/index.html
@@ -11,15 +11,6 @@
     <div class="app-shell">
       <header class="app-header app-header--home">
         <div class="app-header__side app-header__side--left">
-          <button id="userAvatarButton" class="avatar-button" type="button" aria-label="Profil" hidden>U</button>
-          <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
-        </div>
-        <div class="app-header__center">
-          <div class="header-title">
-            <h1>Suivi Matériel</h1>
-          </div>
-        </div>
-        <div class="app-header__side app-header__side--right">
           <div class="header-menu">
             <button
               id="homeMenuButton"
@@ -31,24 +22,40 @@
             >
               <img src="Icon/Trois point.png" alt="" aria-hidden="true" class="header-menu__icon" />
             </button>
-            <div id="homeMenuPanel" class="header-menu__panel" role="menu" hidden>
-              <button id="historyButton" class="header-menu__option" type="button" role="menuitem">
-                Historiques
-              </button>
-              <button id="importDataButton" class="header-menu__option" type="button" role="menuitem">
-                Importer les données
-              </button>
-              <button id="exportDataButton" class="header-menu__option" type="button" role="menuitem">
-                Exporter les données
-              </button>
-              <button id="manageUsersButton" class="header-menu__option" type="button" role="menuitem" hidden>
-                Gestion des utilisateurs
-              </button>
-            </div>
           </div>
         </div>
+        <div class="app-header__center">
+          <div class="header-title">
+            <h1>Suivi Matériel</h1>
+          </div>
+        </div>
+        <div class="app-header__side app-header__side--right">
+          <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
+          <button id="userAvatarButton" class="avatar-button avatar-button--with-arrow" type="button" aria-label="Profil" hidden>
+            <span class="avatar-button__chevron" aria-hidden="true">▾</span>
+            U
+          </button>
+        </div>
       </header>
- 
+
+      <div id="homeMenuOverlay" class="home-menu-overlay" hidden>
+        <aside id="homeMenuPanel" class="header-menu__panel header-menu__drawer" role="menu" aria-label="Menu principal">
+          <button id="historyButton" class="header-menu__option" type="button" role="menuitem">
+            Historiques
+          </button>
+          <button id="importDataButton" class="header-menu__option" type="button" role="menuitem">
+            Importer les données
+          </button>
+          <button id="exportDataButton" class="header-menu__option" type="button" role="menuitem">
+            Exporter les données
+          </button>
+          <button id="manageUsersButton" class="header-menu__option" type="button" role="menuitem" hidden>
+            Gestion des utilisateurs
+          </button>
+        </aside>
+      </div>
+
+
       <main class="page-content">
         <section class="search-panel surface-card section">
           <label class="input-group">

--- a/js/app.js
+++ b/js/app.js
@@ -908,6 +908,7 @@ import { firebaseAuth } from './firebase-core.js';
     const siteEditNameSubmitButton = requireElement('siteEditNameSubmitButton');
     const homeMenuButton = requireElement('homeMenuButton');
     const homeMenuPanel = requireElement('homeMenuPanel');
+    const homeMenuOverlay = requireElement('homeMenuOverlay');
     const importDataButton = requireElement('importDataButton');
     const exportDataButton = requireElement('exportDataButton');
     const manageUsersButton = requireElement('manageUsersButton');
@@ -1346,7 +1347,10 @@ import { firebaseAuth } from './firebase-core.js';
       if (!homeMenuPanel) {
         return;
       }
-      homeMenuPanel.hidden = true;
+      if (homeMenuOverlay) {
+        homeMenuOverlay.hidden = true;
+        homeMenuOverlay.classList.remove('is-open');
+      }
       homeMenuPanel.classList.remove('is-open', 'is-closing');
     }
 
@@ -1359,7 +1363,7 @@ import { firebaseAuth } from './firebase-core.js';
         homeMenuCloseTimer = null;
       }
       homeMenuButton.setAttribute('aria-expanded', 'false');
-      if (homeMenuPanel.hidden || homeMenuPanel.classList.contains('is-closing')) {
+      if (!homeMenuOverlay || homeMenuOverlay.hidden || homeMenuPanel.classList.contains('is-closing')) {
         finalizeHomeMenuClose();
         return;
       }
@@ -1388,14 +1392,18 @@ import { firebaseAuth } from './firebase-core.js';
         window.clearTimeout(homeMenuCloseTimer);
         homeMenuCloseTimer = null;
       }
-      homeMenuPanel.hidden = false;
+      if (!homeMenuOverlay) {
+        return;
+      }
+      homeMenuOverlay.hidden = false;
       homeMenuPanel.classList.remove('is-closing');
       window.requestAnimationFrame(() => {
-        if (homeMenuPanel.hidden) {
+        if (homeMenuOverlay.hidden) {
           return;
         }
         homeMenuPanel.classList.add('is-open');
       });
+      homeMenuOverlay.classList.add('is-open');
       homeMenuButton.setAttribute('aria-expanded', 'true');
     }
 
@@ -1935,9 +1943,9 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
-    if (homeMenuButton && homeMenuPanel) {
+    if (homeMenuButton && homeMenuPanel && homeMenuOverlay) {
       homeMenuButton.addEventListener('click', () => {
-        if (homeMenuPanel.hidden) {
+        if (homeMenuOverlay.hidden) {
           openHomeMenu();
           return;
         }
@@ -1945,10 +1953,20 @@ import { firebaseAuth } from './firebase-core.js';
       });
 
       document.addEventListener('click', (event) => {
-        if (!event.target.closest('.header-menu')) {
+        const clickedInsideHeaderTrigger = event.target.closest('.header-menu');
+        const clickedInsideDrawer = event.target.closest('#homeMenuPanel');
+        if (!clickedInsideHeaderTrigger && !clickedInsideDrawer) {
           closeHomeMenu();
         }
       });
+
+      if (homeMenuOverlay) {
+        homeMenuOverlay.addEventListener('click', (event) => {
+          if (event.target === homeMenuOverlay) {
+            closeHomeMenu();
+          }
+        });
+      }
     }
 
     if (exportDataButton) {


### PR DESCRIPTION
### Motivation
- Simplifier et clarifier le header de la Page 1 en plaçant le bouton d’actions à gauche, le titre centré et l’avatar à droite, sans modifier les actions existantes.
- Afficher les choix du menu trois points dans une sidebar/side-drawer depuis la gauche pour une UX plus professionnelle et cohérente sur mobile/desktop.
- Réutiliser les icônes, textes et logique existants pour éviter toute régression sur les actions et l’authentification.

### Description
- HTML: refactorisé `index.html` pour Page 1 uniquement, en déplaçant `homeMenuButton` dans la colonne gauche, en plaçant `userAvatarButton` à droite avec un petit chevron, et en ajoutant le container `homeMenuOverlay` + `<aside id="homeMenuPanel" class="header-menu__drawer">` pour la drawer.
- CSS: ajouté styles pour la drawer (`.home-menu-overlay`, `.header-menu__drawer`) avec largeur `min(280px, 80vw)`, animation slide-in depuis la gauche, overlay sombre et style du chevron sur l’avatar, en réutilisant les variables et styles existants.
- JS: mis à jour `js/app.js` pour référencer `homeMenuOverlay`, adapter `openHomeMenu()` / `closeHomeMenu()` pour piloter l’overlay + drawer, fermer au clic hors drawer ou au clic sur l’overlay, et préserver les gestionnaires d’options (`history`, `import`, `export`, `manage users`) sans recréer leur logique.
- Portée: modifications limitées à Page 1 (fichiers touchés: `index.html`, `css/style.css`, `js/app.js`) et le menu avatar/auth existant n’a pas été modifié fonctionnellement.

### Testing
- ✅ JavaScript syntax check: `node --check js/app.js && node --check js/ui.js` (passé).
- ⚠️ Visual screenshot attempt with Playwright failed due to environment/npm policy (403), so no automated visual snapshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f397126e64832abd21c7664fd83430)