### PR TITLE
Hide datalist arrow and align “Exporter la demande” modal title

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1706,11 +1706,38 @@ body[data-page="home"] #siteLockManageDialog #siteLockNewPasswordInput.is-shakin
   color: var(--text);
 }
 
+#requestPngModal .modal-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+}
+
 #materialCartModal .modal-subtitle {
   margin: 0.25rem 0 0;
   font-size: 0.82rem;
   font-weight: 500;
   color: var(--text-muted);
+}
+
+#requestPngModal .modal-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+/* Supprimer uniquement la petite flèche du datalist */
+input[list]::-webkit-calendar-picker-indicator {
+  display: none !important;
+  opacity: 0 !important;
+  pointer-events: none;
+}
+
+/* Compatibilité supplémentaire */
+input[list]::-webkit-list-button {
+  opacity: 0 !important;
+  pointer-events: none;
 }
 .modal-actions,
 .form-footer {


### PR DESCRIPTION
### Motivation
- Remove only the small native dropdown arrow on datalist/autocomplete inputs while preserving the existing `datalist`/autocomplete behavior and suggestions. 
- Make the `Exporter la demande` modal header visually identical to other modals in the project by reusing the same title/subtitle styles. 
- Keep all HTML, `list` attributes, datalist options, and JavaScript logic unchanged so the change is presentation-only.

### Description
- Added targeted CSS rules to hide the native arrow only for `input[list]` using `input[list]::-webkit-calendar-picker-indicator` and `input[list]::-webkit-list-button` in `css/style.css` so autocomplete and suggestions remain functional. 
- Introduced `#requestPngModal .modal-title` and `#requestPngModal .modal-subtitle` rules that reuse the same typography, margins, and spacing as existing modal headers to align the title with other modals. 
- Did not modify any HTML, `datalist`, `list` attributes, or JavaScript logic; this is a purely visual/CSS update applied in `css/style.css`.

### Testing
- No automated test suite was run because this is a presentation-only CSS change and there are no repository automated tests for this scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7d1ad9ac832aaacccec9a355a0d3)