### PR TITLE
Fix OUT/Achat matériel tab alignment with final CSS overrides

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5454,3 +5454,69 @@ body {
 .hidden {
   display: none !important;
 }
+
+.site-tabs {
+  width: calc(100% - 48px) !important;
+  margin: 16px 24px 22px !important;
+  padding: 6px !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 0 !important;
+  border: 0 !important;
+  border-radius: 999px !important;
+  background: #eef3f8 !important;
+  box-sizing: border-box !important;
+  overflow: hidden !important;
+  height: 60px !important;
+}
+
+.site-tab {
+  flex: 1 1 0 !important;
+  height: 48px !important;
+  min-height: 48px !important;
+  max-height: 48px !important;
+
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+
+  padding: 0 !important;
+  margin: 0 !important;
+  border: 0 !important;
+  outline: 0 !important;
+  border-radius: 999px !important;
+  background: transparent !important;
+
+  font-size: 16px !important;
+  font-weight: 700 !important;
+  line-height: 48px !important;
+  text-align: center !important;
+  color: #5f6b7a !important;
+
+  position: relative !important;
+  transform: none !important;
+  box-shadow: none !important;
+  overflow: hidden !important;
+
+  transition: background .25s ease, color .25s ease, box-shadow .25s ease !important;
+}
+
+.site-tab.active {
+  background: #2f95e9 !important;
+  color: #ffffff !important;
+  box-shadow: 0 6px 14px rgba(47,149,233,.18) !important;
+  transform: none !important;
+}
+
+.site-tab::before,
+.site-tab::after,
+.site-tab.active::before,
+.site-tab.active::after {
+  display: none !important;
+  content: none !important;
+}
+
+.site-tab * {
+  line-height: 1 !important;
+  transform: none !important;
+}


### PR DESCRIPTION
### Motivation
- Legacy CSS rules were still overriding the intended tab styles, causing the OUT and Achat matériel labels to be vertically misaligned and the active blue background to overflow. 
- The goal is to neutralize the old positioning/transform/line-height/pseudo-element rules and enforce a stable, centered tab layout.

### Description
- Appended a final override block to the end of `css/style.css` containing `.site-tabs`, `.site-tab`, `.site-tab.active`, and neutralization of `.site-tab::before`/`::after` selectors. 
- Enforced flex centering, fixed sizing (`height: 60px` for the container, `48px` for tabs), `line-height: 48px`, and removed transforms and extra paddings/margins using `!important`. 
- Disabled legacy pseudo-elements and internal transforms with `display: none` / `content: none` and `transform: none`, and forced stable internal line-height for all children via `.site-tab * { line-height: 1 !important; transform: none !important; }`.

### Testing
- Ran `rg --files | rg 'style\.css$'` to locate the stylesheet and it succeeded. 
- Ran `rg -n "\.site-tabs|\.site-tab|\.tabs|\.tab" css/style.css` to confirm selectors and it succeeded. 
- Used `sed -n '3800,3965p' css/style.css`, `tail -n 120 css/style.css`, and `nl -ba css/style.css | tail -n 120` to inspect the file end and verify the override block was appended, and all inspections succeeded. 
- The final CSS block is present at the end of `css/style.css` and the override is in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6de670bc832a898d14497ef2e11d)