### PR TITLE
Page 3: add clear (X) button inside search input

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2315,6 +2315,31 @@ body[data-page="item-detail"] .search-input__icon {
 
 body[data-page="item-detail"] #detailSearchInput {
   padding-left: 2.9rem;
+  padding-right: 52px;
+}
+
+body[data-page="item-detail"] .clear-search-btn {
+  display: none;
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background: #eef5fb;
+  color: #6b7280;
+  font-size: 20px;
+  font-weight: 600;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+body[data-page="item-detail"] .clear-search-btn:active {
+  transform: translateY(-50%) scale(0.94);
+  background: #e0eefc;
 }
 
 body[data-page="item-detail"] .app-header--detail {

--- a/js/app.js
+++ b/js/app.js
@@ -3781,6 +3781,7 @@ import { firebaseAuth } from './firebase-core.js';
     const detailStore = requireElement('detailStore');
     const detailTableBody = requireElement('detailTableBody');
     const detailSearchInput = requireElement('detailSearchInput');
+    const clearSearchBtn = document.querySelector('#clearSearchBtn');
     const exportButton = requireElement('exportDetailsButton');
     const detailExportDialog = requireElement('detailExportDialog');
     const detailExportForm = requireElement('detailExportForm');
@@ -4734,6 +4735,22 @@ import { firebaseAuth } from './firebase-core.js';
 
     if (detailSearchInput) {
       detailSearchInput.addEventListener('input', renderTable);
+      const toggleClearButton = () => {
+        if (!detailSearchInput || !clearSearchBtn) {
+          return;
+        }
+        clearSearchBtn.style.display = detailSearchInput.value.trim() ? 'flex' : 'none';
+      };
+      detailSearchInput.addEventListener('input', toggleClearButton);
+      clearSearchBtn?.addEventListener('click', () => {
+        if (!detailSearchInput) {
+          return;
+        }
+        detailSearchInput.value = '';
+        toggleClearButton();
+        detailSearchInput.focus();
+      });
+      toggleClearButton();
     }
 
     if (exportButton) {

--- a/page3.html
+++ b/page3.html
@@ -48,6 +48,7 @@
                 <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
               </span>
               <input id="detailSearchInput" class="search-input" type="text" placeholder="Entrer votre recherche..." autocomplete="off" />
+              <button id="clearSearchBtn" class="clear-search-btn" type="button" aria-label="Effacer la recherche">×</button>
             </label>
           </div>
           <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>


### PR DESCRIPTION
### Motivation

- Ajouter un bouton clear `×` directement dans le champ de recherche de la Page 3 pour permettre à l'utilisateur de vider rapidement la recherche sans modifier la logique existante.
- Le bouton doit être discret (caché par défaut) et n’altérer ni le rendu du tableau ni la mécanique de filtrage actuelle.

### Description

- Ajouté le bouton HTML `button#clearSearchBtn.clear-search-btn` dans la même `label.input-group` que l’`input#detailSearchInput` dans `page3.html`.
- Ajouté `padding-right: 52px` pour `#detailSearchInput` et les styles scoped Page 3 pour `.clear-search-btn` dans `css/style.css` afin d’éviter la collision texte/bouton tout en gardant le design existant.
- Injecté la logique JS dans `js/app.js` qui bascule l’affichage du bouton selon le contenu (`display: none` / `flex`), vide le champ et remet le focus au clic, sans appeler de fonctions de filtrage ni modifier la table.
- Les changements sont limités à la Page 3 (sélecteur `body[data-page="item-detail"]`) et n’altèrent pas Page 1, Page 2, ni la structure ou le rendu du tableau.

### Testing

- Aucun test automatisé spécifique n’existait pour cette modification et aucun test automatique n’a été exécuté; les modifications ont été vérifiées par inspection des fichiers et commits (`git add` / `git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f57f211ff0832a8dc26202502078de)