### PR TITLE
Add date and time to PNG export title for material requests

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -324,6 +324,13 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function buildRequestExportArea() {
+    const now = new Date();
+    const dateText = now.toLocaleDateString("fr-FR");
+    const timeText = now.toLocaleTimeString("fr-FR", {
+      hour: "2-digit",
+      minute: "2-digit"
+    });
+
     const exportArea = document.createElement('div');
     exportArea.id = 'requestExportArea';
 
@@ -338,7 +345,7 @@ import { firebaseDb } from './firebase-core.js';
 
     exportArea.innerHTML = `
       <h2 style="margin:0 0 20px;font-size:28px;font-weight:800;">
-        Demande de matériel
+        Demande de matériel — ${dateText} ${timeText}
       </h2>
       <table style="width:100%;border-collapse:collapse;font-size:20px;">
         <thead>


### PR DESCRIPTION
### Motivation
- Ensure the PNG export of a material request clearly shows the generation timestamp next to the title without changing the visible UI or data behavior.

### Description
- In `js/materiels.js` inside `buildRequestExportArea()` generate `now`, `dateText` with `toLocaleDateString("fr-FR")` and `timeText` with `toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })`.
- Update the export title to render `<h2>Demande de matériel — ${dateText} ${timeText}</h2>` in the off-screen export area.
- The change is limited to the off-screen `#requestExportArea` used for PNG generation and does not affect normal page rendering, modals, Firebase, or the table design.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb15bf1780832a9371beba79858cc9)