### PR TITLE
Ajouter panier flottant de demande de matériel sur materiels.html

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -3,6 +3,8 @@ import { firebaseDb } from './firebase-core.js';
 
 (function () {
   const isMaterialsPage = location.pathname.includes('materiels.html');
+  const CART_KEY = 'materialRequestCart';
+  let materialCart = [];
 
   function requireElement(id) {
     return document.getElementById(id);
@@ -23,6 +25,140 @@ import { firebaseDb } from './firebase-core.js';
       data?.designation || data?.Designation || data?.désignation || data?.['Désignation'] || data?.name || '',
     ).trim();
     return { code, designation };
+  }
+
+  function loadMaterialCart() {
+    try {
+      materialCart = JSON.parse(localStorage.getItem(CART_KEY)) || [];
+    } catch (_error) {
+      materialCart = [];
+    }
+  }
+
+  function saveMaterialCart() {
+    localStorage.setItem(CART_KEY, JSON.stringify(materialCart));
+  }
+
+  function updateMaterialCartBadge() {
+    const badge = document.querySelector('#materialCartBadge');
+    const fab = document.querySelector('#materialCartFab');
+
+    if (!badge || !fab) {
+      return;
+    }
+
+    const count = materialCart.length;
+    badge.textContent = String(count);
+
+    if (count > 0) {
+      badge.classList.add('visible');
+      fab.classList.remove('hidden');
+      return;
+    }
+
+    badge.classList.remove('visible');
+    fab.classList.add('hidden');
+  }
+
+  function addMaterialToCart(material) {
+    const exists = materialCart.some((item) => item.code === material.code);
+
+    if (exists) {
+      window.UiService?.showToast?.('Matériel déjà dans le panier');
+      return;
+    }
+
+    materialCart.push({
+      code: material.code,
+      designation: material.designation,
+    });
+
+    updateMaterialCartBadge();
+    saveMaterialCart();
+    window.UiService?.showToast?.('Matériel ajouté au panier');
+  }
+
+  function removeMaterialFromCart(code) {
+    materialCart = materialCart.filter((item) => item.code !== code);
+    saveMaterialCart();
+    updateMaterialCartBadge();
+    renderMaterialCart();
+  }
+
+  function renderMaterialCart() {
+    const list = document.querySelector('#materialCartList');
+    if (!list) {
+      return;
+    }
+
+    if (!materialCart.length) {
+      list.innerHTML = '<p class="empty-state">Aucun matériel dans la demande.</p>';
+      return;
+    }
+
+    list.innerHTML = materialCart
+      .map((item) => `
+      <div class="material-cart-card">
+        <div>
+          <strong>${escapeHtml(item.code)}</strong>
+          <p>${escapeHtml(item.designation || '-')}</p>
+        </div>
+        <button class="remove-cart-item-btn" data-code="${escapeHtml(item.code)}" type="button" aria-label="Retirer ${escapeHtml(item.code)}">×</button>
+      </div>
+    `)
+      .join('');
+
+    list.querySelectorAll('.remove-cart-item-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        removeMaterialFromCart(btn.dataset.code || '');
+      });
+    });
+  }
+
+  function exportMaterialRequest() {
+    if (!materialCart.length) {
+      window.UiService?.showToast?.('Aucun matériel à exporter');
+      return;
+    }
+
+    const rows = [['Code', 'Désignation'], ...materialCart.map((item) => [item.code, item.designation || ''])];
+
+    const csv = rows
+      .map((row) => row.map((value) => `"${String(value).replace(/"/g, '""')}"`).join(';'))
+      .join('\n');
+
+    const blob = new Blob(['\uFEFF' + csv], {
+      type: 'text/csv;charset=utf-8;',
+    });
+
+    const date = new Date().toISOString().slice(0, 10);
+    const a = document.createElement('a');
+    const url = URL.createObjectURL(blob);
+    a.href = url;
+    a.download = `demande-materiel-${date}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+    window.UiService?.showToast?.('Demande exportée');
+  }
+
+  function openMaterialCartModal() {
+    const modal = requireElement('materialCartModal');
+    if (!modal || typeof modal.showModal !== 'function') {
+      return;
+    }
+    if (!modal.open) {
+      modal.showModal();
+    }
+  }
+
+  function closeMaterialCartModal() {
+    const modal = requireElement('materialCartModal');
+    if (!modal || typeof modal.close !== 'function') {
+      return;
+    }
+    if (modal.open) {
+      modal.close();
+    }
   }
 
   function renderMaterials(materials) {
@@ -61,7 +197,7 @@ import { firebaseDb } from './firebase-core.js';
     }
 
     tbody.innerHTML = safeMaterials.map((item) => `
-    <tr>
+    <tr class="material-row" data-code="${escapeHtml(item.code || '')}" data-designation="${escapeHtml(item.designation || '')}">
       <td>${escapeHtml(item.code || '-')}</td>
       <td>${escapeHtml(item.designation || '-')}</td>
     </tr>
@@ -138,6 +274,43 @@ import { firebaseDb } from './firebase-core.js';
     });
 
     toggleClearButton();
