### PR TITLE
Refine site-detail tabs to full-width premium pill style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3855,31 +3855,37 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
 
 body[data-page="site-detail"] .site-tabs {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 0 0 0.9rem;
-  padding-inline: 0.1rem;
+  align-items: center;
+  width: 100%;
+  margin: 0 0 18px;
+  padding: 6px;
+  border: none;
+  border-radius: 999px;
+  background: #eef3f8;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 body[data-page="site-detail"] .site-tab {
-  border: 1px solid #d5deea;
-  background: #fff;
-  color: #334155;
+  flex: 1;
+  height: 52px;
+  border: none;
+  background: transparent;
+  color: #5f6b7a;
   border-radius: 999px;
-  padding: 0.45rem 0.85rem;
-  font-size: 0.86rem;
-  font-weight: 600;
-  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  font-size: 17px;
+  font-weight: 700;
+  transition: background-color 0.25s ease, color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 body[data-page="site-detail"] .site-tab:active {
-  transform: scale(0.98);
+  transform: scale(0.985);
 }
 
 body[data-page="site-detail"] .site-tab.active {
-  background: var(--detail-primary);
-  border-color: var(--detail-primary);
+  background: #2f95e9;
   color: #fff;
+  box-shadow: 0 4px 12px rgba(47, 149, 233, 0.22);
 }
 
 body[data-page="site-detail"] .site-tab.hidden,


### PR DESCRIPTION
### Motivation
- Modernize the `OUT / Achat matériel` tabs into a single full-width pill bar that visually matches the search bar while keeping the existing behavior intact.
- Remove visible borders and heavy shadows and reuse the app’s existing visual language for a more premium, integrated look.
- Preserve responsiveness and avoid any changes to JS or markup so the existing tab switching remains unchanged.

### Description
- Replaced the `body[data-page="site-detail"] .site-tabs` rules to use `width: 100%`, centered alignment, full pill `border-radius`, light neutral background, no border, `overflow: hidden`, and consistent padding to match the search bar visual width.
- Updated `body[data-page="site-detail"] .site-tab` to `flex: 1` with a fixed `height: 52px`, removed borders, set transparent inactive background, increased font weight/size, and added smooth `transition` timing for click/hover.
- Updated active state `body[data-page="site-detail"] .site-tab.active` to a filled blue background (`#2f95e9`), white text, and a soft drop shadow for the premium look, and retained a subtle press transform on `:active`.
- No JavaScript or markup changes were made; only `css/style.css` was modified.

### Testing
- Located relevant selectors using automated search (`rg`) to ensure the correct rules were updated and targeted.
- Applied the CSS replacement to `css/style.css` via an automated edit and verified the file was updated successfully.
- Inspected the resulting diff of `css/style.css` to confirm the new styles and transitions were applied; these verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd65c345e8832a97d4ca88ec2bb919)