### PR TITLE
Ajouter une confirmation et choix de nom avant l’export PNG

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -384,7 +384,61 @@ import { firebaseDb } from './firebase-core.js';
     return exportArea;
   }
 
-  async function downloadRequestAsPng() {
+  function slugifyFileName(rawName) {
+    return String(rawName || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[\\/:*?"<>|]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function getDefaultRequestPngFileName() {
+    const date = new Date().toISOString().slice(0, 10);
+    return `demande-materiel-${date}`;
+  }
+
+  function resetRequestPngModalState() {
+    const input = requireElement('requestPngFileNameInput');
+    const error = requireElement('requestPngFileNameError');
+    input?.classList.remove('is-error', 'is-shaking');
+    if (error) {
+      error.textContent = '';
+    }
+  }
+
+  function openRequestPngModal() {
+    const input = requireElement('requestPngFileNameInput');
+    const suggestions = requireElement('requestPngFileNameSuggestions');
+    const defaultName = getDefaultRequestPngFileName();
+    const count = Math.max(materialCart.length, 1);
+
+    if (input) {
+      input.value = defaultName;
+    }
+    if (suggestions) {
+      suggestions.innerHTML = [
+        defaultName,
+        'demande-materiel',
+        'demande',
+        `demande-materiel-${count}materiels`
+      ].map((value) => `<option value="${escapeHtml(value)}"></option>`).join('');
+    }
+    resetRequestPngModalState();
+    openDialogById('requestPngModal');
+    window.setTimeout(() => {
+      input?.focus();
+      input?.select();
+    }, 150);
+  }
+
+  function closeRequestPngModal() {
+    closeDialogById('requestPngModal');
+    resetRequestPngModalState();
+  }
+
+  async function downloadRequestAsPng(fileName = '') {
     const showToast = window.UiService?.showToast;
 
     if (!materialCart || materialCart.length === 0) {
@@ -410,9 +464,9 @@ import { firebaseDb } from './firebase-core.js';
         windowHeight: exportArea.scrollHeight
       });
 
-      const date = new Date().toISOString().slice(0, 10);
+      const safeFileName = slugifyFileName(fileName) || getDefaultRequestPngFileName();
       const link = document.createElement('a');
-      link.download = `demande-materiel-${date}.png`;
+      link.download = `${safeFileName}.png`;
       link.href = canvas.toDataURL('image/png');
       link.click();
 
@@ -612,8 +666,50 @@ import { firebaseDb } from './firebase-core.js';
       renderMaterialCart();
     });
 
-    requireElement('downloadRequestPngBtn')?.addEventListener('click', () => {
-      downloadRequestAsPng();
+    requireElement('downloadRequestPngBtn')?.addEventListener('click', openRequestPngModal);
+    requireElement('confirmRequestPngBtn')?.addEventListener('click', () => {
+      const input = requireElement('requestPngFileNameInput');
+      const error = requireElement('requestPngFileNameError');
+      const rawValue = String(input?.value || '');
+      const cleanedValue = slugifyFileName(rawValue);
+
+      if (!cleanedValue) {
+        if (error) {
+          error.textContent = 'Veuillez renseigner un nom de fichier.';
+        }
+        input?.classList.remove('is-shaking');
+        void input?.offsetWidth;
+        input?.classList.add('is-error', 'is-shaking');
+        return;
+      }
+
+      closeRequestPngModal();
+      downloadRequestAsPng(cleanedValue);
+    });
+    requireElement('cancelRequestPngBtn')?.addEventListener('click', closeRequestPngModal);
+    requireElement('requestPngFileNameInput')?.addEventListener('input', () => {
+      const input = requireElement('requestPngFileNameInput');
+      const error = requireElement('requestPngFileNameError');
+      input?.classList.remove('is-error', 'is-shaking');
+      if (error) {
+        error.textContent = '';
+      }
+    });
+    requireElement('requestPngFileNameInput')?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        requireElement('confirmRequestPngBtn')?.click();
+      }
+    });
+    requireElement('requestPngModal')?.addEventListener('click', (event) => {
+      const modal = event.currentTarget;
+      if (event.target === modal) {
+        closeRequestPngModal();
+      }
+    });
+    requireElement('requestPngModal')?.addEventListener('cancel', (event) => {
+      event.preventDefault();
+      closeRequestPngModal();
     });
     requireElement('saveEditQtyBtn')?.addEventListener('click', () => {
       const input = requireElement('editQtyInput');

--- a/materiels.html
+++ b/materiels.html
@@ -147,12 +147,15 @@
       }
 
       .materials-page #editQtyInput.is-error,
-      .materials-page #editQtyInput.is-error:focus {
+      .materials-page #editQtyInput.is-error:focus,
+      .materials-page #requestPngFileNameInput.is-error,
+      .materials-page #requestPngFileNameInput.is-error:focus {
         border-color: #ef4444;
         box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
       }
 
