### PR TITLE
Fix layout in “Exporter la demande” modal header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1692,6 +1692,13 @@ body[data-page="home"] #siteLockManageDialog #siteLockNewPasswordInput.is-shakin
   gap: 0;
 }
 
+#requestPngModal .modal-header {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0;
+}
+
 #materialCartModal .modal-title {
   margin: 0;
   font-size: 16px;

--- a/materiels.html
+++ b/materiels.html
@@ -316,8 +316,8 @@
       <dialog id="requestPngModal" class="modal-card">
         <div class="modal-content modal-content--site-create">
           <div class="modal-header">
-            <h2>Exporter la demande</h2>
-            <p>Choisissez le nom du fichier PNG avant le téléchargement.</p>
+            <h3 class="modal-title">Exporter la demande</h3>
+            <p class="modal-subtitle">Choisissez le nom du fichier PNG avant le téléchargement.</p>
           </div>
           <label class="input-group input-group--site-create">
             <span>Nom du fichier</span>


### PR DESCRIPTION
### Motivation
- Corriger l'alignement vertical du titre et du sous-titre du modal `requestPngModal` qui étaient affichés côte à côte et compressés sur mobile.
- Réutiliser les classes et styles existants du projet (`modal-title`, `modal-subtitle`, animations, bordures) sans introduire de nouveau design.

### Description
- Remplacé le `h2` et le `p` du header du modal par `h3.modal-title` et `p.modal-subtitle` dans `materiels.html`.
- Ajouté une règle CSS ciblée `#requestPngModal .modal-header` pour forcer `flex-direction: column` et `align-items: flex-start` afin d'empiler titre et sous-titre verticalement.
- Aucune nouvelle variable ou animation n'a été créée et les styles existants (tailles, couleurs et espacements) sont réutilisés.

### Testing
- Aucun test automatisé n'a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb57dbb228832aa2654c8d29e88052)