### PR TITLE
Fix page 2 XLS export filenames to prevent Android re-download prompt

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -67,6 +67,35 @@ import { firebaseAuth } from './firebase-core.js';
     }
   }
 
+
+  function toFileSlug(value, fallback = 'intelcia-andranomena') {
+    const normalized = String(value || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]+/g, ' ')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    return normalized || fallback;
+  }
+
+  function buildExportTimestamp(date = new Date()) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const seconds = String(date.getSeconds()).padStart(2, '0');
+    return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}`;
+  }
+
+  function buildPage2ExportFileName(siteName, extension = 'xls') {
+    const safeSiteName = toFileSlug(siteName);
+    const timestamp = buildExportTimestamp();
+    return `suivi-materiel-${safeSiteName}-${timestamp}.${extension}`;
+  }
+
   function highlightMatchText(text, query) {
     const safeText = String(text || '');
     const normalizedQuery = String(query || '').trim();
@@ -2839,9 +2868,9 @@ import { firebaseAuth } from './firebase-core.js';
 
       const title = `SUIVI MATERIEL . ${currentSite.nom}`;
       const workbook = buildSiteExcelContent(title, sortedRows);
-      const fileBaseName = normalizeExportBaseName(fileNameOverride || title, title);
-      downloadExcelFile(`${fileBaseName}.xls`, 'Export Excel', workbook);
-      saveExportFileNameToHistory(fileBaseName);
+      const fileName = buildPage2ExportFileName(currentSite?.nom, 'xls');
+      downloadExcelFile(fileName, 'Export Excel', workbook);
+      saveExportFileNameToHistory(fileName);
     }
 
     function updateSiteExportSubmitState() {
@@ -4389,11 +4418,10 @@ import { firebaseAuth } from './firebase-core.js';
         return;
       }
 
-      const baseName = normalizeExportBaseName(fileNameOverride || `${currentSite.nom} · ${currentItem.numero}`, `${currentSite.nom} · ${currentItem.numero}`);
-      const fileName = `${baseName}.xls`;
       const workbook = buildDetailExcelContent(`${currentSite.nom} · ${currentItem.numero}`, filteredDetails);
+      const fileName = buildPage2ExportFileName(currentSite?.nom, 'xls');
       downloadExcelFile(fileName, 'Export Excel', workbook);
-      saveExportFileNameToHistory(baseName);
+      saveExportFileNameToHistory(fileName);
     }
 
     function updateDetailExportSubmitState() {


### PR DESCRIPTION
### Motivation
- Android treats repeated downloads with the same filename as duplicates and prompts the user to re-download, so exports from page 2 need a unique filename to avoid that prompt. 
- The change must preserve the existing Excel file content and only modify the download filename generation. 

### Description
- Added export filename helpers to `js/app.js`: `toFileSlug`, `buildExportTimestamp`, and `buildPage2ExportFileName` to produce `suivi-materiel-<site>-YYYY-MM-DD-HH-MM-SS.xls`. 
- `toFileSlug` normalizes accents, strips non-alphanumerics, converts to lowercase and replaces spaces with hyphens to produce a safe site slug. 
- Replaced the previous base-name logic in the page-2 site-level export and detail export flows to call `buildPage2ExportFileName(...)` while leaving `buildSiteExcelContent` and `buildDetailExcelContent` output unchanged. 
- The generated filename (including timestamp) is still saved to the export history via the existing `saveExportFileNameToHistory` flow. 

### Testing
- Ran `node --check js/app.js` to verify syntax and it succeeded. 
- Confirmed file changes were staged and committed with `git add js/app.js` and `git commit -m "Fix page2 export filenames with timestamp suffix"`. 
- Observed in-code replacement of the old filename paths to the new `buildPage2ExportFileName` usage and no changes to workbook generation, indicating the export content is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccec09fe8832aadfaa7611a4da42d)