### PR TITLE
Aligner la recherche de la Page 1 sur le style inline de la Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4179,6 +4179,14 @@ body[data-page="home"] .search-panel .input-group {
   position: relative;
   gap: 0;
 }
+body[data-page="home"] .search-panel.search-panel--inline {
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 
 body[data-page="home"] .search-input__icon-wrap {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 
 
       <main class="page-content main-content">
-        <section class="search-panel surface-card section">
+        <section class="search-panel search-panel--inline section">
           <label class="input-group">
             <span class="sr-only">Recherche</span>
             <span class="search-input__icon-wrap" aria-hidden="true">


### PR DESCRIPTION
### Motivation
- Supprimer le conteneur blanc de la section recherche sur la Page 1 pour que l’apparence corresponde à la Page 3 sans changer le champ recherche, l’icône ou le header.

### Description
- Remplacé la classe wrapper de la recherche dans `index.html` de `search-panel surface-card section` vers `search-panel search-panel--inline section` pour utiliser la variante inline existante.
- Ajouté une règle CSS ciblée dans `css/style.css` (`body[data-page="home"] .search-panel.search-panel--inline`) qui neutralise le style de "carte" en supprimant `padding`, `border`, `border-radius`, `background` et `box-shadow`.
- Aucun changement apporté à l’input de recherche, à l’icône, au header, ni aux pages 2 et 3.

### Testing
- Exécuté `git diff -- index.html css/style.css` pour vérifier que seules `index.html` et `css/style.css` sont modifiées et la vérification a réussi.
- Exécuté `git status --short` pour confirmer les deux fichiers modifiés et la vérification a réussi.
- Inspecté les fichiers avec affichage de lignes (`nl -ba index.html` et `nl -ba css/style.css`) pour valider l’application de la classe et l’insertion CSS et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e4e0cac0832a905a5d11824a2bf0)