### PR TITLE
Align Page 1 burger button with detail headers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5180,19 +5180,21 @@ body[data-page="home"] .header-menu__panel.is-closing {
   transform: translateX(-102%);
 }
 
-/* Page 1: align left menu button and use centered burger icon */
-body[data-page="home"] .header-menu__trigger {
+/* Page 1: burger button alignment (scoped to home only) */
+.page1 .header-menu-btn {
+  width: 56px;
+  height: 56px;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   margin: 0;
-  transform: translateY(1px);
+  transform: translateY(0px);
 }
 
-body[data-page="home"] .header-menu__icon {
-  width: 22px;
-  height: 22px;
+.page1 .header-menu-btn img {
+  width: 24px;
+  height: 24px;
   object-fit: contain;
   display: block;
 }

--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
-  <body data-page="home">
+  <body data-page="home" class="page1">
     <div class="app-shell">
       <header class="app-header app-header--home">
         <div class="app-header__side app-header__side--left">
           <div class="header-menu">
             <button
               id="homeMenuButton"
-              class="icon-button header-menu__trigger"
+              class="icon-button header-menu__trigger header-menu-btn"
               type="button"
               aria-label="Plus d'options"
               aria-haspopup="menu"


### PR DESCRIPTION
### Motivation
- Make the Page 1 (home) burger menu button visually align with the header controls used on Page 2 / Page 3 (same vertical centering, visual height and spacing) without changing the global header, its height, title text, avatar, or other pages.
- Scope the fix to Page 1 only to avoid side effects on other headers.

### Description
- Add `class="page1"` to the `<body>` in `index.html` and add a dedicated `header-menu-btn` class to the Page 1 burger button to enable page-scoped styling.
- Introduce `.page1 .header-menu-btn` CSS rules in `css/style.css` to set button size to `56x56`, center content with flexbox, zero `padding`/`margin`, and apply `transform: translateY(0px)` as the micro-adjust baseline.
- Add `.page1 .header-menu-btn img` rules to size the icon to `24x24` with `object-fit: contain` and `display: block`, while keeping the existing `Icon/menu-burger.png` asset.
- No changes were made to the global header layout, header height, the title text, the avatar, Page 2, or Page 3.

### Testing
- Searched codebase for relevant selectors with `rg` to locate header/button usage and confirmed targets were correct, and the search completed successfully.
- Inspected and printed file fragments with `sed`/`nl` to verify the new `body` class and CSS lines were placed as intended, and outputs matched expectations.
- Applied the edits via a small script and verified changes with `git diff -- index.html css/style.css`, and then committed with `git add` + `git commit`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39dd4b7e4832a837ab5e7a6fb823d)