### PR TITLE
Wrap site-detail tabs/search/filters in subtle `.outs-top-section` with premium styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5530,3 +5530,32 @@ body {
   line-height: 1 !important;
   transform: none !important;
 }
+
+body[data-page="site-detail"] .outs-top-section {
+  margin: 18px 16px 22px;
+  padding: 18px 14px 16px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(140, 170, 210, 0.16);
+  border-radius: 30px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.03);
+  box-sizing: border-box;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+body[data-page="site-detail"] .outs-top-section .tabs-wrapper {
+  padding: 0 !important;
+}
+
+body[data-page="site-detail"] .outs-top-section .site-tabs {
+  margin: 0 0 14px !important;
+}
+
+body[data-page="site-detail"] .outs-top-section .search-panel--site {
+  margin: 0;
+  width: 100%;
+  background: transparent;
+  box-shadow: none;
+  border: 0;
+  padding: 0;
+}

--- a/page2.html
+++ b/page2.html
@@ -24,19 +24,19 @@
       </header>
 
       <main class="page-content main-content">
-        <div class="tabs-wrapper">
-          <div class="site-tabs" id="siteTabs">
-            <button class="site-tab active" data-tab="outs" type="button">
-              OUT
-            </button>
+        <div class="outs-top-section">
+          <div class="tabs-wrapper">
+            <div class="site-tabs" id="siteTabs">
+              <button class="site-tab active" data-tab="outs" type="button">
+                OUT
+              </button>
 
-            <button class="site-tab admin-only hidden" data-tab="purchases" type="button">
-              Achat matériel
-            </button>
+              <button class="site-tab admin-only hidden" data-tab="purchases" type="button">
+                Achat matériel
+              </button>
+            </div>
           </div>
-        </div>
 
-        <section id="outsTabContent" class="tab-content active">
           <section class="search-panel search-panel--site surface-card section">
           <label class="input-group">
             <span class="sr-only">Rechercher (OUT ou article)</span>
@@ -71,7 +71,9 @@
             <option value="lastMonth">Plus Ancien</option>
           </select>
           </section>
+        </div>
 
+        <section id="outsTabContent" class="tab-content active">
           <section id="itemList" class="list-grid" aria-live="polite"></section>
         </section>
 


### PR DESCRIPTION
### Motivation
- Regrouper visuellement les contrôles en tête de la page (tabs, recherche, filtres) en une seule section discrète et premium tout en conservant le style et le comportement actuels des cartes OUT.

### Description
- Ajout d’un conteneur `<div class="outs-top-section">` autour des tabs, du champ de recherche et des filtres dans `page2.html`.
- Ajout de styles dans `css/style.css` pour appliquer un fond semi-translucide, une bordure très fine `rgba(140,170,210,0.16)`, `border-radius: 30px`, `backdrop-filter: blur(6px)`, une ombre douce `0 2px 12px rgba(0,0,0,0.03)` et une transition sur `border-color`, `box-shadow` et `background`.
- Ajustements ciblés de spacing pour les `.tabs-wrapper`, `.site-tabs` et `.search-panel--site` à l’intérieur du nouveau conteneur pour préserver l’apparence actuelle.
- Changements limités au bloc supérieur et scindés du reste de la page pour ne pas modifier les cartes OUT ni la logique JS existante.

### Testing
- Aucun test automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf37a6148832a94aaceffe8bdad8d)