### PR TITLE
Ajouter saisie manuelle d’un matériel dans la demande (panier local)

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -9,6 +9,10 @@ import { firebaseDb } from './firebase-core.js';
   let materialCart = [];
   let lastRequestMeta = null;
 
+  function getCartItemKey(item = {}) {
+    return String(item.code || item.manualKey || '');
+  }
+
   function requireElement(id) {
     return document.getElementById(id);
   }
@@ -86,6 +90,7 @@ import { firebaseDb } from './firebase-core.js';
       const savedCart = JSON.parse(localStorage.getItem(CART_KEY)) || [];
       materialCart = savedCart.map((item) => ({
         ...item,
+        manualKey: item.manualKey || '',
         unit: item.unit || getDefaultMaterialUnit(item.designation || ''),
       }));
     } catch (_error) {
@@ -187,7 +192,7 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function removeMaterialFromCart(code) {
-    materialCart = materialCart.filter((item) => item.code !== code);
+    materialCart = materialCart.filter((item) => getCartItemKey(item) !== code);
     saveMaterialCart();
     updateMaterialCartBadge();
     renderMaterialCart();
@@ -208,7 +213,7 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function increaseQty(code) {
-    const item = materialCart.find((cartItem) => cartItem.code === code);
+    const item = materialCart.find((cartItem) => getCartItemKey(cartItem) === code);
     if (!item) {
       return;
     }
@@ -219,7 +224,7 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function decreaseQty(code) {
-    const item = materialCart.find((cartItem) => cartItem.code === code);
+    const item = materialCart.find((cartItem) => getCartItemKey(cartItem) === code);
     if (!item) {
       return;
     }
@@ -230,7 +235,7 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function updateQtyFromInput(code, value) {
-    const item = materialCart.find((cartItem) => cartItem.code === code);
+    const item = materialCart.find((cartItem) => getCartItemKey(cartItem) === code);
     if (!item) {
       return;
     }
@@ -243,7 +248,7 @@ import { firebaseDb } from './firebase-core.js';
 
   function updateMaterialUnit(code, newUnit) {
     materialCart = materialCart.map((item) => {
-      if (item.code === code) {
+      if (getCartItemKey(item) === code) {
         return { ...item, unit: newUnit };
       }
       return item;
@@ -301,10 +306,10 @@ import { firebaseDb } from './firebase-core.js';
           <strong>${escapeHtml(item.code)}</strong>
           <p>${escapeHtml(item.designation || '-')}</p>
           <div class="qty-control">
-            <button class="btn btn-secondary qty-minus" data-code="${escapeHtml(item.code)}" type="button" aria-label="Diminuer la quantité de ${escapeHtml(item.code)}">−</button>
+            <button class="btn btn-secondary qty-minus" data-code="${escapeHtml(getCartItemKey(item))}" type="button" aria-label="Diminuer la quantité de ${escapeHtml(item.code)}">−</button>
             <input
               class="qty-input"
-              data-code="${escapeHtml(item.code)}"
+              data-code="${escapeHtml(getCartItemKey(item))}"
               type="number"
               min="1"
               max="9999"
@@ -312,14 +317,14 @@ import { firebaseDb } from './firebase-core.js';
               inputmode="numeric"
               value="${escapeHtml(item.qty || 1)}"
             />
-            <button class="btn btn-secondary qty-plus" data-code="${escapeHtml(item.code)}" type="button" aria-label="Augmenter la quantité de ${escapeHtml(item.code)}">+</button>
-            <select class="unit-select" data-code="${escapeHtml(item.code)}">
+            <button class="btn btn-secondary qty-plus" data-code="${escapeHtml(getCartItemKey(item))}" type="button" aria-label="Augmenter la quantité de ${escapeHtml(item.code)}">+</button>
+            <select class="unit-select" data-code="${escapeHtml(getCartItemKey(item))}">
               <option value="Pcs" ${item.unit === 'Pcs' ? 'selected' : ''}>Pcs</option>
               <option value="m" ${item.unit === 'm' ? 'selected' : ''}>m</option>
             </select>
           </div>
         </div>
-        <button class="remove-cart-item-btn" data-code="${escapeHtml(item.code)}" type="button" aria-label="Retirer ${escapeHtml(item.code)}">×</button>
+        <button class="remove-cart-item-btn" data-code="${escapeHtml(getCartItemKey(item))}" type="button" aria-label="Retirer ${escapeHtml(item.code)}">×</button>
       </div>
     `)
       .join('');
@@ -640,6 +645,96 @@ import { firebaseDb } from './firebase-core.js';
     closeDialogById('materialCartModal');
   }
 
+  function openManualMaterialModal() {
+    requireElement('manualMaterialError').textContent = '';
+    ['manualMaterialCodeInput', 'manualMaterialDesignationInput', 'manualMaterialQtyInput', 'manualMaterialUnitInput'].forEach((id) => {
+      requireElement(id)?.classList.remove('is-error', 'is-shaking');
+    });
+    requireElement('manualMaterialCodeInput').value = '';
+    requireElement('manualMaterialDesignationInput').value = '';
+    requireElement('manualMaterialQtyInput').value = '1';
+    requireElement('manualMaterialUnitInput').value = 'Pcs';
+    openDialogById('manualMaterialModal');
+    window.setTimeout(() => requireElement('manualMaterialDesignationInput')?.focus(), 100);
+  }
+
+  function closeManualMaterialModal() {
+    closeDialogById('manualMaterialModal');
+  }
+
+  function validateManualMaterialForm() {
+    const designationInput = requireElement('manualMaterialDesignationInput');
+    const qtyInput = requireElement('manualMaterialQtyInput');
+    const unitInput = requireElement('manualMaterialUnitInput');
+    const errorEl = requireElement('manualMaterialError');
+    const clearError = (el) => el?.classList.remove('is-error', 'is-shaking');
+    [designationInput, qtyInput, unitInput].forEach(clearError);
+    errorEl.textContent = '';
+
+    const designation = String(designationInput?.value || '').trim();
+    const qty = parseInt(qtyInput?.value || '', 10);
+    const unit = String(unitInput?.value || '').trim();
+    let firstInvalid = null;
+    let errorMessage = '';
+
+    if (!designation) {
+      firstInvalid = designationInput;
+      errorMessage = 'La désignation est obligatoire.';
+    } else if (!Number.isInteger(qty) || qty < 1) {
+      firstInvalid = qtyInput;
+      errorMessage = 'La quantité doit être un nombre entier ≥ 1.';
+    } else if (!unit) {
+      firstInvalid = unitInput;
+      errorMessage = 'L’unité est obligatoire.';
+    }
+
+    if (firstInvalid) {
+      firstInvalid.classList.add('is-error');
+      firstInvalid.classList.remove('is-shaking');
+      void firstInvalid.offsetWidth;
+      firstInvalid.classList.add('is-shaking');
+      errorEl.textContent = errorMessage;
+      firstInvalid.focus();
+      return null;
+    }
+
+    return { designation, qty, unit };
+  }
+
+  function saveManualMaterial() {
+    const code = String(requireElement('manualMaterialCodeInput')?.value || '').trim();
+    const valid = validateManualMaterialForm();
+    if (!valid) {
+      return;
+    }
+    const { designation, qty, unit } = valid;
+    const manualItem = { code, designation, qty, unit, manual: true };
+    const existing = materialCart.find((item) => String(item.code || '').trim() === code && code);
+    if (existing) {
+      existing.qty = sanitizeQty((Number(existing.qty) || 0) + qty);
+      if (!String(existing.designation || '').trim()) {
+        existing.designation = designation;
+      }
+      if (!String(existing.unit || '').trim()) {
+        existing.unit = unit;
+      }
+    } else {
+      if (materialCart.length >= MAX_CART_LINES) {
+        window.UiService?.showToast?.('Limite de 20 matériels atteinte.');
+        return;
+      }
+      materialCart.push({
+        ...manualItem,
+        manualKey: code || `manual-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      });
+    }
+
+    saveMaterialCart();
+    updateMaterialCartBadge();
+    renderMaterialCart();
+    closeManualMaterialModal();
+  }
+
     function renderMaterials(materials) {
     const tbody = document.querySelector('#materialsTableBody');
 
@@ -823,6 +918,18 @@ import { firebaseDb } from './firebase-core.js';
     requireElement('requestPngModal')?.addEventListener('cancel', (event) => {
       event.preventDefault();
       closeRequestPngModal();
+    });
+    requireElement('openManualMaterialBtn')?.addEventListener('click', openManualMaterialModal);
+    requireElement('saveManualMaterialBtn')?.addEventListener('click', saveManualMaterial);
+    requireElement('cancelManualMaterialBtn')?.addEventListener('click', closeManualMaterialModal);
+    requireElement('manualMaterialModal')?.addEventListener('click', (event) => {
+      if (event.target === event.currentTarget) {
+        closeManualMaterialModal();
+      }
+    });
+    requireElement('manualMaterialModal')?.addEventListener('cancel', (event) => {
+      event.preventDefault();
+      closeManualMaterialModal();
     });
 
     requireElement('materialsTableBody')?.addEventListener('click', (event) => {

--- a/materiels.html
+++ b/materiels.html
@@ -243,6 +243,22 @@
         margin-top: 0;
         flex-shrink: 0;
       }
+
+      .materials-page #manualMaterialDesignationInput.is-error,
+      .materials-page #manualMaterialQtyInput.is-error,
+      .materials-page #manualMaterialUnitInput.is-error,
+      .materials-page #manualMaterialDesignationInput.is-error:focus,
+      .materials-page #manualMaterialQtyInput.is-error:focus,
+      .materials-page #manualMaterialUnitInput.is-error:focus {
+        border-color: #ef4444;
+        box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+      }
+
+      .materials-page #manualMaterialDesignationInput.is-shaking,
+      .materials-page #manualMaterialQtyInput.is-shaking,
+      .materials-page #manualMaterialUnitInput.is-shaking {
+        animation: site-lock-input-shake 300ms ease-in-out 1;
+      }
 </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
@@ -265,6 +281,7 @@
             <div class="header-top page3-summary-header">
               <div class="title-block page3-title-block">
                 <h2 class="section-title">Tableau des matériels</h2>
+                <button id="openManualMaterialBtn" class="btn btn-secondary" type="button">+ Manuel</button>
               </div>
             </div>
           </div>
@@ -341,6 +358,40 @@
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelRequestPngBtn" class="btn btn-neutral" type="button">Annuler</button>
             <button id="confirmRequestPngBtn" class="btn btn-success" type="button">Télécharger</button>
+          </div>
+        </div>
+      </dialog>
+
+      
+
+      <dialog id="manualMaterialModal" class="modal-card">
+        <div class="modal-content modal-content--site-create">
+          <div class="modal-header">
+            <h3 class="modal-title">Ajouter un matériel manuel</h3>
+          </div>
+          <label class="input-group input-group--site-create">
+            <span>Code</span>
+            <input id="manualMaterialCodeInput" type="text" placeholder="Ex : CAB-001" autocomplete="off" />
+          </label>
+          <label class="input-group input-group--site-create">
+            <span>Désignation</span>
+            <input id="manualMaterialDesignationInput" type="text" placeholder="Désignation" autocomplete="off" />
+          </label>
+          <label class="input-group input-group--site-create">
+            <span>Quantité demandée</span>
+            <input id="manualMaterialQtyInput" type="number" min="1" step="1" inputmode="numeric" placeholder="1" />
+          </label>
+          <label class="input-group input-group--site-create">
+            <span>Unité</span>
+            <select id="manualMaterialUnitInput">
+              <option value="Pcs">Pcs</option>
+              <option value="m">m</option>
+            </select>
+          </label>
+          <p id="manualMaterialError" class="form-error" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split modal-actions--site-create">
+            <button id="cancelManualMaterialBtn" class="btn btn-neutral" type="button">Annuler</button>
+            <button id="saveManualMaterialBtn" class="btn btn-success" type="button">Enregistrer</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Permettre à l’utilisateur d’ajouter un matériel non présent dans la base directement dans la demande via une saisie manuelle intégrée à la page des matériels.
- Conserver toutes les contraintes UX/architecture existantes : pas de modification Firebase, pas de nouvelle collection, et stockage uniquement dans le panier local `materialRequestCart`.
- Réutiliser les composants UI existants (boutons, modal, inputs, styles d’erreur) pour garder une apparence et un comportement cohérents.

### Description
- Ajout d’un bouton discret `+ Manuel` dans la carte « Tableau des matériels » qui ouvre un modal de saisie manuelle (HTML ajouté dans `materiels.html`) et ajout de styles d’erreur réutilisant les classes existantes.
- Implémentation du modal avec champs `Code` (facultatif), `Désignation` (obligatoire), `Quantité demandée` (entier ≥ 1), `Unité` (`Pcs`/`m`) et feedback d’erreur (`manualMaterialError`) en réutilisant la classe `.form-error` et les animations `is-error`/`is-shaking`.
- JS : ajout des helpers `openManualMaterialModal`, `closeManualMaterialModal`, `validateManualMaterialForm` et `saveManualMaterial` dans `js/materiels.js`, en conservant le flux attendu `saveMaterialCart()`, `updateMaterialCartBadge()`, `renderMaterialCart()` et fermeture du modal après enregistrement.
- Gestion des lignes manuelles dans `materialCart` : champ interne `manualKey` généré pour les éléments sans code afin d’autoriser suppression/édition/compte du badge; adaptation du rendu et des actions du panier pour utiliser une clé (`getCartItemKey`) (ne modifie pas la table globale ni Firebase).
- Fusion si un `code` manuel existe déjà dans le panier : on augmente la quantité, on complète la désignation si vide et on conserve/complète l’unité selon les règles demandées.

### Testing
- Exécution de vérifications statiques et inspection des diffs/présence des nouvelles balises et fonctions : checks passés avec succès (fichiers modifiés : `materiels.html`, `js/materiels.js`).
- Vérification automatique que le nouveau modal et les IDs attendus sont présents et que les fonctions d’événements sont attachées : OK.
- Aucune suite de tests unitaires automatisés existante n’a été exécutée; les contrôles de dépôt/packaging et la création de la PR ont été complétés sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0e0cf6f4832a8ee125ab5548491b)