### PR TITLE
Améliore les libellés du modal “Demande de matériel”

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -216,6 +216,15 @@ import { firebaseDb } from './firebase-core.js';
     if (!list) {
       return;
     }
+    const countEl = document.querySelector('#cartSelectedCount');
+    const count = materialCart.length;
+
+    if (countEl) {
+      countEl.textContent =
+        count > 1
+          ? `${count} matériels sélectionnés`
+          : `${count} matériel sélectionné`;
+    }
 
     if (!materialCart.length) {
       list.innerHTML = `

--- a/materiels.html
+++ b/materiels.html
@@ -279,12 +279,13 @@
       <dialog id="materialCartModal" class="modal-card">
         <div class="modal-content">
           <div class="modal-header">
-            <h2>Demande de matériel</h2>
+            <h3 class="modal-title">Demande de matériel</h3>
+            <p id="cartSelectedCount" class="modal-subtitle">0 matériel sélectionné</p>
           </div>
           <div id="materialCartList" class="material-cart-list"></div>
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="clearMaterialCartBtn" class="btn btn-secondary" type="button">Vider</button>
-            <button id="downloadRequestPngBtn" class="btn btn-primary" type="button">Image PNG</button>
+            <button id="downloadRequestPngBtn" class="btn btn-primary" type="button">Exporter PNG</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Rendre le libellé du bouton d’export plus clair et afficher un compteur discret du nombre d’articles sélectionnés dans le modal de demande de matériel.
- Respecter la logique existante du panier et la fonctionnalité d’export sans introduire de nouveau design.

### Description
- Remplace le titre `<h2>` par `<h3 class="modal-title">Demande de matériel</h3>` et ajoute le sous-titre initial `<p id="cartSelectedCount" class="modal-subtitle">0 matériel sélectionné</p>` dans `materiels.html`.
- Remplace uniquement le texte du bouton `#downloadRequestPngBtn` de `Image PNG` vers `Exporter PNG` dans `materiels.html`.
- Ajoute dans `renderMaterialCart()` (fichier `js/materiels.js`) la mise à jour du contenu de `#cartSelectedCount` en utilisant `materialCart.length` et la gestion singulier/pluriel (`"matériel"` / `"matériels"`).
- Aucune modification de la logique du panier ni de l’export PNG n’a été faite et les styles texte secondaires existants sont réutilisés.

### Testing
- Exécution d’une recherche dans le dépôt avec `rg` pour localiser les identifiants concernés et vérifier les occurrences, et la recherche a réussi.
- Application automatique des patches sur `materiels.html` et `js/materiels.js` via l’outil de patch, et l’application a réussi.
- Aucun test unitaire ou d’intégration n’a été exécuté car aucun suite automatisée n’a été lancée pour ces changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4c2ee740832ab073047a69656a4c)