### PR TITLE
Focus bleu sur la recherche et affichage inline « Site enregistré : X » (Page 1)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4163,6 +4163,7 @@ body[data-page="site-detail"] .list-card:active {
 .search-input:focus {
   outline: none;
   border: 2px solid #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
 
 body[data-page="home"] .search-panel {
@@ -4623,16 +4624,13 @@ body[data-page="home"] .saved-sites-label__icon {
   flex-shrink: 0;
 }
 
-body[data-page="home"] .site-count-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2rem;
-  padding: 0.2rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(22, 163, 74, 0.14);
+body[data-page="home"] .site-label {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+body[data-page="home"] .site-count {
   color: #166534;
-  font-size: 0.84rem;
   font-weight: 700;
 }
 

--- a/index.html
+++ b/index.html
@@ -86,9 +86,8 @@
         <section class="section-heading section-heading--sticky section-heading--saved">
           <div class="saved-sites-label">
             <img src="Icon/Site.png" alt="" aria-hidden="true" class="saved-sites-label__icon" />
-            <h2>Site enregistré</h2>
+            <h2><span class="site-label">Site enregistré :</span> <span id="siteCount" class="site-count" aria-label="Nombre de sites enregistrés">0</span></h2>
           </div>
-          <span id="siteCount" class="site-count-pill" aria-label="Nombre de sites enregistrés">0</span>
         </section>
 
         <section id="siteList" class="list-grid" aria-live="polite"></section>


### PR DESCRIPTION
### Motivation
- Harmoniser le comportement visuel du champ recherche sur la page d'accueil avec Page 3 en appliquant exactement le même focus bleu et halo. 
- Afficher le compteur de sites dans le libellé pour obtenir le format souhaité `Site enregistré : X` et simplifier l'UI. 
- Rendre le texte « Site enregistré » moins visible tout en conservant le nombre en vert pour la lisibilité et sans créer de nouveau style.

### Description
- Mise à jour de `index.html` pour intégrer le compteur au titre en remplaçant le badge séparé par `<h2><span class="site-label">Site enregistré :</span> <span id="siteCount" class="site-count">0</span></h2>` afin de conserver l'`id="siteCount"` existant. 
- Mise à jour de `css/style.css` pour étendre `.search-input:focus` avec le même bord bleu `#3b82f6` et ajouter le halo `box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15)` réutilisant exactement la couleur utilisée sur Page 3. 
- Remplacement du style de la « pill » verte spécifique à la Page 1 par deux règles `body[data-page="home"] .site-label` et `body[data-page="home"] .site-count` afin de rendre le label plus discret (`color: #6b7280; font-weight: 500;`) et garder le nombre en vert gras sans introduire de nouveau style global.

### Testing
- Aucun test automatisé exécuté sur cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e7ca6f44832ab2ab653872e087dc)