### PR TITLE
Uniformiser le bouton + (FAB) de la Page 3 avec le style partagé

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -86,7 +86,7 @@
 
       <div class="item-detail-fab-row site-detail-fab-row" data-fab-row="create">
         <span id="itemDetailFabLabel" class="site-detail-fab-label fab-label site-detail-fab-label--create">Ajouter un article</span>
-        <button type="button" id="openDetailFormButton" class="fab-add fab-add--item-detail" aria-label="Ajouter une donnée">+</button>
+        <button type="button" id="openDetailFormButton" class="fab" aria-label="Ajouter une donnée">+</button>
       </div>
 
       <dialog id="detailFormModal" class="modal-card detail-form-modal">


### PR DESCRIPTION
### Motivation
- Rendre le bouton flottant de Page 3 identique aux boutons + des Pages 1 et 2 en lui faisant utiliser la même classe CSS partagée afin d'unifier forme/taille/couleur/ombre/position sans changer le comportement.

### Description
- Remplacement de `class="fab-add fab-add--item-detail"` par `class="fab"` sur le bouton `#openDetailFormButton` dans `page3.html`, en conservant l'ID, le libellé "Ajouter un article" et le comportement JavaScript inchangés.

### Testing
- Recherche automatisée avec `rg` pour confirmer les classes utilisées sur les pages a retourné les occurrences attendues et montré que Page 3 référence désormais `class="fab"`.
- Inspection du fichier avec `nl` a confirmé la mise à jour du bouton à la ligne modifiée et que le libellé est préservé.
- L'application du patch a été exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f622de3d94832a8ec871bd795aa5bf)