### PR TITLE
Fix header avatar image fit and centering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3265,10 +3265,10 @@ body[data-page="home"] .app-header--home > h1 {
 .sheet-avatar-img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   object-position: center;
-  border-radius: 50%;
   display: block;
+  background-color: white;
 }
 
 .avatar-initials {


### PR DESCRIPTION
### Motivation
- Corriger le cadrage et la coupe de l’image dans l’avatar du header tout en ne modifiant ni la taille de l’avatar ni le layout du header.

### Description
- Mise à jour de `css/style.css` pour remplacer `object-fit: cover` par `object-fit: contain` sur `.avatar-image, .header-avatar-img, .sheet-avatar-img`, retirer le `border-radius` au niveau de l’image, conserver `width/height: 100%` et `object-position: center`, et ajouter `background-color: white` en s’appuyant sur le conteneur existant (avec `overflow: hidden` et centrage flex) pour le masquage circulaire.

### Testing
- Changement appliqué par script de remplacement et fichier mis à jour puis validé avec `git commit`, la commande de commit a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cf5b3ee4832a9882e40bc3c794f5)