### PR TITLE
Remove default active background from first sidebar item

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5269,5 +5269,11 @@ body.sidebar-open {
 }
 
 .sidebar-item:first-child {
-  background: #f0f7ff;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: inherit !important;
+}
+
+.sidebar-item.active {
+  background: #eef5fb;
 }


### PR DESCRIPTION
### Motivation
- The first sidebar entry (`Historiques`) appeared highlighted on load due to a `:first-child` CSS rule, which should be removed so active styling only comes from the `active` class.

### Description
- Updated `css/style.css` to neutralize `.sidebar-item:first-child` by setting `background: transparent !important;`, removing box-shadow and keeping `color: inherit`.
- Added explicit `.sidebar-item.active { background: #eef5fb; }` so the active background is applied only when the `active` class is present.
- Change is CSS-only and does not touch any JavaScript or alter the sidebar design or other pages.
- Confirmed that no sidebar button in the HTML has the `active` class by default.

### Testing
- Searched the codebase for relevant selectors with `rg` to confirm occurrences and that no HTML has a default `active` class, which succeeded.
- Inspected the updated lines in `css/style.css` with file output commands to verify the replacement succeeded.
- Committed the change with `git commit` to record the update, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f9504998832a903dd79dc0f3748f)