### PR TITLE
Remplacer «Exporter la demande» par «Voir la demande» et ajouter une prévisualisation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1334,6 +1334,23 @@ body[data-page="history"] .list-grid {
   background: transparent;
 }
 
+
+.modal-card--wide {
+  width: min(96vw, 52rem);
+}
+
+.table-rotate-hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+@media (min-width: 768px) {
+  .table-rotate-hint {
+    display: none;
+  }
+}
+
 .modal-card::backdrop {
   background: rgba(15, 23, 42, 0.44);
 }

--- a/js/materiels.js
+++ b/js/materiels.js
@@ -141,8 +141,8 @@ import { firebaseDb } from './firebase-core.js';
     window.UiService?.showToast?.('Demande exportée');
   }
 
-  function openMaterialCartModal() {
-    const modal = requireElement('materialCartModal');
+  function openDialogById(id) {
+    const modal = requireElement(id);
     if (!modal || typeof modal.showModal !== 'function') {
       return;
     }
@@ -151,14 +151,61 @@ import { firebaseDb } from './firebase-core.js';
     }
   }
 
-  function closeMaterialCartModal() {
-    const modal = requireElement('materialCartModal');
+  function closeDialogById(id) {
+    const modal = requireElement(id);
     if (!modal || typeof modal.close !== 'function') {
       return;
     }
     if (modal.open) {
       modal.close();
     }
+  }
+
+  function openMaterialCartModal() {
+    openDialogById('materialCartModal');
+  }
+
+  function closeMaterialCartModal() {
+    closeDialogById('materialCartModal');
+  }
+
+  function openMaterialRequestPreviewModal() {
+    openDialogById('materialRequestPreviewModal');
+  }
+
+  function closeMaterialRequestPreviewModal() {
+    closeDialogById('materialRequestPreviewModal');
+  }
+
+
+  function renderMaterialRequestPreview() {
+    const tbody = requireElement('materialRequestPreviewBody');
+    const table = requireElement('materialRequestPreviewTable');
+    const emptyState = requireElement('materialRequestPreviewEmptyState');
+
+    if (!tbody || !table || !emptyState) {
+      return;
+    }
+
+    if (!materialCart.length) {
+      tbody.innerHTML = '';
+      table.hidden = true;
+      emptyState.hidden = false;
+      return;
+    }
+
+    tbody.innerHTML = materialCart
+      .map((item) => `
+      <tr>
+        <td>${escapeHtml(item.code || '-')}</td>
+        <td>${escapeHtml(item.designation || '-')}</td>
+        <td>${escapeHtml(item.quantity || 1)}</td>
+      </tr>
+    `)
+      .join('');
+
+    table.hidden = false;
+    emptyState.hidden = true;
   }
 
   function renderMaterials(materials) {
@@ -290,11 +337,30 @@ import { firebaseDb } from './firebase-core.js';
       }
     });
 
+    requireElement('materialRequestPreviewModal')?.addEventListener('click', (event) => {
+      const modal = event.currentTarget;
+      if (event.target === modal) {
+        closeMaterialRequestPreviewModal();
+      }
+    });
+
     requireElement('clearMaterialCartBtn')?.addEventListener('click', () => {
       materialCart = [];
       saveMaterialCart();
       updateMaterialCartBadge();
       renderMaterialCart();
+    });
+
+    requireElement('viewMaterialRequestBtn')?.addEventListener('click', () => {
+      closeMaterialCartModal();
+      renderMaterialRequestPreview();
+      openMaterialRequestPreviewModal();
+    });
+
+    requireElement('backToMaterialCartBtn')?.addEventListener('click', () => {
+      closeMaterialRequestPreviewModal();
+      renderMaterialCart();
+      openMaterialCartModal();
     });
 
     requireElement('exportMaterialRequestBtn')?.addEventListener('click', exportMaterialRequest);

--- a/materiels.html
+++ b/materiels.html
@@ -180,7 +180,36 @@
           <div id="materialCartList" class="material-cart-list"></div>
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="clearMaterialCartBtn" class="btn btn-secondary" type="button">Vider</button>
-            <button id="exportMaterialRequestBtn" class="btn btn-primary" type="button">Exporter la demande</button>
+            <button id="viewMaterialRequestBtn" class="btn btn-primary" type="button">Voir la demande</button>
+          </div>
+        </div>
+      </dialog>
+
+
+      <dialog id="materialRequestPreviewModal" class="modal-card modal-card--wide">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h2>Demande de matériel</h2>
+          </div>
+          <p class="table-rotate-hint">Tournez votre téléphone pour mieux voir le tableau.</p>
+          <div class="table-container table-container--card">
+            <div class="table-wrapper table-wrapper--shared">
+              <table class="data-table" id="materialRequestPreviewTable">
+                <thead>
+                  <tr>
+                    <th>Code</th>
+                    <th>Désignation</th>
+                    <th>Quantité demandée</th>
+                  </tr>
+                </thead>
+                <tbody id="materialRequestPreviewBody"></tbody>
+              </table>
+            </div>
+          </div>
+          <p id="materialRequestPreviewEmptyState" class="empty-state" hidden>Aucun matériel dans la demande.</p>
+          <div class="modal-actions modal-actions__row modal-actions__row--pair">
+            <button id="backToMaterialCartBtn" class="btn btn-secondary" type="button">Retour</button>
+            <button id="exportMaterialRequestBtn" class="btn btn-primary" type="button">Exporter</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Remplacer le bouton d’export direct du modal panier par une étape de prévisualisation pour afficher proprement la demande avant export. 
- Conserver la logique d’export existante mais déplacer son action dans une vue dédiée afin d’améliorer l’UX sans toucher aux données Firebase ni aux autres pages.

### Description
- Dans `materiels.html` : remplacement du bouton `#exportMaterialRequestBtn` par `#viewMaterialRequestBtn` dans le modal panier et ajout d’un nouveau modal `#materialRequestPreviewModal` contenant le tableau lecture seule (`#materialRequestPreviewTable`, `#materialRequestPreviewBody`) et les boutons `#backToMaterialCartBtn` et `#exportMaterialRequestBtn` (Exporter). 
- Dans `js/materiels.js` : ajout des helpers `openDialogById` / `closeDialogById`, ajout des fonctions `openMaterialRequestPreviewModal`, `closeMaterialRequestPreviewModal` et `renderMaterialRequestPreview()` qui construit le tableau en lecture seule à partir de `materialCart` (colonnes Code, Désignation, Quantité demandée), et câblage des événements pour `viewMaterialRequestBtn`, `backToMaterialCartBtn` et réutilisation de `exportMaterialRequest()` pour l’export. 
- Dans `css/style.css` : ajout de la classe `.modal-card--wide` pour agrandir la modal de prévisualisation et de `.table-rotate-hint` pour l’indication responsive «Tournez votre téléphone pour mieux voir le tableau.» sans forcer la rotation. 
- Comportement conservé : la fonction d’export CSV `exportMaterialRequest()` n’a pas été modifiée, les données Firebase ne sont pas touchées, et les styles existants (modal, tableau, boutons, animations) ont été réutilisés.

### Testing
- Vérifications statiques réalisées : inspection des diffs et des fichiers modifiés via `git diff` et affichage des fichiers avec `nl`/`sed`, et recherches de références via `rg`, toutes exécutées avec succès. 
- Vérification du câblage des événements et de la présence des nouveaux éléments en affichant les portions modifiées de `materiels.html`, `js/materiels.js` et `css/style.css`, toutes réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ba311244832aa1f1db9268b7446e)