### PR TITLE
Fix Page 1 sidebar navigation for History and User Management

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2035,7 +2035,10 @@ import { firebaseAuth } from './firebase-core.js';
         event.preventDefault();
         event.stopPropagation();
 
-        runSidebarAction(openUserManagement);
+        closeSidebar();
+        window.setTimeout(() => {
+          openUserManagement();
+        }, 180);
       });
     }
 
@@ -2044,7 +2047,10 @@ import { firebaseAuth } from './firebase-core.js';
         event.preventDefault();
         event.stopPropagation();
 
-        runSidebarAction(openHistory);
+        closeSidebar();
+        window.setTimeout(() => {
+          openHistory();
+        }, 180);
       });
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the sidebar buttons on Page 1 open the existing pages directly while closing the sidebar cleanly, without introducing new pages or duplicating navigation logic.

### Description
- Updated the `manageUsersButton` click handler in `js/app.js` to call `closeSidebar()` then `openUserManagement()` after a 180ms timeout instead of using `runSidebarAction()`.
- Updated the `historyButton` click handler in `js/app.js` to call `closeSidebar()` then `openHistory()` after a 180ms timeout instead of using `runSidebarAction()`.
- Kept existing functions and behavior for `importDataButton` and `exportDataButton` unchanged and did not alter admin permission logic or sidebar design/animation.

### Testing
- Ran a JavaScript syntax check with `node --check js/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e5df89a8832a8407df06e5ef5df1)