### PR TITLE
Centrer l'image de l'avatar dans l'en-tête (Page 1)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3266,6 +3266,7 @@ body[data-page="home"] .app-header--home > h1 {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center;
   border-radius: 50%;
   display: block;
 }


### PR DESCRIPTION
### Motivation
- Corriger le cadrage de la photo dans l'avatar du header de la page d'accueil pour que le visage soit parfaitement centré sans modifier la taille du conteneur ni la structure du header.

### Description
- Ajout de `object-position: center` à la règle `.avatar-image, .header-avatar-img, .sheet-avatar-img` dans `css/style.css` pour recentrer l'image à l'intérieur du cercle tout en conservant les dimensions et le style existants.

### Testing
- Exécution de recherches et vérifications automatiques avec `rg` et inspection du fichier via `git diff` / `nl` pour confirmer la présence de `object-position: center` dans `css/style.css`, toutes les vérifications sont revenues sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cd5bd9fc832aa80fb45ef3aa6b46)