### PR TITLE
Déplacer les onglets OUT/Achat en bas (mobile)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3853,26 +3853,20 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   gap: 0.45rem;
 }
 
-body[data-page="site-detail"] .tabs-wrapper {
-  width: 100%;
-  padding: 0 24px;
-  box-sizing: border-box;
-}
-
 body[data-page="site-detail"] .site-tabs {
   display: flex;
   width: 100%;
-  margin: 10px 0 12px;
-  padding: 4px;
+  padding: 6px;
   background: #eef3f8;
   border-radius: 999px;
   box-sizing: border-box;
   gap: 4px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
 }
 
 body[data-page="site-detail"] .site-tab {
   flex: 1;
-  min-height: 42px;
+  height: 52px;
   border: none;
   background: transparent;
   border-radius: 999px;
@@ -3884,6 +3878,14 @@ body[data-page="site-detail"] .site-tab {
   color: #5f6b7a;
   padding: 0;
   transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+body[data-page="site-detail"] .bottom-tabs {
+  position: fixed;
+  left: clamp(0.75rem, 2.4vw, 1.25rem);
+  right: clamp(0.75rem, 2.4vw, 1.25rem);
+  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+  z-index: 999;
 }
 
 body[data-page="site-detail"] .site-tab.active {
@@ -5444,4 +5446,3 @@ body {
 .hidden {
   display: none !important;
 }
-

--- a/page2.html
+++ b/page2.html
@@ -24,18 +24,6 @@
       </header>
 
       <main class="page-content main-content">
-          <div class="tabs-wrapper">
-            <div class="site-tabs" id="siteTabs">
-              <button class="site-tab active" data-tab="outs" type="button">
-                OUT
-              </button>
-
-              <button class="site-tab admin-only hidden" data-tab="purchases" type="button">
-                Achat matériel
-              </button>
-            </div>
-          </div>
-
           <section class="search-panel search-panel--site surface-card section">
           <label class="input-group">
             <span class="sr-only">Rechercher (OUT ou article)</span>
@@ -81,6 +69,18 @@
           </div>
         </section>
       </main>
+
+      <div class="bottom-tabs" aria-label="Navigation des onglets">
+        <div class="site-tabs bottom-tabs-inner" id="siteTabs">
+          <button class="site-tab bottom-tab active" data-tab="outs" type="button">
+            OUT
+          </button>
+
+          <button class="site-tab bottom-tab admin-only hidden" data-tab="purchases" type="button">
+            Achat matériel
+          </button>
+        </div>
+      </div>
 
       <div class="site-detail-fab-stack" aria-hidden="false">
         <div class="site-detail-fab-row" data-fab-row="create">


### PR DESCRIPTION
### Motivation
- Le switch d’onglets (OUT / Achat matériel) devait être fixé en bas de l’écran mobile au-dessus de la safe area, visible pendant le scroll, sans introduire de conteneur ou carte blanche supplémentaire.
- Il fallait conserver exactement le rendu visuel actuel (bouton actif bleu, inactif gris clair, coins très arrondis, même hauteur, transition et police) et réutiliser les classes existantes pour ne pas casser la logique JS.

### Description
- Suppression du bloc d’onglets en haut sous le header et ajout d’un nouveau conteneur fixe en bas dans `page2.html` (`<div class="bottom-tabs">` contenant `#siteTabs` et `.site-tab`).
- Ajout des styles pour ancrer le composant en bas avec support `env(safe-area-inset-bottom)` et `position: fixed` via la nouvelle règle `body[data-page="site-detail"] .bottom-tabs` dans `css/style.css`.
- Ajustement des styles existants de `.site-tabs` et `.site-tab` pour correspondre aux contraintes demandées (hauteur `52px`, `flex: 1` sur chaque onglet, padding, ombre légère et bordure arrondie) tout en conservant les classes et l’apparence active/inactive.
- Nettoyage ciblé de l’ancien wrapper `.tabs-wrapper` en supprimant son usage dans le HTML et en évitant les styles conflictuels afin que le nouveau tab reste indépendant du contenu scrollable.

### Testing
- Exécution de la recherche ciblée `rg -n "Achat matériel|OUT|tab|tabs" page2.html css/style.css js/*.js` pour vérifier les références et l’absence de l’ancien bloc, et la commande a renvoyé les résultats attendus.
- Inspection des fichiers modifiés avec `sed -n` et `nl` pour valider la présence du nouveau markup `bottom-tabs` et des règles CSS correspondantes, et ces fichiers contiennent bien les changements souhaités.
- Vérification finale des diffs locaux pour s’assurer que seules `page2.html` et `css/style.css` ont été touchées, et cette vérification a confirmé l’impact limité du patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfca85744832a99ec016e6cdbc7d6)