### PR TITLE
Retire le bouton Copier et harmonise le bouton Image PNG

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -577,7 +577,6 @@ import { firebaseDb } from './firebase-core.js';
       openMaterialCartModal();
     });
 
-    document.querySelector('#copyRequestBtn')?.addEventListener('click', copyMaterialRequest);
     document.querySelector('#downloadRequestPngBtn')?.addEventListener('click', downloadRequestAsPng);
     requireElement('saveEditQtyBtn')?.addEventListener('click', () => {
       const input = requireElement('editQtyInput');

--- a/materiels.html
+++ b/materiels.html
@@ -298,12 +298,7 @@
           </div>
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="backToMaterialCartBtn" class="btn btn-secondary" type="button">Retour</button>
-            <button id="copyRequestBtn" class="primary-btn" type="button">
-              Copier
-            </button>
-            <button id="downloadRequestPngBtn" class="primary-btn" type="button">
-              Image PNG
-            </button>
+            <button id="downloadRequestPngBtn" class="btn btn-primary" type="button">Image PNG</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Harmoniser le modal « Demande de matériel » en supprimant le bouton « Copier » et en appliquant au bouton « Image PNG » les classes de boutons déjà présentes dans le projet pour une apparence cohérente sans toucher à la logique d’export PNG ni aux autres éléments du modal.

### Description
- Suppression du bouton HTML `<button id="copyRequestBtn">` dans `materiels.html`.
- Le bouton PNG conserve `id="downloadRequestPngBtn"` et reçoit `class="btn btn-primary"` pour réutiliser le style existant du projet.
- Suppression de l'écouteur `document.querySelector('#copyRequestBtn')?.addEventListener(...)` dans `js/materiels.js` et maintien du listener existant pour `downloadRequestAsPng`.
- Aucun nouveau CSS, style inline ou modification du bouton `Retour`, du tableau ou du panier n'a été ajoutée.

### Testing
- Recherche textuelle avec `rg` pour valider la suppression de `copyRequestBtn` et la présence de `downloadRequestPngBtn`, vérifiée avec succès.
- Vérification du diff et commit via `git status`/`git commit` pour confirmer les modifications, toutes les commandes ont abouti avec succès.
- Confirmation par inspection du code que le listener de `downloadRequestAsPng` est toujours présent et actif via `document.querySelector('#downloadRequestPngBtn')?.addEventListener('click', downloadRequestAsPng)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0997e810832a8d75cda42b4734c1)