-      .materials-page #editQtyInput.is-shaking {
+      .materials-page #editQtyInput.is-shaking,
+      .materials-page #requestPngFileNameInput.is-shaking {
         animation: site-lock-input-shake 300ms ease-in-out 1;
       }
 
@@ -306,6 +309,25 @@
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelEditQtyBtn" class="btn btn-neutral" type="button">Annuler</button>
             <button id="saveEditQtyBtn" class="btn btn-success" type="button">Enregistrer</button>
+          </div>
+        </div>
+      </dialog>
+
+      <dialog id="requestPngModal" class="modal-card">
+        <div class="modal-content modal-content--site-create">
+          <div class="modal-header">
+            <h2>Exporter la demande</h2>
+            <p>Choisissez le nom du fichier PNG avant le téléchargement.</p>
+          </div>
+          <label class="input-group input-group--site-create">
+            <span>Nom du fichier</span>
+            <input id="requestPngFileNameInput" type="text" list="requestPngFileNameSuggestions" autocomplete="off" />
+          </label>
+          <datalist id="requestPngFileNameSuggestions"></datalist>
+          <p id="requestPngFileNameError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split modal-actions--site-create">
+            <button id="cancelRequestPngBtn" class="btn btn-neutral" type="button">Annuler</button>
+            <button id="confirmRequestPngBtn" class="btn btn-success" type="button">Télécharger</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Ajouter une étape de confirmation avant le téléchargement PNG pour permettre à l’utilisateur de saisir un nom de fichier sans modifier la logique d’export existante.
- Conserver intégralement le rendu et le comportement `html2canvas` et le toast de succès tout en améliorant l’UX.

### Description
- Ajout d’un modal `requestPngModal` dans `materiels.html` réutilisant les styles, animations et boutons existants, avec champ `Nom du fichier`, suggestions (`datalist`) et actions `Annuler / Télécharger`.
- Extension minimale de l’API d’export en adaptant `downloadRequestAsPng()` pour accepter un paramètre `fileName` sans dupliquer la logique `html2canvas` ni remplacer la fonction existante.
- Implémentation d’une fonction `slugifyFileName()` et d’un fallback `getDefaultRequestPngFileName()` pour nettoyer le nom (suppression des caractères interdits, normalisation des accents, espaces → tirets) et construire le `link.download` final.
- Gestion UX complète : ouverture/fermeture du modal, focus automatique, validation (bordure rouge + animation shake + message d’erreur), Enter déclenche le téléchargement, Échap/clic extérieur/Annuler ferment le modal, et le nom validé est transmis à `downloadRequestAsPng(fileName)`.

### Testing
- Exécution de la vérification syntaxique `node --check js/materiels.js` — succès.
- Contrôle d’état git (`git status --short`) et création d’un commit de changement — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb54fc6960832aa1bcdaf85f1b9975)