### PR TITLE
Add role-aware OUT / "Achat matériel" tabs on site detail page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3853,6 +3853,40 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   gap: 0.45rem;
 }
 
+body[data-page="site-detail"] .site-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 0.9rem;
+  padding-inline: 0.1rem;
+}
+
+body[data-page="site-detail"] .site-tab {
+  border: 1px solid #d5deea;
+  background: #fff;
+  color: #334155;
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.86rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+body[data-page="site-detail"] .site-tab:active {
+  transform: scale(0.98);
+}
+
+body[data-page="site-detail"] .site-tab.active {
+  background: var(--detail-primary);
+  border-color: var(--detail-primary);
+  color: #fff;
+}
+
+body[data-page="site-detail"] .site-tab.hidden,
+body[data-page="site-detail"] .tab-content.hidden {
+  display: none !important;
+}
+
 body[data-page="site-detail"] .filter-chip-group {
   display: flex;
   flex-wrap: wrap;

--- a/js/app.js
+++ b/js/app.js
@@ -3271,6 +3271,13 @@ import { firebaseAuth } from './firebase-core.js';
       'body[data-page="site-detail"] .site-detail-fab-label--create',
     );
     const siteDetailFabStack = document.querySelector('body[data-page="site-detail"] .site-detail-fab-stack');
+    const siteTabs = document.getElementById('siteTabs');
+    const siteTabButtons = Array.from(document.querySelectorAll('.site-tab'));
+    const outsTabContent = document.getElementById('outsTabContent');
+    const purchasesTabContent = document.getElementById('purchasesTabContent');
+    const purchasesTabButton = document.querySelector('[data-tab="purchases"]');
+    let isAdminTabAllowed = Boolean(permissions?.isAdmin);
+    let activeSiteTab = 'outs';
     let itemFormErrorTimeoutId = null;
     let itemNumberErrorClearTimer = null;
     let itemAvailabilityDebounceTimer = null;
@@ -3304,6 +3311,44 @@ import { firebaseAuth } from './firebase-core.js';
         createButtonRow.hidden = !isAuthenticated;
         createButtonRow.style.display = isAuthenticated ? '' : 'none';
       }
