### PR TITLE
Improve empty material request modal button disabled UX

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -187,6 +187,21 @@ import { firebaseDb } from './firebase-core.js';
     renderMaterialCart();
   }
 
+
+  function syncMaterialCartActionsState() {
+    const isEmpty = materialCart.length === 0;
+    const clearBtn = requireElement('clearMaterialCartBtn');
+    const viewBtn = requireElement('viewMaterialRequestBtn');
+
+    [clearBtn, viewBtn].forEach((btn) => {
+      if (!btn) {
+        return;
+      }
+      btn.disabled = isEmpty;
+      btn.classList.toggle('is-disabled-soft', isEmpty);
+    });
+  }
+
   function renderMaterialCart() {
     const list = document.querySelector('#materialCartList');
     if (!list) {
@@ -200,6 +215,7 @@ import { firebaseDb } from './firebase-core.js';
           <p class="empty-cart-hint">💡 Ajoutez des matériels depuis la liste pour créer une demande</p>
         </div>
       `;
+      syncMaterialCartActionsState();
       return;
     }
 
@@ -249,6 +265,8 @@ import { firebaseDb } from './firebase-core.js';
         updateMaterialUnit(select.dataset.code || '', select.value);
       });
     });
+
+    syncMaterialCartActionsState();
   }
 
   function formatMaterialRequestText() {
@@ -578,6 +596,7 @@ import { firebaseDb } from './firebase-core.js';
 
     loadMaterialCart();
     updateMaterialCartBadge();
+    syncMaterialCartActionsState();
 
     requireElement('materialCartFab')?.addEventListener('click', () => {
       const fab = requireElement('materialCartFab');

--- a/materiels.html
+++ b/materiels.html
@@ -192,6 +192,14 @@
         text-align: center;
       }
 
+
+      .materials-page .btn.is-disabled-soft,
+      .materials-page .btn.is-disabled-soft:active {
+        opacity: 0.6;
+        transform: none;
+        pointer-events: none;
+      }
+
       .materials-page #materialCartFab.bounce {
         animation: material-cart-fab-bounce 300ms ease;
       }


### PR DESCRIPTION
### Motivation
- Ensure the modal UI looks professional when the material request is empty by keeping the action buttons visible but disabled, preserving layout, animations and existing styles. 
- Provide a clear disabled affordance (reduced opacity, no click animation, `not-allowed` behavior) without introducing new components or changing other request flows.

### Description
- Added `syncMaterialCartActionsState()` in `js/materiels.js` to toggle `disabled` and the CSS helper class `is-disabled-soft` on the `clearMaterialCartBtn` and `viewMaterialRequestBtn` based on `materialCart.length`. 
- Invoked `syncMaterialCartActionsState()` at page init (after `loadMaterialCart()`), after rendering the empty cart state in `renderMaterialCart()`, and after rendering the cart with items. 
- Added a small CSS rule in `materiels.html` for `.btn.is-disabled-soft` that reduces opacity, removes transform on active, and disables pointer interactions while keeping size and placement unchanged. 
- Left the empty hint text (`💡 Ajoutez des matériels depuis la liste pour créer une demande`) and the floating cart FAB behaviour (badge display) untouched.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab90d44b8832aa72486f254bb6333)