### PR TITLE
Move material cart FAB to bottom-right above main FAB

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -46,9 +46,11 @@
         background: rgba(59, 130, 246, 0.08);
       }
 
+      .materials-page #materialCartFab,
       .materials-page .cart-fab {
-        left: 24px;
-        right: auto;
+        right: 24px !important;
+        left: auto !important;
+        bottom: calc(112px + env(safe-area-inset-bottom)) !important;
       }
 
       .materials-page .cart-badge {


### PR DESCRIPTION
### Motivation
- Align the material cart floating action button with other FABs by moving it from bottom-left to bottom-right and placing it above the existing "+" FAB for consistent UX.

### Description
- Updated CSS in `materiels.html` to target `#materialCartFab` and `.cart-fab` and set `right: 24px !important;`, `left: auto !important;`, and `bottom: calc(112px + env(safe-area-inset-bottom)) !important;`, while leaving the badge and cart logic untouched.

### Testing
- No automated tests were executed; this is a CSS-only change limited to `materiels.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ad7c818c832aa03c731e382c9c22)