### PR TITLE
Ajout d'un footer professionnel collant sur toutes les pages

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -122,3 +122,41 @@ body {
   80% { transform: translateX(3px); }
   100% { transform: translateX(0); }
 }
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+.main-content {
+  flex: 1;
+}
+
+.app-footer {
+  width: 100%;
+  text-align: center;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.92);
+  padding: 16px 10px;
+  margin-top: 40px;
+  opacity: 0.8;
+  transition: opacity 0.3s ease;
+}
+
+.app-footer::before {
+  content: "";
+  display: block;
+  width: 90%;
+  height: 1px;
+  margin: 0 auto 12px;
+  background: rgba(255,255,255,0.22);
+}
+
+.app-footer:hover {
+  opacity: 1;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -5302,3 +5302,41 @@ body.sidebar-open {
 .sidebar-item.active {
   background: #eef5fb;
 }
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+.main-content {
+  flex: 1;
+}
+
+.app-footer {
+  width: 100%;
+  text-align: center;
+  font-size: 13px;
+  color: #6b7280;
+  padding: 16px 10px;
+  margin-top: 40px;
+  opacity: 0.8;
+  transition: opacity 0.3s ease;
+}
+
+.app-footer::before {
+  content: "";
+  display: block;
+  width: 90%;
+  height: 1px;
+  margin: 0 auto 12px;
+  background: rgba(0,0,0,0.05);
+}
+
+.app-footer:hover {
+  opacity: 1;
+}

--- a/historiques.html
+++ b/historiques.html
@@ -18,7 +18,7 @@
         <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
       </header>
 
-      <main class="page-content page-content--history">
+      <main class="page-content page-content--history main-content">
         <section id="historyList" class="history-list" aria-live="polite"></section>
       </main>
 
@@ -28,5 +28,7 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
+      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
+
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
       </aside>
 
 
-      <main class="page-content">
+      <main class="page-content main-content">
         <section class="search-panel surface-card section">
           <label class="input-group">
             <span class="sr-only">Recherche</span>
@@ -266,5 +266,7 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
+      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
+
   </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/login.css" />
   </head>
   <body>
-    <main class="login-page">
+    <main class="login-page main-content">
       <section class="login-card" aria-label="Connexion">
         <header class="login-card__header">
           <h1>Connexion</h1>
@@ -51,5 +51,7 @@
     </main>
 
     <script type="module" src="js/login.js"></script>
+      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
+
   </body>
 </html>

--- a/page2.html
+++ b/page2.html
@@ -23,7 +23,7 @@
         </div>
       </header>
 
-      <main class="page-content">
+      <main class="page-content main-content">
         <section class="search-panel search-panel--site surface-card section">
           <label class="input-group">
             <span class="sr-only">Rechercher (OUT ou article)</span>
@@ -145,5 +145,7 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
+      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
+
   </body>
 </html>

--- a/page3.html
+++ b/page3.html
@@ -21,7 +21,7 @@
         <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
       </header>
 
-      <main class="page-content page-content--wide">
+      <main class="page-content page-content--wide main-content">
         <section class="surface-card table-card section">
           <div class="section-heading section-heading--table">
             <div class="header-top page3-summary-header">
@@ -173,5 +173,7 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
+      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
+
   </body>
 </html>

--- a/users.html
+++ b/users.html
@@ -17,7 +17,7 @@
         </div>
         <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
       </header>
-      <main class="page-content page-content--wide">
+      <main class="page-content page-content--wide main-content">
         <section class="surface-card details-card">
           <div class="maintenance-card-header">
             <h2 class="section-title">Maintenance de la page</h2>
@@ -251,5 +251,7 @@
         },
       );
     </script>
+      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
+
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Uniformiser le bas de page avec un footer discret et professionnel affiché sur toutes les pages du projet.
- S’assurer que le footer reste en bas de la fenêtre même lorsque le contenu est court (layout sticky footer) sans casser le layout existant.

### Description
- Ajout de la balise `<footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>` avant `</body>` sur `index.html`, `page2.html`, `page3.html`, `historiques.html`, `users.html` et `login.html`.
- Application de la classe `main-content` aux conteneurs principaux (`<main>` / `<main class="login-page">`) pour qu’ils soient flexibles et repoussent le footer en bas.
- Ajout de règles CSS dans `css/style.css` et `css/login.css` pour activer le layout flex ( `html, body { height: 100%; }`, `body { display: flex; flex-direction: column; }`, `.main-content { flex: 1; }`) et styliser `.app-footer` (taille, couleur, séparation subtile, transition hover).
- Adaptation spécifique des couleurs dans `css/login.css` pour préserver le contraste sur la page de connexion.

### Testing
- Vérification de la présence des classes et du footer avec `rg -n "app-footer|main-content" index.html page2.html page3.html historiques.html users.html login.html css/style.css css/login.css`, qui a retourné les fichiers modifiés et emplacements attendus (succès).
- Inspection des fichiers modifiés pour confirmer l’ajout du markup et des règles CSS (vérification locale réussie).
- Vérification de l’état du dépôt avec `git status --short` pour s’assurer que les fichiers attendus ont été modifiés (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cc2e1cac832ab2c9aaaf25d17742)