### PR TITLE
Reuse existing clear-search button for materials search (materiels.html)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2319,7 +2319,12 @@ body[data-page="item-detail"] #detailSearchInput {
   padding-right: 52px;
 }
 
-body[data-page="item-detail"] .clear-search-btn {
+body[data-page="all-materials"] #materialsSearchInput {
+  padding-right: 52px;
+}
+
+body[data-page="item-detail"] .clear-search-btn,
+body[data-page="all-materials"] .clear-search-btn {
   display: none;
   position: absolute;
   right: 16px;
@@ -2338,7 +2343,8 @@ body[data-page="item-detail"] .clear-search-btn {
   padding: 0;
 }
 
-body[data-page="item-detail"] .clear-search-btn:active {
+body[data-page="item-detail"] .clear-search-btn:active,
+body[data-page="all-materials"] .clear-search-btn:active {
   transform: translateY(-50%) scale(0.94);
   background: #e0eefc;
 }

--- a/js/materiels.js
+++ b/js/materiels.js
@@ -97,6 +97,7 @@ import { firebaseDb } from './firebase-core.js';
 
     const backButton = requireElement('materialsBackButton');
     const searchInput = requireElement('materialsSearchInput');
+    const clearSearchBtn = requireElement('materialsClearSearchBtn');
     let allMaterials = [];
 
     backButton?.addEventListener('click', () => {
@@ -118,6 +119,25 @@ import { firebaseDb } from './firebase-core.js';
     };
 
     searchInput?.addEventListener('input', applySearch);
+
+    const toggleClearButton = () => {
+      if (!searchInput || !clearSearchBtn) {
+        return;
+      }
+      clearSearchBtn.style.display = searchInput.value.trim() ? 'flex' : 'none';
+    };
+
+    searchInput?.addEventListener('input', toggleClearButton);
+    clearSearchBtn?.addEventListener('click', () => {
+      if (!searchInput) {
+        return;
+      }
+      searchInput.value = '';
+      searchInput.dispatchEvent(new Event('input'));
+      searchInput.focus();
+    });
+
+    toggleClearButton();
 
     try {
       allMaterials = await loadAllMaterials();

--- a/materiels.html
+++ b/materiels.html
@@ -74,6 +74,7 @@
                 <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
               </span>
               <input id="materialsSearchInput" class="search-input" type="text" placeholder="Rechercher un matériel..." autocomplete="off" />
+              <button id="materialsClearSearchBtn" class="clear-search-btn" type="button" aria-label="Effacer la recherche">×</button>
             </label>
           </div>
           <div class="table-container table-container--card">


### PR DESCRIPTION
### Motivation
- Ajouter le bouton « clear (X) » au champ de recherche de la page `materiels.html` pour qu’il ait le même comportement et rendu que les autres pages.
- Réutiliser à 100% les classes, le HTML et la logique JavaScript déjà présentes (`clear-search-btn` et pattern de Page 1 / Page 3) sans créer de nouveaux styles ou animations.
- Assurer l’alignement visuel et le comportement (apparition à la saisie, suppression du texte, redéclenchement de la recherche, mise au focus) identiques aux pages existantes.

### Description
- Ajout du markup du bouton dans `materiels.html` en réutilisant la classe existante avec l’id `materialsClearSearchBtn` et la classe `clear-search-btn` placée dans le même `label.input-group` que l’`input`.
- Réutilisation de la logique existante dans `js/materiels.js` en déclarant `const clearSearchBtn = requireElement('materialsClearSearchBtn');`, en ajoutant la fonction de toggle de visibilité, et en ajoutant le handler `click` qui vide le champ, redéclenche l’événement `input` et remet le focus.
- Extension des sélecteurs CSS dans `css/style.css` pour appliquer les règles existantes de `.clear-search-btn` à `body[data-page="all-materials"]` et ajout de `padding-right` pour `#materialsSearchInput` afin de conserver l’espacement identique à la page de référence.

### Testing
- Recherches de références et vérifications de classes effectuées avec `rg` (recherche des sélecteurs et IDs), et elles ont réussi.
- Inspection des changements via `git diff -- materiels.html js/materiels.js css/style.css` a été exécutée et a montré les modifications attendues.
- Validation du dépôt local avec `git status --short` puis `git commit -m "Add existing clear-search button behavior to materiels search"` a été exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9699cb9fc832aab471744841726e7)