### PR TITLE
Orienter les libellés de la page vers “Demande matériels”

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2460,6 +2460,10 @@ body[data-page="item-detail"] .title-block .section-title,
   display: block;
   margin-top: 16px;
   margin-bottom: 20px;
+  padding: 0.72rem 1.05rem;
+  font-weight: 600;
+  min-width: 205px;
+  width: fit-content;
 }
 
 .page3-sub-info {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             Historiques
           </button>
           <button id="sidebarAllMaterialsBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="materiels.html">
-            Tous les matériels
+            Demande matériels
           </button>
           <button id="sidebarImportBtn" class="header-menu__option sidebar-item" type="button" role="menuitem">
             Importer les données

--- a/materiels.html
+++ b/materiels.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Tous les matériels - Suivi Matériel</title>
+    <title>Demande matériels - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
@@ -263,7 +263,7 @@
         </div>
         <div class="app-header__center">
           <div class="header-title header-title--stacked">
-            <h1>Tous les matériels</h1>
+            <h1>Demande matériels</h1>
           </div>
         </div>
         <div class="app-header__side app-header__side--right" aria-hidden="true"></div>


### PR DESCRIPTION
### Motivation
- Recentrer l’UX sur le flux « Demande matériels » en remplaçant le wording de consultation par un libellé orienté demande tout en conservant l’ergonomie existante.
- Conserver le titre de section `Tableau des matériels` car il décrit la liste d’articles et ne doit pas changer.
- Diminuer légèrement la dominance visuelle du bouton `+ Créer une demande` pour qu’il soit moins dominant sans altérer son style ni sa position.

### Description
- Remplacement du texte du bouton sidebar dans `index.html` : `Tous les matériels` → `Demande matériels`.
- Mise à jour du `<title>` et du `<h1>` dans `materiels.html` pour afficher `Demande matériels` (le reste du markup et la navigation sont inchangés).
- Ajout d’un override ciblé dans `css/style.css` sur `.page3 .page3-title-block #openManualMaterialBtn` pour ajuster le padding, la `font-weight` et la largeur minimale afin de réduire légèrement son impact visuel.
- Aucune logique JavaScript, navigation, panier, export, modals ou comportements responsives n’a été modifiée ; les composants existants ont été réutilisés.

### Testing
- Exécution de recherches de contenu avec `rg` pour vérifier les remplacements de libellés réussis.
- Inspection du diff pour `index.html`, `materiels.html` et `css/style.css` afin de confirmer que seules des modifications de texte/CSS ciblées ont été introduites.
- Les vérifications automatiques de fichiers ont réussi et ne révèlent pas de changements fonctionnels inattendus.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5c295784832aac683c56aa6c5af6)