### PR TITLE
Corriger collisions de nom de fichier PNG en ajoutant horodatage

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -468,9 +468,20 @@ import { firebaseDb } from './firebase-core.js';
     return exportArea;
   }
 
+  function formatFileNameDatePart(value) {
+    return String(value).padStart(2, '0');
+  }
+
   function getDefaultRequestPngFileName() {
-    const date = new Date().toISOString().slice(0, 10);
-    return `demande-materiel-${date}`;
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = formatFileNameDatePart(now.getMonth() + 1);
+    const day = formatFileNameDatePart(now.getDate());
+    const hours = formatFileNameDatePart(now.getHours());
+    const minutes = formatFileNameDatePart(now.getMinutes());
+    const seconds = formatFileNameDatePart(now.getSeconds());
+
+    return `demande-materiel-${year}-${month}-${day}-${hours}-${minutes}-${seconds}`;
   }
 
   function updateExportTitleCounter() {


### PR DESCRIPTION
### Motivation
- Android signale une confirmation de retéléchargement quand le même nom de fichier est réutilisé, il faut donc générer automatiquement un nom unique avec heure et secondes.

### Description
- Ajout d'un helper `formatFileNameDatePart` pour zéro-remplir les composants date/heure.
- Remplacement de `getDefaultRequestPngFileName()` dans `js/materiels.js` pour produire `demande-materiel-YYYY-MM-DD-HH-MM-SS` au lieu du format date seule.
- Le flux d'export (génération du canvas et téléchargement du `.png`) est inchangé et seule la construction du nom de fichier a été modifiée.

### Testing
- Exécution d'un contrôle automatisé de diff/check du dépôt sans erreurs détectées.
- Vérification automatisée du diff pour s'assurer que la modification se limite à la génération du nom de fichier.
- Aucune suite de tests unitaires modifiée et aucun test automatique échoué.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcae64554c832aac1cf47f19038020)