### PR TITLE
Remove request-number generation and display from material request PNG export

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -1,4 +1,4 @@
-import { collection, doc, getDocs, runTransaction, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+import { addDoc, collection, getDocs, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseDb } from './firebase-core.js';
 
 (function () {
@@ -44,16 +44,6 @@ import { firebaseDb } from './firebase-core.js';
 
   async function createMaterialRequestRecord(requestTitle = '') {
     const cleanedTitle = String(requestTitle || '').trim();
-    const counterRef = doc(firebaseDb, 'counters', 'materialRequestCounter');
-    const requestNumber = await runTransaction(firebaseDb, async (transaction) => {
-      const counterSnap = await transaction.get(counterRef);
-      const currentValue = Number(counterSnap.data()?.current) || 0;
-      const nextValue = currentValue + 1;
-      transaction.set(counterRef, { current: nextValue }, { merge: true });
-      return String(nextValue).padStart(3, '0');
-    });
-
-    const requestRef = doc(collection(firebaseDb, 'materialRequests'));
     const items = materialCart.map((item) => ({
       code: String(item.code || ''),
       designation: String(item.designation || ''),
@@ -61,17 +51,13 @@ import { firebaseDb } from './firebase-core.js';
       unit: item.unit || 'Pcs',
     }));
 
-    await runTransaction(firebaseDb, async (transaction) => {
-      transaction.set(requestRef, {
-        requestNumber,
-        requestTitle: cleanedTitle,
-        createdAt: serverTimestamp(),
-        items,
-      });
+    await addDoc(collection(firebaseDb, 'materialRequests'), {
+      requestTitle: cleanedTitle,
+      createdAt: serverTimestamp(),
+      items,
     });
 
     return {
-      requestNumber,
       requestTitle: cleanedTitle,
       createdAtLabel: formatRequestDateTime(new Date()),
     };
@@ -383,13 +369,9 @@ import { firebaseDb } from './firebase-core.js';
     }
 
     const mainTitle = buildRequestMainTitle(requestMeta?.requestTitle);
-    const requestNumber = requestMeta?.requestNumber ? `N° ${requestMeta.requestNumber}` : '';
     const createdAtLabel = requestMeta?.createdAtLabel || formatRequestDateTime(new Date());
 
     let text = `📦 ${mainTitle}\n`;
-    if (requestNumber) {
-      text += `${requestNumber}\n`;
-    }
     text += `${createdAtLabel}\n\n`;
     text += 'Code | Désignation | Qté | Unité\n';
     text += '----------------------------------\n';
@@ -456,8 +438,7 @@ import { firebaseDb } from './firebase-core.js';
       <h1 style="margin:0;font-size:28px;font-weight:800;">
         ${escapeHtml(sanitizeText(buildRequestMainTitle(requestMeta?.requestTitle)))}
       </h1>
-      <p style="margin:8px 0 0;font-size:20px;font-weight:700;color:#1e40af;">N° ${escapeHtml(requestMeta?.requestNumber || "---")}</p>
-      <p style="margin:8px 0 20px;font-size:18px;color:#334155;">${escapeHtml(sanitizeText(requestMeta?.createdAtLabel || formatRequestDateTime(new Date())))}</p>
+      <p style="margin:6px 0 20px;font-size:18px;color:#334155;">${escapeHtml(sanitizeText(requestMeta?.createdAtLabel || formatRequestDateTime(new Date())))}</p>
       <table style="width:100%;border-collapse:collapse;font-size:20px;">
         <thead>
           <tr style="background:#eef5fb;">


### PR DESCRIPTION
### Motivation
- Remove the visible “N° …” request number from the PNG export and eliminate the logic that generated/incremented it in Firestore while leaving all other data (title, date, table, other collections) unchanged.
- Ensure the export header spacing is tightened so the date sits directly under the title with no reserved line for the number.

### Description
- Replaced the Firestore transaction/counter flow with a simple `addDoc(collection(firebaseDb, 'materialRequests'), ...)` write and removed all `materialRequestCounter` increment logic from `createMaterialRequestRecord` in `js/materiels.js`.
- Removed the `requestNumber` from the return payload and from anywhere it was rendered or included in exported text, including `formatMaterialRequestText` and `buildRequestExportArea`.
- Updated imports to use `addDoc` instead of `runTransaction`/`doc` and removed number-related HTML, adjusting the date paragraph to `margin:6px 0 20px` so the date is directly under the title.
- Kept all other behavior intact (materials table, title handling, other Firestore collections) and only removed the counter/number-specific code paths.

### Testing
- Ran static syntax check with `node --check js/materiels.js`, which passed successfully.
- Verified via search that numeric counter generation and `N°` rendering were removed by checking for occurrences of `requestNumber`, `materialRequestCounter`, `runTransaction`, and `N°` in `js/materiels.js` (no remaining hits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc57643f60832ab515f83317f5141b)