### PR TITLE
Align Page 1 burger menu with Page 2 header layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5118,6 +5118,29 @@ body[data-page="home"] .app-header__side--right {
   gap: 0.45rem;
 }
 
+body[data-page="home"] .header-menu {
+  margin-left: 0;
+  align-self: auto;
+}
+
+body[data-page="home"] #homeMenuButton {
+  width: 2.65rem;
+  height: 2.65rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background 0.2s ease, transform 0.2s ease;
+  margin: 0;
+  position: static;
+  top: auto;
+  bottom: auto;
+  transform: none;
+  align-self: auto;
+}
+
 .avatar-button--with-arrow {
   position: relative;
   padding-right: 0.78rem;
@@ -5179,4 +5202,3 @@ body[data-page="home"] .header-menu__panel.is-closing {
   opacity: 1;
   transform: translateX(-102%);
 }
-

--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
   </head>
   <body data-page="home" class="page1">
     <div class="app-shell">
-      <header class="app-header app-header--home">
+      <header class="app-header app-header--home page1-header">
         <div class="app-header__side app-header__side--left">
           <div class="header-menu">
             <button
               id="homeMenuButton"
-              class="back-button header-menu__trigger"
+              class="back-button header-action-btn menu-btn header-menu__trigger"
               type="button"
               aria-label="Plus d'options"
               aria-haspopup="menu"
@@ -31,7 +31,7 @@
         </div>
         <div class="app-header__side app-header__side--right">
           <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
-          <button id="userAvatarButton" class="avatar-button avatar-button--with-arrow" type="button" aria-label="Profil" hidden>
+          <button id="userAvatarButton" class="avatar-button header-action-btn avatar-btn avatar-button--with-arrow" type="button" aria-label="Profil" hidden>
             <span class="avatar-button__chevron" aria-hidden="true">▾</span>
             U
           </button>


### PR DESCRIPTION
### Motivation
- Fix a slight vertical/horizontal misalignment of the Page 1 burger menu so it matches the balanced left/center/right alignment used by Page 2 while keeping the existing visual design and constraints. 

### Description
- Updated the Page 1 header markup in `index.html` to mirror Page 2 structure by adding `page1-header` on the header and adding the action classes `header-action-btn`, `menu-btn` to the burger trigger and `avatar-btn` to the avatar button. 
- Added page-1 scoped CSS overrides in `css/style.css` targeting `body[data-page="home"] .header-menu` and `body[data-page="home"] #homeMenuButton` to apply the same sizing, border-radius, background, display, alignment, padding and transition behavior as Page 2 action buttons. 
- Removed offset-causing behavior on the Page 1 menu trigger by clearing `margin`, `position` offsets and `transform` so the button vertically centers like the Page 2 back button, and preserved the existing burger icon `Icon/menu-burger.png` and title text. 
- Only Page 1 files were changed; Page 2 and Page 3 files were not modified. 

### Testing
- Ran repository searches and inspected diffs with `rg` and `git diff -- index.html css/style.css` to validate the exact changes, which showed only the intended `index.html` and `css/style.css` edits and succeeded. 
- Verified working tree status with `git status --short` and created a commit with `git commit -m "Align page 1 burger button with page 2 header action layout"`, both commands completed successfully. 
- Manually reviewed the generated diff to confirm no changes to `page2.html` or `page3.html` and that only page-1 scoped CSS was added, with no new icons or global CSS introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4782cea64832a8f932d447edcd75e)