### PR TITLE
Simplify manual material modal to Code + Désignation and default qty/unit in cart

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -647,13 +647,11 @@ import { firebaseDb } from './firebase-core.js';
 
   function openManualMaterialModal() {
     requireElement('manualMaterialError').textContent = '';
-    ['manualMaterialCodeInput', 'manualMaterialDesignationInput', 'manualMaterialQtyInput', 'manualMaterialUnitInput'].forEach((id) => {
+    ['manualMaterialCodeInput', 'manualMaterialDesignationInput'].forEach((id) => {
       requireElement(id)?.classList.remove('is-error', 'is-shaking');
     });
     requireElement('manualMaterialCodeInput').value = '';
     requireElement('manualMaterialDesignationInput').value = '';
-    requireElement('manualMaterialQtyInput').value = '1';
-    requireElement('manualMaterialUnitInput').value = 'Pcs';
     openDialogById('manualMaterialModal');
     window.setTimeout(() => requireElement('manualMaterialDesignationInput')?.focus(), 100);
   }
@@ -664,28 +662,18 @@ import { firebaseDb } from './firebase-core.js';
 
   function validateManualMaterialForm() {
     const designationInput = requireElement('manualMaterialDesignationInput');
-    const qtyInput = requireElement('manualMaterialQtyInput');
-    const unitInput = requireElement('manualMaterialUnitInput');
     const errorEl = requireElement('manualMaterialError');
     const clearError = (el) => el?.classList.remove('is-error', 'is-shaking');
-    [designationInput, qtyInput, unitInput].forEach(clearError);
+    [designationInput].forEach(clearError);
     errorEl.textContent = '';
 
     const designation = String(designationInput?.value || '').trim();
-    const qty = parseInt(qtyInput?.value || '', 10);
-    const unit = String(unitInput?.value || '').trim();
     let firstInvalid = null;
     let errorMessage = '';
 
     if (!designation) {
       firstInvalid = designationInput;
       errorMessage = 'La désignation est obligatoire.';
-    } else if (!Number.isInteger(qty) || qty < 1) {
-      firstInvalid = qtyInput;
-      errorMessage = 'La quantité doit être un nombre entier ≥ 1.';
-    } else if (!unit) {
-      firstInvalid = unitInput;
-      errorMessage = 'L’unité est obligatoire.';
     }
 
     if (firstInvalid) {
@@ -698,7 +686,7 @@ import { firebaseDb } from './firebase-core.js';
       return null;
     }
 
-    return { designation, qty, unit };
+    return { designation, qty: 1, unit: 'Pcs' };
   }
 
   function saveManualMaterial() {
@@ -733,6 +721,7 @@ import { firebaseDb } from './firebase-core.js';
     updateMaterialCartBadge();
     renderMaterialCart();
     closeManualMaterialModal();
+    openMaterialCartModal();
   }
 
     function renderMaterials(materials) {

--- a/materiels.html
+++ b/materiels.html
@@ -245,18 +245,12 @@
       }
 
       .materials-page #manualMaterialDesignationInput.is-error,
-      .materials-page #manualMaterialQtyInput.is-error,
-      .materials-page #manualMaterialUnitInput.is-error,
-      .materials-page #manualMaterialDesignationInput.is-error:focus,
-      .materials-page #manualMaterialQtyInput.is-error:focus,
-      .materials-page #manualMaterialUnitInput.is-error:focus {
+      .materials-page #manualMaterialDesignationInput.is-error:focus {
         border-color: #ef4444;
         box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
       }
 
-      .materials-page #manualMaterialDesignationInput.is-shaking,
-      .materials-page #manualMaterialQtyInput.is-shaking,
-      .materials-page #manualMaterialUnitInput.is-shaking {
+      .materials-page #manualMaterialDesignationInput.is-shaking {
         animation: site-lock-input-shake 300ms ease-in-out 1;
       }
 </style>
@@ -376,17 +370,6 @@
           <label class="input-group input-group--site-create">
             <span>Désignation</span>
             <input id="manualMaterialDesignationInput" type="text" placeholder="Désignation" autocomplete="off" />
-          </label>
-          <label class="input-group input-group--site-create">
-            <span>Quantité demandée</span>
-            <input id="manualMaterialQtyInput" type="number" min="1" step="1" inputmode="numeric" placeholder="1" />
-          </label>
-          <label class="input-group input-group--site-create">
-            <span>Unité</span>
-            <select id="manualMaterialUnitInput">
-              <option value="Pcs">Pcs</option>
-              <option value="m">m</option>
-            </select>
           </label>
           <p id="manualMaterialError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">


### PR DESCRIPTION
### Motivation
- Rendre le modal “Ajouter un matériel manuel” plus simple en supprimant les champs Quantité et Unité pour que ces paramètres soient gérés ensuite dans le panier.
- Préserver la logique existante du panier, l’export PNG, les matériels existants et le design/modal sans ajouter de nouveaux styles.

### Description
- Supprimé les champs `manualMaterialQtyInput` et `manualMaterialUnitInput` du HTML du modal (`materiels.html`) pour ne garder que `Code` et `Désignation`.
- Ajusté les sélecteurs CSS d’erreur/animation pour ne cibler que le champ `manualMaterialDesignationInput` (`materiels.html`).
- Mise à jour de la logique JS (`js/materiels.js`) pour n’effectuer la réinitialisation/validation que sur `Code` et `Désignation` et retourner des valeurs par défaut `qty: 1` et `unit: 'Pcs'` lors de l’enregistrement.
- À l’enregistrement, le matériel manuel est ajouté/mis à jour dans le panier, le modal manuel se ferme et le modal panier est ouvert/rafraîchi; la gestion quantité/unité dans le panier reste inchangée.

### Testing
- Recherches et vérifications par grep des références supprimées et des fonctions modifiées ont été exécutées avec `rg` and succeeded. 
- Changements appliqués (modifications de `materiels.html` et `js/materiels.js`) et commit réalisé avec `git commit` which succeeded. 
- Aucun test automatisé unitaire n’était présent ou requis; les vérifications ci-dessus ont validé l’absence de références orphelines et le commit a été créé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc11a45834832aadfee0dabb598cf0)