### PR TITLE
Créer une page dédiée pour la demande matériel et remplacer le modal d’aperçu

### DIFF
--- a/demande-materiel.html
+++ b/demande-materiel.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Demande de matériel - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+    <style>
+      .request-page .request-actions {
+        display: flex;
+        gap: 0.75rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .request-page .request-actions .btn {
+        flex: 1;
+      }
+    </style>
+  </head>
+  <body data-page="material-request" class="page3 materials-page request-page">
+    <div class="app-shell app-shell--wide">
+      <header class="app-header app-header--detail">
+        <div class="app-header__side app-header__side--left">
+          <button class="back-button" type="button" id="requestBackButton" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
+        </div>
+        <div class="app-header__center">
+          <div class="header-title header-title--stacked">
+            <h1>Demande de matériel</h1>
+          </div>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
+      </header>
+
+      <main class="page-content page-content--wide main-content">
+        <section class="surface-card table-card section">
+          <div class="section-heading section-heading--table">
+            <div class="header-top page3-summary-header">
+              <div class="title-block page3-title-block">
+                <h2 class="section-title">Tableau de la demande</h2>
+              </div>
+            </div>
+          </div>
+          <div class="page3-sub-info">
+            <div id="requestCount" class="article-count page3-article-count">
+              <span class="count-number page3-count-number">0</span>
+              <span class="count-label page3-count-label">Matériels</span>
+            </div>
+          </div>
+
+          <div class="request-actions">
+            <button id="downloadRequestPngBtn" class="btn btn-primary" type="button">Image PNG</button>
+            <button id="clearMaterialRequestBtn" class="btn btn-secondary" type="button">Vider la demande</button>
+          </div>
+
+          <div class="table-container table-container--card">
+            <div class="table-wrapper table-wrapper--shared">
+              <table class="data-table" id="materialRequestTable">
+                <thead>
+                  <tr>
+                    <th>Code</th>
+                    <th>Désignation</th>
+                    <th>Quantité demandée</th>
+                    <th>Unité</th>
+                  </tr>
+                </thead>
+                <tbody id="materialRequestBody"></tbody>
+              </table>
+            </div>
+          </div>
+          <p id="materialRequestEmptyState" class="empty-state" hidden>Aucune demande de matériel.<br />Ajoutez des matériels depuis la page Tous les matériels.</p>
+        </section>
+      </main>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script src="js/ui.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+    <script type="module" src="js/demande-materiel.js"></script>
+  </body>
+</html>

--- a/js/demande-materiel.js
+++ b/js/demande-materiel.js
@@ -1,0 +1,159 @@
+(function () {
+  const CART_KEY = 'materialRequestCart';
+
+  function requireElement(id) {
+    return document.getElementById(id);
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function loadMaterialCart() {
+    try {
+      return JSON.parse(localStorage.getItem(CART_KEY)) || [];
+    } catch (_error) {
+      return [];
+    }
+  }
+
+  function saveMaterialCart(items) {
+    localStorage.setItem(CART_KEY, JSON.stringify(items));
+  }
+
+  function buildRequestExportArea(items) {
+    const exportArea = document.createElement('div');
+
+    exportArea.style.position = 'fixed';
+    exportArea.style.left = '-9999px';
+    exportArea.style.top = '0';
+    exportArea.style.width = '900px';
+    exportArea.style.background = '#ffffff';
+    exportArea.style.padding = '32px';
+    exportArea.style.fontFamily = 'Arial, sans-serif';
+    exportArea.style.color = '#111827';
+
+    exportArea.innerHTML = `
+      <h2 style="margin:0 0 20px;font-size:28px;font-weight:800;">Demande de matériel</h2>
+      <table style="width:100%;border-collapse:collapse;font-size:20px;">
+        <thead>
+          <tr style="background:#eef5fb;">
+            <th style="text-align:left;padding:16px;border:1px solid #cbd5e1;">Code</th>
+            <th style="text-align:left;padding:16px;border:1px solid #cbd5e1;">Désignation</th>
+            <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;">Quantité</th>
+            <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;">Unité</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${items.map((item) => `
+            <tr>
+              <td style="padding:14px;border:1px solid #cbd5e1;">${escapeHtml(item.code || '-')}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;">${escapeHtml(item.designation || '-')}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;">${escapeHtml(item.qty || 1)}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;">${escapeHtml(item.unit || 'Pcs')}</td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    `;
+
+    document.body.appendChild(exportArea);
+    return exportArea;
+  }
+
+  async function downloadRequestAsPng(items) {
+    if (!items.length) {
+      window.UiService?.showToast?.('Aucune demande à télécharger');
+      return;
+    }
+
+    if (typeof window.html2canvas !== 'function') {
+      window.UiService?.showToast?.('Export PNG indisponible');
+      return;
+    }
+
+    const exportArea = buildRequestExportArea(items);
+
+    try {
+      const canvas = await window.html2canvas(exportArea, {
+        backgroundColor: '#ffffff',
+        scale: 2,
+        useCORS: true,
+        width: exportArea.scrollWidth,
+        height: exportArea.scrollHeight,
+        windowWidth: exportArea.scrollWidth,
+        windowHeight: exportArea.scrollHeight,
+      });
+
+      const date = new Date().toISOString().slice(0, 10);
+      const link = document.createElement('a');
+      link.download = `demande-materiel-${date}.png`;
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+
+      window.UiService?.showToast?.('Image PNG téléchargée ✔');
+    } catch (error) {
+      console.error('Erreur export PNG :', error);
+      window.UiService?.showToast?.('Erreur téléchargement PNG');
+    } finally {
+      exportArea.remove();
+    }
+  }
+
+  function render(items) {
+    const tbody = requireElement('materialRequestBody');
+    const table = requireElement('materialRequestTable');
+    const emptyState = requireElement('materialRequestEmptyState');
+    const count = requireElement('requestCount')?.querySelector('.count-number');
+
+    if (!tbody || !table || !emptyState || !count) {
+      return;
+    }
+
+    count.textContent = String(items.length);
+
+    if (!items.length) {
+      tbody.innerHTML = '';
+      table.hidden = true;
+      emptyState.hidden = false;
+      return;
+    }
+
+    tbody.innerHTML = items.map((item) => `
+      <tr>
+        <td>${escapeHtml(item.code || '-')}</td>
+        <td>${escapeHtml(item.designation || '-')}</td>
+        <td>${escapeHtml(item.qty || 1)}</td>
+        <td>${escapeHtml(item.unit || 'Pcs')}</td>
+      </tr>
+    `).join('');
+
+    table.hidden = false;
+    emptyState.hidden = true;
+  }
+
+  function init() {
+    let items = loadMaterialCart();
+    render(items);
+
+    requireElement('requestBackButton')?.addEventListener('click', () => {
+      window.location.assign('materiels.html');
+    });
+
+    requireElement('clearMaterialRequestBtn')?.addEventListener('click', () => {
+      items = [];
+      saveMaterialCart(items);
+      render(items);
+      window.UiService?.showToast?.('Demande vidée');
+    });
+
+    requireElement('downloadRequestPngBtn')?.addEventListener('click', () => downloadRequestAsPng(items));
+  }
+
+  init();
+})();

--- a/js/materiels.js
+++ b/js/materiels.js
@@ -426,15 +426,7 @@ import { firebaseDb } from './firebase-core.js';
     closeDialogById('materialCartModal');
   }
 
-  function openMaterialRequestPreviewModal() {
-    openDialogById('materialRequestPreviewModal');
-  }
-
-  function closeMaterialRequestPreviewModal() {
-    closeDialogById('materialRequestPreviewModal');
-  }
-
-  function openEditQtyModal() {
+      function openEditQtyModal() {
     openDialogById('editQtyModal');
     window.setTimeout(() => {
       requireElement('editQtyInput')?.focus();
@@ -447,38 +439,7 @@ import { firebaseDb } from './firebase-core.js';
   }
 
 
-  function renderMaterialRequestPreview() {
-    const tbody = requireElement('materialRequestPreviewBody');
-    const table = requireElement('materialRequestPreviewTable');
-    const emptyState = requireElement('materialRequestPreviewEmptyState');
-
-    if (!tbody || !table || !emptyState) {
-      return;
-    }
-
-    if (!materialCart.length) {
-      tbody.innerHTML = '';
-      table.hidden = true;
-      emptyState.hidden = false;
-      return;
-    }
-
-    tbody.innerHTML = materialCart
-      .map((item) => `
-      <tr>
-        <td>${escapeHtml(item.code || '-')}</td>
-        <td>${escapeHtml(item.designation || '-')}</td>
-        <td>${escapeHtml(item.qty || 1)}</td>
-        <td>${escapeHtml(item.unit || 'Pcs')}</td>
-      </tr>
-    `)
-      .join('');
-
-    table.hidden = false;
-    emptyState.hidden = true;
-  }
-
-  function renderMaterials(materials) {
+    function renderMaterials(materials) {
     const tbody = document.querySelector('#materialsTableBody');
 
     if (!tbody) {
@@ -617,13 +578,6 @@ import { firebaseDb } from './firebase-core.js';
       }
     });
 
-    requireElement('materialRequestPreviewModal')?.addEventListener('click', (event) => {
-      const modal = event.currentTarget;
-      if (event.target === modal) {
-        closeMaterialRequestPreviewModal();
-      }
-    });
-
     requireElement('clearMaterialCartBtn')?.addEventListener('click', () => {
       materialCart = [];
       saveMaterialCart();
@@ -633,17 +587,8 @@ import { firebaseDb } from './firebase-core.js';
 
     requireElement('viewMaterialRequestBtn')?.addEventListener('click', () => {
       closeMaterialCartModal();
-      renderMaterialRequestPreview();
-      openMaterialRequestPreviewModal();
+      window.location.href = 'demande-materiel.html';
     });
-
-    requireElement('backToMaterialCartBtn')?.addEventListener('click', () => {
-      closeMaterialRequestPreviewModal();
-      renderMaterialCart();
-      openMaterialCartModal();
-    });
-
-    document.querySelector('#downloadRequestPngBtn')?.addEventListener('click', downloadRequestAsPng);
     requireElement('saveEditQtyBtn')?.addEventListener('click', () => {
       const input = requireElement('editQtyInput');
       const error = requireElement('editQtyError');

--- a/materiels.html
+++ b/materiels.html
@@ -290,37 +290,7 @@
       </dialog>
 
 
-      <dialog id="materialRequestPreviewModal" class="modal-card modal-card--wide">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h2>Demande de matériel</h2>
-          </div>
-          <p class="table-rotate-hint">Tournez votre téléphone pour mieux voir le tableau.</p>
-          <div id="requestCaptureArea">
-            <h3>Demande de matériel</h3>
-            <div class="table-container table-container--card">
-              <div class="table-wrapper table-wrapper--shared">
-                <table class="data-table" id="materialRequestPreviewTable">
-                <thead>
-                  <tr>
-                    <th>Code</th>
-                    <th>Désignation</th>
-                    <th>Quantité demandée</th>
-                    <th>Unité</th>
-                  </tr>
-                </thead>
-                  <tbody id="materialRequestPreviewBody"></tbody>
-                </table>
-              </div>
-            </div>
-            <p id="materialRequestPreviewEmptyState" class="empty-state" hidden>Aucun matériel dans la demande.</p>
-          </div>
-          <div class="modal-actions modal-actions__row modal-actions__row--pair">
-            <button id="backToMaterialCartBtn" class="btn btn-secondary" type="button">Retour</button>
-            <button id="downloadRequestPngBtn" class="btn btn-primary" type="button">Image PNG</button>
-          </div>
-        </div>
-      </dialog>
+      
 
       <dialog id="editQtyModal" class="modal-card">
         <div class="modal-content modal-content--site-create">


### PR DESCRIPTION
### Motivation
- Transformer le flux « Voir la demande » en une page dédiée pour la consultation finale et l’export PNG tout en conservant le modal panier pour création/modification rapide.
- Réutiliser les styles existants (header, carte, tableau, boutons) et ne pas modifier les logiques de quantités/unités ni la navigation principale.

### Description
- Ajout de la page `demande-materiel.html` qui reprend le header, la card et le tableau et affiche le titre, le compteur (`X matériels`) et les actions `Image PNG` / `Vider la demande`.
- Ajout de `js/demande-materiel.js` qui lit le panier depuis `localStorage` (clé `materialRequestCart`), affiche un état vide si nécessaire, rend un tableau lecture seule (`item.code`, `item.designation`, `item.qty`, `item.unit`), gère le bouton retour vers `materiels.html`, le vidage du panier et l’export PNG via une zone hors-écran.
- Modification de `js/materiels.js` pour remplacer l’ouverture du modal d’aperçu par une redirection `window.location.href = 'demande-materiel.html'` et suppression des fonctions/handlers liés au modal d’aperçu tout en conservant le modal panier et les contrôles de quantité/unité.
- Suppression du markup HTML du modal d’aperçu dans `materiels.html` et conservation du modal panier, des boutons d’édition, et du badge panier.

### Testing
- Exécution de la vérification syntaxique JS avec `node --check js/materiels.js && node --check js/demande-materiel.js`, qui a réussi.
- Recherche/inspection des références au modal d’aperçu pour s’assurer qu’elles ont été retirées, ce qui a confirmé la suppression du flux modal d’aperçu.
- Changements commités (création de `demande-materiel.html` et `js/demande-materiel.js`, modifications de `materiels.html` et `js/materiels.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabcab4acc832a81a3d96506fc11dd)