+
+    loadMaterialCart();
+    updateMaterialCartBadge();
+
+    requireElement('materialCartFab')?.addEventListener('click', () => {
+      renderMaterialCart();
+      openMaterialCartModal();
+    });
+
+    requireElement('materialCartModal')?.addEventListener('click', (event) => {
+      const modal = event.currentTarget;
+      if (event.target === modal) {
+        closeMaterialCartModal();
+      }
+    });
+
+    requireElement('clearMaterialCartBtn')?.addEventListener('click', () => {
+      materialCart = [];
+      saveMaterialCart();
+      updateMaterialCartBadge();
+      renderMaterialCart();
+    });
+
+    requireElement('exportMaterialRequestBtn')?.addEventListener('click', exportMaterialRequest);
+
+    requireElement('materialsTableBody')?.addEventListener('click', (event) => {
+      const row = event.target.closest('tr.material-row');
+      if (!row) {
+        return;
+      }
+      const code = String(row.dataset.code || '').trim();
+      if (!code) {
+        return;
+      }
+      const designation = String(row.dataset.designation || '').trim();
+      addMaterialToCart({ code, designation });
+    });
 
     try {
       allMaterials = await loadAllMaterials();

--- a/materiels.html
+++ b/materiels.html
@@ -37,6 +37,77 @@
       .materials-page #materialsSearchInput {
         padding-left: 3rem;
       }
+
+      .materials-page #materialsTableBody tr {
+        cursor: pointer;
+      }
+
+      .materials-page #materialsTableBody tr:hover {
+        background: rgba(59, 130, 246, 0.08);
+      }
+
+      .materials-page .cart-fab {
+        left: 24px;
+        right: auto;
+      }
+
+      .materials-page .cart-badge {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        min-width: 22px;
+        height: 22px;
+        border-radius: 999px;
+        background: #ef4444;
+        color: #fff;
+        font-size: 12px;
+        font-weight: 800;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 0 4px;
+      }
+
+      .materials-page .cart-badge.visible {
+        display: flex;
+      }
+
+      .materials-page .material-cart-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.65rem;
+        margin: 0.75rem 0 1rem;
+        max-height: 45vh;
+        overflow: auto;
+      }
+
+      .materials-page .material-cart-card {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.75rem;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 14px;
+        padding: 0.65rem 0.75rem;
+        background: #f8fbff;
+      }
+
+      .materials-page .material-cart-card p {
+        margin: 0.2rem 0 0;
+        color: #64748b;
+      }
+
+      .materials-page .remove-cart-item-btn {
+        border: 0;
+        width: 30px;
+        height: 30px;
+        border-radius: 999px;
+        background: #e2e8f0;
+        color: #0f172a;
+        font-size: 1.1rem;
+        line-height: 1;
+      }
+
     </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
@@ -93,6 +164,25 @@
           <p id="materialsEmptyState" class="empty-state" hidden>Aucun matériel disponible.</p>
         </section>
       </main>
+
+      <button id="materialCartFab" class="fab fab-add cart-fab hidden" type="button" aria-label="Voir la demande matériel">
+        🛒
+        <span id="materialCartBadge" class="cart-badge">0</span>
+      </button>
+
+      <dialog id="materialCartModal" class="modal-card">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h2>Demande de matériel</h2>
+          </div>
+          <div id="materialCartList" class="material-cart-list"></div>
+          <div class="modal-actions modal-actions__row modal-actions__row--pair">
+            <button id="clearMaterialCartBtn" class="btn btn-secondary" type="button">Vider</button>
+            <button id="exportMaterialRequestBtn" class="btn btn-primary" type="button">Exporter la demande</button>
+          </div>
+        </div>
+      </dialog>
+
       <div id="toast" class="toast" aria-live="polite"></div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Permettre aux utilisateurs de sélectionner plusieurs matériels depuis la liste et créer une « demande de matériel » sans modifier les données Firebase ni rendre le tableau modifiable. 
- Conserver l'apparence existante en réutilisant les composants UI (FAB, modal, toasts, boutons) et en évitant toute nouvelle charte graphique. 
- Garder l'état de la sélection pendant la navigation via une persistance locale (`localStorage`).

### Description
- Rend chaque ligne du tableau cliquable et collecte `code` et `designation` en `data-` attributes pour l'ajout au panier (aucune modification des sources de données ni du tableau en lecture seule). 
- Ajoute le bouton flottant panier (FAB) en bas gauche avec badge dynamique et la modal de consultation/gestion du panier (`materiels.html` : ajout du bouton, de la `<dialog>` et de styles ciblés `.materials-page`). 
- Implémente la logique frontend dans `js/materiels.js` : `loadMaterialCart`, `saveMaterialCart`, `updateMaterialCartBadge`, `addMaterialToCart`, `removeMaterialFromCart`, `renderMaterialCart`, `exportMaterialRequest`, et les wrappers `openMaterialCartModal`/`closeMaterialCartModal`. 
- L'export produit un CSV UTF-8 BOM avec séparateur `;` nommé `demande-materiel-YYYY-MM-DD.csv`, et les toasts utilisent `UiService.showToast` quand disponible; le panier est persisté sous la clé `materialRequestCart`.

### Testing
- Syntax check : `node --check js/materiels.js` exécuté avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96f7312cc832a9de039eb5c8be8af)