### PR TITLE
Améliorer l’UX du panier vide sur materiels.html

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -68,9 +68,8 @@ import { firebaseDb } from './firebase-core.js';
 
   function updateMaterialCartBadge() {
     const badge = document.querySelector('#materialCartBadge');
-    const fab = document.querySelector('#materialCartFab');
 
-    if (!badge || !fab) {
+    if (!badge) {
       return;
     }
 
@@ -79,12 +78,10 @@ import { firebaseDb } from './firebase-core.js';
 
     if (count > 0) {
       badge.classList.add('visible');
-      fab.classList.remove('hidden');
       return;
     }
 
     badge.classList.remove('visible');
-    fab.classList.add('hidden');
   }
 
   function editQtyDirectly(code) {
@@ -164,7 +161,12 @@ import { firebaseDb } from './firebase-core.js';
     }
 
     if (!materialCart.length) {
-      list.innerHTML = '<p class="empty-state">Aucun matériel dans la demande.</p>';
+      list.innerHTML = `
+        <div class="empty-cart">
+          <p>Aucun matériel dans la demande.</p>
+          <p class="empty-cart-hint">💡 Ajoutez des matériels depuis la liste pour créer une demande</p>
+        </div>
+      `;
       return;
     }
 
@@ -434,6 +436,13 @@ import { firebaseDb } from './firebase-core.js';
     updateMaterialCartBadge();
 
     requireElement('materialCartFab')?.addEventListener('click', () => {
+      const fab = requireElement('materialCartFab');
+      if (!materialCart.length && fab) {
+        fab.classList.add('bounce');
+        window.setTimeout(() => {
+          fab.classList.remove('bounce');
+        }, 300);
+      }
       renderMaterialCart();
       openMaterialCartModal();
     });

--- a/materiels.html
+++ b/materiels.html
@@ -167,6 +167,31 @@
         color: inherit;
       }
 
+      .materials-page .empty-cart {
+        text-align: center;
+      }
+
+      .materials-page .empty-cart p {
+        margin: 0;
+      }
+
+      .materials-page .empty-cart-hint {
+        margin-top: 6px;
+        font-size: 13px;
+        color: #6b7280;
+        text-align: center;
+      }
+
+      .materials-page #materialCartFab.bounce {
+        animation: material-cart-fab-bounce 300ms ease;
+      }
+
+      @keyframes material-cart-fab-bounce {
+        0% { transform: scale(1); }
+        50% { transform: scale(1.08); }
+        100% { transform: scale(1); }
+      }
+
     </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
@@ -228,7 +253,7 @@
         </section>
       </main>
 
-      <button id="materialCartFab" class="fab fab-add cart-fab hidden" type="button" aria-label="Voir la demande matériel">
+      <button id="materialCartFab" class="fab fab-add cart-fab" type="button" aria-label="Voir la demande matériel">
         🛒
         <span id="materialCartBadge" class="cart-badge">0</span>
       </button>


### PR DESCRIPTION
### Motivation
- Rendre le bouton panier (FAB) toujours visible pour améliorer la découverte et l’accès à la demande même quand le panier est vide.
- Afficher le badge du panier uniquement quand il y a des éléments pour éviter le bruit visuel quand il est vide.
- Fournir un message d’état vide plus utile dans la modal panier avec une astuce pour guider l’utilisateur.
- Ajouter un micro-feedback (bounce) lors du clic sur le FAB vide pour confirmer l’action sans modifier le design global.

### Description
- `js/materiels.js` : `updateMaterialCartBadge()` met à jour seulement la visibilité du badge (`visible`) et ne masque plus le FAB ; le rendu vide dans `renderMaterialCart()` a été remplacé par un bloc `empty-cart` avec une ligne d’astuce `empty-cart-hint` ; le listener du FAB ajoute une classe `bounce` 300ms quand le panier est vide.
- `materiels.html` : suppression de la classe `hidden` sur le bouton `#materialCartFab` pour le rendre toujours visible et ajout de styles légers pour `.empty-cart`, `.empty-cart-hint` et l’animation `material-cart-fab-bounce` (réutilisation des couleurs existantes).
- Aucun nouveau composant lourd ni changement du design global ; les couleurs et tailles suivent les styles déjà présents.

### Testing
- Recherche de résidus de logique de masquage du FAB avec `rg` (recherche des occurrences de `fab.classList.add('hidden')` / `fab.classList.remove('hidden')`) a été exécutée et n’a trouvé aucune occurrence après modifications, validation réussie.
- Vérification que `#materialCartFab` n’a plus la classe `hidden` dans `materiels.html` a été effectuée et validée par inspection du fichier modifié.
- Les changements ont été ajoutés et committés (`git commit`) avec le message d’amélioration, commande exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fa3e4c68832aaa535f8b8e5b92ee)