### PR TITLE
Align Page 1 floating + button with shared Page 2/3 styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4628,11 +4628,6 @@ body[data-page="home"] .site-count-pill {
   font-weight: 700;
 }
 
-body[data-page="home"] .fab {
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
-  box-shadow: 0 18px 28px rgba(39, 141, 218, 0.35);
-}
-
 body[data-page="site-detail"] .app-header--detail {
   --detail-side-size: clamp(2.5rem, 7.8vw, 2.75rem);
   min-height: var(--header-height);
@@ -5282,5 +5277,4 @@ body {
 .main-content {
   flex: 1;
 }
-
 

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
       </main>
 
 
-      <button id="openCreateSite" class="fab fab-add" type="button" aria-label="Créer un site">+</button>
+      <button id="openCreateSite" class="fab" type="button" aria-label="Créer un site">+</button>
 
       <dialog id="siteDialog" class="modal-card">
         <form class="modal-content modal-content--site-create" id="siteForm">


### PR DESCRIPTION
### Motivation
- Uniformiser l’apparence du bouton flottant « + » sur la Page 1 pour qu’il ait exactement la même taille, forme, position et ombre que sur Page 2 / Page 3 en réutilisant le style partagé existant plutôt qu’un override spécifique à la page.

### Description
- Remplacé la classe du bouton de Page 1 dans `index.html` pour utiliser `class="fab"` afin d’employer le style partagé existant.;
- Supprimé l’override spécifique `body[data-page="home"] .fab` dans `css/style.css` pour que le bouton hérite des règles globales `.fab` (gradient, box-shadow, dimensions); 
- Aucune modification apportée aux fichiers de Page 2 / Page 3, ni à la logique JavaScript ou à d’autres éléments de l’UI.

### Testing
- Vérification des fichiers modifiés et aperçu des lignes concernées via `git status --short` et `nl -ba` a été exécutée et a réussi; 
- Les changements ont été ajoutés et enregistrés avec `git add` puis `git commit` et le commit s’est terminé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61ec25e74832ab379c421dc7ba930)