### PR TITLE
Make `.site-tabs` full-width and split `.site-tab` 50/50

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5457,22 +5457,27 @@ body {
 
 .site-tabs {
   width: calc(100% - 48px) !important;
+  max-width: none !important;
   margin: 16px 24px 22px !important;
   padding: 6px !important;
+
   display: flex !important;
   align-items: center !important;
-  gap: 0 !important;
+
+  height: 60px !important;
+  min-height: 60px !important;
+
   border: none !important;
   border-radius: 999px !important;
   background: #eef3f8 !important;
   box-sizing: border-box !important;
   overflow: hidden !important;
-  height: 60px !important;
-  min-height: 60px !important;
 }
 
 .site-tab {
-  flex: 1 1 0 !important;
+  flex: 1 1 50% !important;
+  width: 50% !important;
+  max-width: none !important;
   height: 48px !important;
   min-height: 48px !important;
   max-height: 48px !important;


### PR DESCRIPTION
### Motivation
- The tabs container is visually narrower than the search field and must match its visual width without changing JS, animation, or the header.
- The goal is to ensure the two tabs (`OUT` and `Achat matériel`) always each occupy half the available tab container and the active background fills its half.

### Description
- Updated the `.site-tabs` rules in `css/style.css` to add `max-width: none`, keep `width: calc(100% - 48px)` and enforce the requested margins/padding/height for full visual width parity with the search field.
- Adjusted `.site-tab` to `flex: 1 1 50%`, `width: 50%` and `max-width: none` so the two tabs evenly split the container.
- Preserved all JS logic, animations and header code by limiting changes to CSS only and removed layout-limiting properties that could shrink the tabs.

### Testing
- Ran `rg -n "\.site-tabs|\.site-tab" -S` to locate selectors and verify updates, which returned the expected occurrences.
- Executed the automated Python replacement script which printed `updated` to confirm the CSS patch applied successfully.
- Inspected the updated CSS block with `sed -n '5458,5510p' css/style.css` to confirm the new properties are present and correctly ordered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdaf89fd3c832ab60fab072d24b17d)