### PR TITLE
Intégrer workflow Admin «Achat matériel» dans la Page 2

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2610,6 +2610,7 @@ import { firebaseAuth } from './firebase-core.js';
     );
 
     loadUserNames();
+    setSiteTab('outs');
   }
 
   function initSiteDetailPage(permissions) {
@@ -2643,11 +2644,23 @@ import { firebaseAuth } from './firebase-core.js';
     const siteExportCancelButton = requireElement('siteExportCancelButton');
     const itemSearchInput = requireElement('itemSearchInput');
     const itemDateFilter = requireElement('itemDateFilter');
+    const purchaseDialog = requireElement('purchaseDialog');
+    const purchaseForm = requireElement('purchaseForm');
+    const purchaseStoreInput = requireElement('purchaseStoreInput');
+    const purchaseDesignationInput = requireElement('purchaseDesignationInput');
+    const purchaseQtyInput = requireElement('purchaseQtyInput');
+    const purchaseFormError = requireElement('purchaseFormError');
+    const purchaseSubmitButton = requireElement('purchaseSubmitButton');
+    const purchaseInfoCard = requireElement('purchaseInfoCard');
+    const purchaseTabButton = document.getElementById('purchaseTabButton');
+    const outsFilterGroup = requireElement('outsFilterGroup');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
     const itemNumberLabel = itemDialog?.querySelector('.input-group--item-create > span');
 
     let currentSite = StorageService.getSite(siteId);
     let currentItems = [];
+    let currentPurchases = [];
+    let activeTab = 'outs';
     let detailCountsByItem = {};
     let detailDesignationsByItem = {};
     let detailRowsByItem = {};
@@ -3097,6 +3110,49 @@ import { firebaseAuth } from './firebase-core.js';
       });
     }
 
