### PR TITLE
Add premium inline loading UX for PNG generation

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -569,9 +569,29 @@ import { firebaseDb } from './firebase-core.js';
     if (!confirmButton) {
       return;
     }
-    confirmButton.disabled = Boolean(isLoading);
-    confirmButton.classList.toggle('is-disabled-soft', Boolean(isLoading));
-    confirmButton.textContent = isLoading ? 'Génération...' : 'Télécharger';
+
+    const isBusy = Boolean(isLoading);
+    const loader = confirmButton.querySelector('.btn-loader');
+    const text = confirmButton.querySelector('.btn-text');
+    const modalContent = document.querySelector('#requestPngModal .modal-content');
+
+    confirmButton.disabled = isBusy;
+    confirmButton.classList.toggle('is-disabled-soft', isBusy);
+    confirmButton.classList.toggle('loading', isBusy);
+
+    if (loader) {
+      loader.classList.toggle('hidden', !isBusy);
+    }
+
+    if (text) {
+      text.textContent = isBusy ? 'Génération...' : 'Télécharger';
+    } else {
+      confirmButton.textContent = isBusy ? 'Génération...' : 'Télécharger';
+    }
+
+    if (modalContent) {
+      modalContent.classList.toggle('is-exporting', isBusy);
+    }
   }
 
   

--- a/materiels.html
+++ b/materiels.html
@@ -277,6 +277,45 @@
       .materials-page .request-png-preview-image {
         border-radius: 10px;
       }
+
+
+      .materials-page #confirmRequestPngBtn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .materials-page #confirmRequestPngBtn .btn-loader {
+        width: 18px;
+        height: 18px;
+        border: 2px solid rgba(255,255,255,0.35);
+        border-top-color: #ffffff;
+        border-radius: 50%;
+        animation: request-png-spin 0.8s linear infinite;
+        display: inline-block;
+        margin-right: 10px;
+        flex-shrink: 0;
+      }
+
+      .materials-page #confirmRequestPngBtn .btn-loader.hidden {
+        display: none;
+      }
+
+      .materials-page #confirmRequestPngBtn.loading,
+      .materials-page #confirmRequestPngBtn.loading:active {
+        opacity: 0.75;
+        cursor: not-allowed;
+        transform: none;
+      }
+
+      .materials-page #requestPngModal .modal-content.is-exporting {
+        opacity: 0.7;
+        pointer-events: none;
+      }
+
+      @keyframes request-png-spin {
+        to { transform: rotate(360deg); }
+      }
 </style>
   </head>
   <body data-page="all-materials" class="page3 materials-page">
@@ -375,7 +414,10 @@
           <p id="exportTitleError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelRequestPngBtn" class="btn btn-neutral" type="button">Annuler</button>
-            <button id="confirmRequestPngBtn" class="btn btn-success" type="button">Télécharger</button>
+            <button id="confirmRequestPngBtn" class="btn btn-success" type="button">
+              <span class="btn-loader hidden" aria-hidden="true"></span>
+              <span class="btn-text">Télécharger</span>
+            </button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Improve the user experience during PNG generation by adding a modern inline loading indicator inside the confirmation button and preventing double submissions while keeping existing button/modal visuals and border radius.
- Keep the UX premium by avoiding fullscreen spinners or system popups and by adding a subtle content dimming for the modal while exporting.

### Description
- Added an inline loader markup to the confirm button in `materiels.html` with a `btn-loader` element and a `btn-text` slot so visuals can be swapped without changing button layout.
- Introduced scoped CSS in `materiels.html` for the inline spinner, `loading` button state, and optional modal-content dimming under the class `is-exporting` (spinner size, animation, opacity and pointer lock included).
- Replaced the previous simple text toggle with `setRequestPngLoadingState` in `js/materiels.js` to: toggle `disabled`, toggle `is-disabled-soft` and `loading` classes, show/hide the inline spinner, swap the text between `Télécharger` and `Génération...`, and toggle the modal `is-exporting` state.
- Ensured the existing guard (`isRequestPngDownloading`) and the PNG generation flow remain intact so double clicks are prevented and the preview modal still opens on success.

### Testing
- Verified inserted markup and styles by inspecting `materiels.html` and locating the new `btn-loader`, `btn-text`, and CSS blocks using `rg` and `nl`/`sed` snippets; searches returned the expected matches.
- Verified the updated `setRequestPngLoadingState` and related references in `js/materiels.js` via code inspection using `rg` and file previews; matches and line snippets are present and correct.
- No automated runtime tests were added; the static inspections above completed successfully and the PNG export code path was preserved unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc0121df0832a9501c799bc6b0638)