### PR TITLE
Harmonize “Ajouter un matériel” modal validation with existing styles

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -627,9 +627,14 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function openManualMaterialModal() {
-    requireElement('manualMaterialError').textContent = '';
+    const errorEl = requireElement('manualMaterialError');
+    clearTimeout(errorEl?._hideTimer);
+    if (errorEl) {
+      errorEl.textContent = '';
+      errorEl.classList.remove('visible');
+    }
     ['manualMaterialCodeInput', 'manualMaterialDesignationInput'].forEach((id) => {
-      requireElement(id)?.classList.remove('is-error', 'is-shaking');
+      requireElement(id)?.classList.remove('input-error', 'shake');
     });
     requireElement('manualMaterialCodeInput').value = '';
     requireElement('manualMaterialDesignationInput').value = '';
@@ -641,29 +646,35 @@ import { firebaseDb } from './firebase-core.js';
     closeDialogById('manualMaterialModal');
   }
 
+  function showTempFieldError(input, errorEl, message) {
+    if (!input || !errorEl) {
+      return;
+    }
+
+    input.classList.add('input-error');
+    input.classList.remove('shake');
+    void input.offsetWidth;
+    input.classList.add('shake');
+
+    errorEl.textContent = message;
+    errorEl.classList.add('visible');
+
+    clearTimeout(errorEl._hideTimer);
+    errorEl._hideTimer = window.setTimeout(() => {
+      errorEl.textContent = '';
+      errorEl.classList.remove('visible');
+      input.classList.remove('input-error');
+    }, 2500);
+  }
+
   function validateManualMaterialForm() {
     const designationInput = requireElement('manualMaterialDesignationInput');
     const errorEl = requireElement('manualMaterialError');
-    const clearError = (el) => el?.classList.remove('is-error', 'is-shaking');
-    [designationInput].forEach(clearError);
-    errorEl.textContent = '';
 
     const designation = String(designationInput?.value || '').trim();
-    let firstInvalid = null;
-    let errorMessage = '';
-
     if (!designation) {
-      firstInvalid = designationInput;
-      errorMessage = 'La désignation est obligatoire.';
-    }
-
-    if (firstInvalid) {
-      firstInvalid.classList.add('is-error');
-      firstInvalid.classList.remove('is-shaking');
-      void firstInvalid.offsetWidth;
-      firstInvalid.classList.add('is-shaking');
-      errorEl.textContent = errorMessage;
-      firstInvalid.focus();
+      showTempFieldError(designationInput, errorEl, 'La désignation est obligatoire.');
+      designationInput?.focus();
       return null;
     }
 
@@ -892,6 +903,16 @@ import { firebaseDb } from './firebase-core.js';
     requireElement('openManualMaterialBtn')?.addEventListener('click', openManualMaterialModal);
     requireElement('saveManualMaterialBtn')?.addEventListener('click', saveManualMaterial);
     requireElement('cancelManualMaterialBtn')?.addEventListener('click', closeManualMaterialModal);
+    requireElement('manualMaterialDesignationInput')?.addEventListener('input', () => {
+      const input = requireElement('manualMaterialDesignationInput');
+      const error = requireElement('manualMaterialError');
+      clearTimeout(error?._hideTimer);
+      input?.classList.remove('input-error', 'shake');
+      if (error) {
+        error.textContent = '';
+        error.classList.remove('visible');
+      }
+    });
     requireElement('manualMaterialModal')?.addEventListener('click', (event) => {
       if (event.target === event.currentTarget) {
         closeManualMaterialModal();

--- a/materiels.html
+++ b/materiels.html
@@ -244,13 +244,13 @@
         flex-shrink: 0;
       }
 
-      .materials-page #manualMaterialDesignationInput.is-error,
-      .materials-page #manualMaterialDesignationInput.is-error:focus {
+      .materials-page #manualMaterialDesignationInput.input-error,
+      .materials-page #manualMaterialDesignationInput.input-error:focus {
         border-color: #ef4444;
         box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
       }
 
-      .materials-page #manualMaterialDesignationInput.is-shaking {
+      .materials-page #manualMaterialDesignationInput.shake {
         animation: site-lock-input-shake 300ms ease-in-out 1;
       }
 </style>


### PR DESCRIPTION
### Motivation
- Rendre le comportement visuel et interactif du modal `Ajouter un matériel` identique aux autres modals en réutilisant les classes d’erreur déjà présentes dans le projet.
- Remplacer le style et l’état d’erreur permanents par un message d’erreur temporaire et un effet de shake cohérents avec le reste de l’application.

### Description
- Remplacé les classes locales `is-error` / `is-shaking` par les classes partagées `input-error` et `shake` dans `js/materiels.js` et les sélecteurs CSS de `materiels.html` pour réutiliser le style existant du projet.
- Ajouté la fonction `showTempFieldError(input, errorEl, message)` qui applique `input-error` + `shake`, affiche le message (`La désignation est obligatoire.`) et l’efface automatiquement après `2500ms`.
- Modifié `validateManualMaterialForm()` pour utiliser `showTempFieldError` et garder le modal ouvert tout en remettant le focus sur le champ de désignation quand la validation échoue.
- Ajouté un gestionnaire `input` sur `manualMaterialDesignationInput` qui annule le timer d’effacement, retire `input-error`/`shake` et vide le message immédiatement lors de la frappe.

### Testing
- Aucun test automatisé n’a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5e887128832a93b9b04accf05095)