+
+    function genMaterialRef() {
+      const d = new Date();
+      const part = `${d.getFullYear().toString().slice(-2)}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+      return `MAT-${part}${Math.floor(Math.random() * 9000 + 1000)}`;
+    }
+
+    function setSiteTab(nextTab) {
+      const isAdmin = Boolean(permissions?.isAdmin);
+      activeTab = isAdmin && nextTab === 'purchase' ? 'purchase' : 'outs';
+      const isPurchase = activeTab === 'purchase';
+      purchaseInfoCard.hidden = !isPurchase;
+      outsFilterGroup.hidden = isPurchase;
+      filterChipButtons.forEach((btn)=>btn.closest('button')?.toggleAttribute?.('hidden', isPurchase));
+      const createItemLabel = document.querySelector('body[data-page="site-detail"] .site-detail-fab-label--create');
+      if (createItemLabel) createItemLabel.textContent = isPurchase ? 'Ajouter matériel' : 'Créer un OUT';
+      if (purchaseTabButton) {
+        purchaseTabButton.setAttribute('aria-selected', String(isPurchase));
+        purchaseTabButton.classList.toggle('is-active', isPurchase);
+      }
+      const outsTab = document.querySelector('[data-site-tab="outs"]');
+      outsTab?.setAttribute('aria-selected', String(!isPurchase));
+      outsTab?.classList.toggle('is-active', !isPurchase);
+      itemCount.innerHTML = isPurchase
+        ? `<span class="outs-number">${currentPurchases.length}</span><span class="outs-label">Achat matériel</span>`
+        : itemCount.innerHTML;
+      if (isPurchase) {
+        renderPurchases();
+      } else {
+        renderItems();
+      }
+    }
+
+    function renderPurchases() {
+      itemCount.innerHTML = `<span class="outs-number">${currentPurchases.length}</span><span class="outs-label">Achat matériel</span>`;
+      if (!currentPurchases.length) {
+        UiService.renderEmptyState(itemList, 'Aucun achat matériel
+Ajoutez un nouveau matériel en appuyant sur +.');
+        return;
+      }
+      itemList.innerHTML = currentPurchases.map((p)=>`<article class="list-card"><div class="list-card__title-row"><h3 class="list-card__title">${escapeHtml(p.ref || '')}</h3></div><p>${escapeHtml(p.designation||'')}</p><p>${escapeHtml(p.magasin||'')}</p><p>Qté : ${escapeHtml(String(p.quantite||''))}</p><p>Créé le ${formatDateLabel(p.createdAt)}</p><p>${escapeHtml(p.createdByName||'Utilisateur')}</p></article>`).join('');
+    }
+
     function renderItems() {
       const query = itemSearchInput.value.trim().toUpperCase();
       const filteredItems = currentItems.filter((item) => {
@@ -3114,7 +3170,9 @@ import { firebaseAuth } from './firebase-core.js';
         return itemDesignations.some((designation) => String(designation || '').toUpperCase().includes(query));
       });
 
-      itemCount.innerHTML = `<span class="outs-number">${filteredItems.length}</span><span class="outs-label">OUT${filteredItems.length > 1 ? 'S' : ''}</span>`;
+      if (activeTab === 'outs') {
+        itemCount.innerHTML = `<span class="outs-number">${filteredItems.length}</span><span class="outs-label">OUT${filteredItems.length > 1 ? 'S' : ''}</span>`;
+      }
 
       if (!filteredItems.length) {
         UiService.renderEmptyState(
@@ -3417,6 +3475,7 @@ import { firebaseAuth } from './firebase-core.js';
     });
 
     openCreateItem?.addEventListener('click', () => {
+      if (activeTab === 'purchase') { purchaseForm.reset(); purchaseFormError.textContent=''; purchaseDialog.showModal(); purchaseStoreInput.focus(); return; }
       setItemDialogMode(ITEM_DIALOG_MODE_CREATE);
       itemForm.reset();
       clearItemFormError();
@@ -3584,6 +3643,10 @@ import { firebaseAuth } from './firebase-core.js';
       siteDetailScrollContainer?.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
     }
 
+    document.querySelector('[data-site-tab="outs"]')?.addEventListener('click', ()=>setSiteTab('outs'));
+    purchaseTabButton?.addEventListener('click', ()=>setSiteTab('purchase'));
+    purchaseTabButton.hidden = !permissions.isAdmin;
+
     itemSearchInput.addEventListener('input', () => {
       window.localStorage.setItem(searchStorageKey, itemSearchInput.value);
       renderItems();
@@ -3702,6 +3765,21 @@ import { firebaseAuth } from './firebase-core.js';
       }
     });
 
+    purchaseForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const magasin = String(purchaseStoreInput.value || '').trim();
+      const designation = String(purchaseDesignationInput.value || '').trim();
+      const quantite = Number(purchaseQtyInput.value || 0);
+      if (!magasin || !designation || !(quantite > 0)) { purchaseFormError.textContent = 'Veuillez remplir ce champ'; return; }
+      purchaseSubmitButton.disabled = true;
+      const result = await StorageService.createMaterialPurchase({ siteId, siteName: currentSite?.nom || '', magasin, designation, quantite, ref: genMaterialRef() });
+      purchaseSubmitButton.disabled = false;
+      if (!result?.ok) { purchaseFormError.textContent = 'Enregistrement impossible.'; return; }
+      purchaseDialog.close();
+    });
+
+    StorageService.subscribeMaterialPurchases(siteId, (rows)=>{ currentPurchases = rows; if (activeTab === 'purchase') renderPurchases(); });
+
     StorageService.subscribeSites((sites) => {
       currentSite = sites.find((site) => site.id === siteId) || currentSite;
       if (!currentSite) {
@@ -3752,6 +3830,7 @@ import { firebaseAuth } from './firebase-core.js';
     );
 
     loadUserNames();
+    setSiteTab('outs');
   }
 
   function initItemDetailPage(permissions) {
@@ -4832,6 +4911,21 @@ import { firebaseAuth } from './firebase-core.js';
     detailSkeletonTimerId = window.setTimeout(() => {
       showDetailTableSkeleton();
     }, 120);
+
+    purchaseForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const magasin = String(purchaseStoreInput.value || '').trim();
+      const designation = String(purchaseDesignationInput.value || '').trim();
+      const quantite = Number(purchaseQtyInput.value || 0);
+      if (!magasin || !designation || !(quantite > 0)) { purchaseFormError.textContent = 'Veuillez remplir ce champ'; return; }
+      purchaseSubmitButton.disabled = true;
+      const result = await StorageService.createMaterialPurchase({ siteId, siteName: currentSite?.nom || '', magasin, designation, quantite, ref: genMaterialRef() });
+      purchaseSubmitButton.disabled = false;
+      if (!result?.ok) { purchaseFormError.textContent = 'Enregistrement impossible.'; return; }
+      purchaseDialog.close();
+    });
+
+    StorageService.subscribeMaterialPurchases(siteId, (rows)=>{ currentPurchases = rows; if (activeTab === 'purchase') renderPurchases(); });
 
     StorageService.subscribeSites((sites) => {
       currentSite = sites.find((site) => site.id === siteId) || currentSite;

--- a/js/storage.js
+++ b/js/storage.js
@@ -27,6 +27,7 @@ const state = {
   sites: [],
   itemsBySite: new Map(),
   detailsByItem: new Map(),
+  purchasesBySite: new Map(),
   listeners: {
     sites: new Set(),
     itemCounts: new Set(),
@@ -34,6 +35,7 @@ const state = {
     detailCountsBySite: new Map(),
     detailDesignationsBySite: new Map(),
     detailRowsBySite: new Map(),
+    purchasesBySite: new Map(),
     detailsByPair: new Map(),
   },
 };
@@ -676,7 +678,15 @@ function applySnapshot(snapshot) {
   state.sites = Array.isArray(snapshot.page1) ? clone(snapshot.page1) : [];
 
   state.itemsBySite = new Map();
+  state.purchasesBySite = new Map();
   (Array.isArray(snapshot.page2) ? snapshot.page2 : []).forEach((item) => {
+    if (String(item.type || '') === 'material_purchase') {
+      const pSiteId = String(item.siteId || '');
+      if (!pSiteId) { return; }
+      if (!state.purchasesBySite.has(pSiteId)) { state.purchasesBySite.set(pSiteId, []); }
+      state.purchasesBySite.get(pSiteId).push(item);
+      return;
+    }
     const siteId = String(item.siteId || '');
     if (!siteId) {
       return;
@@ -745,6 +755,8 @@ function emitForSite(siteId) {
     }
   });
   (state.listeners.detailRowsBySite.get(siteId) || new Set()).forEach((listener) => listener(clone(rowsByItem)));
+  const purchases = clone(state.purchasesBySite.get(siteId) || []);
+  (state.listeners.purchasesBySite.get(siteId) || new Set()).forEach((listener) => listener(purchases));
 }
 
 function emitAll() {
@@ -1689,6 +1701,36 @@ async function importData(payload) {
   return true;
 }
 
+
+function subscribeMaterialPurchases(siteId, onChange, onError) {
+  try {
+    const unsubscribe = subscribeFactory(state.listeners.purchasesBySite, siteId, onChange);
+    onChange(clone(state.purchasesBySite.get(siteId) || []));
+    return unsubscribe;
+  } catch (error) {
+    if (typeof onError === 'function') { onError(error); }
+    return () => {};
+  }
+}
+
+async function createMaterialPurchase(payload) {
+  const siteId = sanitizeText(payload?.siteId || '', false);
+  if (!siteId) return { ok: false, reason: 'site_not_found' };
+  const magasin = sanitizeText(payload?.magasin || '', true);
+  const designation = sanitizeText(payload?.designation || '', true);
+  const quantite = Number(payload?.quantite || 0);
+  if (!magasin || !designation || !(quantite > 0)) return { ok: false, reason: 'invalid_payload' };
+  const timestamp = nowIso();
+  const creatorName = await resolveCurrentUserName();
+  const docPayload = { type: 'material_purchase', ref: sanitizeText(payload?.ref || uid(), true), siteId, siteName: sanitizeText(payload?.siteName || '', true), magasin, designation, quantite, createdAt: timestamp, createdByName: creatorName, createdByEmail: resolveCurrentUserEmail(), dateModification: timestamp };
+  const created = await addDoc(makePageItemsCollection('page2'), docPayload);
+  const next = { id: created.id, ...docPayload };
+  if (!state.purchasesBySite.has(siteId)) state.purchasesBySite.set(siteId, []);
+  state.purchasesBySite.get(siteId).unshift(next);
+  persistOfflineState(); emitAll();
+  return { ok: true, id: next.id };
+}
+
 window.StorageService = {
   init,
   getSites,
@@ -1701,6 +1743,7 @@ window.StorageService = {
   subscribeDetailCounts,
   subscribeDetailDesignations,
   subscribeDetailRows,
+  subscribeMaterialPurchases,
   getDetailRowsBySite,
   getAllDetails,
   createSite,
@@ -1716,6 +1759,7 @@ window.StorageService = {
   createDetail,
   updateDetail,
   removeDetail,
+  createMaterialPurchase,
   exportData,
   importData,
   ensureCurrentUser,

--- a/page2.html
+++ b/page2.html
@@ -36,6 +36,10 @@
               autocomplete="off"
             />
           </label>
+          <div id="siteDetailTabs" class="filter-chip-group filters site-detail-tabs" role="tablist" aria-label="Sections">
+            <button class="filter-chip is-active" type="button" role="tab" aria-selected="true" data-site-tab="outs">OUTS</button>
+            <button class="filter-chip" type="button" role="tab" aria-selected="false" data-site-tab="purchase" id="purchaseTabButton" hidden>ACHAT MATÉRIEL</button>
+          </div>
           <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>
             <span class="auth-required-card__icon" aria-hidden="true">i</span>
             <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>
@@ -44,7 +48,7 @@
               <span aria-hidden="true">›</span>
             </button>
           </section>
-          <div class="filter-chip-group filters" role="group" aria-label="Filtrer les résultats par date">
+          <div id="outsFilterGroup" class="filter-chip-group filters" role="group" aria-label="Filtrer les résultats par date">
             <button class="filter-chip" type="button" data-filter-chip="all">Tous</button>
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>
@@ -59,6 +63,10 @@
           </select>
         </section>
 
+        <section id="purchaseInfoCard" class="auth-required-card auth-required-card--embedded section" hidden>
+          <span class="auth-required-card__icon" aria-hidden="true">i</span>
+          <p class="auth-required-card__message">Liste des achats de matériel. Appuyez sur + pour ajouter.</p>
+        </section>
         <section id="itemList" class="list-grid" aria-live="polite"></section>
       </main>
 
@@ -112,6 +120,19 @@
               <span class="btn-loading-spinner" aria-hidden="true"></span>
               <span class="btn-label-loading" aria-hidden="true">Création...</span>
             </button>
+          </div>
+        </form>
+      </dialog>
+      <dialog id="purchaseDialog" class="modal-card">
+        <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="purchaseForm">
+          <div class="modal-header"><h2>Ajouter un matériel</h2></div>
+          <label class="input-group input-group--site-create input-group--item-create"><span>Magasin</span><input id="purchaseStoreInput" type="text" placeholder="Sélectionner un magasin" /></label>
+          <label class="input-group input-group--site-create input-group--item-create"><span>Désignation</span><input id="purchaseDesignationInput" type="text" placeholder="Entrer la désignation" /></label>
+          <label class="input-group input-group--site-create input-group--item-create"><span>Qté</span><input id="purchaseQtyInput" type="number" min="1" step="1" placeholder="Entrer la quantité" /></label>
+          <p id="purchaseFormError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
+            <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>
+            <button id="purchaseSubmitButton" type="submit" class="btn btn-success"><span class="btn-label-default">Enregistrer</span></button>
           </div>
         </form>
       </dialog>


### PR DESCRIPTION
### Motivation
- Ajouter l’onglet «ACHAT MATÉRIEL» sur la page détail site pour permettre aux Admins d’enregistrer des achats matériel sans créer de nouvelle page.
- Respecter le design existant en réutilisant les composants CSS (cards, modal, inputs, FAB) et sans modifier les pages OUTS existantes.

### Description
- Ajout d’un bandeau d’onglets sous la recherche dans `page2.html` avec `OUTS` (par défaut) et `ACHAT MATÉRIEL` (masqué en HTML et affiché uniquement pour `Admin`).
- Création de la section d’information `Achat matériel`, d’un `dialog` modal `purchaseDialog` (champs `Magasin`, `Désignation`, `Qté`, erreurs et boutons `Annuler`/`Enregistrer`) et rendu des achats en cards en réutilisant les classes existantes.
- Ajout dans `js/app.js` de la gestion d’état d’onglet (`setSiteTab`), du FAB dynamique (libellé et action), du header/subtitle dynamique et du rendu/empty-state pour la liste des achats, ainsi que du traitement de soumission du formulaire d’ajout qui appelle `StorageService.createMaterialPurchase`.
- Extension de `js/storage.js` pour séparer les documents `page2` par `type: 'material_purchase'`, stocker les achats dans `state.purchasesBySite`, exposer `subscribeMaterialPurchases(siteId, ...)` et `createMaterialPurchase(payload)` qui enregistrent en Firestore les champs demandés (`ref`, `siteId`, `siteName`, `magasin`, `designation`, `quantite`, `createdAt`, `createdByName`, `createdByEmail`).

### Testing
- Vérification de la syntaxe des scripts avec `node --check js/app.js` qui a réussi.
- Vérification de la syntaxe des scripts avec `node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f649434254832abe08822290aa3c0d)