### PR TITLE
Fix cart FAB position on materials page

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -50,7 +50,7 @@
       .materials-page .cart-fab {
         right: 24px !important;
         left: auto !important;
-        bottom: calc(112px + env(safe-area-inset-bottom)) !important;
+        bottom: 24px !important;
       }
 
       .materials-page .cart-badge {


### PR DESCRIPTION
### Motivation
- Positionner le bouton panier sur la page `materiels.html` au même emplacement qu’un FAB principal en supprimant le décalage élevé basé sur `calc(... + env(...))`.

### Description
- Dans `materiels.html` la règle CSS pour `.materials-page #materialCartFab, .materials-page .cart-fab` a été modifiée pour définir `right: 24px !important`, `left: auto !important` et `bottom: 24px !important`, en supprimant l’ancien `bottom: calc(... + env(...))` et sans toucher au badge, à la taille ni à la logique du panier.

### Testing
- Exécutés les recherches et vérifications avec `rg` et `nl` pour localiser et inspecter la règle, puis le fichier `materiels.html` a été mis à jour et commité avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b4d34cec832ab7f756b111f39fdd)