### PR TITLE
Add Page 1-specific footer spacing to avoid overlap with floating + button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5340,3 +5340,8 @@ body {
 .app-footer:hover {
   opacity: 1;
 }
+.page1 .app-footer {
+  margin-top: 60px;
+  margin-bottom: 90px;
+}
+


### PR DESCRIPTION
### Motivation
- Prevent the floating `+` button on Page 1 from sitting too close to the footer by adding extra bottom spacing only for Page 1.

### Description
- Add a targeted CSS rule in `css/style.css`: ` .page1 .app-footer { margin-top: 60px; margin-bottom: 90px; }` to increase space below the footer on Page 1.
- The change is limited to `css/style.css` and only affects Page 1; Page 2 and Page 3, the `+` button position, footer text, header, and cards remain unchanged.

### Testing
- Confirmed the new rule is present in `css/style.css` at the expected location using `nl`/`sed`, and the file reflects the update; test succeeded.
- Performed a repo-wide search with `rg` for `.app-footer` and page selectors to ensure no unintended modifications to Page 2 or Page 3 styles; test succeeded.
- Verified the footer text and button selectors were not altered by inspecting the affected files; test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6111e42e0832ab2bdfd774f7b217c)