### PR TITLE
Limiter le panier «Demande de matériel» à 20 lignes

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -5,6 +5,7 @@ import { firebaseDb } from './firebase-core.js';
   const isMaterialsPage = location.pathname.includes('materiels.html');
   const CART_KEY = 'materialRequestCart';
   const HINT_KEY = 'materialsHintSeen';
+  const MAX_CART_LINES = 20;
   let materialCart = [];
   let currentEditingQtyCode = null;
 
@@ -131,6 +132,14 @@ import { firebaseDb } from './firebase-core.js';
     if (existing) {
       existing.qty = (Number(existing.qty) || 1) + 1;
     } else {
+      if (materialCart.length >= MAX_CART_LINES) {
+        window.UiService?.showToast?.('Limite de 20 matériels atteinte.');
+        const cartFab = requireElement('materialCartFab');
+        cartFab?.classList.remove('bounce');
+        void cartFab?.offsetWidth;
+        cartFab?.classList.add('bounce');
+        return;
+      }
       materialCart.push({
         code: material.code,
         designation: material.designation,


### PR DESCRIPTION
### Motivation
- Empêcher l’ajout de plus de 20 matériels différents dans la demande tout en conservant la possibilité de modifier la quantité ou l’unité pour les lignes existantes.
- Préserver le comportement existant (export PNG, suppression, modal, animations, toasts) et réutiliser le système visuel/animation existant pour l’erreur UX.

### Description
- Ajout de la constante `MAX_CART_LINES = 20` dans `js/materiels.js` pour centraliser la limite.
- Vérification de la limite dans `addMaterialToCart` uniquement pour les nouveaux matériels (branche `!existing`) afin d’autoriser l’incrément de quantité sur les lignes existantes.
- En cas de dépassement, l’ajout est refusé, le toast `Limite de 20 matériels atteinte.` est affiché via `window.UiService.showToast`, et le bouton panier rejoue l’animation `bounce`.
- Aucun changement aux flux de quantité, unité, suppression, export PNG ou modal existants.

### Testing
- Exécution de `node --check js/materiels.js` pour valider la syntaxe JavaScript, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb117d0020832a8209b7b6dff3023e)