### PR TITLE
Update Page 1 sidebar visibility based on auth status and role

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2083,6 +2083,27 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
+    function updateSidebarPermissions() {
+      const isAdmin = Boolean(currentPermissions?.isAdmin);
+      const isStandard = Boolean(currentPermissions?.isStandard);
+      const isLimited = !isAdmin && !isStandard;
+
+      const hideImportExport = !isAuthenticated || isLimited;
+      const hideUsers = !isAuthenticated || !isAdmin;
+
+      if (importDataButton) {
+        importDataButton.hidden = hideImportExport;
+      }
+
+      if (exportDataButton) {
+        exportDataButton.hidden = hideImportExport;
+      }
+
+      if (manageUsersButton) {
+        manageUsersButton.hidden = hideUsers;
+      }
+    }
+
     function mettreAJourPermissionsUI(nextPermissions) {
       currentPermissions = { ...currentPermissions, ...(nextPermissions || {}) };
 
@@ -2090,17 +2111,7 @@ import { firebaseAuth } from './firebase-core.js';
         openCreateSite.hidden = !isAuthenticated;
       }
 
-      if (importDataButton) {
-        importDataButton.hidden = !currentPermissions.canImportExport;
-      }
-
-      if (exportDataButton) {
-        exportDataButton.hidden = !currentPermissions.canImportExport;
-      }
-
-      if (manageUsersButton) {
-        manageUsersButton.hidden = !currentPermissions.canManageUsers;
-      }
+      updateSidebarPermissions();
 
       closeSidebar();
       renderSites();


### PR DESCRIPTION
### Motivation
- Appliquer la règle d’affichage du sidebar sur la Page 1 selon l’état de connexion et le rôle existant sans toucher à l’authentification ni aux fonctions métier.
- Garantir que l’affichage est correct dès l’ouverture du menu et après toute connexion/déconnexion.

### Description
- Ajout de la fonction `updateSidebarPermissions()` dans `js/app.js` qui calcule `isAdmin`, `isStandard` et cache/affiche `importDataButton`, `exportDataButton` et `manageUsersButton` en conséquence.
- `mettreAJourPermissionsUI()` met désormais à jour `currentPermissions`, appelle `updateSidebarPermissions()` puis ferme le sidebar et rafraîchit la liste des sites.
- La logique réutilise les flags de permissions existants (`currentPermissions.isAdmin`, `currentPermissions.isStandard`) et n’altère pas Firebase Auth ni les fonctions d’import/export/users.

### Testing
- Recherche et inspection de fichiers avec `rg` et `sed` pour valider les emplacements de modification, qui ont réussi.
- Application du patch via un script Python qui a remplacé l’ancien bloc et a imprimé `patched` pour indiquer le succès.
- Validation locale des changements avec `git status --short`, affichage de la section modifiée `nl -ba js/app.js | sed -n '2070,2145p'` et `git commit`, tous exécutés avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5724f8e88832a950c7437314322c5)