### PR TITLE
Supprimer le container .outs-top-section et son style global

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5531,31 +5531,3 @@ body {
   transform: none !important;
 }
 
-body[data-page="site-detail"] .outs-top-section {
-  margin: 18px 16px 22px;
-  padding: 18px 14px 16px;
-  background: rgba(255, 255, 255, 0.55);
-  border: 1px solid rgba(140, 170, 210, 0.16);
-  border-radius: 30px;
-  backdrop-filter: blur(6px);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.03);
-  box-sizing: border-box;
-  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
-}
-
-body[data-page="site-detail"] .outs-top-section .tabs-wrapper {
-  padding: 0 !important;
-}
-
-body[data-page="site-detail"] .outs-top-section .site-tabs {
-  margin: 0 0 14px !important;
-}
-
-body[data-page="site-detail"] .outs-top-section .search-panel--site {
-  margin: 0;
-  width: 100%;
-  background: transparent;
-  box-shadow: none;
-  border: 0;
-  padding: 0;
-}

--- a/page2.html
+++ b/page2.html
@@ -24,7 +24,6 @@
       </header>
 
       <main class="page-content main-content">
-        <div class="outs-top-section">
           <div class="tabs-wrapper">
             <div class="site-tabs" id="siteTabs">
               <button class="site-tab active" data-tab="outs" type="button">
@@ -71,7 +70,6 @@
             <option value="lastMonth">Plus Ancien</option>
           </select>
           </section>
-        </div>
 
         <section id="outsTabContent" class="tab-content active">
           <section id="itemList" class="list-grid" aria-live="polite"></section>


### PR DESCRIPTION
### Motivation
- Le wrapper global ajouté autour des tabs/recherche/filtres crée une grande carte blanche qui casse l’interface légère du haut de page.
- L’objectif est de revenir à un rendu où les tabs, la recherche et les filtres sont des éléments séparés tout en conservant le style « segmented control » des tabs.
- Il ne faut pas toucher aux cartes OUT, au header ni au comportement JavaScript.

### Description
- Retiré le wrapper HTML `.outs-top-section` de `page2.html` pour rendre tabs, recherche et filtres indépendants à la racine du contenu. 
- Supprimé le bloc CSS ciblant `.outs-top-section` et ses overrides dans `css/style.css`, en enlevant background, border, border-radius, backdrop-filter, box-shadow, padding et margin appliqués à ce conteneur.
- Conservé intact le style des tabs (`.tabs-wrapper`, `.site-tabs`, `.site-tab`, `.site-tab.active`) afin de garder le contrôle segmenté visuel.
- Aucun changement côté cartes OUT, header ou fichiers JavaScript.

### Testing
- Vérification du diff pour s’assurer que seules `page2.html` et `css/style.css` ont été modifiées et que les suppressions correspondent aux éléments attendus (OK).
- Inspection des fichiers modifiés pour confirmer la suppression du wrapper HTML et du bloc CSS ciblé (OK).
- Validation de l’état du dépôt et enregistrement des modifications (modifications présentes et appliquées avec succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf61067d8832a882390ae2ad3b02e)