### PR TITLE
Persist and preload last PNG export request title

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -506,6 +506,36 @@ import { firebaseDb } from './firebase-core.js';
     }
   }
 
+
+  const LAST_TITLE_KEY = 'lastMaterialRequestTitle';
+
+  function preloadLastRequestTitle() {
+    const input = requireElement('exportTitleInput');
+
+    if (!input) return;
+
+    const savedTitle = localStorage.getItem(LAST_TITLE_KEY);
+
+    if (savedTitle) {
+      input.value = savedTitle;
+
+      // garder le compteur existant synchronisé
+      input.dispatchEvent(new Event('input'));
+    }
+  }
+
+  function saveLastRequestTitle() {
+    const input = requireElement('exportTitleInput');
+
+    if (!input) return;
+
+    const value = input.value.trim();
+
+    if (value) {
+      localStorage.setItem(LAST_TITLE_KEY, value);
+    }
+  }
+
   function resetRequestPngModalState() {
     const input = requireElement('exportTitleInput');
     const error = requireElement('exportTitleError');
@@ -522,10 +552,8 @@ import { firebaseDb } from './firebase-core.js';
     requireElement('materialCartModal')?.classList.add('hidden');
 
     const input = requireElement('exportTitleInput');
-    if (input) {
-      input.value = '';
-    }
     resetRequestPngModalState();
+    preloadLastRequestTitle();
     openDialogById('requestPngModal');
     window.setTimeout(() => {
       input?.focus();
@@ -763,6 +791,7 @@ import { firebaseDb } from './firebase-core.js';
       const input = requireElement('exportTitleInput');
       const cleanedValue = String(input?.value || '').trim();
 
+      saveLastRequestTitle();
       closeRequestPngModal();
       downloadRequestAsPng(cleanedValue);
     });


### PR DESCRIPTION
### Motivation
- Remember the last "Titre de la demande" used when exporting the material request as PNG so users don’t need to retype it each time.
- Implement this without changing UI, buttons, counter behaviour, export flow, other modals, pages, or business logic.

### Description
- Added a storage key constant `LAST_TITLE_KEY = 'lastMaterialRequestTitle'` and two functions `preloadLastRequestTitle()` and `saveLastRequestTitle()` in `js/materiels.js` to load and persist the title to `localStorage`.
- `preloadLastRequestTitle()` fills the `#exportTitleInput` with the saved value and dispatches an `input` event to keep the existing `0 / 25` counter synchronized.
- `saveLastRequestTitle()` stores the trimmed non-empty value from `#exportTitleInput` into `localStorage`.
- Integrated the preload call when opening the export PNG modal and the save call on the `Télécharger` (`confirmRequestPngBtn`) click just before the modal closes and the existing PNG export continues.

### Testing
- Verified file changes with `git diff -- js/materiels.js` which showed the intended insertions and deletions and succeeded.
- Confirmed repository state with `git status --short` and committed the change with `git add`/`git commit` which succeeded.
- Searched for relevant DOM hooks using `rg` to ensure correct wiring points (modal open and confirm button) and validated the new functions are invoked; searches completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0a2fb230832aa1bf11d7d28746e9)