### PR TITLE
Afficher le nombre de lignes du panier & saisie directe de la quantité

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -47,7 +47,7 @@ import { firebaseDb } from './firebase-core.js';
       return;
     }
 
-    const count = materialCart.reduce((sum, item) => sum + (Number(item.qty) || 1), 0);
+    const count = materialCart.length;
     badge.textContent = String(count);
 
     if (count > 0) {
@@ -58,6 +58,32 @@ import { firebaseDb } from './firebase-core.js';
 
     badge.classList.remove('visible');
     fab.classList.add('hidden');
+  }
+
+  function editQtyDirectly(code) {
+    const item = materialCart.find((cartItem) => cartItem.code === code);
+    if (!item) {
+      return;
+    }
+
+    const currentQty = Number(item.qty) || 1;
+    const value = window.prompt('Entrer la quantité demandée :', String(currentQty));
+
+    if (value === null) {
+      return;
+    }
+
+    const qty = parseInt(value, 10);
+
+    if (!Number.isFinite(qty) || qty < 1) {
+      window.UiService?.showToast?.('Quantité invalide');
+      return;
+    }
+
+    item.qty = qty;
+    saveMaterialCart();
+    updateMaterialCartBadge();
+    renderMaterialCart();
   }
 
   function addMaterialToCart(material) {
@@ -127,7 +153,7 @@ import { firebaseDb } from './firebase-core.js';
           <p>${escapeHtml(item.designation || '-')}</p>
           <div class="qty-control">
             <button class="btn btn-secondary qty-minus" data-code="${escapeHtml(item.code)}" type="button" aria-label="Diminuer la quantité de ${escapeHtml(item.code)}">−</button>
-            <span class="qty-value">${escapeHtml(item.qty || 1)}</span>
+            <button class="qty-value qty-edit-btn" data-code="${escapeHtml(item.code)}" type="button">${escapeHtml(item.qty || 1)}</button>
             <button class="btn btn-secondary qty-plus" data-code="${escapeHtml(item.code)}" type="button" aria-label="Augmenter la quantité de ${escapeHtml(item.code)}">+</button>
           </div>
         </div>
@@ -148,6 +174,12 @@ import { firebaseDb } from './firebase-core.js';
 
     list.querySelectorAll('.qty-minus').forEach((btn) => {
       btn.addEventListener('click', () => decreaseQty(btn.dataset.code || ''));
+    });
+
+    document.querySelectorAll('.qty-edit-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        editQtyDirectly(btn.dataset.code || '');
+      });
     });
   }
 

--- a/materiels.html
+++ b/materiels.html
@@ -128,6 +128,14 @@
         font-weight: 700;
       }
 
+      .materials-page .qty-edit-btn {
+        border: 0;
+        background: transparent;
+        padding: 0;
+        line-height: 1.2;
+        cursor: pointer;
+      }
+
     </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">


### PR DESCRIPTION
### Motivation
- Le badge du panier doit refléter le nombre de lignes différentes plutôt que la somme des quantités pour une lecture plus pertinente du nombre d’articles distincts.
- Permettre à l’utilisateur de modifier rapidement la quantité d’une ligne en cliquant sur la valeur affichée sans remplacer les boutons `-` / `+` existants.
- Réutiliser les styles et composants existants sans toucher au reste de l’application ni à Firebase, et préserver l’export CSV.

### Description
- La fonction `updateMaterialCartBadge` affiche maintenant `materialCart.length` au lieu de la somme des `qty` pour le badge du panier.
- Le rendu du panier (`renderMaterialCart`) remplace le `span` de quantité par un bouton compact `.qty-edit-btn` placé entre les boutons `-` et `+` pour rester visuel et discret.
- Ajout de la fonction `editQtyDirectly(code)` qui ouvre un `prompt` pour saisir une quantité, valide que c’est un entier >= 1 et met à jour le `materialCart`, puis appelle `saveMaterialCart`, `updateMaterialCartBadge` et `renderMaterialCart`.
- Le clic sur les éléments `.qty-edit-btn` est branché après le rendu pour appeler `editQtyDirectly`, et un petit style CSS a été ajouté pour que le bouton garde un rendu compact et cohérent.
- L’export CSV et sa colonne `Quantité demandée` restent inchangés.

### Testing
- Exécution de `git -C /workspace/Album status --short` pour vérifier l’état du dépôt et préparation du commit, et la commande s’est terminée avec succès.
- Commit des fichiers modifiés `js/materiels.js` et `materiels.html` réalisé avec succès; aucune suite de tests unitaires automatisés n’était présente ni exécutée pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c278ca08832aa1aeda9d8b683ff5)