### PR TITLE
Replace quantity edit modal with inline numeric input in cart

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -7,7 +7,6 @@ import { firebaseDb } from './firebase-core.js';
   const HINT_KEY = 'materialsHintSeen';
   const MAX_CART_LINES = 20;
   let materialCart = [];
-  let currentEditingQtyCode = null;
 
   function requireElement(id) {
     return document.getElementById(id);
@@ -105,26 +104,6 @@ import { firebaseDb } from './firebase-core.js';
     badge.classList.remove('visible');
   }
 
-  function editQtyDirectly(code) {
-    const item = materialCart.find((cartItem) => cartItem.code === code);
-    if (!item) {
-      return;
-    }
-
-    currentEditingQtyCode = code;
-
-    const input = requireElement('editQtyInput');
-    const error = requireElement('editQtyError');
-    if (input) {
-      input.value = String(item.qty || 1);
-      input.classList.remove('is-error', 'is-shaking');
-    }
-    if (error) {
-      error.textContent = '';
-    }
-
-    openEditQtyModal();
-  }
 
   function addMaterialToCart(material) {
     const existing = materialCart.find((item) => item.code === material.code);
@@ -182,6 +161,24 @@ import { firebaseDb } from './firebase-core.js';
     saveMaterialCart();
     updateMaterialCartBadge();
     renderMaterialCart();
+  }
+
+  function updateQtyFromInput(code, value) {
+    const item = materialCart.find((cartItem) => cartItem.code === code);
+    if (!item) {
+      return;
+    }
+
+    const qty = parseInt(value, 10);
+
+    if (!Number.isFinite(qty) || qty < 1) {
+      item.qty = 1;
+    } else {
+      item.qty = qty;
+    }
+
+    saveMaterialCart();
+    updateMaterialCartBadge();
   }
 
   function updateMaterialUnit(code, newUnit) {
@@ -245,7 +242,14 @@ import { firebaseDb } from './firebase-core.js';
           <p>${escapeHtml(item.designation || '-')}</p>
           <div class="qty-control">
             <button class="btn btn-secondary qty-minus" data-code="${escapeHtml(item.code)}" type="button" aria-label="Diminuer la quantité de ${escapeHtml(item.code)}">−</button>
-            <button class="qty-value qty-edit-btn" data-code="${escapeHtml(item.code)}" type="button">${escapeHtml(item.qty || 1)}</button>
+            <input
+              class="qty-input"
+              data-code="${escapeHtml(item.code)}"
+              type="number"
+              min="1"
+              inputmode="numeric"
+              value="${escapeHtml(item.qty || 1)}"
+            />
             <button class="btn btn-secondary qty-plus" data-code="${escapeHtml(item.code)}" type="button" aria-label="Augmenter la quantité de ${escapeHtml(item.code)}">+</button>
             <select class="unit-select" data-code="${escapeHtml(item.code)}">
               <option value="Pcs" ${item.unit === 'Pcs' ? 'selected' : ''}>Pcs</option>
@@ -272,11 +276,24 @@ import { firebaseDb } from './firebase-core.js';
       btn.addEventListener('click', () => decreaseQty(btn.dataset.code || ''));
     });
 
-    document.querySelectorAll('.qty-edit-btn').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        editQtyDirectly(btn.dataset.code || '');
+    list.querySelectorAll('.qty-input').forEach((input) => {
+      input.addEventListener('input', () => {
+        updateQtyFromInput(input.dataset.code || '', input.value);
+      });
+
+      input.addEventListener('change', () => {
+        updateQtyFromInput(input.dataset.code || '', input.value);
+      });
+
+      input.addEventListener('blur', () => {
+        if (!input.value || Number(input.value) < 1) {
+          input.value = '1';
+        }
+
+        updateQtyFromInput(input.dataset.code || '', input.value);
       });
     });
