### PR TITLE
Remove 'Achat matériel' tabs and form from Page 2 (restore OUT-only layout)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5282,33 +5282,3 @@ body {
 .hidden {
   display: none !important;
 }
-
-.page2-tabs {
-  display: flex;
-  gap: 10px;
-  padding: 0 24px;
-  margin: 16px 0;
-}
-
-.page2-tab {
-  border: none;
-  border-radius: 999px;
-  padding: 10px 18px;
-  background: #ffffff;
-  color: #374151;
-  font-weight: 700;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
-}
-
-.page2-tab.active {
-  background: #2f9be8;
-  color: #ffffff;
-}
-
-.page2-tab-section {
-  display: none;
-}
-
-.page2-tab-section.active {
-  display: block;
-}

--- a/js/app.js
+++ b/js/app.js
@@ -2643,10 +2643,6 @@ import { firebaseAuth } from './firebase-core.js';
     const siteExportCancelButton = requireElement('siteExportCancelButton');
     const itemSearchInput = requireElement('itemSearchInput');
     const itemDateFilter = requireElement('itemDateFilter');
-    const achatMaterielTab = document.querySelector('#achatMaterielTab');
-    const outTab = document.querySelector('[data-tab="out"]');
-    const outSection = document.querySelector('#outSection');
-    const achatSection = document.querySelector('#achatSection');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
     const itemNumberLabel = itemDialog?.querySelector('.input-group--item-create > span');
 
@@ -2671,65 +2667,6 @@ import { firebaseAuth } from './firebase-core.js';
 
     siteTitle.textContent = currentSite ? currentSite.nom : 'Chargement...';
 
-    function getCurrentUserRoleForSiteDetail() {
-      if (permissions?.isAdmin) {
-        return 'admin';
-      }
-      if (permissions?.isStandard) {
-        return 'standard';
-      }
-      return 'limite';
-    }
-
-    function activateOutSection() {
-      document.querySelectorAll('.page2-tab').forEach((tab) => tab.classList.remove('active'));
-      document.querySelectorAll('.page2-tab-section').forEach((section) => section.classList.remove('active'));
-      outTab?.classList.add('active');
-      outSection?.classList.add('active');
-      achatSection?.classList.remove('active');
-    }
-
-    function updateAchatMaterielTabVisibility() {
-      const user = firebaseAuth.currentUser;
-      const role = getCurrentUserRoleForSiteDetail();
-      const normalizedRole = String(role || '').toLowerCase();
-      const isAdmin = !!user && normalizedRole === 'admin';
-
-      if (!isAdmin) {
-        achatMaterielTab?.classList.add('hidden');
-        activateOutSection();
-        return;
-      }
-
-      achatMaterielTab?.classList.remove('hidden');
-    }
-
-    document.querySelectorAll('.page2-tab').forEach((tab) => {
-      tab.addEventListener('click', () => {
-        const tabName = tab.dataset.tab;
-        const role = getCurrentUserRoleForSiteDetail();
-        const normalizedRole = String(role || '').toLowerCase();
-        const isAdmin = !!firebaseAuth.currentUser && normalizedRole === 'admin';
-
-        if (tabName === 'achat' && !isAdmin) {
-          updateAchatMaterielTabVisibility();
-          return;
-        }
-
-        document.querySelectorAll('.page2-tab').forEach((button) => button.classList.remove('active'));
-        document.querySelectorAll('.page2-tab-section').forEach((section) => section.classList.remove('active'));
-        tab.classList.add('active');
-
-        if (tabName === 'out') {
-          outSection?.classList.add('active');
-        }
-        if (tabName === 'achat') {
-          achatSection?.classList.add('active');
-        }
-      });
-    });
-
-    updateAchatMaterielTabVisibility();
 
     async function loadUserNames() {
       try {
@@ -3475,10 +3412,8 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
-    updateAchatMaterielTabVisibility();
     onAuthStateChanged(firebaseAuth, (user) => {
       updateCreateItemButtonVisibility(user || null);
-      updateAchatMaterielTabVisibility();
     });
 
     openCreateItem?.addEventListener('click', () => {

--- a/page2.html
+++ b/page2.html
@@ -59,36 +59,7 @@
           </select>
         </section>
 
-        <div class="page2-tabs" role="tablist" aria-label="Sections page 2">
-          <button class="page2-tab active" data-tab="out" type="button">OUT</button>
-          <button class="page2-tab admin-only hidden" data-tab="achat" id="achatMaterielTab" type="button">
-            Achat matériel
-          </button>
-        </div>
-
-        <section id="outSection" class="page2-tab-section active">
-          <section id="itemList" class="list-grid" aria-live="polite"></section>
-        </section>
-
-        <section id="achatSection" class="page2-tab-section">
-          <form id="achatMaterielForm" class="surface-card section">
-            <label class="input-group">
-              <span>Désignation</span>
-              <input id="achatDesignationInput" name="designation" type="text" placeholder=" " />
-            </label>
-            <label class="input-group magasin-group">
-              <span class="magasin-label">Magasin</span>
-              <input id="achatStoreInput" name="store" type="text" placeholder=" " />
-            </label>
-            <label class="input-group">
-              <span>Quantité</span>
-              <input id="achatQuantityInput" name="quantity" type="number" min="0" step="1" placeholder="0" />
-            </label>
-            <div class="modal-actions modal-actions--site-create">
-              <button type="submit" class="btn btn-success">Ajouter matériel</button>
-            </div>
-          </form>
-        </section>
+        <section id="itemList" class="list-grid" aria-live="polite"></section>
       </main>
 
       <div class="site-detail-fab-stack" aria-hidden="false">


### PR DESCRIPTION
### Motivation
- Remove the whole "Achat matériel" feature from Page 2 and restore the original single-view OUT layout so Page 2 only shows the OUT list with existing header, filters and actions. 

### Description
- Deleted the Page 2 tabs UI and buttons and rendered the OUT list directly by replacing the tab wrappers with `#itemList` in `page2.html`. 
- Removed the entire "Achat matériel" form (fields `achatDesignationInput`, `achatStoreInput`, `achatQuantityInput` and the `Ajouter matériel` button) from `page2.html`. 
- Removed tab management logic and related references in `js/app.js`, including removal of `updateAchatMaterielTabVisibility()`, the tab click handlers, and references to `data-tab`, `achatSection`, `outSection`, and `achatMaterielTab`. 
- Removed Page 2 tab CSS rules from `css/style.css` for `.page2-tabs`, `.page2-tab`, `.page2-tab.active`, `.page2-tab-section`, and `.page2-tab-section.active` to eliminate visual remnants. 

### Testing
- Ran repository searches to verify no remaining feature traces with `rg -n "Achat matériel|achatSection|page2-tab|data-tab|outSection|updateAchatMaterielTabVisibility|achatMaterielTab"` and `rg -n "achat|Achat|data-tab|page2-tab|achatSection|outSection|updateAchatMaterielTabVisibility|achatMaterielTab" page2.html js/app.js css/style.css`, which returned no lingering references in the modified files. 
- Verified working tree and staged changes with `git status --short` and committed the changes with `git commit -m "Remove Page 2 achat matériel tabs and logic"`, which succeeded. 
- Confirmed the header, filters, export button and create (`+`) flow were not modified during the change by restricting edits to the tab/form/tab-related code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f644e8820c832ab8f0ddd970e6cefc)