### PR TITLE
Add smooth swipe-to-close gesture for Page 1 sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5186,6 +5186,8 @@ body.sidebar-open {
   background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
   border-radius: 0 26px 26px 0;
   padding: 20px 16px;
+  will-change: transform;
+  touch-action: pan-y;
 }
 
 .sidebar-header {

--- a/js/app.js
+++ b/js/app.js
@@ -1345,6 +1345,10 @@ import { firebaseAuth } from './firebase-core.js';
     const HOME_MENU_ANIMATION_LOCK_MS = 320;
     let homeMenuCloseTimer = null;
     let sidebarAnimating = false;
+    let touchStartX = 0;
+    let touchCurrentX = 0;
+    let isDraggingSidebar = false;
+    let sidebarWidth = 0;
     const homeMenuStateKey = '__homeMenuOpen__';
     const homeMenuCloseButton = requireElement('homeMenuCloseButton');
 
@@ -1363,6 +1367,12 @@ import { firebaseAuth } from './firebase-core.js';
       }
       homeMenuPanel.hidden = true;
       homeMenuPanel.classList.remove('is-open', 'is-closing');
+      homeMenuPanel.style.transform = '';
+      homeMenuPanel.style.transition = '';
+      if (homeMenuOverlay) {
+        homeMenuOverlay.style.opacity = '';
+      }
+      isDraggingSidebar = false;
       sidebarAnimating = false;
     }
 
@@ -1382,6 +1392,7 @@ import { firebaseAuth } from './firebase-core.js';
 
       homeMenuPanel.classList.remove('is-open');
       homeMenuPanel.classList.add('is-closing');
+      homeMenuPanel.style.transform = '';
       const onTransitionEnd = (event) => {
         if (event.target !== homeMenuPanel) {
           return;
@@ -1977,6 +1988,53 @@ import { firebaseAuth } from './firebase-core.js';
 
       homeMenuPanel.addEventListener('click', (event) => {
         event.stopPropagation();
+      });
+
+      homeMenuPanel.addEventListener('touchstart', (event) => {
+        if (!homeMenuPanel.classList.contains('is-open') || sidebarAnimating) {
+          return;
+        }
+        touchStartX = event.touches[0].clientX;
+        touchCurrentX = touchStartX;
+        sidebarWidth = homeMenuPanel.offsetWidth || 0;
+        isDraggingSidebar = true;
+        homeMenuPanel.style.transition = 'none';
+      }, { passive: true });
+
+      homeMenuPanel.addEventListener('touchmove', (event) => {
+        if (!isDraggingSidebar || !sidebarWidth) {
+          return;
+        }
+        touchCurrentX = event.touches[0].clientX;
+        const deltaX = touchCurrentX - touchStartX;
+        if (deltaX < 0) {
+          const translateX = Math.max(deltaX, -sidebarWidth);
+          homeMenuPanel.style.transform = `translateX(${translateX}px)`;
+          const progress = Math.min(Math.abs(deltaX) / sidebarWidth, 1);
+          homeMenuOverlay.style.opacity = String(1 - progress * 0.45);
+        }
+      }, { passive: true });
+
+      homeMenuPanel.addEventListener('touchend', () => {
+        if (!isDraggingSidebar) {
+          return;
+        }
+        isDraggingSidebar = false;
+        const deltaX = touchCurrentX - touchStartX;
+        homeMenuPanel.style.transition = '';
+        homeMenuOverlay.style.opacity = '';
+        if (Math.abs(deltaX) > sidebarWidth * 0.35 && deltaX < 0) {
+          closeSidebar();
+          return;
+        }
+        homeMenuPanel.style.transform = '';
+      });
+
+      homeMenuPanel.addEventListener('touchcancel', () => {
+        isDraggingSidebar = false;
+        homeMenuPanel.style.transition = '';
+        homeMenuPanel.style.transform = '';
+        homeMenuOverlay.style.opacity = '';
       });
 
       homeMenuOverlay.addEventListener('click', closeSidebar);


### PR DESCRIPTION
### Motivation
- Permettre une fermeture tactile fluide du sidebar de la Page 1 en suivant le doigt sans supprimer ou remplacer l’animation existante.
- Offrir un comportement mobile natif où un glissement vers la gauche ferme le drawer si le déplacement dépasse une fraction de sa largeur.

### Description
- Ajout de la gestion tactile (`touchstart`, `touchmove`, `touchend`, `touchcancel`) scindée sur `homeMenuPanel` avec état local (`touchStartX`, `touchCurrentX`, `isDraggingSidebar`, `sidebarWidth`) pour suivre le doigt et appliquer un `transform` inline pendant le drag dans `js/app.js`.
- Implémentation d’un seuil de fermeture d’environ `35%` de la largeur du sidebar pour déclencher `closeSidebar()`, sinon retour à l’état ouvert en conservant les transitions basées sur les classes (`is-open` / `is-closing`).
- Nettoyage garanti des styles inline (`transform`, `transition`) et de l’opacité de l’overlay dans `finalizeHomeMenuClose()` et après annulation pour éviter des styles persistants.
- Ajout de `will-change: transform` et `touch-action: pan-y` à la règle `.app-sidebar` dans `css/style.css` pour améliorer la fluidité tactile sans modifier le design ou l’arborescence du sidebar.

### Testing
- Exécution de vérifications automatisées par commandes shell pour inspecter les fichiers et plages modifiées avec `rg`/`sed`/`nl` et contrôler l’état git, toutes réussies.
- Validation de commit automatisée via `git add` et `git commit` qui a réussi et inclut les deux fichiers modifiés (`js/app.js`, `css/style.css`).
- Aucun test unitaire automatique dédié au composant sidebar n’était présent dans le dépôt; les modifications ont été limitées pour rester compatibles avec les mécanismes d’ouverture/fermeture existants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8eca04d90832aa7e5e455ffd87662)