### PR TITLE
Ajouter le menu et la page “Tous les matériels” en lecture seule

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
           <button id="sidebarHistoryBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="historiques.html">
             Historiques
           </button>
+          <button id="sidebarAllMaterialsBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="materiels.html">
+            Tous les matériels
+          </button>
           <button id="sidebarImportBtn" class="header-menu__option sidebar-item" type="button" role="menuitem">
             Importer les données
           </button>

--- a/js/app.js
+++ b/js/app.js
@@ -914,6 +914,7 @@ import { firebaseAuth } from './firebase-core.js';
     const manageUsersButton = requireElement('sidebarUsersBtn');
     const usersSidebarBtn = homeMenuPanel?.querySelector('#sidebarUsersBtn') || null;
     const historySidebarBtn = homeMenuPanel?.querySelector('#sidebarHistoryBtn') || null;
+    const allMaterialsSidebarBtn = homeMenuPanel?.querySelector('#sidebarAllMaterialsBtn') || null;
     const sidebarItems = homeMenuPanel ? Array.from(homeMenuPanel.querySelectorAll('.sidebar-item')) : [];
     const siteLockDialog = requireElement('siteLockDialog');
     const siteLockForm = requireElement('siteLockForm');
@@ -2120,6 +2121,15 @@ import { firebaseAuth } from './firebase-core.js';
         event.preventDefault();
         event.stopPropagation();
         window.location.assign('users.html');
+      });
+    }
+
+
+    if (allMaterialsSidebarBtn) {
+      allMaterialsSidebarBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        window.location.assign('materiels.html');
       });
     }
 

