### PR TITLE
Add bottom safe-area padding on Page 1 to prevent FAB/footer overlap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -162,6 +162,10 @@ body[data-page="history"] {
   background: linear-gradient(180deg, #d8ecff 0%, #eef6ff 45%, #f6f9ff 100%);
 }
 
+body.page1 {
+  padding-bottom: 140px; /* espace sécurisé pour le bouton + */
+}
+
 button,
 input,
 select,


### PR DESCRIPTION
### Motivation
- Ensure a clear safe area between the footer and the floating action button on Page 1 so the UI does not appear cramped or overlapped.

### Description
- Add a Page 1-specific CSS rule `body.page1 { padding-bottom: 140px; }` in `css/style.css` to provide the bottom safe area while leaving `.app-footer`, the floating button, and other pages unchanged and relying on the existing `class="page1"` on `index.html`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6136ffe64832aa32a06e326ee9267)