### PR TITLE
Add PNG export to material request modal and align buttons with existing styles

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -252,6 +252,46 @@ import { firebaseDb } from './firebase-core.js';
     window.UiService?.showToast?.('Demande copiée ✔');
   }
 
+
+  async function downloadRequestAsPng() {
+    const area = document.querySelector('#requestCaptureArea');
+    const showToast = window.UiService?.showToast;
+
+    if (!area) {
+      showToast?.('Zone de demande introuvable');
+      return;
+    }
+
+    if (!materialCart || materialCart.length === 0) {
+      showToast?.('Aucune demande à télécharger');
+      return;
+    }
+
+    if (typeof window.html2canvas !== 'function') {
+      showToast?.('Export PNG indisponible');
+      return;
+    }
+
+    try {
+      const canvas = await window.html2canvas(area, {
+        backgroundColor: '#ffffff',
+        scale: 2,
+        useCORS: true
+      });
+
+      const date = new Date().toISOString().slice(0, 10);
+      const link = document.createElement('a');
+      link.download = `demande-materiel-${date}.png`;
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+
+      showToast?.('Image PNG téléchargée ✔');
+    } catch (error) {
+      console.error('Erreur export PNG :', error);
+      showToast?.('Erreur téléchargement PNG');
+    }
+  }
+
   function openDialogById(id) {
     const modal = requireElement(id);
     if (!modal || typeof modal.showModal !== 'function') {
@@ -496,6 +536,7 @@ import { firebaseDb } from './firebase-core.js';
     });
 
     document.querySelector('#copyRequestBtn')?.addEventListener('click', copyMaterialRequest);
+    document.querySelector('#downloadRequestPngBtn')?.addEventListener('click', downloadRequestAsPng);
     requireElement('saveEditQtyBtn')?.addEventListener('click', () => {
       const input = requireElement('editQtyInput');
       const error = requireElement('editQtyError');

--- a/materiels.html
+++ b/materiels.html
@@ -278,9 +278,11 @@
             <h2>Demande de matériel</h2>
           </div>
           <p class="table-rotate-hint">Tournez votre téléphone pour mieux voir le tableau.</p>
-          <div class="table-container table-container--card">
-            <div class="table-wrapper table-wrapper--shared">
-              <table class="data-table" id="materialRequestPreviewTable">
+          <div id="requestCaptureArea">
+            <h3>Demande de matériel</h3>
+            <div class="table-container table-container--card">
+              <div class="table-wrapper table-wrapper--shared">
+                <table class="data-table" id="materialRequestPreviewTable">
                 <thead>
                   <tr>
                     <th>Code</th>
@@ -288,15 +290,19 @@
                     <th>Quantité demandée</th>
                   </tr>
                 </thead>
-                <tbody id="materialRequestPreviewBody"></tbody>
-              </table>
+                  <tbody id="materialRequestPreviewBody"></tbody>
+                </table>
+              </div>
             </div>
+            <p id="materialRequestPreviewEmptyState" class="empty-state" hidden>Aucun matériel dans la demande.</p>
           </div>
-          <p id="materialRequestPreviewEmptyState" class="empty-state" hidden>Aucun matériel dans la demande.</p>
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="backToMaterialCartBtn" class="btn btn-secondary" type="button">Retour</button>
             <button id="copyRequestBtn" class="primary-btn" type="button">
               Copier
+            </button>
+            <button id="downloadRequestPngBtn" class="primary-btn" type="button">
+              Image PNG
             </button>
           </div>
         </div>
@@ -324,6 +330,7 @@
 
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script type="module" src="js/materiels.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a client-side PNG export of the material request so users can download the request as an image without backend/render dependencies. 
- Ensure the modal action buttons keep using existing button classes so the UI style remains consistent and no new CSS is introduced.

### Description
- Wrapped the request preview content in a new `#requestCaptureArea` element so captures target only the request title, table and empty state and exclude modal actions and overlay. 
- Added an `Image PNG` button (`#downloadRequestPngBtn`) to the request preview modal and kept `Copier` on the existing `primary-btn` class while leaving `Retour` as the secondary button. 
- Included `html2canvas` via CDN in `materiels.html` before the main script and implemented `downloadRequestAsPng()` in `js/materiels.js` to render the capture, generate a `demande-materiel-YYYY-MM-DD.png` file and show success/error toasts. 
- Wired the new button to the export function by adding an event listener for `#downloadRequestPngBtn` in `js/materiels.js` and preserved the existing copy-to-clipboard behavior (`copyMaterialRequest`).

### Testing
- Verified selectors and presence of the new DOM elements by searching the codebase with `rg` for `downloadRequestPngBtn`, `requestCaptureArea` and `html2canvas`, and confirmed matches were present. 
- Inspected the modified files with `sed`/`nl` to confirm the `#requestCaptureArea` wrapper, `Image PNG` button, the `html2canvas` script tag, and the `downloadRequestAsPng()` implementation were inserted as expected. 
- Performed a local smoke check to ensure the new button listener is registered in `js/materiels.js` and the copy action remains wired, with all automated checks passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa017a8d8c832a9508b0a37f544c63)