### PR TITLE
Add one-time tip banner on materials page

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -4,6 +4,7 @@ import { firebaseDb } from './firebase-core.js';
 (function () {
   const isMaterialsPage = location.pathname.includes('materiels.html');
   const CART_KEY = 'materialRequestCart';
+  const HINT_KEY = 'materialsHintSeen';
   let materialCart = [];
   let currentEditingQtyCode = null;
 
@@ -38,6 +39,31 @@ import { firebaseDb } from './firebase-core.js';
 
   function saveMaterialCart() {
     localStorage.setItem(CART_KEY, JSON.stringify(materialCart));
+  }
+
+  function initMaterialsHint() {
+    const hint = document.querySelector('#materialsHint');
+    const closeBtn = document.querySelector('#closeMaterialsHint');
+
+    if (!hint) {
+      return;
+    }
+
+    const alreadySeen = localStorage.getItem(HINT_KEY) === 'true';
+
+    if (!alreadySeen) {
+      hint.classList.remove('hidden');
+    }
+
+    closeBtn?.addEventListener('click', () => {
+      localStorage.setItem(HINT_KEY, 'true');
+      hint.classList.add('hidden');
+    });
+  }
+
+  function markMaterialsHintSeen() {
+    localStorage.setItem(HINT_KEY, 'true');
+    document.querySelector('#materialsHint')?.classList.add('hidden');
   }
 
   function updateMaterialCartBadge() {
@@ -98,6 +124,7 @@ import { firebaseDb } from './firebase-core.js';
     saveMaterialCart();
     updateMaterialCartBadge();
     renderMaterialCart();
+    markMaterialsHintSeen();
     window.UiService?.showToast?.('Matériel ajouté au panier');
   }
 
@@ -400,6 +427,8 @@ import { firebaseDb } from './firebase-core.js';
     });
 
     toggleClearButton();
+
+    initMaterialsHint();
 
     loadMaterialCart();
     updateMaterialCartBadge();

--- a/materiels.html
+++ b/materiels.html
@@ -146,6 +146,27 @@
         animation: site-lock-input-shake 300ms ease-in-out 1;
       }
 
+      .materials-page .materials-hint {
+        margin: 14px 0;
+        padding: 12px 14px;
+        border-radius: 16px;
+        background: #eef7ff;
+        color: #2563eb;
+        font-size: 14px;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .materials-page .materials-hint button {
+        border: none;
+        background: transparent;
+        font-size: 20px;
+        color: inherit;
+      }
+
     </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
@@ -176,6 +197,10 @@
               <span class="count-number page3-count-number">0</span>
               <span class="count-label page3-count-label">Matériels</span>
             </div>
+          </div>
+          <div id="materialsHint" class="materials-hint hidden">
+            <span>👋 Astuce : appuyez sur un matériel pour l’ajouter à votre demande.</span>
+            <button id="closeMaterialsHint" type="button" aria-label="Fermer l’astuce">×</button>
           </div>
           <div class="search-panel search-panel--inline">
             <label class="input-group">


### PR DESCRIPTION
### Motivation
- Afficher une astuce légère dans `materiels.html` uniquement lors de la première utilisation pour guider l’utilisateur à ajouter un matériel à la demande.
- Persister l’état d’affichage dans `localStorage` pour ne plus réafficher l’astuce après fermeture ou après le premier ajout au panier.
- Réutiliser les styles existants et ne pas impacter les autres pages, la recherche, le tableau ou le panier.

### Description
- Ajout d’un bloc HTML dans `materiels.html` au-dessus du panneau de recherche : un petit hint avec `id="materialsHint"` et un bouton de fermeture `id="closeMaterialsHint"`.
- Ajout de styles page-scoped minimalistes dans la balise `<style>` de `materiels.html` sous la classe `.materials-page .materials-hint` et réutilisation de la classe utilitaire `.hidden` existante pour le masquage.
- Implémentation JS dans `js/materiels.js` : ajout de la constante `HINT_KEY = 'materialsHintSeen'`, des fonctions `initMaterialsHint()` et `markMaterialsHintSeen()`, et appel de `initMaterialsHint()` depuis `initMaterialsPage()`.
- Marquage de l’astuce comme vue lors de la fermeture manuelle ou après un ajout réussi au panier via `markMaterialsHintSeen()` appelé depuis `addMaterialToCart()`.

### Testing
- Vérification automatisée que les identifiants et fonctions (`HINT_KEY`, `initMaterialsHint`, `markMaterialsHintSeen`, `materialsHint`) sont présents dans les fichiers modifiés ; recherche passée avec succès.
- Inspection automatisée du HTML/CSS modifié pour s’assurer que le hint est inséré dans la position demandée et que le style est scoped à la page ; vérifications passées.
- Validation automatisée que les changements ont été recorded et le PR créé via l’outil de publication interne ; opération réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f7722770832aaaa3bcff3c313bc9)