### PR TITLE
Wire Page 1 sidebar buttons to existing handlers (history / import / export / users)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1473,8 +1473,6 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     function openImportFilePicker() {
-      closeSidebar();
-
       const fileInput = document.createElement('input');
       fileInput.type = 'file';
       fileInput.accept = '.su,.json,application/json';
@@ -1988,6 +1986,18 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
+    function openHistory() {
+      UiService.navigate('historiques.html');
+    }
+
+    function openImportModal() {
+      openImportFilePicker();
+    }
+
+    function openUserManagement() {
+      UiService.navigate('users.html');
+    }
+
     if (exportDataButton) {
       exportDataButton.addEventListener('click', () => {
         closeSidebar();
@@ -1998,20 +2008,20 @@ import { firebaseAuth } from './firebase-core.js';
     if (importDataButton) {
       importDataButton.addEventListener('click', () => {
         closeSidebar();
-        openImportFilePicker();
+        openImportModal();
       });
     }
     if (manageUsersButton) {
       manageUsersButton.addEventListener('click', () => {
         closeSidebar();
-        UiService.navigate('users.html');
+        openUserManagement();
       });
     }
 
     if (historyButton) {
       historyButton.addEventListener('click', () => {
         closeSidebar();
-        UiService.navigate('historiques.html');
+        openHistory();
       });
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the new Page 1 sidebar triggers the exact same existing actions as the legacy 3‑dot menu without duplicating or changing business logic.
- Keep permission visibility and existing import/export/history/user flows untouched while centralizing the sidebar close behavior.

### Description
- Added lightweight wrappers `openHistory`, `openImportModal`, and `openUserManagement` in `js/app.js` and wired the sidebar buttons to call these wrappers so they reuse existing handlers. 
- Kept the existing `exportAllData()` flow unchanged and left its sidebar wiring intact to reuse the original export logic.
- Removed the duplicate `closeSidebar()` call from inside `openImportFilePicker()` so closing the sidebar is performed by the click handlers only.
- Modified only `js/app.js` (Page 1 initialization flow) and did not alter Firebase, routes/pages, import/export logic, permissions, Page 2, or Page 3.

### Testing
- Ran a local inspection of changes with `git diff -- js/app.js` and verified the new wrapper functions and updated event handlers were added (succeeded).
- Committed the change with `git commit` to record the modification in the repository (succeeded).
- Verified the updated `js/app.js` region with `nl -ba js/app.js | sed -n` to confirm the `openHistory`/`openImportModal`/`openUserManagement` functions and event listener updates exist (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d9efc2d8832aac33fa1e543a2920)