### PR TITLE
Fix segmented-control tab alignment on site-detail (page2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3856,8 +3856,8 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
 body[data-page="site-detail"] .site-tabs {
   display: flex;
   align-items: center;
-  width: 100%;
-  margin: 0 0 18px;
+  width: calc(100% - 48px);
+  margin: 16px 24px 22px;
   padding: 6px;
   border: none;
   border-radius: 999px;
@@ -3868,24 +3868,37 @@ body[data-page="site-detail"] .site-tabs {
 
 body[data-page="site-detail"] .site-tab {
   flex: 1;
-  height: 52px;
+  height: 48px;
   border: none;
+  outline: none;
   background: transparent;
-  color: #5f6b7a;
   border-radius: 999px;
-  font-size: 17px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-size: 16px;
   font-weight: 700;
-  transition: background-color 0.25s ease, color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
+  line-height: 1;
+  color: #5f6b7a;
+
+  padding: 0;
+  margin: 0;
+
+  transform: none;
+  box-shadow: none;
+  transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease;
 }
 
 body[data-page="site-detail"] .site-tab:active {
-  transform: scale(0.985);
+  transform: scale(0.98);
 }
 
 body[data-page="site-detail"] .site-tab.active {
   background: #2f95e9;
   color: #fff;
-  box-shadow: 0 4px 12px rgba(47, 149, 233, 0.22);
+  box-shadow: 0 6px 14px rgba(47, 149, 233, 0.18);
 }
 
 body[data-page="site-detail"] .site-tab.hidden,


### PR DESCRIPTION
### Motivation
- The segmented tabs for `OUT` / `Achat matériel` on the site detail page showed vertical misalignment and visual drift between active and inactive states.
- The goal was to produce a stable, premium-looking segmented control without changing any JS, header, search, or filters logic.

### Description
- Adjusted `.site-tabs` container in `css/style.css` to use `width: calc(100% - 48px)` and `margin: 16px 24px 22px` while keeping the pill background and overflow handling.
- Normalized `.site-tab` so both states share `height: 48px`, `display: flex`, `align-items: center`, `justify-content: center`, `font-size: 16px`, `line-height: 1`, and removed vertical padding/margins and unwanted transforms/box-shadows.
- Tuned interaction and active styles to `:active { transform: scale(.98) }` and `.site-tab.active { background: #2f95e9; color: #fff; box-shadow: 0 6px 14px rgba(47,149,233,.18) }` for a stable, non-shifting look.

### Testing
- Inspected the HTML to ensure tab markup was untouched with `sed -n '1,260p' page2.html`, which succeeded.
- Located relevant CSS selectors with `rg -n ".site-tabs|.site-tab" css/style.css`, which returned the expected rule locations.
- Verified the final CSS block with `nl -ba css/style.css | sed -n '3850,3915p'` to confirm the new styles are present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6b51a3c4832a879f78586d9d1a4f)