### PR TITLE
Remove tab slider and enforce .site-tab.active styling to fix OUT/purchases tab compression

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5462,12 +5462,13 @@ body {
   display: flex !important;
   align-items: center !important;
   gap: 0 !important;
-  border: 0 !important;
+  border: none !important;
   border-radius: 999px !important;
   background: #eef3f8 !important;
   box-sizing: border-box !important;
   overflow: hidden !important;
   height: 60px !important;
+  min-height: 60px !important;
 }
 
 .site-tab {
@@ -5482,14 +5483,14 @@ body {
 
   padding: 0 !important;
   margin: 0 !important;
-  border: 0 !important;
-  outline: 0 !important;
+  border: none !important;
+  outline: none !important;
   border-radius: 999px !important;
   background: transparent !important;
 
   font-size: 16px !important;
   font-weight: 700 !important;
-  line-height: 48px !important;
+  line-height: 1 !important;
   text-align: center !important;
   color: #5f6b7a !important;
 
@@ -5508,6 +5509,8 @@ body {
   transform: none !important;
 }
 
+.site-tabs::before,
+.site-tabs::after,
 .site-tab::before,
 .site-tab::after,
 .site-tab.active::before,

--- a/js/app.js
+++ b/js/app.js
@@ -3557,17 +3557,24 @@ import { firebaseAuth } from './firebase-core.js';
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
     updateTabsByRole();
     setActiveSiteTab('outs');
-    siteTabs?.addEventListener('click', (event) => {
-      const tab = event.target.closest('.site-tab');
-      if (!tab) {
-        return;
-      }
-      const targetTab = tab.dataset.tab;
-      if (targetTab === 'purchases' && !isAdminTabAllowed) {
-        setActiveSiteTab('outs');
-        return;
-      }
-      setActiveSiteTab(targetTab);
+    document.querySelectorAll('.site-tab').forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const targetTab = tab.dataset.tab;
+        if (targetTab === 'purchases' && !isAdminTabAllowed) {
+          setActiveSiteTab('outs');
+          return;
+        }
+
+        siteTabButtons.forEach((button) => {
+          button.classList.remove('active');
+        });
+
+        tab.classList.add('active');
+        activeSiteTab = targetTab === 'purchases' && isAdminTabAllowed ? 'purchases' : 'outs';
+        outsTabContent?.classList.toggle('hidden', activeSiteTab !== 'outs');
+        purchasesTabContent?.classList.toggle('hidden', activeSiteTab !== 'purchases');
+        updateFabByActiveTab(activeSiteTab);
+      });
     });
     onAuthStateChanged(firebaseAuth, (user) => {
       updateCreateItemButtonVisibility(user || null);


### PR DESCRIPTION
### Motivation
- Un ancien système d’indicateur/slider faisait bouger et recalculer la largeur/position de l’actif, provoquant la compression du bouton actif lors du chargement des OUT. 
- Il faut que le fond bleu actif provienne uniquement de `.site-tab.active` sans pseudo-éléments, `absolute`, `transform` ni calculs JS.

### Description
- Remplacé/renforcé le bloc CSS final des onglets dans `css/style.css` pour appliquer les dimensions pill, supprimer `::before/::after` et forcer l’absence d’effets positionnels ou transform (fond actif uniquement via `.site-tab.active`).
- Simplifié le gestionnaire de clics dans `js/app.js` pour n’ajouter/retirer que la classe `.active` et basculer la visibilité des contenus `#outsTabContent` / `#purchasesTabContent`, en conservant la garde `isAdminTabAllowed` pour l’onglet `purchases`.
- Éliminé implicitement toute logique d’indicateur/slider (pas de `transform`, `width`/`left` calculés, ni d’appels à `updateTabIndicator`/`moveTabIndicator`/`setTabIndicator`) en remplaçant le code concerné.
- Fichiers modifiés : `css/style.css`, `js/app.js`.

### Testing
- Recherches automatiques avec `rg` pour motifs liés à l’indicateur/slider et aux propriétés calculées ont été exécutées et n’ont plus trouvé de code actif (succès). 
- Inspection du diff via `git diff` a confirmé que seules `css/style.css` et `js/app.js` ont été touchées comme prévu (succès). 
- Les changements ont été ajoutés et validés dans un commit (`git commit`) avec message de correction (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd73e65258832ab8b2325c19f25331)