### PR TITLE
Fix sidebar navigation for Historiques and Gestion des utilisateurs on Page 1

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1987,7 +1987,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     function openHistory() {
-      UiService.navigate('historiques.html');
+      window.location.href = 'historiques.html';
     }
 
     function openImportModal() {
@@ -1995,7 +1995,7 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     function openUserManagement() {
-      UiService.navigate('users.html');
+      window.location.href = 'users.html';
     }
 
     let sidebarActionRunning = false;


### PR DESCRIPTION
### Motivation
- Ensure the Page 1 sidebar buttons open the intended static pages (`historiques.html` and `users.html`) while keeping the sidebar close behavior and animation intact.

### Description
- In `js/app.js` replace `UiService.navigate('historiques.html')` and `UiService.navigate('users.html')` with `window.location.href = 'historiques.html'` and `window.location.href = 'users.html'` respectively so the buttons navigate directly to the existing pages.

### Testing
- Confirmed target pages exist with `rg --files` and inspected the changed lines with `nl -ba js/app.js | sed -n '1980,2025p'`, which show the new `window.location.href` usages and the surrounding sidebar close logic intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e93a254c832ab65ef2a702c0ea45)