### PR TITLE
Fix PNG preview modal layout and image-only zoom

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -574,6 +574,108 @@ import { firebaseDb } from './firebase-core.js';
     confirmButton.textContent = isLoading ? 'Génération...' : 'Télécharger';
   }
 
+  
+
+  const previewZoomState = {
+    scale: 1,
+    minScale: 1,
+    maxScale: 4,
+    translateX: 0,
+    translateY: 0,
+    activePointers: new Map(),
+    pinchDistance: 0,
+    pinchScaleStart: 1,
+    panStartX: 0,
+    panStartY: 0,
+    translateStartX: 0,
+    translateStartY: 0
+  };
+
+  function applyPreviewTransform() {
+    const image = requireElement('requestPngPreviewImage');
+    if (!image) return;
+    image.style.transform = `translate(${previewZoomState.translateX}px, ${previewZoomState.translateY}px) scale(${previewZoomState.scale})`;
+    image.style.cursor = previewZoomState.scale > 1 ? 'grab' : 'default';
+  }
+
+  function resetPreviewZoom() {
+    previewZoomState.scale = 1;
+    previewZoomState.translateX = 0;
+    previewZoomState.translateY = 0;
+    previewZoomState.activePointers.clear();
+    previewZoomState.pinchDistance = 0;
+    applyPreviewTransform();
+  }
+
+  function getPointerDistance(p1, p2) {
+    const dx = p1.x - p2.x;
+    const dy = p1.y - p2.y;
+    return Math.hypot(dx, dy);
+  }
+
+  function initPreviewZoomHandlers() {
+    const image = requireElement('requestPngPreviewImage');
+    if (!image || image.dataset.zoomBound === '1') return;
+
+    image.dataset.zoomBound = '1';
+    image.style.touchAction = 'none';
+
+    image.addEventListener('pointerdown', (event) => {
+      image.setPointerCapture?.(event.pointerId);
+      previewZoomState.activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+      if (previewZoomState.activePointers.size === 1 && previewZoomState.scale > 1) {
+        previewZoomState.panStartX = event.clientX;
+        previewZoomState.panStartY = event.clientY;
+        previewZoomState.translateStartX = previewZoomState.translateX;
+        previewZoomState.translateStartY = previewZoomState.translateY;
+      }
+
+      if (previewZoomState.activePointers.size === 2) {
+        const [p1, p2] = Array.from(previewZoomState.activePointers.values());
+        previewZoomState.pinchDistance = getPointerDistance(p1, p2);
+        previewZoomState.pinchScaleStart = previewZoomState.scale;
+      }
+    });
+
+    image.addEventListener('pointermove', (event) => {
+      if (!previewZoomState.activePointers.has(event.pointerId)) return;
+      previewZoomState.activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+      if (previewZoomState.activePointers.size === 2) {
+        const [p1, p2] = Array.from(previewZoomState.activePointers.values());
+        const distance = getPointerDistance(p1, p2);
+        if (previewZoomState.pinchDistance > 0) {
+          const nextScale = previewZoomState.pinchScaleStart * (distance / previewZoomState.pinchDistance);
+          previewZoomState.scale = Math.min(previewZoomState.maxScale, Math.max(previewZoomState.minScale, nextScale));
+          applyPreviewTransform();
+        }
+        event.preventDefault();
+        return;
+      }
+
+      if (previewZoomState.activePointers.size === 1 && previewZoomState.scale > 1) {
+        previewZoomState.translateX = previewZoomState.translateStartX + (event.clientX - previewZoomState.panStartX);
+        previewZoomState.translateY = previewZoomState.translateStartY + (event.clientY - previewZoomState.panStartY);
+        applyPreviewTransform();
+        event.preventDefault();
+      }
+    });
+
+    const clearPointer = (event) => {
+      previewZoomState.activePointers.delete(event.pointerId);
+      if (previewZoomState.activePointers.size < 2) previewZoomState.pinchDistance = 0;
+      if (previewZoomState.scale <= 1) {
+        previewZoomState.translateX = 0;
+        previewZoomState.translateY = 0;
+        applyPreviewTransform();
+      }
+    };
+
+    image.addEventListener('pointerup', clearPointer);
+    image.addEventListener('pointercancel', clearPointer);
+  }
+
   function setRequestPngPreviewImage(dataUrl) {
     const image = requireElement('requestPngPreviewImage');
     if (image) {
@@ -583,10 +685,13 @@ import { firebaseDb } from './firebase-core.js';
 
   function openRequestPngPreviewModal(dataUrl) {
     setRequestPngPreviewImage(dataUrl);
+    initPreviewZoomHandlers();
+    resetPreviewZoom();
     openDialogById('requestPngPreviewModal');
   }
 
   function closeRequestPngPreviewModal() {
+    resetPreviewZoom();
     closeDialogById('requestPngPreviewModal');
   }
 

--- a/materiels.html
+++ b/materiels.html
@@ -256,17 +256,25 @@
 
       .materials-page .request-png-preview-wrap {
         margin: 0.4rem 0 0.9rem;
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        border-radius: 14px;
-        background: #f8fbff;
-        padding: 0.5rem;
+      }
+
+      .materials-page .preview-image-scroll {
+        max-height: 45vh;
+        overflow: auto;
+        border-radius: 16px;
+        background: #f8fafc;
+        border: 1px solid #e5e7eb;
+        touch-action: pan-x pan-y pinch-zoom;
+      }
+
+      .materials-page .preview-image-scroll img {
+        width: 100%;
+        height: auto;
+        display: block;
+        transform-origin: center center;
       }
 
       .materials-page .request-png-preview-image {
-        display: block;
-        width: 100%;
-        max-height: 52vh;
-        object-fit: contain;
         border-radius: 10px;
       }
 </style>
@@ -378,11 +386,11 @@
       <dialog id="requestPngPreviewModal" class="modal-card">
         <div class="modal-content modal-content--site-create">
           <div class="modal-header">
-            <h3 class="modal-title">Image générée</h3>
+            <h2 class="modal-title">Image générée</h2>
             <p class="modal-subtitle">Votre demande a été téléchargée avec succès.</p>
           </div>
-          <div class="request-png-preview-wrap">
-            <img id="requestPngPreviewImage" class="request-png-preview-image" alt="Aperçu de l’image PNG générée" />
+          <div class="request-png-preview-wrap preview-image-scroll">
+            <img id="requestPngPreviewImage" class="request-png-preview-image" alt="Aperçu demande matériel" />
           </div>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="requestPngPreviewOkBtn" class="btn btn-success" type="button">OK</button>


### PR DESCRIPTION
### Motivation
- Corriger l’affichage du modal d’aperçu PNG pour respecter l’ordre et le style des modals existants (titre puis sous-titre, puis image, puis bouton OK). 
- Permettre le zoom/pinch et le glisser uniquement sur l’image d’aperçu sans affecter le `body` ni le modal lui-même afin de garder le bouton OK et le fond fixes. 
- Ne pas modifier la logique d’export PNG ni les autres modals du projet. 

### Description
- HTML : remplacer le titre en `<h3>` par `<h2 class="modal-title">Image générée</h2>` et envelopper l’image dans un conteneur `div` avec la classe `preview-image-scroll` et mettre à jour l’`alt` de l’image (`requestPngPreviewImage`) dans `materiels.html`. 
- CSS : ajouter les règles pour `.preview-image-scroll` et son `img` (max-height, `overflow: auto`, `touch-action: pan-x pan-y pinch-zoom`, bordures et style d’origine réutilisé) et conserver le style existant du bouton OK dans `materiels.html`. 
- JS : ajouter un état et des gestionnaires pointer events pour le zoom/pinch et le pan uniquement sur `requestPngPreviewImage` (`initPreviewZoomHandlers`, `applyPreviewTransform`, `resetPreviewZoom`) et initialiser/resetter le zoom à l’ouverture/fermeture du modal dans `js/materiels.js`. 
- Fichiers modifiés : `materiels.html` et `js/materiels.js`. 

### Testing
- Exécution automatisée : `node --check js/materiels.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb1ba5c60832ab30d56ec830ffb1b)