### PR TITLE
Ne plus empiler les toasts et afficher le compteur lors d'ajout au panier

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -152,7 +152,7 @@ import { firebaseDb } from './firebase-core.js';
     updateMaterialCartBadge();
     renderMaterialCart();
     markMaterialsHintSeen();
-    window.UiService?.showToast?.('Matériel ajouté au panier');
+    window.UiService?.showToast?.(`${materialCart.length} matériel${materialCart.length > 1 ? 's' : ''} dans le panier`);
   }
 
   function removeMaterialFromCart(code) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -13,9 +13,9 @@
   const INLINE_LOADER_ID = "pageInlineLoader";
   const CONTENT_LOADING_DELAY_MS = 120;
   let hideTimerId = null;
-  let toastClearTimerId = null;
+  let toastTimer = null;
   const toastQueue = [];
-  let activeToast = null;
+  let activeToastOptions = null;
   let hasWindowLoaded = document.readyState === "complete";
   let isAppReady = false;
   let inlineLoaderTimerId = null;
@@ -238,19 +238,19 @@
       window.clearTimeout(hideTimerId);
       hideTimerId = null;
     }
-    if (toastClearTimerId) {
-      window.clearTimeout(toastClearTimerId);
-      toastClearTimerId = null;
+    if (toastTimer) {
+      window.clearTimeout(toastTimer);
+      toastTimer = null;
     }
 
     toast.classList.remove(TOAST_VISIBLE_CLASS, TOAST_WITH_ACTION_CLASS);
     toast.removeAttribute("data-type");
-    toastClearTimerId = window.setTimeout(() => {
+    toastTimer = window.setTimeout(() => {
       if (!toast.classList.contains(TOAST_VISIBLE_CLASS)) {
         toast.textContent = "";
       }
-      activeToast = null;
-      toastClearTimerId = null;
+      activeToastOptions = null;
+      toastTimer = null;
       processToastQueue();
     }, TOAST_HIDE_ANIMATION_DURATION);
   }
@@ -266,11 +266,11 @@
   }
 
   function processToastQueue() {
-    if (activeToast || toastQueue.length === 0) {
+    if (activeToastOptions || toastQueue.length === 0) {
       return;
     }
-    activeToast = toastQueue.shift();
-    renderToast(activeToast);
+    activeToastOptions = toastQueue.shift();
+    renderToast(activeToastOptions);
   }
 
   function renderToast(options) {
@@ -322,6 +322,21 @@
 
   function showToast(messageOrOptions, maybeOptions = {}) {
     const options = normalizeToastOptions(messageOrOptions, maybeOptions);
+    if (toastTimer) {
+      window.clearTimeout(toastTimer);
+      toastTimer = null;
+    }
+    if (hideTimerId) {
+      window.clearTimeout(hideTimerId);
+      hideTimerId = null;
+    }
+
+    if (activeToastOptions) {
+      activeToastOptions = options;
+      renderToast(activeToastOptions);
+      return;
+    }
+
     toastQueue.push(options);
     processToastQueue();
   }


### PR DESCRIPTION
### Motivation
- Éviter que plusieurs toasts « Matériel ajouté au panier » ne s’empilent quand l’utilisateur clique rapidement. 
- Améliorer l’UX en réutilisant le toast visible, en mettant à jour son texte et en relançant son timer tout en conservant l’animation existante.

### Description
- Mise à jour de `js/ui.js` : remplacement du timer de nettoyage par `toastTimer`, ajout de `activeToastOptions` et modification de `showToast()` pour réutiliser le toast actif (mettre à jour le message et relancer le timer) au lieu d’empiler de nouvelles notifications, tout en conservant les classes CSS et le flux d’animation existant (`toast--visible`, `toast--with-action`).
- Ajustement du flux de masquage pour nettoyer `activeToastOptions` et relancer le traitement de la file après l’animation de disparition avec la même durée d’animation (`TOAST_HIDE_ANIMATION_DURATION`).
- Mise à jour de `js/materiels.js` : remplacement du message statique par `window.UiService?.showToast?.(`${materialCart.length} matériel${materialCart.length > 1 ? 's' : ''} dans le panier`);` pour afficher le nombre d’articles lors d’ajouts rapides.

### Testing
- Aucun test automatique n’a été exécuté dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb50c3360c832aba7822c79a3aa1de)