### PR TITLE
Remove avatar chevron from home header avatar button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5142,27 +5142,6 @@ body[data-page="home"] #homeMenuButton {
   align-self: auto;
 }
 
-.avatar-button--with-arrow {
-  position: relative;
-  padding-right: 0.78rem;
-}
-
-.avatar-button__chevron {
-  position: absolute;
-  right: 0.18rem;
-  bottom: 0.18rem;
-  width: 1rem;
-  height: 1rem;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.9);
-  color: #1f2a37;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.55rem;
-  line-height: 1;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
-}
 
 .home-menu-overlay {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
         </div>
         <div class="app-header__side app-header__side--right">
           <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
-          <button id="userAvatarButton" class="avatar-button header-action-btn avatar-btn avatar-button--with-arrow" type="button" aria-label="Profil" hidden>
-            <span class="avatar-button__chevron" aria-hidden="true">▾</span>
+          <button id="userAvatarButton" class="avatar-button header-action-btn avatar-btn" type="button" aria-label="Profil" hidden>
             U
           </button>
         </div>


### PR DESCRIPTION
### Motivation
- Fix the visual misalignment in the home header by removing the decorative dropdown chevron next to the avatar while preserving the header structure, avatar size, and avatar interaction behavior.

### Description
- Removed the chevron element (`<span class="avatar-button__chevron">▾</span>`) and the `avatar-button--with-arrow` class from the avatar button in `index.html`, and removed the `.avatar-button--with-arrow` and `.avatar-button__chevron` rules from `css/style.css`, keeping the base avatar centering rules intact.

### Testing
- Ran `git -C /workspace/Album status --short`, `rg -n "avatar-button__chevron|avatar-button--with-arrow" index.html css/style.css` (no occurrences found), and `git -C /workspace/Album commit -m "Remove avatar chevron from home header"`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d18b8d80832ab813ebb19a916a1b)