+
 
     list.querySelectorAll('.unit-select').forEach((select) => {
       select.addEventListener('change', () => {
@@ -507,19 +524,6 @@ import { firebaseDb } from './firebase-core.js';
     closeDialogById('materialCartModal');
   }
 
-      function openEditQtyModal() {
-    openDialogById('editQtyModal');
-    window.setTimeout(() => {
-      requireElement('editQtyInput')?.focus();
-    }, 150);
-  }
-
-  function closeEditQtyModal() {
-    closeDialogById('editQtyModal');
-    currentEditingQtyCode = null;
-  }
-
-
     function renderMaterials(materials) {
     const tbody = document.querySelector('#materialsTableBody');
 
@@ -710,47 +714,6 @@ import { firebaseDb } from './firebase-core.js';
     requireElement('requestPngModal')?.addEventListener('cancel', (event) => {
       event.preventDefault();
       closeRequestPngModal();
-    });
-    requireElement('saveEditQtyBtn')?.addEventListener('click', () => {
-      const input = requireElement('editQtyInput');
-      const error = requireElement('editQtyError');
-      const qty = parseInt(input?.value ?? '', 10);
-
-      if (!Number.isFinite(qty) || qty < 1) {
-        if (error) {
-          error.textContent = 'Veuillez entrer une quantité valide.';
-        }
-        input?.classList.remove('is-shaking');
-        void input?.offsetWidth;
-        input?.classList.add('is-error', 'is-shaking');
-        return;
-      }
-
-      const item = materialCart.find((cartItem) => cartItem.code === currentEditingQtyCode);
-      if (!item) {
-        return;
-      }
-
-      item.qty = qty;
-      saveMaterialCart();
-      updateMaterialCartBadge();
-      renderMaterialCart();
-      closeEditQtyModal();
-    });
-    requireElement('cancelEditQtyBtn')?.addEventListener('click', closeEditQtyModal);
-    requireElement('editQtyInput')?.addEventListener('input', () => {
-      const input = requireElement('editQtyInput');
-      const error = requireElement('editQtyError');
-      input?.classList.remove('is-error', 'is-shaking');
-      if (error) {
-        error.textContent = '';
-      }
-    });
-    requireElement('editQtyModal')?.addEventListener('click', (event) => {
-      const modal = event.currentTarget;
-      if (event.target === modal) {
-        closeEditQtyModal();
-      }
     });
 
     requireElement('materialsTableBody')?.addEventListener('click', (event) => {

--- a/materiels.html
+++ b/materiels.html
@@ -122,18 +122,21 @@
         padding: 0.2rem 0.45rem;
       }
 
-      .materials-page .qty-value {
-        min-width: 1.5rem;
+      .materials-page .qty-input {
+        width: 44px;
+        height: 36px;
+        border: none;
+        background: transparent;
         text-align: center;
-        font-weight: 700;
+        font-weight: 800;
+        font-size: inherit;
+        outline: none;
       }
 
-      .materials-page .qty-edit-btn {
-        border: 0;
-        background: transparent;
-        padding: 0;
-        line-height: 1.2;
-        cursor: pointer;
+      .materials-page .qty-input:focus {
+        background: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 0 0 2px rgba(47,155,232,0.18);
       }
 
       .materials-page .unit-select {
@@ -146,15 +149,12 @@
         font-size: 14px;
       }
 
-      .materials-page #editQtyInput.is-error,
-      .materials-page #editQtyInput.is-error:focus,
       .materials-page #requestPngFileNameInput.is-error,
       .materials-page #requestPngFileNameInput.is-error:focus {
         border-color: #ef4444;
         box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
       }
 
-      .materials-page #editQtyInput.is-shaking,
       .materials-page #requestPngFileNameInput.is-shaking {
         animation: site-lock-input-shake 300ms ease-in-out 1;
       }
@@ -289,26 +289,6 @@
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="clearMaterialCartBtn" class="btn btn-secondary" type="button">Vider</button>
             <button id="downloadRequestPngBtn" class="btn btn-primary" type="button">Exporter PNG</button>
-          </div>
-        </div>
-      </dialog>
-
-
-      
-
-      <dialog id="editQtyModal" class="modal-card">
-        <div class="modal-content modal-content--site-create">
-          <div class="modal-header">
-            <h2>Modifier la quantité</h2>
-          </div>
-          <label class="input-group input-group--site-create">
-            <span>Quantité demandée</span>
-            <input id="editQtyInput" type="number" min="1" inputmode="numeric" />
-          </label>
-          <p id="editQtyError" class="form-error" aria-live="polite"></p>
-          <div class="modal-actions modal-actions--split modal-actions--site-create">
-            <button id="cancelEditQtyBtn" class="btn btn-neutral" type="button">Annuler</button>
-            <button id="saveEditQtyBtn" class="btn btn-success" type="button">Enregistrer</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Simplify quantity editing in the material cart by removing the modal workflow and enabling direct inline edits to improve UX and open the numeric keyboard on mobile.
- Keep existing `-` / `+` buttons functional and avoid disruptive re-renders while typing to preserve focus.

### Description
- Replaced the modal-driven quantity button with an inline `<input type="number" class="qty-input" ...>` in each cart row in `materiels.html` and `js/materiels.js`.
- Added `updateQtyFromInput(code, value)` in `js/materiels.js` to validate (`>= 1`), persist changes via `saveMaterialCart()`, and refresh the cart badge via `updateMaterialCartBadge()` without forcing a re-render on every keystroke.
- Wired `.qty-input` event listeners for `input`, `change`, and `blur` to call `updateQtyFromInput` and normalize empty/invalid values back to `1`, while keeping `increaseQty`/`decreaseQty` behavior intact.
- Removed modal-related code paths and controls (`editQtyModal`, `editQtyDirectly`, `editQtyInput`, `saveEditQtyBtn`, `cancelEditQtyBtn`, and associated listeners/DOM) and added minimal CSS for `.qty-input` and its `:focus` state to match the existing design.

### Testing
- Ran `node --check js/materiels.js` to validate the modified script, which succeeded.
- Verified via ripgrep there are no remaining references to removed modal/edit selectors (such as `editQtyModal`, `editQtyDirectly`, `qty-edit-btn`, `editQtyInput`) which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5acecdb0832a9a80a88593dbb4dd)