+    }
+
+    function updateTabsByRole() {
+      isAdminTabAllowed = Boolean(permissions?.isAdmin);
+      if (purchasesTabButton) {
+        purchasesTabButton.classList.toggle('hidden', !isAdminTabAllowed);
+      }
+      if (!isAdminTabAllowed && activeSiteTab === 'purchases') {
+        setActiveSiteTab('outs');
+      }
+    }
+
+    function updateFabByActiveTab(tabName) {
+      const shouldShowFab = tabName === 'outs';
+      if (openCreateItem) {
+        openCreateItem.classList.toggle('hidden', !shouldShowFab);
+      }
+      if (createItemLabel) {
+        createItemLabel.classList.toggle('hidden', !shouldShowFab);
+      }
+      const createButtonRow = openCreateItem?.closest('[data-fab-row="create"]');
+      if (createButtonRow) {
+        createButtonRow.classList.toggle('hidden', !shouldShowFab);
+      }
+      if (siteDetailFabStack) {
+        siteDetailFabStack.classList.toggle('hidden', !shouldShowFab);
+      }
+    }
+
+    function setActiveSiteTab(tabName) {
+      const safeTabName = tabName === 'purchases' && isAdminTabAllowed ? 'purchases' : 'outs';
+      activeSiteTab = safeTabName;
+      siteTabButtons.forEach((tab) => {
+        tab.classList.toggle('active', tab.dataset.tab === safeTabName);
+      });
+      outsTabContent?.classList.toggle('hidden', safeTabName !== 'outs');
+      purchasesTabContent?.classList.toggle('hidden', safeTabName !== 'purchases');
+      updateFabByActiveTab(safeTabName);
     }
 
     function getItemNumberMaxLength() {
@@ -3510,8 +3555,23 @@ import { firebaseAuth } from './firebase-core.js';
     }
 
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
+    updateTabsByRole();
+    setActiveSiteTab('outs');
+    siteTabs?.addEventListener('click', (event) => {
+      const tab = event.target.closest('.site-tab');
+      if (!tab) {
+        return;
+      }
+      const targetTab = tab.dataset.tab;
+      if (targetTab === 'purchases' && !isAdminTabAllowed) {
+        setActiveSiteTab('outs');
+        return;
+      }
+      setActiveSiteTab(targetTab);
+    });
     onAuthStateChanged(firebaseAuth, (user) => {
       updateCreateItemButtonVisibility(user || null);
+      updateTabsByRole();
     });
 
     openCreateItem?.addEventListener('click', () => {

--- a/page2.html
+++ b/page2.html
@@ -24,7 +24,18 @@
       </header>
 
       <main class="page-content main-content">
-        <section class="search-panel search-panel--site surface-card section">
+        <div class="site-tabs" id="siteTabs">
+          <button class="site-tab active" data-tab="outs" type="button">
+            OUT
+          </button>
+
+          <button class="site-tab admin-only hidden" data-tab="purchases" type="button">
+            Achat matériel
+          </button>
+        </div>
+
+        <section id="outsTabContent" class="tab-content active">
+          <section class="search-panel search-panel--site surface-card section">
           <label class="input-group">
             <span class="sr-only">Rechercher (OUT ou article)</span>
             <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
@@ -57,9 +68,16 @@
             <option value="yesterday">Hier</option>
             <option value="lastMonth">Plus Ancien</option>
           </select>
+          </section>
+
+          <section id="itemList" class="list-grid" aria-live="polite"></section>
         </section>
 
-        <section id="itemList" class="list-grid" aria-live="polite"></section>
+        <section id="purchasesTabContent" class="tab-content hidden">
+          <div class="empty-state">
+            Achat matériel bientôt disponible.
+          </div>
+        </section>
       </main>
 
       <div class="site-detail-fab-stack" aria-hidden="false">


### PR DESCRIPTION
### Motivation
- Introduire un système d’onglets sous le header sur la page de détail de site pour séparer l’affichage `OUT` et un futur espace `Achat matériel` sans modifier le header ni casser l’UI OUT existante. 
- Restreindre la visibilité de l’onglet `Achat matériel` au rôle Admin en réutilisant la logique de permissions déjà présente dans le projet.

### Description
- HTML: Ajout d’une barre d’onglets dans `page2.html` (`<div class="site-tabs" id="siteTabs">`) et encapsulation du contenu OUT existant dans `<section id="outsTabContent" class="tab-content active">`, plus un placeholder `<section id="purchasesTabContent" class="tab-content hidden">` pour l’onglet Achat matériel. 
- CSS: Ajout de styles légers réutilisant le langage visuel des filtres/pills dans `css/style.css` (`.site-tabs`, `.site-tab`, état `.active`, et règles pour `.hidden` / `.tab-content.hidden`).
- JS: Implémentation dans `js/app.js` de la gestion des onglets dans `initSiteDetailPage` via `updateTabsByRole()`, `setActiveSiteTab()`, et `updateFabByActiveTab()` qui utilisent `permissions.isAdmin` pour afficher/masquer l’onglet achats et forcer le fallback vers `outs` pour les non-admins; le FAB `Créer un OUT` est masqué quand l’onglet `purchases` est actif, et la logique de création/recherche/filtre OUT reste inchangée.
- Respect des contraintes: le header, la recherche OUT, les filtres OUT, la création/export d’OUT et le système de rôles existant n’ont pas été modifiés ou réimplémentés.

### Testing
- Executed `git diff --check` which returned no issues and succeeded. 
- Verified repository status with `git status --short` and created the commit with `git add` + `git commit`, both commands succeeded. 
- Manual file diffs inspected for `page2.html`, `css/style.css`, and `js/app.js` to confirm markup, styles and JS wiring were added as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd62147080832a9c370f44b1bbf111)