### PR TITLE
Corriger visibilité de la sidebar (Page 1) selon auth/role

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,16 +47,16 @@
           <button id="homeMenuCloseButton" class="sidebar-close" type="button" aria-label="Fermer le menu">×</button>
         </div>
         <div class="sidebar-actions">
-          <button id="historyButton" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="historiques.html">
+          <button id="sidebarHistoryBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="historiques.html">
             Historiques
           </button>
-          <button id="importDataButton" class="header-menu__option sidebar-item" type="button" role="menuitem">
+          <button id="sidebarImportBtn" class="header-menu__option sidebar-item" type="button" role="menuitem">
             Importer les données
           </button>
-          <button id="exportDataButton" class="header-menu__option sidebar-item" type="button" role="menuitem">
+          <button id="sidebarExportBtn" class="header-menu__option sidebar-item" type="button" role="menuitem">
             Exporter les données
           </button>
-          <button id="manageUsersButton" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="users.html" hidden>
+          <button id="sidebarUsersBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="users.html" hidden>
             Gestion des utilisateurs
           </button>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -909,12 +909,11 @@ import { firebaseAuth } from './firebase-core.js';
     const homeMenuButton = requireElement('homeMenuButton');
     const homeMenuPanel = requireElement('homeMenuPanel');
     const homeMenuOverlay = requireElement('homeMenuOverlay');
-    const importDataButton = requireElement('importDataButton');
-    const exportDataButton = requireElement('exportDataButton');
-    const manageUsersButton = requireElement('manageUsersButton');
-    const historyButton = requireElement('historyButton');
-    const usersSidebarBtn = homeMenuPanel?.querySelector('#manageUsersButton') || null;
-    const historySidebarBtn = homeMenuPanel?.querySelector('#historyButton') || null;
+    const importDataButton = requireElement('sidebarImportBtn');
+    const exportDataButton = requireElement('sidebarExportBtn');
+    const manageUsersButton = requireElement('sidebarUsersBtn');
+    const usersSidebarBtn = homeMenuPanel?.querySelector('#sidebarUsersBtn') || null;
+    const historySidebarBtn = homeMenuPanel?.querySelector('#sidebarHistoryBtn') || null;
     const sidebarItems = homeMenuPanel ? Array.from(homeMenuPanel.querySelectorAll('.sidebar-item')) : [];
     const siteLockDialog = requireElement('siteLockDialog');
     const siteLockForm = requireElement('siteLockForm');
@@ -1401,6 +1400,7 @@ import { firebaseAuth } from './firebase-core.js';
       if (!homeMenuPanel || !homeMenuButton || sidebarAnimating) {
         return;
       }
+      updateSidebarPermissions();
       if (!homeMenuOverlay?.hidden || homeMenuPanel.classList.contains('is-open')) {
         return;
       }
