### PR TITLE
Harden page-specific init and ensure skeleton teardown

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,17 @@
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
 import { firebaseAuth } from './firebase-core.js';
 
+console.log('Page actuelle :', location.pathname);
+window.addEventListener('error', (e) => {
+  console.error('Erreur JS détectée :', e.message, e.filename, e.lineno);
+});
+
 (function () {
   const { StorageService, UiService } = window;
+  const isPage1 = location.pathname.includes('index.html') || location.pathname === '/';
+  const isPage2 = location.pathname.includes('page2.html');
+  const isPage3 = location.pathname.includes('page3.html');
+  console.log('isPage1:', isPage1, 'isPage2:', isPage2, 'isPage3:', isPage3);
 
   function requireElement(id) {
     return document.getElementById(id);
@@ -5273,17 +5282,29 @@ Ajoutez un nouveau matériel en appuyant sur +.');
     }
   }
 
-
-  try {
-    bootstrap().catch((error) => {
-      console.error('Erreur init app :', error);
-    }).finally(() => {
-      UiService.markAppReady();
-      document.body.classList.remove('loading', 'is-loading');
-    });
-  } catch (error) {
-    console.error('Erreur init app :', error);
+  function hideGlobalSkeleton() {
+    console.log('Skeleton supprimé');
+    document.querySelector('.skeleton-container')?.remove();
     UiService.markAppReady();
-    document.body.classList.remove('loading', 'is-loading');
   }
+
+  function safeInit() {
+    console.log('Init app start');
+    try {
+      bootstrap().catch((error) => {
+        console.error('Erreur init app :', error);
+      }).finally(() => {
+        console.log('Fin init → enlever skeleton');
+        hideGlobalSkeleton();
+        document.body.classList.remove('loading', 'is-loading');
+      });
+    } catch (error) {
+      console.error('Erreur INIT :', error);
+      console.log('Fin init → enlever skeleton');
+      hideGlobalSkeleton();
+      document.body.classList.remove('loading', 'is-loading');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', safeInit);
 })();


### PR DESCRIPTION
### Motivation
- Certaines pages restaient bloquées en état skeleton quand du code spécifique à la Page 2 lançait des erreurs ou s'exécutait dans le mauvais contexte, empêchant le teardown global du chargement.
- L'objectif est d'améliorer l'observabilité et de garantir la suppression du skeleton même en cas d'erreur d'initialisation.

### Description
- Ajout de logs diagnostics au démarrage (`location.pathname`) et d'un gestionnaire global d'erreurs `window.addEventListener('error', ...)` pour repérer où une erreur runtime survient dans `js/app.js`.
- Introduction de flags explicites de pages (`isPage1`, `isPage2`, `isPage3`) avec log pour faciliter l'isolation du code par page dans un contexte multi-pages.
- Remplacement de l'appel direct à `bootstrap()` par un wrapper `safeInit()` lié à l'événement `DOMContentLoaded` qui capture les exceptions, logge le début/fin d'init et nettoie toujours l'état de loading.
- Ajout de `hideGlobalSkeleton()` qui supprime la `.skeleton-container` et appelle `UiService.markAppReady()` pour garantir le teardown visuel même si l'init échoue, et nettoyage systématique de `document.body.classList`.

### Testing
- Aucun test automatisé n'a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f650b7ba10832a8eff077b6134bf9e)