### PR TITLE
Ajuste le libellé et l'espacement du bouton manuel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2455,6 +2455,13 @@ body[data-page="item-detail"] .title-block .section-title,
   color: #1f2937;
 }
 
+
+.page3 .page3-title-block #openManualMaterialBtn {
+  display: block;
+  margin-top: 16px;
+  margin-bottom: 20px;
+}
+
 .page3-sub-info {
   display: flex;
   justify-content: space-between;
@@ -2464,7 +2471,7 @@ body[data-page="item-detail"] .title-block .section-title,
 }
 
 .page3 .page3-sub-info {
-  margin-top: 10px;
+  margin-top: 0;
   padding-top: 10px;
   border-top: 1px solid rgba(0, 0, 0, 0.06);
   width: 95%;

--- a/materiels.html
+++ b/materiels.html
@@ -275,7 +275,7 @@
             <div class="header-top page3-summary-header">
               <div class="title-block page3-title-block">
                 <h2 class="section-title">Tableau des matériels</h2>
-                <button id="openManualMaterialBtn" class="btn btn-secondary" type="button">+ Manuel</button>
+                <button id="openManualMaterialBtn" class="btn btn-secondary" type="button">+ Créer une demande</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Rendre le bouton existant plus professionnel et aéré sans créer un nouveau composant ni modifier son style visuel ou ses animations.
- Améliorer la hiérarchie visuelle entre le titre, le bouton et le compteur pour un rendu plus « premium » et lisible.

### Description
- Remplace le libellé du bouton `#openManualMaterialBtn` de `+ Manuel` vers `+ Créer une demande` dans `materiels.html` en conservant l'ID et les classes existantes.
- Ajoute une règle CSS ciblée `.page3 .page3-title-block #openManualMaterialBtn` dans `css/style.css` pour appliquer `margin-top: 16px` et `margin-bottom: 20px` sans toucher à la taille, la couleur, le padding, le border-radius ou les transitions.
- Ajuste `margin-top` de la règle `.page3 .page3-sub-info` à `0` pour éviter l'empilement d'espacements et préserver l'alignement gauche avec le titre, le compteur, la recherche et le tableau.

### Testing
- Aucun test automatisé n'a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc20c35548832aab08ce0ee188c15b)