### PR TITLE
Fix oversized search icon on materiels page

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -6,8 +6,40 @@
     <title>Tous les matériels - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+      .materials-page .search-panel .input-group {
+        position: relative;
+      }
+
+      .materials-page .search-input__icon-wrap {
+        position: absolute;
+        left: 0.85rem;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 24px !important;
+        height: 24px !important;
+        flex: 0 0 24px !important;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        overflow: hidden;
+      }
+
+      .materials-page .search-input__icon,
+      .materials-page .search-input__icon-wrap img,
+      .materials-page .search-panel img {
+        width: 24px !important;
+        height: 24px !important;
+        object-fit: contain !important;
+      }
+
+      .materials-page #materialsSearchInput {
+        padding-left: 3rem;
+      }
+    </style>
   </head>
-  <body data-page="all-materials" class="page3">
+  <body data-page="all-materials" class="page3 materials-page">
     <div class="app-shell app-shell--wide">
       <header class="app-header app-header--detail">
         <div class="app-header__side app-header__side--left">


### PR DESCRIPTION
### Motivation
- The search magnifier in the Materiels card was rendering oversized and overflowing the card, so the icon must be constrained and aligned without changing other pages or adding assets.
- The goal was to reuse the existing search component styling used elsewhere and scope fixes only to the materiels page.

### Description
- Added a `materials-page` class on the `<body>` in `materiels.html` to scope page-specific overrides.
- Injected page-local CSS into `materiels.html` that positions the icon inside the search input container and forces the icon (image/SVG) to `24x24` with `object-fit: contain` and `overflow: hidden` to prevent overflow.
- Adjusted the search input left padding on the materiels page so text does not overlap the icon while keeping the same visual pattern as other pages.
- No other pages, markup patterns, or icon assets were modified or added.

### Testing
- Ran targeted searches to verify relevant selectors and occurrences with `rg` which returned the expected locations and showed no unexpected global rules affecting this page.
- Inspected the updated `materiels.html` content with `sed`/`nl` to confirm the `materials-page` class and the injected CSS are present and correct.
- Verified the modified file diff to ensure only `materiels.html` was changed and the search markup structure was preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9665ca550832a9e61daa720de4615)