### PR TITLE
feat: ajouter la copie de demande matériel depuis le modal

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -208,33 +208,48 @@ import { firebaseDb } from './firebase-core.js';
     });
   }
 
-  function exportMaterialRequest() {
-    if (!materialCart.length) {
-      window.UiService?.showToast?.('Aucun matériel à exporter');
-      return;
+  function formatMaterialRequestText() {
+    if (!materialCart || materialCart.length === 0) {
+      return 'Aucune demande de matériel.';
     }
 
-    const rows = [
-      ['Code', 'Désignation', 'Quantité demandée'],
-      ...materialCart.map((item) => [item.code, item.designation || '', item.qty || 1]),
-    ];
+    let text = '📦 DEMANDE DE MATÉRIEL\n\n';
+    text += 'Code | Désignation | Qté\n';
+    text += '----------------------------------\n';
 
-    const csv = rows
-      .map((row) => row.map((value) => `"${String(value).replace(/"/g, '""')}"`).join(';'))
-      .join('\n');
+    materialCart.forEach((item) => {
+      const code = item.code || '';
+      const designation = item.designation || '';
+      const qty = item.qty || 1;
 
-    const blob = new Blob(['\uFEFF' + csv], {
-      type: 'text/csv;charset=utf-8;',
+      text += `${code} | ${designation} | ${qty}\n`;
     });
 
-    const date = new Date().toISOString().slice(0, 10);
-    const a = document.createElement('a');
-    const url = URL.createObjectURL(blob);
-    a.href = url;
-    a.download = `demande-materiel-${date}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
-    window.UiService?.showToast?.('Demande exportée');
+    return text;
+  }
+
+  function copyMaterialRequest() {
+    const text = formatMaterialRequestText();
+    const showToast = window.UiService?.showToast;
+
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(text)
+        .then(() => showToast?.('Demande copiée ✔'))
+        .catch(() => fallbackCopy(text));
+    } else {
+      fallbackCopy(text);
+    }
+  }
+
+  function fallbackCopy(text) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+
+    window.UiService?.showToast?.('Demande copiée ✔');
   }
 
   function openDialogById(id) {
@@ -480,7 +495,7 @@ import { firebaseDb } from './firebase-core.js';
       openMaterialCartModal();
     });
 
-    requireElement('exportMaterialRequestBtn')?.addEventListener('click', exportMaterialRequest);
+    document.querySelector('#copyRequestBtn')?.addEventListener('click', copyMaterialRequest);
     requireElement('saveEditQtyBtn')?.addEventListener('click', () => {
       const input = requireElement('editQtyInput');
       const error = requireElement('editQtyError');

--- a/materiels.html
+++ b/materiels.html
@@ -295,7 +295,9 @@
           <p id="materialRequestPreviewEmptyState" class="empty-state" hidden>Aucun matériel dans la demande.</p>
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="backToMaterialCartBtn" class="btn btn-secondary" type="button">Retour</button>
-            <button id="exportMaterialRequestBtn" class="btn btn-primary" type="button">Exporter</button>
+            <button id="copyRequestBtn" class="primary-btn" type="button">
+              Copier
+            </button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Permettre à l'utilisateur de copier la demande de matériel sous forme de texte lisible (WhatsApp / Notes / Email) directement depuis la prévisualisation sans modifier le panier ni la logique existante.

### Description
- Remplace le bouton `Exporter` par un bouton `Copier` (`#copyRequestBtn`) dans le modal de prévisualisation de la demande. 
- Ajoute `formatMaterialRequestText()` qui produit un texte formaté avec en-tête et lignes `Code | Désignation | Qté` ou un message vide si le panier est vide. 
- Ajoute `copyMaterialRequest()` utilisant `navigator.clipboard` si disponible et `fallbackCopy()` (textarea + `document.execCommand('copy')`) pour anciens navigateurs/Android, et réutilise le toast existant via `window.UiService?.showToast`. 
- Branche l'événement clic du nouveau bouton sur `copyMaterialRequest` sans toucher à Firebase, à la gestion du panier ou au bouton `Retour`.

### Testing
- Exécuté recherche de symboles avec `rg` pour vérifier l'ajout de `copyRequestBtn`, `formatMaterialRequestText`, `copyMaterialRequest` et `fallbackCopy`, et tous ont été trouvés avec les chemins attendus. 
- Inspecté les modifications via `git diff` pour valider le remplacement du bouton et l'insertion des nouvelles fonctions. 
- Vérifié l'état du dépôt et que les fichiers modifiés sont prêts; les inspections automatiques ont réussi sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fe0adbac832aaf0273bbd4598dc1)