### PR TITLE
Aligner le compteur du titre d'export sous le champ (à droite)

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -227,7 +227,23 @@
         100% { transform: scale(1); }
       }
 
-    </style>
+    
+      .materials-page #requestPngModal .site-input-feedback-row {
+        width: 100%;
+        margin-top: 0.24rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .materials-page #requestPngModal #exportTitleCounter {
+        width: auto;
+        text-align: right;
+        margin-top: 0;
+        flex-shrink: 0;
+      }
+</style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
     <div class="app-shell app-shell--wide">
@@ -316,10 +332,11 @@
           <label class="input-group input-group--site-create">
             <span>Titre de la demande</span>
             <input id="exportTitleInput" type="text" maxlength="25" placeholder="Ex : INTELCIA, TITAN I, HAG 36..." autocomplete="off" />
+            <div class="site-input-feedback-row">
+              <span aria-hidden="true"></span>
+              <span id="exportTitleCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
+            </div>
           </label>
-          <div class="input-meta-row">
-            <span id="exportTitleCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
-          </div>
           <p id="exportTitleError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelRequestPngBtn" class="btn btn-neutral" type="button">Annuler</button>


### PR DESCRIPTION
### Motivation
- Harmoniser le positionnement du compteur du modal “Exporter la demande” pour qu’il apparaisse sous le champ et aligné à droite comme les autres formulaires du projet.
- Réutiliser les structures/classes existantes du projet pour conserver le design et la logique actuelle sans créer de nouveau composant.
- Préserver la contrainte de longueur (`maxlength="25"`) et ne pas toucher au comportement JavaScript du compteur.

### Description
- Déplacé le `#exportTitleCounter` directement après `#exportTitleInput` à l’intérieur du `label.input-group` en remplaçant le bloc `input-meta-row` par un wrapper existant `site-input-feedback-row`.
- Conservé la classe compteur existante `input-char-counter` et le `maxlength="25"` sur l’input sans modification de la logique JS.
- Ajouté du style scoped dans `materiels.html` pour `#requestPngModal .site-input-feedback-row` et `#exportTitleCounter` afin de garantir l’alignement à droite et l’apparence cohérente avec les autres formulaires.

### Testing
- Aucun test automatisé spécifique n’a été exécuté sur ce changement.
- Les modifications sont limitées au HTML/CSS et ont été vérifiées via inspection du diff et placement structurel du compteur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb886d550c832ab7f6167454d5be31)