### PR TITLE
Hide material cart modal before opening PNG export modal

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -442,6 +442,10 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function openRequestPngModal() {
+    closeMaterialCartModal?.();
+    requireElement('materialCartModal')?.classList.remove('active', 'open', 'show');
+    requireElement('materialCartModal')?.classList.add('hidden');
+
     const input = requireElement('requestPngFileNameInput');
     const suggestions = requireElement('requestPngFileNameSuggestions');
     const defaultName = getDefaultRequestPngFileName();
@@ -533,6 +537,7 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function openMaterialCartModal() {
+    requireElement('materialCartModal')?.classList.remove('hidden');
     openDialogById('materialCartModal');
   }
 


### PR DESCRIPTION
### Motivation
- Prevent the material cart dialog from remaining visible behind the PNG export confirmation modal, which produced a confusing stacked-modal UI.

### Description
- In `openRequestPngModal()` call `closeMaterialCartModal?.()` and remove `active`, `open`, `show` classes then add `hidden` to `#materialCartModal` before opening the export modal, and update `openMaterialCartModal()` to remove `hidden` before reopening the cart.

### Testing
- Ran `git -C /workspace/Album status --short && git -C /workspace/Album diff -- js/materiels.js` and `git -C /workspace/Album add js/materiels.js && git -C /workspace/Album commit -m "Fix: hide cart modal before opening PNG export modal"`, and both commands completed successfully; no automated unit tests existed or were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7fdc01bc832a8e9dc63da82e8b11)