### PR TITLE
Finalise le design des bottom-tabs mobile (page2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3856,36 +3856,37 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
 body[data-page="site-detail"] .site-tabs {
   display: flex;
   width: 100%;
-  padding: 6px;
+  gap: 8px;
+  padding: 8px;
   background: #eef3f8;
-  border-radius: 999px;
+  border-radius: 24px;
   box-sizing: border-box;
-  gap: 4px;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
 }
 
 body[data-page="site-detail"] .site-tab {
   flex: 1;
   height: 52px;
-  border: none;
+  border: none !important;
+  outline: none;
   background: transparent;
-  border-radius: 999px;
+  border-radius: 18px;
   display: grid;
   place-items: center;
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 700;
   line-height: 1;
-  color: #5f6b7a;
+  color: #5f667a;
   padding: 0;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: all 0.25s ease;
 }
 
 body[data-page="site-detail"] .bottom-tabs {
   position: fixed;
-  left: clamp(0.75rem, 2.4vw, 1.25rem);
-  right: clamp(0.75rem, 2.4vw, 1.25rem);
-  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
-  z-index: 999;
+  left: 16px;
+  right: 16px;
+  bottom: calc(4px + env(safe-area-inset-bottom));
+  z-index: 1000;
 }
 
 
@@ -3905,6 +3906,11 @@ body.page2 #createOutFab {
 body[data-page="site-detail"] .site-tab.active {
   background: #2f95e9;
   color: #fff;
+  box-shadow: 0 4px 12px rgba(47, 149, 233, 0.25);
+}
+
+body[data-page="site-detail"] .site-tab:not(.active) {
+  background: transparent;
 }
 
 body[data-page="site-detail"] .site-tab.hidden,


### PR DESCRIPTION
### Motivation
- Rendre le composant bottom-tabs de la page2 plus proche du bord bas et visuellement ancré tout en conservant le support `safe-area`. 
- Moderniser les boutons internes pour obtenir un rendu minimal, premium et cohérent avec les UI iOS/Android récents. 
- Supprimer les bordures visibles et conserver la hauteur, les couleurs actives/inactives et les animations existantes sans toucher à la logique JS. 

### Description
- Ajustement du conteneur `body[data-page="site-detail"] .site-tabs` pour ajouter `gap: 8px`, `padding: 8px`, `border-radius: 24px` et `box-shadow: 0 4px 16px rgba(0,0,0,0.08)` dans `css/style.css`. 
- Modification des boutons `body[data-page="site-detail"] .site-tab` pour appliquer `border: none !important`, `outline: none`, `border-radius: 18px`, `font-size: 17px`, `color: #5f667a` et `transition: all 0.25s ease`. 
- Repositionnement du wrapper `body[data-page="site-detail"] .bottom-tabs` avec `left: 16px`, `right: 16px`, `bottom: calc(4px + env(safe-area-inset-bottom))` et `z-index: 1000` pour un espacement réduit au fond de l’écran. 
- Ajout d’un style d’élévation pour l’état actif `body[data-page="site-detail"] .site-tab.active` (`box-shadow: 0 4px 12px rgba(47,149,233,0.25)`) et explicitation de l’état inactif via `body[data-page="site-detail"] .site-tab:not(.active) { background: transparent; }`. 

### Testing
- Aucune suite de tests automatisés n’a été exécutée pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe019bb36c832aa6755923ee2b42c6)