### PR TITLE
Align Page 1 FAB color with Page 2/Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1294,10 +1294,10 @@ body[data-page="history"] .list-grid {
   height: 56px;
   border: 0;
   border-radius: 50%;
-  background: #3b82f6;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   color: #fff;
   font-size: 2rem;
-  box-shadow: 0 14px 28px rgba(17, 24, 39, 0.28);
+  box-shadow: 0 10px 22px rgba(39, 141, 218, 0.32);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 


### PR DESCRIPTION
### Motivation
- Make the floating "+" button on Page 1 visually identical to the FABs used on Page 2 and Page 3 by reusing the same existing FAB color and shadow.

### Description
- Updated the `.fab` rule in `css/style.css` to use `background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);` and adjusted the `box-shadow` to `0 10px 22px rgba(39, 141, 218, 0.32)` while keeping size, position, shape and behavior unchanged and without modifying Page 2/3 selectors.

### Testing
- Verified the change by searching for `.fab` and inspecting the `css/style.css` snippet with `rg` and `sed`/`nl` to confirm the `.fab` block contains the new gradient and shadow and that no automated checks failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62073b458832a9fa2926a356731af)