### PR TITLE
Fix rebond et double-exécution des clics du sidebar sur la Page 1

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1998,30 +1998,53 @@ import { firebaseAuth } from './firebase-core.js';
       UiService.navigate('users.html');
     }
 
+    let sidebarActionRunning = false;
+    function runSidebarAction(action) {
+      if (sidebarActionRunning) {
+        return;
+      }
+
+      sidebarActionRunning = true;
+      closeSidebar();
+
+      window.setTimeout(() => {
+        action();
+        sidebarActionRunning = false;
+      }, 200);
+    }
+
     if (exportDataButton) {
-      exportDataButton.addEventListener('click', () => {
-        closeSidebar();
-        exportAllData();
+      exportDataButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        runSidebarAction(exportAllData);
       });
     }
 
     if (importDataButton) {
-      importDataButton.addEventListener('click', () => {
-        closeSidebar();
-        openImportModal();
+      importDataButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        runSidebarAction(openImportModal);
       });
     }
     if (manageUsersButton) {
-      manageUsersButton.addEventListener('click', () => {
-        closeSidebar();
-        openUserManagement();
+      manageUsersButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        runSidebarAction(openUserManagement);
       });
     }
 
     if (historyButton) {
-      historyButton.addEventListener('click', () => {
-        closeSidebar();
-        openHistory();
+      historyButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        runSidebarAction(openHistory);
       });
     }
 


### PR DESCRIPTION
### Motivation
- Éviter le rebond/flash et l’exécution multiple d’une action quand on clique sur une option du sidebar sur la Page 1.
- Garantir que le sidebar se ferme proprement avant de lancer l’action tout en conservant l’UI et les animations existantes.

### Description
- Ajout d’un verrou `sidebarActionRunning` et de la fonction utilitaire `runSidebarAction(action)` dans `js/app.js` pour empêcher les doubles exécutions et exécuter l’action après fermeture du sidebar via `setTimeout`.
- Mise à jour des handlers des boutons du sidebar (`historyButton`, `importDataButton`, `exportDataButton`, `manageUsersButton`) pour appeler `event.preventDefault()` et `event.stopPropagation()` et utiliser `runSidebarAction(...)`.
- Le sidebar est fermé d’abord via `closeSidebar()` et l’action existante est appelée ensuite; les fonctions métier existantes (`openHistory`, `openImportModal`, `openUserManagement`, `exportAllData`) ne sont pas modifiées.
- Changements limités à la Page 1 logique (`index.html` + `js/app.js`); Page 2 et Page 3, le design et les animations ne sont pas modifiés.

### Testing
- Exécution de `node --check js/app.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e1661184832a812f539c49c69338)