### PR TITLE
Remonter le FAB de la page2 au-dessus des bottom-tabs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3888,6 +3888,20 @@ body[data-page="site-detail"] .bottom-tabs {
   z-index: 999;
 }
 
+
+
+.page2 .fab,
+.page2 #createOutFab,
+body.page2 .fab,
+body.page2 #createOutFab {
+  bottom: calc(92px + env(safe-area-inset-bottom)) !important;
+  z-index: 1001 !important;
+}
+
+.bottom-tabs {
+  z-index: 1000 !important;
+}
+
 body[data-page="site-detail"] .site-tab.active {
   background: #2f95e9;
   color: #fff;


### PR DESCRIPTION
### Motivation
- Corriger le conflit où le FAB "+" de la page 2 était coincé sous l'onglet bottom-tabs en le remontant uniquement pour la page2 sans changer la taille, le style, ni la position du bottom-tabs.

### Description
- Ajout de règles CSS ciblées dans `css/style.css` pour ` .page2 .fab`, `.page2 #createOutFab`, `body.page2 .fab`, `body.page2 #createOutFab` avec `bottom: calc(92px + env(safe-area-inset-bottom)) !important` et `z-index: 1001 !important`, et ajout de ` .bottom-tabs { z-index: 1000 !important; }`, sans modifier `page2.html` car le `<body class="page2">` existe déjà.

### Testing
- Inspecté les fichiers avec `rg`/`sed`, vérifié le diff avec `git diff` et enregistré la modification avec `git commit`, toutes les commandes se sont terminées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdff2ff968832abe7f2c1819c865a5)