### PR TITLE
Adjust spacing between Code and Désignation in detail modal

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -107,7 +107,7 @@
                   <span id="codeInputCounter" class="input-char-counter" aria-live="polite">0 / 0</span>
                 </div>
               </label>
-              <label class="input-group input-group--wide">
+              <label class="input-group input-group--wide input-group--site-create">
                 <span>Désignation <span class="required-asterisk" aria-hidden="true">*</span></span>
                 <input id="designationInput" name="designation" type="text" maxlength="120" required />
                 <div class="detail-input-feedback-row">


### PR DESCRIPTION
### Motivation
- Augmenter l’espacement vertical entre le champ `Code` et le libellé `Désignation` dans la modal de détail tout en réutilisant les styles existants pour préserver la cohérence visuelle.

### Description
- Appliqué la classe existante `input-group--site-create` au `label` de la `Désignation` dans `page3.html` pour réutiliser l’espacement défini dans `css/style.css` (`.input-group--site-create { margin-top: 0.35rem; }`) sans ajouter de styles inline ni de nouvelle classe.

### Testing
- Aucun test automatisé n’a été exécuté pour ce changement purement visuel et structurel (modification légère d’un attribut de classe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca05b4c60832a8ccd93fb18351a14)