### PR TITLE
Replace browser quantity prompt with in-app edit modal

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -5,6 +5,7 @@ import { firebaseDb } from './firebase-core.js';
   const isMaterialsPage = location.pathname.includes('materiels.html');
   const CART_KEY = 'materialRequestCart';
   let materialCart = [];
+  let currentEditingQtyCode = null;
 
   function requireElement(id) {
     return document.getElementById(id);
@@ -66,24 +67,19 @@ import { firebaseDb } from './firebase-core.js';
       return;
     }
 
-    const currentQty = Number(item.qty) || 1;
-    const value = window.prompt('Entrer la quantité demandée :', String(currentQty));
+    currentEditingQtyCode = code;
 
-    if (value === null) {
-      return;
+    const input = requireElement('editQtyInput');
+    const error = requireElement('editQtyError');
+    if (input) {
+      input.value = String(item.qty || 1);
+      input.classList.remove('is-error', 'is-shaking');
+    }
+    if (error) {
+      error.textContent = '';
     }
 
-    const qty = parseInt(value, 10);
-
-    if (!Number.isFinite(qty) || qty < 1) {
-      window.UiService?.showToast?.('Quantité invalide');
-      return;
-    }
-
-    item.qty = qty;
-    saveMaterialCart();
-    updateMaterialCartBadge();
-    renderMaterialCart();
+    openEditQtyModal();
   }
 
   function addMaterialToCart(material) {
@@ -246,6 +242,18 @@ import { firebaseDb } from './firebase-core.js';
 
   function closeMaterialRequestPreviewModal() {
     closeDialogById('materialRequestPreviewModal');
+  }
+
+  function openEditQtyModal() {
+    openDialogById('editQtyModal');
+    window.setTimeout(() => {
+      requireElement('editQtyInput')?.focus();
+    }, 150);
+  }
+
+  function closeEditQtyModal() {
+    closeDialogById('editQtyModal');
+    currentEditingQtyCode = null;
   }
 
 
@@ -435,6 +443,47 @@ import { firebaseDb } from './firebase-core.js';
     });
 
     requireElement('exportMaterialRequestBtn')?.addEventListener('click', exportMaterialRequest);
+    requireElement('saveEditQtyBtn')?.addEventListener('click', () => {
+      const input = requireElement('editQtyInput');
+      const error = requireElement('editQtyError');
+      const qty = parseInt(input?.value ?? '', 10);
+
+      if (!Number.isFinite(qty) || qty < 1) {
+        if (error) {
+          error.textContent = 'Veuillez entrer une quantité valide.';
+        }
+        input?.classList.remove('is-shaking');
+        void input?.offsetWidth;
+        input?.classList.add('is-error', 'is-shaking');
+        return;
+      }
+
+      const item = materialCart.find((cartItem) => cartItem.code === currentEditingQtyCode);
+      if (!item) {
+        return;
+      }
+
+      item.qty = qty;
+      saveMaterialCart();
+      updateMaterialCartBadge();
+      renderMaterialCart();
+      closeEditQtyModal();
+    });
+    requireElement('cancelEditQtyBtn')?.addEventListener('click', closeEditQtyModal);
+    requireElement('editQtyInput')?.addEventListener('input', () => {
+      const input = requireElement('editQtyInput');
+      const error = requireElement('editQtyError');
+      input?.classList.remove('is-error', 'is-shaking');
+      if (error) {
+        error.textContent = '';
+      }
+    });
+    requireElement('editQtyModal')?.addEventListener('click', (event) => {
+      const modal = event.currentTarget;
+      if (event.target === modal) {
+        closeEditQtyModal();
+      }
+    });
 
     requireElement('materialsTableBody')?.addEventListener('click', (event) => {
       const row = event.target.closest('tr.material-row');

--- a/materiels.html
+++ b/materiels.html
@@ -136,6 +136,16 @@
         cursor: pointer;
       }
 
+      .materials-page #editQtyInput.is-error,
+      .materials-page #editQtyInput.is-error:focus {
+        border-color: #ef4444;
+        box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+      }
+
+      .materials-page #editQtyInput.is-shaking {
+        animation: site-lock-input-shake 300ms ease-in-out 1;
+      }
+
     </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
@@ -236,6 +246,23 @@
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="backToMaterialCartBtn" class="btn btn-secondary" type="button">Retour</button>
             <button id="exportMaterialRequestBtn" class="btn btn-primary" type="button">Exporter</button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog id="editQtyModal" class="modal-card">
+        <div class="modal-content modal-content--site-create">
+          <div class="modal-header">
+            <h2>Modifier la quantité</h2>
+          </div>
+          <label class="input-group input-group--site-create">
+            <span>Quantité demandée</span>
+            <input id="editQtyInput" type="number" min="1" inputmode="numeric" />
+          </label>
+          <p id="editQtyError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split modal-actions--site-create">
+            <button id="cancelEditQtyBtn" class="btn btn-neutral" type="button">Annuler</button>
+            <button id="saveEditQtyBtn" class="btn btn-success" type="button">Enregistrer</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Replace the unprofessional browser `prompt()` used to edit cart quantities with the project’s existing internal modal UI to keep UX consistent and avoid system prompts. 
- Reuse existing modal structure/animations/buttons/colors to match other forms and preserve the visual/validation conventions (shake + red border on error). 
- Keep existing cart behavior intact (badge, localStorage, export, render) and avoid changing other pages or closing the cart modal when editing quantity. 

### Description
- Added an `editQtyModal` `<dialog>` to `materiels.html` that reuses existing classes (`modal-card`, `modal-content--site-create`, `input-group--site-create`, `form-error`, `btn`), with the requested fields and buttons and an `#editQtyError` error element. 
- Added page-scoped styles for `#editQtyInput` error and shake states to match existing animations and design. 
- Removed the `window.prompt()` flow from `js/materiels.js` and introduced `let currentEditingQtyCode = null` to track the edited item. 
- Implemented `openEditQtyModal()` / `closeEditQtyModal()` and wired `saveEditQtyBtn`, `cancelEditQtyBtn`, input `input` handler and backdrop click-to-close; validation enforces `qty >= 1`, shows inline error text and triggers the existing shake animation, and on success updates `materialCart`, persists with `saveMaterialCart()`, updates the badge and re-renders the cart. 

### Testing
- No repository unit test suite was available for this change; performed automated repository checks and commits which succeeded (`rg` searches to verify selectors and classes, `git status --short`, and `git commit`).
- Verified via static inspection that `prompt()` usage was removed and that the modal markup, event handlers and cart update calls (`saveMaterialCart`, `updateMaterialCartBadge`, `renderMaterialCart`) are correctly wired. 
- Created the pull request metadata (automated `make_pr`) to capture the change for further review and QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c5ffc860832a812c660785280a93)