### PR TITLE
Ajouter l’onglet « Achat matériel » (visible uniquement Admin) sur Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5278,3 +5278,37 @@ body {
   flex: 1;
 }
 
+
+.hidden {
+  display: none !important;
+}
+
+.page2-tabs {
+  display: flex;
+  gap: 10px;
+  padding: 0 24px;
+  margin: 16px 0;
+}
+
+.page2-tab {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  background: #ffffff;
+  color: #374151;
+  font-weight: 700;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
+}
+
+.page2-tab.active {
+  background: #2f9be8;
+  color: #ffffff;
+}
+
+.page2-tab-section {
+  display: none;
+}
+
+.page2-tab-section.active {
+  display: block;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -2643,6 +2643,10 @@ import { firebaseAuth } from './firebase-core.js';
     const siteExportCancelButton = requireElement('siteExportCancelButton');
     const itemSearchInput = requireElement('itemSearchInput');
     const itemDateFilter = requireElement('itemDateFilter');
+    const achatMaterielTab = document.querySelector('#achatMaterielTab');
+    const outTab = document.querySelector('[data-tab="out"]');
+    const outSection = document.querySelector('#outSection');
+    const achatSection = document.querySelector('#achatSection');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
     const itemNumberLabel = itemDialog?.querySelector('.input-group--item-create > span');
 
@@ -2666,6 +2670,66 @@ import { firebaseAuth } from './firebase-core.js';
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
 
     siteTitle.textContent = currentSite ? currentSite.nom : 'Chargement...';
+
+    function getCurrentUserRoleForSiteDetail() {
+      if (permissions?.isAdmin) {
+        return 'admin';
+      }
+      if (permissions?.isStandard) {
+        return 'standard';
+      }
+      return 'limite';
+    }
+
+    function activateOutSection() {
+      document.querySelectorAll('.page2-tab').forEach((tab) => tab.classList.remove('active'));
+      document.querySelectorAll('.page2-tab-section').forEach((section) => section.classList.remove('active'));
+      outTab?.classList.add('active');
+      outSection?.classList.add('active');
+      achatSection?.classList.remove('active');
+    }
+
+    function updateAchatMaterielTabVisibility() {
+      const user = firebaseAuth.currentUser;
+      const role = getCurrentUserRoleForSiteDetail();
+      const normalizedRole = String(role || '').toLowerCase();
+      const isAdmin = !!user && normalizedRole === 'admin';
+
+      if (!isAdmin) {
+        achatMaterielTab?.classList.add('hidden');
+        activateOutSection();
+        return;
+      }
+
+      achatMaterielTab?.classList.remove('hidden');
+    }
+
+    document.querySelectorAll('.page2-tab').forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const tabName = tab.dataset.tab;
+        const role = getCurrentUserRoleForSiteDetail();
+        const normalizedRole = String(role || '').toLowerCase();
+        const isAdmin = !!firebaseAuth.currentUser && normalizedRole === 'admin';
+
+        if (tabName === 'achat' && !isAdmin) {
+          updateAchatMaterielTabVisibility();
+          return;
+        }
+
+        document.querySelectorAll('.page2-tab').forEach((button) => button.classList.remove('active'));
+        document.querySelectorAll('.page2-tab-section').forEach((section) => section.classList.remove('active'));
+        tab.classList.add('active');
+
+        if (tabName === 'out') {
+          outSection?.classList.add('active');
+        }
+        if (tabName === 'achat') {
+          achatSection?.classList.add('active');
+        }
+      });
+    });
+
+    updateAchatMaterielTabVisibility();
 
     async function loadUserNames() {
       try {
@@ -3411,8 +3475,10 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
+    updateAchatMaterielTabVisibility();
     onAuthStateChanged(firebaseAuth, (user) => {
       updateCreateItemButtonVisibility(user || null);
+      updateAchatMaterielTabVisibility();
     });
 
     openCreateItem?.addEventListener('click', () => {

--- a/page2.html
+++ b/page2.html
@@ -59,7 +59,36 @@
           </select>
         </section>
 
-        <section id="itemList" class="list-grid" aria-live="polite"></section>
+        <div class="page2-tabs" role="tablist" aria-label="Sections page 2">
+          <button class="page2-tab active" data-tab="out" type="button">OUT</button>
+          <button class="page2-tab admin-only hidden" data-tab="achat" id="achatMaterielTab" type="button">
+            Achat matériel
+          </button>
+        </div>
+
+        <section id="outSection" class="page2-tab-section active">
+          <section id="itemList" class="list-grid" aria-live="polite"></section>
+        </section>
+
+        <section id="achatSection" class="page2-tab-section">
+          <form id="achatMaterielForm" class="surface-card section">
+            <label class="input-group">
+              <span>Désignation</span>
+              <input id="achatDesignationInput" name="designation" type="text" placeholder=" " />
+            </label>
+            <label class="input-group magasin-group">
+              <span class="magasin-label">Magasin</span>
+              <input id="achatStoreInput" name="store" type="text" placeholder=" " />
+            </label>
+            <label class="input-group">
+              <span>Quantité</span>
+              <input id="achatQuantityInput" name="quantity" type="number" min="0" step="1" placeholder="0" />
+            </label>
+            <div class="modal-actions modal-actions--site-create">
+              <button type="submit" class="btn btn-success">Ajouter matériel</button>
+            </div>
+          </form>
+        </section>
       </main>
 
       <div class="site-detail-fab-stack" aria-hidden="false">


### PR DESCRIPTION
### Motivation
- Ajouter un onglet « Achat matériel » dans Page 2 accessible uniquement aux utilisateurs Admin en réutilisant la gestion des rôles existante. 
- Ne pas afficher l’onglet aux utilisateurs non connectés, ni aux rôles Limité et Standard, et préserver le comportement par défaut d’OUT. 
- Conserver toute la logique existante de la liste OUT et ne pas toucher à Page 1 ni Page 3. 

### Description
- HTML : ajout d’une barre d’onglets `.page2-tabs` dans `page2.html`, encapsulation de la liste existante dans `#outSection` et ajout de `#achatSection` contenant le formulaire (`Désignation`, `Magasin`, `Quantité`, bouton `Ajouter matériel`). 
- JS : introduction de sélecteurs pour `#achatMaterielTab`, `#outSection` et `#achatSection`, ajout de `getCurrentUserRoleForSiteDetail()` et de `updateAchatMaterielTabVisibility()` pour baser la visibilité sur les permissions existantes (`permissions.isAdmin`), plus gestion des clics d’onglets et protection visuelle qui force le retour sur OUT si un non-admin tente d’ouvrir l’onglet `achat`. 
- Intégration : appel de `updateAchatMaterielTabVisibility()` au chargement de la page et après `onAuthStateChanged(firebaseAuth, ...)` pour mettre à jour la visibilité en réponse aux changements d’authentification/role. 
- CSS : ajout des styles pour les onglets (`.page2-tabs`, `.page2-tab`, `.page2-tab.active`, `.page2-tab-section`) et d’un utilitaire `.hidden`. 
- Contrainte respectée : la logique OUT existante n’a pas été modifiée et Page 1/Page 3 n’ont pas été touchées. 

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js`, qui a réussi. 
- Contrôle basique de l’état du repo et commit des fichiers modifiés (`page2.html`, `js/app.js`, `css/style.css`) réalisé (opération de commit réussie).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f641b7c334832a9185a05109ce22d0)