### PR TITLE
Cap quantity input at 9999 and refine quantity field UI

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -141,12 +141,26 @@ import { firebaseDb } from './firebase-core.js';
     renderMaterialCart();
   }
 
+  function sanitizeQty(value) {
+    let qty = parseInt(value, 10);
+
+    if (!Number.isFinite(qty) || qty < 1) {
+      qty = 1;
+    }
+
+    if (qty > 9999) {
+      qty = 9999;
+    }
+
+    return qty;
+  }
+
   function increaseQty(code) {
     const item = materialCart.find((cartItem) => cartItem.code === code);
     if (!item) {
       return;
     }
-    item.qty = (Number(item.qty) || 1) + 1;
+    item.qty = sanitizeQty((Number(item.qty) || 1) + 1);
     saveMaterialCart();
     updateMaterialCartBadge();
     renderMaterialCart();
@@ -157,7 +171,7 @@ import { firebaseDb } from './firebase-core.js';
     if (!item) {
       return;
     }
-    item.qty = Math.max(1, (Number(item.qty) || 1) - 1);
+    item.qty = sanitizeQty((Number(item.qty) || 1) - 1);
     saveMaterialCart();
     updateMaterialCartBadge();
     renderMaterialCart();
@@ -169,13 +183,7 @@ import { firebaseDb } from './firebase-core.js';
       return;
     }
 
-    const qty = parseInt(value, 10);
-
-    if (!Number.isFinite(qty) || qty < 1) {
-      item.qty = 1;
-    } else {
-      item.qty = qty;
-    }
+    item.qty = sanitizeQty(value);
 
     saveMaterialCart();
     updateMaterialCartBadge();
@@ -247,6 +255,8 @@ import { firebaseDb } from './firebase-core.js';
               data-code="${escapeHtml(item.code)}"
               type="number"
               min="1"
+              max="9999"
+              maxlength="4"
               inputmode="numeric"
               value="${escapeHtml(item.qty || 1)}"
             />
@@ -278,6 +288,12 @@ import { firebaseDb } from './firebase-core.js';
 
     list.querySelectorAll('.qty-input').forEach((input) => {
       input.addEventListener('input', () => {
+        input.value = input.value.replace(/\D/g, '');
+
+        if (input.value.length > 4) {
+          input.value = input.value.slice(0, 4);
+        }
+
         updateQtyFromInput(input.dataset.code || '', input.value);
       });
 

--- a/materiels.html
+++ b/materiels.html
@@ -123,20 +123,34 @@
       }
 
       .materials-page .qty-input {
-        width: 44px;
+        width: 52px;
         height: 36px;
         border: none;
         background: transparent;
         text-align: center;
         font-weight: 800;
-        font-size: inherit;
+        font-size: 18px;
+        color: #111827;
         outline: none;
+        box-shadow: none;
+        padding: 0;
       }
 
       .materials-page .qty-input:focus {
-        background: #ffffff;
-        border-radius: 12px;
-        box-shadow: 0 0 0 2px rgba(47,155,232,0.18);
+        border: none;
+        outline: none;
+        box-shadow: none;
+        background: transparent;
+      }
+
+      .materials-page .qty-input::-webkit-outer-spin-button,
+      .materials-page .qty-input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      .materials-page .qty-input[type=number] {
+        -moz-appearance: textfield;
       }
 
       .materials-page .unit-select {


### PR DESCRIPTION
### Motivation
- Ensure quantity values are always between `1` and `9999` regardless of typing or +/- controls to avoid excessive orders and enforce a 4-digit limit.
- Prevent non-numeric characters from being entered and make the quantity field visually ultra-discreet and modern by removing focus glow and spinners.

### Description
- Added a central `sanitizeQty` function that parses input and clamps values to the range `1..9999`, and used it from `increaseQty`, `decreaseQty` and `updateQtyFromInput` in `js/materiels.js`.
- Added `max="9999"` and `maxlength="4"` attributes to the rendered quantity `input` and added an `input` handler that strips non-digits and truncates input to 4 characters before updating the cart.
- Updated CSS for `.materials-page .qty-input` in `materiels.html` to increase width, set a compact font size and color, remove borders, outline, focus glow and native number spinners for a cleaner, discreet appearance.

### Testing
- Ran `git diff -- materiels.html js/materiels.js` to verify the exact code changes were applied and present in the working tree.
- Committed the changes with `git commit -m "Cap quantity input at 9999 and simplify qty field styling"` to record the update.
- Inspected the modified files with `nl`/`sed` to confirm `sanitizeQty` usage and the new input handlers and CSS were inserted as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5d9daa18832a81d99a9de864dc7b)