### PR TITLE
Modal « Demande de matériel » : empiler titre et sous‑titre et aligner à gauche

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1684,6 +1684,27 @@ body[data-page="home"] #siteLockManageDialog #siteLockNewPasswordInput.is-shakin
   margin-bottom: 1rem;
 }
 
+
+#materialCartModal .modal-header {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0;
+}
+
+#materialCartModal .modal-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+#materialCartModal .modal-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
 .modal-actions,
 .form-footer {
   display: flex;


### PR DESCRIPTION
### Motivation
- Rééquilibrer le header du modal « Demande de matériel » sur mobile en plaçant le compteur (ex. `1 matériel sélectionné`) sous le titre et aligné à gauche tout en conservant le style, l’espacement et les animations existants.

### Description
- Ajout de styles CSS scoped dans `css/style.css` pour `#materialCartModal .modal-header`, `#materialCartModal .modal-title` et `#materialCartModal .modal-subtitle` afin de passer le header en flux vertical et d’ajuster la typographie et l’espacement sans modifier la structure HTML ni la logique JS de comptage.

### Testing
- Aucun test automatisé ajouté ou exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4e289960832ab0bbb967cee4b1ba)