### PR TITLE
Masquer “Demande matériels” pour les utilisateurs non connectés

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2180,6 +2180,7 @@ import { firebaseAuth } from './firebase-core.js';
       const isLimited = normalizedRole === 'limité' || normalizedRole === 'limite' || normalizedRole === 'limited';
 
       setSidebarItemVisible('#sidebarHistoryBtn', true);
+      setSidebarItemVisible('#sidebarAllMaterialsBtn', isConnected);
 
       if (!isConnected || isLimited) {
         setSidebarItemVisible('#sidebarImportBtn', false);


### PR DESCRIPTION
### Motivation
- Rendre l’entrée de menu `Demande matériels` invisible pour les utilisateurs non connectés en réutilisant la logique existante de visibilité côté sidebar et sans ajouter de nouvelle authentification ni de nouvelle fonction.

### Description
- Ajout de `setSidebarItemVisible('#sidebarAllMaterialsBtn', isConnected);` dans la fonction `updateSidebarPermissions()` de `js/app.js` pour afficher le bouton uniquement lorsque `isConnected` est vrai, sans modifier les autres règles ni le design/animation du sidebar.

### Testing
- Aucun test automatisé n'a été configuré ni exécuté pour ce dépôt; la modification s'appuie sur le chemin d'exécution existant où `updateSidebarPermissions()` est invoquée lors des changements d'état d'authentification pour garantir le comportement dynamique (apparition/disparition au login/logout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9c001ecc832abc6fbb26bf4640a3)