### PR TITLE
Fix Page 3 FAB alignment by reusing existing FAB classes

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -86,7 +86,7 @@
 
       <div class="item-detail-fab-row site-detail-fab-row" data-fab-row="create">
         <span id="itemDetailFabLabel" class="site-detail-fab-label fab-label site-detail-fab-label--create">Ajouter un article</span>
-        <button type="button" id="openDetailFormButton" class="fab" aria-label="Ajouter une donnée">+</button>
+        <button type="button" id="openDetailFormButton" class="fab fab-add--item-detail" aria-label="Ajouter une donnée">+</button>
       </div>
 
       <dialog id="detailFormModal" class="modal-card detail-form-modal">


### PR DESCRIPTION
### Motivation
- Aligner le symbole `+` du bouton FAB de Page 3 exactement comme Page 1 et Page 2 en réutilisant les règles CSS existantes sans ajouter de nouveau style ni modifier les autres pages.

### Description
- Remplacé la classe du bouton `#openDetailFormButton` dans `page3.html` de `class="fab"` à `class="fab fab-add--item-detail"` pour appliquer le même comportement d’alignement que les autres FAB.

### Testing
- Localement j’ai recherché et inspecté les FAB avec `rg`/`sed`/`nl`, appliqué la modification via un script, puis vérifié le changement avec `git diff -- page3.html`, `git status --short` et validé le commit, toutes les commandes ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6253e8220832aa390302b8263aa01)