@@ -2083,25 +2083,60 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
+    function getCurrentUserRole() {
+      if (currentPermissions?.isAdmin) {
+        return 'admin';
+      }
+      if (currentPermissions?.isStandard) {
+        return 'standard';
+      }
+      return 'limite';
+    }
+
+    function setSidebarItemVisible(selector, visible) {
+      const el = document.querySelector(selector);
+      if (!el) {
+        return;
+      }
+      el.hidden = !visible;
+      el.style.display = visible ? 'flex' : 'none';
+    }
+
     function updateSidebarPermissions() {
-      const isAdmin = Boolean(currentPermissions?.isAdmin);
-      const isStandard = Boolean(currentPermissions?.isStandard);
-      const isLimited = !isAdmin && !isStandard;
+      const user = firebaseAuth.currentUser;
+      const role = getCurrentUserRole();
+      const isConnected = Boolean(user);
+      const normalizedRole = String(role || '').toLowerCase();
+      const isAdmin = normalizedRole === 'admin';
+      const isStandard = normalizedRole === 'standard';
+      const isLimited = normalizedRole === 'limité' || normalizedRole === 'limite' || normalizedRole === 'limited';
 
-      const hideImportExport = !isAuthenticated || isLimited;
-      const hideUsers = !isAuthenticated || !isAdmin;
+      setSidebarItemVisible('#sidebarHistoryBtn', true);
 
-      if (importDataButton) {
-        importDataButton.hidden = hideImportExport;
+      if (!isConnected || isLimited) {
+        setSidebarItemVisible('#sidebarImportBtn', false);
+        setSidebarItemVisible('#sidebarExportBtn', false);
+        setSidebarItemVisible('#sidebarUsersBtn', false);
+        return;
       }
 
-      if (exportDataButton) {
-        exportDataButton.hidden = hideImportExport;
+      if (isStandard) {
+        setSidebarItemVisible('#sidebarImportBtn', true);
+        setSidebarItemVisible('#sidebarExportBtn', true);
+        setSidebarItemVisible('#sidebarUsersBtn', false);
+        return;
       }
 
-      if (manageUsersButton) {
-        manageUsersButton.hidden = hideUsers;
+      if (isAdmin) {
+        setSidebarItemVisible('#sidebarImportBtn', true);
+        setSidebarItemVisible('#sidebarExportBtn', true);
+        setSidebarItemVisible('#sidebarUsersBtn', true);
+        return;
       }
+
+      setSidebarItemVisible('#sidebarImportBtn', false);
+      setSidebarItemVisible('#sidebarExportBtn', false);
+      setSidebarItemVisible('#sidebarUsersBtn', false);
     }
 
     function mettreAJourPermissionsUI(nextPermissions) {


### PR DESCRIPTION
### Motivation
- Les boutons `Importer`, `Exporter` et `Gestion des utilisateurs` restaient visibles pour des utilisateurs non connectés ou au rôle « Limité », ce qui doit être restreint selon les règles métiers.
- Rendre le contrôle d'affichage de la sidebar fiable en utilisant des sélecteurs stables et une fonction de visibilité centralisée sans toucher au design ni recréer la gestion des rôles.

### Description
- Renommé les identifiants des boutons dans `index.html` en `#sidebarHistoryBtn`, `#sidebarImportBtn`, `#sidebarExportBtn` et `#sidebarUsersBtn` pour des sélecteurs explicites et stables.
- Mis à jour `js/app.js` pour utiliser les nouveaux sélecteurs et pour que tous les handlers continuent de fonctionner avec ces IDs.
- Ajouté la fonction utilitaire `setSidebarItemVisible(selector, visible)` qui synchronise `hidden` et `style.display` pour gérer l'affichage sans modifier le design visuel.
- Implémenté `getCurrentUserRole()` (usage de l'état `currentPermissions`) et réécrit `updateSidebarPermissions()` pour appliquer la logique demandée : non connecté ou limité → seul `Historiques` visible ; standard → `Historiques` + `Importer` + `Exporter` visibles et `Users` caché ; admin → tout visible ; fallback inconnu → comportement limité.
- Appelé `updateSidebarPermissions()` à l'ouverture de la sidebar (`openSidebar()`) et laissé le traitement réactif existant à l'`onAuthStateChanged` pour les mises à jour en temps réel.
- Aucune modification des fonctions d'import/export, du composant Historiques, du design de la sidebar, ni des pages 2 / 3; la gestion des rôles existante a été réutilisée.

### Testing
- Vérification par recherche de code avec `rg` que les anciens sélecteurs ont été remplacés et que les nouveaux `#sidebar*Btn` sont référencés dans `js/app.js` et `index.html`, résultat : réussi.
- Inspection des fichiers modifiés via `nl`/`sed` pour confirmer l'ajout de `getCurrentUserRole()`, `setSidebarItemVisible()` et la nouvelle `updateSidebarPermissions()`, résultat : réussi.
- Test fonctionnel rapide en parcourant le code et les handlers sidebar pour s'assurer que les clics et comportements existants (ouvrir importateur, exporter, navigation utilisateurs/historiques) restent attachés aux nouveaux éléments, résultat : vérifié et ok.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f57570d384832a9a933e535bbcec35)