### PR TITLE
Fix incorrect default active state in sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
           <button id="homeMenuCloseButton" class="sidebar-close" type="button" aria-label="Fermer le menu">×</button>
         </div>
         <div class="sidebar-actions">
-          <button id="historyButton" class="header-menu__option sidebar-item" type="button" role="menuitem">
+          <button id="historyButton" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="historiques.html">
             Historiques
           </button>
           <button id="importDataButton" class="header-menu__option sidebar-item" type="button" role="menuitem">
@@ -56,7 +56,7 @@
           <button id="exportDataButton" class="header-menu__option sidebar-item" type="button" role="menuitem">
             Exporter les données
           </button>
-          <button id="manageUsersButton" class="header-menu__option sidebar-item" type="button" role="menuitem" hidden>
+          <button id="manageUsersButton" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="users.html" hidden>
             Gestion des utilisateurs
           </button>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -915,6 +915,7 @@ import { firebaseAuth } from './firebase-core.js';
     const historyButton = requireElement('historyButton');
     const usersSidebarBtn = homeMenuPanel?.querySelector('#manageUsersButton') || null;
     const historySidebarBtn = homeMenuPanel?.querySelector('#historyButton') || null;
+    const sidebarItems = homeMenuPanel ? Array.from(homeMenuPanel.querySelectorAll('.sidebar-item')) : [];
     const siteLockDialog = requireElement('siteLockDialog');
     const siteLockForm = requireElement('siteLockForm');
     const siteLockPasswordInput = requireElement('siteLockPasswordInput');
@@ -1988,6 +1989,30 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
+    function setActiveSidebarItem(targetItem) {
+      sidebarItems.forEach((item) => item.classList.remove('active'));
+      if (targetItem) {
+        targetItem.classList.add('active');
+      }
+    }
+
+    if (sidebarItems.length) {
+      const currentPage = window.location.pathname;
+      let activeItemFromPage = null;
+
+      sidebarItems.forEach((item) => {
+        const link = String(item.getAttribute('data-link') || '').trim();
+        if (link && currentPage.includes(link)) {
+          activeItemFromPage = item;
+        }
+        item.addEventListener('click', () => {
+          setActiveSidebarItem(item);
+        });
+      });
+
+      setActiveSidebarItem(activeItemFromPage);
+    }
+
     function openHistory() {
       window.location.href = 'historiques.html';
     }
@@ -2047,9 +2072,6 @@ import { firebaseAuth } from './firebase-core.js';
         window.location.assign('historiques.html');
       });
     }
-
-    console.log('historySidebarBtn', historySidebarBtn);
-    console.log('usersSidebarBtn', usersSidebarBtn);
 
     const openCreateSite = requireElement('openCreateSite');
 


### PR DESCRIPTION
### Motivation
- Fix a UX bug where a sidebar entry could appear active by default (misleading visual state) and ensure active state is driven by user interaction or current page.

### Description
- Added `data-link` attributes to the relevant sidebar items in `index.html` to enable page-aware activation (`historiques.html`, `users.html`).
- Implemented active-state management in `js/app.js` by collecting `.sidebar-item` elements, adding a `setActiveSidebarItem` helper that removes `active` from all items and applies it to the clicked/target item, and wiring click handlers to call it.
- Auto-activates the matching sidebar item when `window.location.pathname` contains the `data-link` value.
- Removed leftover debug `console.log` calls and did not change any CSS rules (existing `.sidebar-item.active` styling is preserved).

### Testing
- Ran project-wide searches to confirm there is no `class="sidebar-item active"` remaining and that `data-link` attributes were added, and the check passed.
- Searched for the new symbols (`setActiveSidebarItem`, `data-link`, `.sidebar-item`) to verify the JS logic was injected into `js/app.js`, and the check passed.
- Executed automated repository checks used during the rollout (pattern searches used above) with all checks succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f6484870832a8c3855dba92fde04)