### PR TITLE
Align maintenance header (toggle + status) on Admin page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2307,21 +2307,38 @@ body[data-page="users-management"] .maintenance-access-checkbox {
 
 body[data-page="users-management"] .maintenance-card-header {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
   gap: 1rem;
-  flex-wrap: wrap;
 }
 
 body[data-page="users-management"] .maintenance-card-header .section-title {
   margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 body[data-page="users-management"] .maintenance-toggle-row {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+@media (max-width: 420px) {
+  body[data-page="users-management"] .maintenance-card-header {
+    gap: 0.75rem;
+  }
+
+  body[data-page="users-management"] .maintenance-card-header .section-title {
+    font-size: 1rem;
+  }
+
+  body[data-page="users-management"] .maintenance-toggle-row {
+    gap: 0.55rem;
+  }
 }
 
 .users-avatar {


### PR DESCRIPTION
### Motivation
- Corriger le désalignement vertical entre le titre « Maintenance de la page » et le groupe actions (toggle + statut) pour obtenir un rendu centré, professionnel et homogène.
- Conserver le style existant du switch, les couleurs, les animations et la structure de la carte tout en améliorant uniquement le layout et la responsivité.

### Description
- Modifié `css/style.css` pour renforcer le layout en utilisant `display: flex`, `justify-content: space-between` et `align-items: center` sur le sélecteur `body[data-page="users-management"] .maintenance-card-header`.
- Permis au titre de se comporter comme un élément flexible en ajoutant `flex: 1 1 auto` et `min-width: 0` à `.section-title` afin d’éviter le débordement et préserver l’alignement.
- Verrouillé le groupe actions avec `flex: 0 0 auto` et `white-space: nowrap` et ajusté les `gap` pour une espacement homogène entre toggle et statut sans toucher au style du switch.
- Ajouté une petite règle `@media (max-width: 420px)` pour réduire les gaps et la taille du titre sur petits écrans afin d’assurer un rendu premium en mobile.

### Testing
- Aucun test automatisé n'a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5c6031e8832a893580be29d218bc)