--- a/js/materiels.js
+++ b/js/materiels.js
@@ -1,0 +1,96 @@
+(function () {
+  const { StorageService } = window;
+
+  function requireElement(id) {
+    return document.getElementById(id);
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function normalizeMaterials(details) {
+    const map = new Map();
+
+    details.forEach((item) => {
+      const code = String(item?.code || item?.ref || item?.reference || '').trim();
+      const designation = String(item?.designation || item?.['désignation'] || item?.name || '').trim();
+
+      if (code && !map.has(code)) {
+        map.set(code, {
+          code,
+          designation,
+        });
+      }
+    });
+
+    return Array.from(map.values()).sort((a, b) =>
+      String(a.designation).localeCompare(String(b.designation), 'fr', { sensitivity: 'base' }),
+    );
+  }
+
+  function renderRows(rows) {
+    const tbody = requireElement('materialsTableBody');
+    const emptyState = requireElement('materialsEmptyState');
+    const table = requireElement('materialsDataTable');
+    const countNumber = document.querySelector('#materialsCount .count-number');
+
+    if (!tbody || !emptyState || !table || !countNumber) {
+      return;
+    }
+
+    countNumber.textContent = String(rows.length);
+
+    if (!rows.length) {
+      tbody.innerHTML = '';
+      table.hidden = true;
+      emptyState.hidden = false;
+      return;
+    }
+
+    emptyState.hidden = true;
+    table.hidden = false;
+    tbody.innerHTML = rows
+      .map(
+        (material) => `\n          <tr>\n            <td>${escapeHtml(material.code)}</td>\n            <td>${escapeHtml(material.designation)}</td>\n          </tr>\n        `,
+      )
+      .join('');
+  }
+
+  async function init() {
+    const backButton = requireElement('materialsBackButton');
+    const searchInput = requireElement('materialsSearchInput');
+
+    backButton?.addEventListener('click', () => {
+      window.location.assign('index.html');
+    });
+
+    await StorageService.init();
+    const details = await StorageService.getAllDetails();
+    const materials = normalizeMaterials(details);
+
+    const applySearch = () => {
+      const query = String(searchInput?.value || '').trim().toLowerCase();
+      if (!query) {
+        renderRows(materials);
+        return;
+      }
+      const filtered = materials.filter((material) => {
+        const code = String(material.code || '').toLowerCase();
+        const designation = String(material.designation || '').toLowerCase();
+        return code.includes(query) || designation.includes(query);
+      });
+      renderRows(filtered);
+    };
+
+    searchInput?.addEventListener('input', applySearch);
+    renderRows(materials);
+  }
+
+  init();
+})();

--- a/materiels.html
+++ b/materiels.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Tous les matériels - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  </head>
+  <body data-page="all-materials" class="page3">
+    <div class="app-shell app-shell--wide">
+      <header class="app-header app-header--detail">
+        <div class="app-header__side app-header__side--left">
+          <button class="back-button" type="button" id="materialsBackButton" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
+        </div>
+        <div class="app-header__center">
+          <div class="header-title header-title--stacked">
+            <h1>Tous les matériels</h1>
+          </div>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
+      </header>
+
+      <main class="page-content page-content--wide main-content">
+        <section class="surface-card table-card section">
+          <div class="section-heading section-heading--table">
+            <div class="header-top page3-summary-header">
+              <div class="title-block page3-title-block">
+                <h2 class="section-title">Tableau des matériels</h2>
+              </div>
+            </div>
+          </div>
+          <div class="page3-sub-info">
+            <div id="materialsCount" class="article-count page3-article-count">
+              <span class="count-number page3-count-number">0</span>
+              <span class="count-label page3-count-label">Matériels</span>
+            </div>
+          </div>
+          <div class="search-panel search-panel--inline">
+            <label class="input-group">
+              <span class="search-input__icon-wrap" aria-hidden="true">
+                <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
+              </span>
+              <input id="materialsSearchInput" class="search-input" type="text" placeholder="Rechercher un matériel..." autocomplete="off" />
+            </label>
+          </div>
+          <div class="table-container table-container--card">
+            <div class="table-wrapper table-wrapper--shared">
+              <table class="data-table" id="materialsDataTable">
+                <thead>
+                  <tr>
+                    <th>Code</th>
+                    <th>Désignation</th>
+                  </tr>
+                </thead>
+                <tbody id="materialsTableBody"></tbody>
+              </table>
+            </div>
+          </div>
+          <p id="materialsEmptyState" class="empty-state" hidden>Aucun matériel disponible.</p>
+        </section>
+      </main>
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script type="module" src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script type="module" src="js/materiels.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Fournir un accès depuis la sidebar à une vue en lecture seule listant tous les matériels existants sans créer de nouvelle source de données ni modifier les pages existantes.
- Respecter l’UI existante et les contraintes (pas de modification/suppression, mêmes styles, ne pas impacter Historiques / Importer / Exporter / Gestion utilisateurs). 

### Description
- Ajoute un nouvel item de sidebar `Tous les matériels` dans `index.html` (classe `header-menu__option sidebar-item`) positionné après `Historiques` et avant `Importer les données`.
- Branche la navigation au clic vers `materiels.html` via un listener ajouté dans `js/app.js` sans toucher aux comportements existants des autres boutons.
- Crée la page `materiels.html` en réutilisant la structure et les styles existants (header interne, bouton retour, card/table, recherche, empty state) et sans éléments éditables.
- Ajoute `js/materiels.js` qui initialise `StorageService`, récupère les détails via `StorageService.getAllDetails()`, déduplique par `code`, trie par `designation` (A→Z, locale `fr`), affiche le tableau lecture seule (`Code` / `Désignation`) et fournit une recherche côté client sur `code` et `désignation`.

### Testing
- Exécution des vérifications de dépôt avec `git status --short` qui a réussi.
- Vérification du diff via `git diff -- js/app.js index.html materiels.html js/materiels.js` qui a affiché les modifications attendues.
- Commit des fichiers modifiés/créés (`index.html`, `js/app.js`, `materiels.html`, `js/materiels.js`) avec `git commit` qui a réussi.
- Aucune suite de tests unitaires automatisés spécifique au projet n’a été exécutée pendant cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f0ef8fac832ab7f7c8d4610c98aa)