### PR TITLE
Corriger export PNG pour capturer toute la table de la demande matériel

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -252,15 +252,49 @@ import { firebaseDb } from './firebase-core.js';
     window.UiService?.showToast?.('Demande copiée ✔');
   }
 
+  function buildRequestExportArea() {
+    const exportArea = document.createElement('div');
+    exportArea.id = 'requestExportArea';
+
+    exportArea.style.position = 'fixed';
+    exportArea.style.left = '-9999px';
+    exportArea.style.top = '0';
+    exportArea.style.width = '900px';
+    exportArea.style.background = '#ffffff';
+    exportArea.style.padding = '32px';
+    exportArea.style.fontFamily = 'Arial, sans-serif';
+    exportArea.style.color = '#111827';
+
+    exportArea.innerHTML = `
+      <h2 style="margin:0 0 20px;font-size:28px;font-weight:800;">
+        Demande de matériel
+      </h2>
+      <table style="width:100%;border-collapse:collapse;font-size:20px;">
+        <thead>
+          <tr style="background:#eef5fb;">
+            <th style="text-align:left;padding:16px;border:1px solid #cbd5e1;">Code</th>
+            <th style="text-align:left;padding:16px;border:1px solid #cbd5e1;">Désignation</th>
+            <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;">Qté</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${materialCart.map((item) => `
+            <tr>
+              <td style="padding:14px;border:1px solid #cbd5e1;">${item.code || '-'}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;">${item.designation || '-'}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;">${item.qty || 1}</td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    `;
+
+    document.body.appendChild(exportArea);
+    return exportArea;
+  }
 
   async function downloadRequestAsPng() {
-    const area = document.querySelector('#requestCaptureArea');
     const showToast = window.UiService?.showToast;
-
-    if (!area) {
-      showToast?.('Zone de demande introuvable');
-      return;
-    }
 
     if (!materialCart || materialCart.length === 0) {
       showToast?.('Aucune demande à télécharger');
@@ -272,11 +306,17 @@ import { firebaseDb } from './firebase-core.js';
       return;
     }
 
+    const exportArea = buildRequestExportArea();
+
     try {
-      const canvas = await window.html2canvas(area, {
+      const canvas = await window.html2canvas(exportArea, {
         backgroundColor: '#ffffff',
         scale: 2,
-        useCORS: true
+        useCORS: true,
+        width: exportArea.scrollWidth,
+        height: exportArea.scrollHeight,
+        windowWidth: exportArea.scrollWidth,
+        windowHeight: exportArea.scrollHeight
       });
 
       const date = new Date().toISOString().slice(0, 10);
@@ -289,6 +329,8 @@ import { firebaseDb } from './firebase-core.js';
     } catch (error) {
       console.error('Erreur export PNG :', error);
       showToast?.('Erreur téléchargement PNG');
+    } finally {
+      exportArea.remove();
     }
   }
 


### PR DESCRIPTION
### Motivation
- Le tableau de la demande dans le modal est scrollable et `html2canvas` ne capturait que la partie visible, il faut un export contenant toutes les lignes indépendamment du scroll.

### Description
- Ajout de `buildRequestExportArea()` pour générer une zone d’export temporaire hors écran (position fixe, `left: -9999px`) contenant le titre et le tableau complet construit depuis `materialCart`.
- Mise à jour de `downloadRequestAsPng()` pour capturer la zone temporaire (`exportArea`) au lieu de l’aire visible du modal, en passant `width/height` basés sur `exportArea.scrollWidth/scrollHeight` à `html2canvas`.
- Garantie de nettoyage de la zone temporaire via un bloc `finally` (`exportArea.remove()`), et conservation des notifications de succès/erreur.
- Le rendu évite ainsi d’inclure le modal visible, les boutons ou l’overlay sombre et ne dépend plus du scroll du modal.

### Testing
- Recherche des références liées avec `rg -n "downloadRequestAsPng|requestCaptureArea|materialCart|html2canvas" .` pour valider les points touchés — succès.
- Inspection du fichier modifié avec `sed -n '230,330p' js/materiels.js` et `nl -ba js/materiels.js | sed -n '246,345p'` pour vérifier l’ajout de `buildRequestExportArea()` et l’usage de `exportArea` dans `downloadRequestAsPng()` — inspection réussie.
- Application du correctif via le patch a réussi et les modifications ont été ajoutées au fichier `js/materiels.js` — opération réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0689780c832abe555c9bfe97db08)