### PR TITLE
Remove all footers and cleanup footer spacing/styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -162,9 +162,6 @@ body[data-page="history"] {
   background: linear-gradient(180deg, #d8ecff 0%, #eef6ff 45%, #f6f9ff 100%);
 }
 
-body.page1 {
-  padding-bottom: 140px; /* espace sécurisé pour le bouton + */
-}
 
 button,
 input,
@@ -5321,31 +5318,4 @@ body {
   flex: 1;
 }
 
-.app-footer {
-  width: 100%;
-  text-align: center;
-  font-size: 13px;
-  color: #6b7280;
-  padding: 16px 10px;
-  margin-top: 40px;
-  opacity: 0.8;
-  transition: opacity 0.3s ease;
-}
-
-.app-footer::before {
-  content: "";
-  display: block;
-  width: 90%;
-  height: 1px;
-  margin: 0 auto 12px;
-  background: rgba(0,0,0,0.05);
-}
-
-.app-footer:hover {
-  opacity: 1;
-}
-.page1 .app-footer {
-  margin-top: 60px;
-  margin-bottom: 90px;
-}
 

--- a/historiques.html
+++ b/historiques.html
@@ -28,7 +28,6 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
-      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
 
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -266,7 +266,6 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
-      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
 
   </body>
 </html>

--- a/page2.html
+++ b/page2.html
@@ -145,7 +145,6 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
-      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
 
   </body>
 </html>

--- a/page3.html
+++ b/page3.html
@@ -173,7 +173,6 @@
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
     <script type="module" src="js/app.js"></script>
-      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
 
   </body>
 </html>

--- a/users.html
+++ b/users.html
@@ -251,7 +251,6 @@
         },
       );
     </script>
-      <footer class="app-footer">© 2026 Suivi Matériel — Tous droits réservés</footer>
 
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Remove the persistent footer element from all pages to eliminate the visible footer and the extra bottom spacing. 
- Clean up footer-specific CSS and page padding so the layout remains identical without empty space at the bottom.

### Description
- Deleted the footer HTML block from `index.html`, `page2.html`, `page3.html`, `historiques.html`, and `users.html`. 
- Removed footer-related CSS rules from `css/style.css`, including `.app-footer`, `.app-footer::before`, `.app-footer:hover`, and `.page1 .app-footer`. 
- Removed the `body.page1 { padding-bottom: 140px; }` rule to prevent unnecessary bottom padding while keeping other page and component styles unchanged.

### Testing
- Performed a repository-wide search for `app-footer` and footer-related `padding-bottom` occurrences and confirmed no remaining footer markup or the specific padding rule. 
- Verified the working tree shows the expected modified files and reviewed the diff confirming the footer and CSS blocks were removed. 
- Changes were committed to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f617c48368832a84aacb96af3c98ed)