### PR TITLE
Ajoute un modal d’aperçu après le téléchargement automatique du PNG

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -8,6 +8,7 @@ import { firebaseDb } from './firebase-core.js';
   const MAX_CART_LINES = 20;
   let materialCart = [];
   let lastRequestMeta = null;
+  let isRequestPngDownloading = false;
 
   function getCartItemKey(item = {}) {
     return String(item.code || item.manualKey || '');
@@ -552,6 +553,32 @@ import { firebaseDb } from './firebase-core.js';
     resetRequestPngModalState();
   }
 
+  function setRequestPngLoadingState(isLoading) {
+    const confirmButton = requireElement('confirmRequestPngBtn');
+    if (!confirmButton) {
+      return;
+    }
+    confirmButton.disabled = Boolean(isLoading);
+    confirmButton.classList.toggle('is-disabled-soft', Boolean(isLoading));
+    confirmButton.textContent = isLoading ? 'Génération...' : 'Télécharger';
+  }
+
+  function setRequestPngPreviewImage(dataUrl) {
+    const image = requireElement('requestPngPreviewImage');
+    if (image) {
+      image.src = String(dataUrl || '');
+    }
+  }
+
+  function openRequestPngPreviewModal(dataUrl) {
+    setRequestPngPreviewImage(dataUrl);
+    openDialogById('requestPngPreviewModal');
+  }
+
+  function closeRequestPngPreviewModal() {
+    closeDialogById('requestPngPreviewModal');
+  }
+
   async function downloadRequestAsPng(customTitle = '') {
     const showToast = window.UiService?.showToast;
 
@@ -583,12 +610,13 @@ import { firebaseDb } from './firebase-core.js';
       });
 
       const safeFileName = getDefaultRequestPngFileName();
+      const dataUrl = canvas.toDataURL('image/png');
       const link = document.createElement('a');
       link.download = `${safeFileName}.png`;
-      link.href = canvas.toDataURL('image/png');
+      link.href = dataUrl;
       link.click();
 
-      showToast?.('Téléchargement en cours...');
+      openRequestPngPreviewModal(dataUrl);
     } catch (error) {
       console.error('Erreur export PNG :', error);
       showToast?.('Erreur téléchargement PNG');
@@ -863,13 +891,25 @@ import { firebaseDb } from './firebase-core.js';
     });
 
     requireElement('downloadRequestPngBtn')?.addEventListener('click', openRequestPngModal);
-    requireElement('confirmRequestPngBtn')?.addEventListener('click', () => {
+    requireElement('confirmRequestPngBtn')?.addEventListener('click', async () => {
+      if (isRequestPngDownloading) {
+        return;
+      }
+
       const input = requireElement('exportTitleInput');
       const cleanedValue = String(input?.value || '').trim();
 
+      isRequestPngDownloading = true;
+      setRequestPngLoadingState(true);
       saveLastRequestTitle();
       closeRequestPngModal();
-      downloadRequestAsPng(cleanedValue);
+
+      try {
+        await downloadRequestAsPng(cleanedValue);
+      } finally {
+        isRequestPngDownloading = false;
+        setRequestPngLoadingState(false);
+      }
     });
     requireElement('cancelRequestPngBtn')?.addEventListener('click', closeRequestPngModal);
     requireElement('exportTitleInput')?.addEventListener('input', () => {
@@ -899,6 +939,15 @@ import { firebaseDb } from './firebase-core.js';
     requireElement('requestPngModal')?.addEventListener('cancel', (event) => {
       event.preventDefault();
       closeRequestPngModal();
+    });
+    requireElement('requestPngPreviewOkBtn')?.addEventListener('click', closeRequestPngPreviewModal);
+    requireElement('requestPngPreviewModal')?.addEventListener('click', (event) => {
+      if (event.target === event.currentTarget) {
+        event.preventDefault();
+      }
+    });
+    requireElement('requestPngPreviewModal')?.addEventListener('cancel', (event) => {
+      event.preventDefault();
     });
     requireElement('openManualMaterialBtn')?.addEventListener('click', openManualMaterialModal);
     requireElement('saveManualMaterialBtn')?.addEventListener('click', saveManualMaterial);

--- a/materiels.html
+++ b/materiels.html
@@ -253,6 +253,22 @@
       .materials-page #manualMaterialDesignationInput.shake {
         animation: site-lock-input-shake 300ms ease-in-out 1;
       }
+
+      .materials-page .request-png-preview-wrap {
+        margin: 0.4rem 0 0.9rem;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 14px;
+        background: #f8fbff;
+        padding: 0.5rem;
+      }
+
+      .materials-page .request-png-preview-image {
+        display: block;
+        width: 100%;
+        max-height: 52vh;
+        object-fit: contain;
+        border-radius: 10px;
+      }
 </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
@@ -357,6 +373,22 @@
       </dialog>
 
       
+
+
+      <dialog id="requestPngPreviewModal" class="modal-card">
+        <div class="modal-content modal-content--site-create">
+          <div class="modal-header">
+            <h3 class="modal-title">Image générée</h3>
+            <p class="modal-subtitle">Votre demande a été téléchargée avec succès.</p>
+          </div>
+          <div class="request-png-preview-wrap">
+            <img id="requestPngPreviewImage" class="request-png-preview-image" alt="Aperçu de l’image PNG générée" />
+          </div>
+          <div class="modal-actions modal-actions--split modal-actions--site-create">
+            <button id="requestPngPreviewOkBtn" class="btn btn-success" type="button">OK</button>
+          </div>
+        </div>
+      </dialog>
 
       <dialog id="manualMaterialModal" class="modal-card">
         <div class="modal-content modal-content--site-create">


### PR DESCRIPTION
### Motivation
- Conserver le téléchargement automatique du PNG tout en affichant ensuite un aperçu dans un modal pour confirmer le fichier exact généré.
- Empêcher les doubles clics et indiquer l’état de génération pendant la création du PNG.
- Respecter l’UX demandée : la prévisualisation doit être la même image téléchargée et le modal ne doit se fermer que via le bouton OK.

### Description
- Généré un `dataUrl` unique depuis le `canvas` et réutilisé pour le téléchargement et l’aperçu afin d’assurer que l’image affichée est exactement celle téléchargée, les modifications se trouvent dans `js/materiels.js` (ajout de `isRequestPngDownloading`, `setRequestPngLoadingState`, `setRequestPngPreviewImage`, `openRequestPngPreviewModal`, et adaptation de `downloadRequestAsPng`).
- Bloqué les doubles clics en utilisant le flag `isRequestPngDownloading` et un état de chargement sur le bouton `confirmRequestPngBtn` qui devient `Génération...` et est désactivé pendant le traitement.
- Ajout d’un nouveau modal d’aperçu `requestPngPreviewModal` et de styles de prévisualisation dans `materiels.html`, réutilisant la structure/animations/boutons existants et rendant le modal non closible par backdrop ou par `cancel` (fermeture uniquement via `requestPngPreviewOkBtn`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/materiels.js` — réussite.
- Le build local a accepté les changements et le fichier `materiels.html` et `js/materiels.js` ont été modifiés sans erreurs de parsing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcaa873178832aa38b13158ced3e41)