### PR TITLE
Use shared header button style for Page 1 burger button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5180,21 +5180,3 @@ body[data-page="home"] .header-menu__panel.is-closing {
   transform: translateX(-102%);
 }
 
-/* Page 1: burger button alignment (scoped to home only) */
-.page1 .header-menu-btn {
-  width: 56px;
-  height: 56px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  margin: 0;
-  transform: translateY(0px);
-}
-
-.page1 .header-menu-btn img {
-  width: 24px;
-  height: 24px;
-  object-fit: contain;
-  display: block;
-}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
           <div class="header-menu">
             <button
               id="homeMenuButton"
-              class="icon-button header-menu__trigger header-menu-btn"
+              class="back-button header-menu__trigger"
               type="button"
               aria-label="Plus d'options"
               aria-haspopup="menu"


### PR DESCRIPTION
### Motivation
- Make the Page 1 burger menu button visually identical to the existing header buttons used on Page 2 / Page 3 by reusing the existing header button CSS and avoiding any new CSS or classes.

### Description
- Replaced the Page 1 burger button classes in `index.html` from `icon-button header-menu__trigger header-menu-btn` to `back-button header-menu__trigger` and removed the Page 1-specific CSS rules `.page1 .header-menu-btn` and `.page1 .header-menu-btn img` from `css/style.css`, keeping the `Icon/menu-burger.png` icon and the existing menu/sidebar behavior unchanged.

### Testing
- No automated test suite is present in the project; changes were validated by inspecting the file diffs with `git diff -- index.html css/style.css` and confirming the commit, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ffa6ca4832a9caac6e54359fe31)