### PR TITLE
Align “Ajouter un matériel” modal header with shared modal style

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -361,7 +361,7 @@
       <dialog id="manualMaterialModal" class="modal-card">
         <div class="modal-content modal-content--site-create">
           <div class="modal-header">
-            <h3 class="modal-title">Ajouter un matériel manuel</h3>
+            <h2>Ajouter un matériel</h2>
           </div>
           <label class="input-group input-group--site-create">
             <span>Code</span>


### PR DESCRIPTION
### Motivation
- Align the manual material modal header with other project modals so the title uses the same typography and vertical spacing without introducing new styles or changing animations.

### Description
- Replace the custom `h3.modal-title` text `"Ajouter un matériel manuel"` with a shared `h2` title `"Ajouter un matériel"` in `materiels.html` so the modal reuses the existing `.modal-header h2` rules for size, weight and top spacing.

### Testing
- Verified the updated markup in `materiels.html` by inspecting the modified lines and confirming the title now uses an `h2`, and confirmed no CSS or behavior changes were required and automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc24ea0f0c832a8d543662a8189be8)