### PR TITLE
Page 3 : afficher les lignes lorsque le champ de recherche est vide

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4748,8 +4748,10 @@ import { firebaseAuth } from './firebase-core.js';
         }
         detailSearchInput.value = '';
         toggleClearButton();
+        renderTable();
         detailSearchInput.focus();
       });
+      detailSearchInput.value = '';
       toggleClearButton();
     }
 


### PR DESCRIPTION
### Motivation
- Résoudre le cas où la page 3 affiche 0 articles au chargement parce que le champ de recherche contient une valeur résiduelle ou qu'aucun rendu n'est déclenché après la remise à zéro.

### Description
- Appel explicite de `renderTable()` après la remise à zéro effectuée par le bouton `clearSearchBtn` et réinitialisation de `detailSearchInput.value = ''` lors de l'initialisation pour empêcher qu'une valeur autofill/stale masque les lignes (changement dans `js/app.js`).

### Testing
- Aucun test automatisé exécuté pour ce correctif ciblé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f581ba0750832a839ec41a1eff90eb)