### PR TITLE
Add row numbering to material request PNG export table

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -350,6 +350,7 @@ import { firebaseDb } from './firebase-core.js';
       <table style="width:100%;border-collapse:collapse;font-size:20px;">
         <thead>
           <tr style="background:#eef5fb;">
+            <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;width:52px;">#</th>
             <th style="text-align:left;padding:16px;border:1px solid #cbd5e1;">Code</th>
             <th style="text-align:left;padding:16px;border:1px solid #cbd5e1;">Désignation</th>
             <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;">Qté</th>
@@ -357,8 +358,9 @@ import { firebaseDb } from './firebase-core.js';
           </tr>
         </thead>
         <tbody>
-          ${materialCart.map((item) => `
+          ${materialCart.map((item, index) => `
             <tr>
+              <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;width:52px;">${index + 1}</td>
               <td style="padding:14px;border:1px solid #cbd5e1;">${item.code || '-'}</td>
               <td style="padding:14px;border:1px solid #cbd5e1;">${item.designation || '-'}</td>
               <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;">${item.qty || 1}</td>


### PR DESCRIPTION
### Motivation
- Provide automatic line numbers for material request exports so the generated PNG shows a first `#` column with row indices; change is implemented in the export HTML generation in `js/materiels.js`.

### Description
- Inserted a narrow, centered `#` header cell and updated the export rows to use `materialCart.map((item, index) => ...)` so each row now prepends a numbered cell with `${index + 1}`, while reusing the existing inline table styles (padding, borders, colors).

### Testing
- Performed repository search and inspected the generated HTML diff for `js/materiels.js` to confirm the header addition and the numbered `<td>` in each exported row, and static validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb47760a40832ab46c83e95c6d5288)