### PR TITLE
Fix sidebar navigation for Historiques and User Management buttons

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -913,6 +913,8 @@ import { firebaseAuth } from './firebase-core.js';
     const exportDataButton = requireElement('exportDataButton');
     const manageUsersButton = requireElement('manageUsersButton');
     const historyButton = requireElement('historyButton');
+    const usersSidebarBtn = homeMenuPanel?.querySelector('#manageUsersButton') || null;
+    const historySidebarBtn = homeMenuPanel?.querySelector('#historyButton') || null;
     const siteLockDialog = requireElement('siteLockDialog');
     const siteLockForm = requireElement('siteLockForm');
     const siteLockPasswordInput = requireElement('siteLockPasswordInput');
@@ -2030,29 +2032,24 @@ import { firebaseAuth } from './firebase-core.js';
         runSidebarAction(openImportModal);
       });
     }
-    if (manageUsersButton) {
-      manageUsersButton.addEventListener('click', (event) => {
+    if (usersSidebarBtn) {
+      usersSidebarBtn.addEventListener('click', (event) => {
         event.preventDefault();
         event.stopPropagation();
-
-        closeSidebar();
-        window.setTimeout(() => {
-          openUserManagement();
-        }, 180);
+        window.location.assign('users.html');
       });
     }
 
-    if (historyButton) {
-      historyButton.addEventListener('click', (event) => {
+    if (historySidebarBtn) {
+      historySidebarBtn.addEventListener('click', (event) => {
         event.preventDefault();
         event.stopPropagation();
-
-        closeSidebar();
-        window.setTimeout(() => {
-          openHistory();
-        }, 180);
+        window.location.assign('historiques.html');
       });
     }
+
+    console.log('historySidebarBtn', historySidebarBtn);
+    console.log('usersSidebarBtn', usersSidebarBtn);
 
     const openCreateSite = requireElement('openCreateSite');
 


### PR DESCRIPTION
### Motivation
- The sidebar "Historiques" and "Gestion des utilisateurs" clicks were not navigating because handlers relied on global IDs and a delayed `closeSidebar()`/`setTimeout` flow that could be blocked by other listeners. 
- The intent is to navigate directly from the sidebar to `historiques.html` and `users.html` without closing the sidebar first or using delayed logic.

### Description
- Scope the sidebar button elements to the panel by adding `usersSidebarBtn = homeMenuPanel?.querySelector('#manageUsersButton')` and `historySidebarBtn = homeMenuPanel?.querySelector('#historyButton')` so IDs in other parts of the page cannot interfere. 
- Replace the previous `manageUsersButton` and `historyButton` handlers with direct sidebar handlers that call `window.location.assign('users.html')` and `window.location.assign('historiques.html')` respectively. 
- Remove the previous `closeSidebar()` + `setTimeout()` navigation path for these two actions and avoid using `runSidebarAction` or other delayed/indirect flows for them. 
- Add `console.log('historySidebarBtn', ...)` and `console.log('usersSidebarBtn', ...)` to help verify element resolution at runtime.

### Testing
- Searched the codebase to confirm the new selectors and direct navigation calls with ripgrep (`rg`) and verified occurrences of `usersSidebarBtn`, `historySidebarBtn`, and `window.location.assign('users.html'/'historiques.html')`; the searches succeeded. 
- Verified there are no remaining delayed navigation flows for these buttons by grepping for the previous `setTimeout`/`closeSidebar` patterns around the handlers; the check succeeded. 
- Committed the change (`git commit`) successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4eb5f0c18832a8015d2cb725f8a83)