### PR TITLE
PNG export modal: custom request title (25-char max)

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -365,7 +365,7 @@ import { firebaseDb } from './firebase-core.js';
     window.UiService?.showToast?.('Demande copiée ✔');
   }
 
-  function buildRequestExportArea() {
+  function buildRequestExportArea(finalTitle) {
     const now = new Date();
     const dateText = now.toLocaleDateString("fr-FR");
     const timeText = now.toLocaleTimeString("fr-FR", {
@@ -386,9 +386,9 @@ import { firebaseDb } from './firebase-core.js';
     exportArea.style.color = '#111827';
 
     exportArea.innerHTML = `
-      <h2 style="margin:0 0 20px;font-size:28px;font-weight:800;">
-        Demande de matériel — ${dateText} ${timeText}
-      </h2>
+      <h1 style="margin:0 0 20px;font-size:28px;font-weight:800;">
+        ${escapeHtml(finalTitle)}
+      </h1>
       <table style="width:100%;border-collapse:collapse;font-size:20px;">
         <thead>
           <tr style="background:#eef5fb;">
@@ -417,28 +417,39 @@ import { firebaseDb } from './firebase-core.js';
     return exportArea;
   }
 
-  function slugifyFileName(rawName) {
-    return String(rawName || '')
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .replace(/[\\/:*?"<>|]/g, '')
-      .replace(/\s+/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-+|-+$/g, '');
-  }
-
   function getDefaultRequestPngFileName() {
     const date = new Date().toISOString().slice(0, 10);
     return `demande-materiel-${date}`;
   }
 
+  function updateExportTitleCounter() {
+    const input = requireElement('exportTitleInput');
+    const counter = requireElement('exportTitleCounter');
+    if (!input || !counter) {
+      return;
+    }
+    const maxLength = input.maxLength > 0 ? input.maxLength : 25;
+    if (input.value.length > maxLength) {
+      input.value = input.value.slice(0, maxLength);
+    }
+    const currentLength = input.value.length;
+    counter.textContent = `${currentLength} / ${maxLength}`;
+    counter.classList.remove('is-warning', 'is-limit');
+    if (currentLength >= maxLength) {
+      counter.classList.add('is-limit');
+    } else if (currentLength / maxLength >= 0.8) {
+      counter.classList.add('is-warning');
+    }
+  }
+
   function resetRequestPngModalState() {
-    const input = requireElement('requestPngFileNameInput');
-    const error = requireElement('requestPngFileNameError');
+    const input = requireElement('exportTitleInput');
+    const error = requireElement('exportTitleError');
     input?.classList.remove('is-error', 'is-shaking');
     if (error) {
       error.textContent = '';
     }
+    updateExportTitleCounter();
   }
 
   function openRequestPngModal() {
@@ -446,21 +457,9 @@ import { firebaseDb } from './firebase-core.js';
     requireElement('materialCartModal')?.classList.remove('active', 'open', 'show');
     requireElement('materialCartModal')?.classList.add('hidden');
 
-    const input = requireElement('requestPngFileNameInput');
-    const suggestions = requireElement('requestPngFileNameSuggestions');
-    const defaultName = getDefaultRequestPngFileName();
-    const count = Math.max(materialCart.length, 1);
-
+    const input = requireElement('exportTitleInput');
     if (input) {
-      input.value = defaultName;
-    }
-    if (suggestions) {
-      suggestions.innerHTML = [
-        defaultName,
-        'demande-materiel',
-        'demande',
-        `demande-materiel-${count}materiels`
-      ].map((value) => `<option value="${escapeHtml(value)}"></option>`).join('');
+      input.value = '';
     }
     resetRequestPngModalState();
     openDialogById('requestPngModal');
@@ -475,7 +474,7 @@ import { firebaseDb } from './firebase-core.js';
     resetRequestPngModalState();
   }
 
-  async function downloadRequestAsPng(fileName = '') {
+  async function downloadRequestAsPng(customTitle = '') {
     const showToast = window.UiService?.showToast;
 
     if (!materialCart || materialCart.length === 0) {
@@ -488,7 +487,15 @@ import { firebaseDb } from './firebase-core.js';
       return;
     }
 
-    const exportArea = buildRequestExportArea();
+    const now = new Date();
+    const formattedDate = `${now.toLocaleDateString('fr-FR')} ${now.toLocaleTimeString('fr-FR', {
+      hour: '2-digit',
+      minute: '2-digit'
+    })}`;
+    const finalTitle = customTitle
+      ? `Demande matériels - ${customTitle} - ${formattedDate}`
+      : `Demande matériels - ${formattedDate}`;
+    const exportArea = buildRequestExportArea(finalTitle);
 
     try {
       const canvas = await window.html2canvas(exportArea, {
@@ -501,7 +508,7 @@ import { firebaseDb } from './firebase-core.js';
         windowHeight: exportArea.scrollHeight
       });
 
-      const safeFileName = slugifyFileName(fileName) || getDefaultRequestPngFileName();
+      const safeFileName = getDefaultRequestPngFileName();
       const link = document.createElement('a');
       link.download = `${safeFileName}.png`;
       link.href = canvas.toDataURL('image/png');
@@ -693,34 +700,26 @@ import { firebaseDb } from './firebase-core.js';
 
     requireElement('downloadRequestPngBtn')?.addEventListener('click', openRequestPngModal);
     requireElement('confirmRequestPngBtn')?.addEventListener('click', () => {
-      const input = requireElement('requestPngFileNameInput');
-      const error = requireElement('requestPngFileNameError');
-      const rawValue = String(input?.value || '');
-      const cleanedValue = slugifyFileName(rawValue);
-
-      if (!cleanedValue) {
-        if (error) {
-          error.textContent = 'Veuillez renseigner un nom de fichier.';
-        }
-        input?.classList.remove('is-shaking');
-        void input?.offsetWidth;
-        input?.classList.add('is-error', 'is-shaking');
-        return;
-      }
+      const input = requireElement('exportTitleInput');
+      const cleanedValue = String(input?.value || '').trim();
 
       closeRequestPngModal();
       downloadRequestAsPng(cleanedValue);
     });
     requireElement('cancelRequestPngBtn')?.addEventListener('click', closeRequestPngModal);
-    requireElement('requestPngFileNameInput')?.addEventListener('input', () => {
-      const input = requireElement('requestPngFileNameInput');
-      const error = requireElement('requestPngFileNameError');
+    requireElement('exportTitleInput')?.addEventListener('input', () => {
+      const input = requireElement('exportTitleInput');
+      const error = requireElement('exportTitleError');
+      if (input && input.maxLength > 0 && input.value.length > input.maxLength) {
+        input.value = input.value.slice(0, input.maxLength);
+      }
+      updateExportTitleCounter();
       input?.classList.remove('is-error', 'is-shaking');
       if (error) {
         error.textContent = '';
       }
     });
-    requireElement('requestPngFileNameInput')?.addEventListener('keydown', (event) => {
+    requireElement('exportTitleInput')?.addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
         event.preventDefault();
         requireElement('confirmRequestPngBtn')?.click();

--- a/materiels.html
+++ b/materiels.html
@@ -163,13 +163,13 @@
         font-size: 14px;
       }
 
-      .materials-page #requestPngFileNameInput.is-error,
-      .materials-page #requestPngFileNameInput.is-error:focus {
+      .materials-page #exportTitleInput.is-error,
+      .materials-page #exportTitleInput.is-error:focus {
         border-color: #ef4444;
         box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
       }
 
-      .materials-page #requestPngFileNameInput.is-shaking {
+      .materials-page #exportTitleInput.is-shaking {
         animation: site-lock-input-shake 300ms ease-in-out 1;
       }
 
@@ -308,17 +308,19 @@
       </dialog>
 
       <dialog id="requestPngModal" class="modal-card">
-        <div class="modal-content modal-content--site-create">
+          <div class="modal-content modal-content--site-create">
           <div class="modal-header">
             <h3 class="modal-title">Exporter la demande</h3>
-            <p class="modal-subtitle">Choisissez le nom du fichier PNG avant le téléchargement.</p>
+            <p class="modal-subtitle">Personnalisez le titre affiché dans l’image PNG.</p>
           </div>
           <label class="input-group input-group--site-create">
-            <span>Nom du fichier</span>
-            <input id="requestPngFileNameInput" type="text" list="requestPngFileNameSuggestions" autocomplete="off" />
+            <span>Titre de la demande</span>
+            <input id="exportTitleInput" type="text" maxlength="25" placeholder="Ex : INTELCIA, TITAN I, HAG 36..." autocomplete="off" />
           </label>
-          <datalist id="requestPngFileNameSuggestions"></datalist>
-          <p id="requestPngFileNameError" class="form-error" aria-live="polite"></p>
+          <div class="input-meta-row">
+            <span id="exportTitleCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
+          </div>
+          <p id="exportTitleError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelRequestPngBtn" class="btn btn-neutral" type="button">Annuler</button>
             <button id="confirmRequestPngBtn" class="btn btn-success" type="button">Télécharger</button>


### PR DESCRIPTION
### Motivation
- Standardize the title shown inside the exported PNG while keeping the file name automatic, and allow a short custom label for the request.
- Replace the previous file-name-focused UX with a dedicated input used only to build the image heading and constrained to 25 characters.

### Description
- Update `materiels.html` to change the modal subtitle to `Personnalisez le titre affiché dans l’image PNG.`, relabel the input to `Titre de la demande`, add the placeholder `Ex : INTELCIA, TITAN I, HAG 36...`, and add a character counter element `exportTitleCounter` showing `0 / 25` underneath the input.
- Replace the old input id with `exportTitleInput`, add `maxlength="25"`, and reuse existing `input-char-counter` styles (no new CSS components added) by adjusting the modal CSS selectors accordingly.
- Modify `js/materiels.js` to:
  - Accept a `finalTitle` parameter in `buildRequestExportArea(finalTitle)` and render it as `<h1>${finalTitle}</h1>` inside the export area.
  - Add `updateExportTitleCounter()` to update the live counter and apply existing counter classes (`is-warning`, `is-limit`); enforce trimming to `maxlength` to prevent overflow and handle paste/typing defensively.
  - Change `downloadRequestAsPng` to accept a `customTitle` and compute `finalTitle` as either `Demande matériels - {customTitle} - {date/heure}` or `Demande matériels - {date/heure}` when empty, while keeping the file name generation automatic via `getDefaultRequestPngFileName()` (resulting filename: `demande-materiel-YYYY-MM-DD.png`).
  - Wire modal events to the new input ids and remove the previous filename slugification/validation logic so the field no longer renames the file.

### Testing
- Ran targeted code searches with `rg -n` to verify replacements of labels and ids and to ensure no leftover `requestPngFileName*` occurrences; the searches returned expected results and no old identifiers remained.
- Inspected modified regions with `sed`/`nl` to confirm `exportTitleInput`, `exportTitleCounter`, and `buildRequestExportArea(finalTitle)` were correctly inserted; visual inspection matched requirements.
- Performed static checks to verify the counter updates, maxlength enforcement and that filename remains automatic; these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb84d1398c832abe6e51e4c26ba914)