### PR TITLE
Fix generated image modal header stacking

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1727,6 +1727,11 @@ body[data-page="home"] #siteLockManageDialog #siteLockNewPasswordInput.is-shakin
   color: var(--text-muted);
 }
 
+
+#requestPngPreviewModal .modal-header {
+  display: block;
+}
+
 /* Supprimer uniquement la petite flèche du datalist */
 input[list]::-webkit-calendar-picker-indicator {
   display: none !important;


### PR DESCRIPTION
### Motivation
- Corriger l'affichage côte-à-côte du titre et du sous-titre dans le modal d'aperçu PNG afin qu'ils utilisent la même structure que les autres modals (titre au-dessus, sous-titre en dessous). 

### Description
- Ajout d'une règle ciblée `#requestPngPreviewModal .modal-header { display: block; }` dans `css/style.css` pour forcer l'empilement vertical tout en réutilisant les classes existantes `modal-header`, `modal-title` et `modal-subtitle` sans ajouter de nouveaux styles et sans modifier le zoom, `preview-image-scroll`, `pngPreviewImage`, le bouton OK ni l'export PNG. 

### Testing
- Exécutées des vérifications automatiques : `rg` pour localiser le modal et les sélecteurs, `sed`/`nl` pour inspecter `materiels.html` et `css/style.css`, et validation du diff du fichier modifié pour confirmer l'ajout de la règle (tous OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb7026ea8832aa1c009fa4a9f035a)