### PR TITLE
Fixed bottom navigation bar for page2 (OUT / Achat matériel)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3853,43 +3853,54 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   gap: 0.45rem;
 }
 
-body[data-page="site-detail"] .site-tabs {
+.bottom-navigation {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
   display: flex;
-  width: 100%;
-  gap: 8px;
-  padding: 8px;
-  background: #eef3f8;
-  border-radius: 24px;
-  box-sizing: border-box;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  align-items: center;
+  justify-content: space-around;
+  height: calc(72px + env(safe-area-inset-bottom));
+  padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.08);
 }
 
-body[data-page="site-detail"] .site-tab {
+.bottom-nav-item {
   flex: 1;
-  height: 52px;
-  border: none !important;
-  outline: none;
+  height: 56px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border: none;
   background: transparent;
-  border-radius: 18px;
-  display: grid;
-  place-items: center;
-  font-size: 17px;
+  color: #64748b;
+  font-size: 13px;
   font-weight: 700;
-  line-height: 1;
-  color: #5f667a;
-  padding: 0;
+  border-radius: 18px;
   transition: all 0.25s ease;
 }
 
-body[data-page="site-detail"] .bottom-tabs {
-  position: fixed;
-  left: 16px;
-  right: 16px;
-  bottom: calc(4px + env(safe-area-inset-bottom));
-  z-index: 1000;
+.bottom-nav-item.active {
+  color: #2f95e9;
+  background: rgba(47, 149, 233, 0.12);
 }
 
+.bottom-nav-icon {
+  font-size: 20px;
+  line-height: 1;
+}
 
+.bottom-nav-label {
+  font-size: 13px;
+  line-height: 1;
+}
 
 .page2 .fab,
 .page2 #createOutFab,
@@ -3899,21 +3910,14 @@ body.page2 #createOutFab {
   z-index: 1001 !important;
 }
 
-.bottom-tabs {
-  z-index: 1000 !important;
+.page2 main,
+.page2 .page-content,
+.page2 .outs-list,
+body.page2 main {
+  padding-bottom: calc(110px + env(safe-area-inset-bottom)) !important;
 }
 
-body[data-page="site-detail"] .site-tab.active {
-  background: #2f95e9;
-  color: #fff;
-  box-shadow: 0 4px 12px rgba(47, 149, 233, 0.25);
-}
-
-body[data-page="site-detail"] .site-tab:not(.active) {
-  background: transparent;
-}
-
-body[data-page="site-detail"] .site-tab.hidden,
+body[data-page="site-detail"] .bottom-nav-item.hidden,
 body[data-page="site-detail"] .tab-content.hidden {
   display: none !important;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -3271,8 +3271,7 @@ import { firebaseAuth } from './firebase-core.js';
       'body[data-page="site-detail"] .site-detail-fab-label--create',
     );
     const siteDetailFabStack = document.querySelector('body[data-page="site-detail"] .site-detail-fab-stack');
-    const siteTabs = document.getElementById('siteTabs');
-    const siteTabButtons = Array.from(document.querySelectorAll('.site-tab'));
+    const siteTabButtons = Array.from(document.querySelectorAll('.bottom-nav-item'));
     const outsTabContent = document.getElementById('outsTabContent');
     const purchasesTabContent = document.getElementById('purchasesTabContent');
     const purchasesTabButton = document.querySelector('[data-tab="purchases"]');
@@ -3557,23 +3556,14 @@ import { firebaseAuth } from './firebase-core.js';
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
     updateTabsByRole();
     setActiveSiteTab('outs');
-    document.querySelectorAll('.site-tab').forEach((tab) => {
+    siteTabButtons.forEach((tab) => {
       tab.addEventListener('click', () => {
         const targetTab = tab.dataset.tab;
         if (targetTab === 'purchases' && !isAdminTabAllowed) {
           setActiveSiteTab('outs');
           return;
         }
-
-        siteTabButtons.forEach((button) => {
-          button.classList.remove('active');
-        });
-
-        tab.classList.add('active');
-        activeSiteTab = targetTab === 'purchases' && isAdminTabAllowed ? 'purchases' : 'outs';
-        outsTabContent?.classList.toggle('hidden', activeSiteTab !== 'outs');
-        purchasesTabContent?.classList.toggle('hidden', activeSiteTab !== 'purchases');
-        updateFabByActiveTab(activeSiteTab);
+        setActiveSiteTab(targetTab);
       });
     });
     onAuthStateChanged(firebaseAuth, (user) => {

--- a/page2.html
+++ b/page2.html
@@ -70,17 +70,17 @@
         </section>
       </main>
 
-      <div class="bottom-tabs" aria-label="Navigation des onglets">
-        <div class="site-tabs bottom-tabs-inner" id="siteTabs">
-          <button class="site-tab bottom-tab active" data-tab="outs" type="button">
-            OUT
-          </button>
+      <nav class="bottom-navigation" aria-label="Navigation des onglets">
+        <button class="bottom-nav-item active" data-tab="outs" type="button">
+          <span class="bottom-nav-icon">📦</span>
+          <span class="bottom-nav-label">OUT</span>
+        </button>
 
-          <button class="site-tab bottom-tab admin-only hidden" data-tab="purchases" type="button">
-            Achat matériel
-          </button>
-        </div>
-      </div>
+        <button class="bottom-nav-item admin-only hidden" data-tab="purchases" type="button">
+          <span class="bottom-nav-icon">🛒</span>
+          <span class="bottom-nav-label">Achat matériel</span>
+        </button>
+      </nav>
 
       <div class="site-detail-fab-stack" aria-hidden="false">
         <div class="site-detail-fab-row" data-fab-row="create">


### PR DESCRIPTION
### Motivation
- Remplacer l’ancien composant d’onglets flottant par une vraie barre de navigation fixe en bas, stylée comme une application mobile, pour améliorer l’ergonomie sur page2 (site-detail).
- Conserver l’architecture existante: ne pas modifier le header, les cartes OUT, la recherche, les filtres ni la logique Admin/FAB/switch OUT ↔ Achat matériel.
- Assurer que le FAB reste au-dessus de la barre et que le contenu principal ne soit pas caché par la nouvelle barre.

### Description
- Remplacé le markup des onglets dans `page2.html` par `<nav class="bottom-navigation">` contenant deux boutons `.bottom-nav-item` (OUT, Achat matériel avec icônes), et supprimé la structure `bottom-tabs / site-tabs / site-tab / bottom-tab` existante.
- Ajouté le style mobile natif dans `css/style.css` (`.bottom-navigation`, `.bottom-nav-item`, `.bottom-nav-icon`, `.bottom-nav-label`) avec support `env(safe-area-inset-bottom)`, ombre, fond clair, état actif/inactif et hauteur compacte, et ajouté `padding-bottom` au contenu pour éviter le recouvrement des cartes.
- Conservé et forcé le positionnement du FAB au-dessus de la barre via les règles existantes (`bottom: calc(92px + env(safe-area-inset-bottom))`, `z-index: 1001`) sans modifier son comportement.
- Mis à jour `js/app.js` pour cibler les nouveaux boutons via `document.querySelectorAll('.bottom-nav-item')` et réutiliser `setActiveSiteTab(...)` afin de préserver la logique de basculement, l’affichage conditionnel `admin-only` et la gestion du FAB.

### Testing
- Exécuté `node --check js/app.js` pour vérifier la validité syntaxique du bundle JavaScript, et la vérification a réussi.
- Vérifié les diffs et l’état git (`git status` / `git diff`) pour confirmer les modifications sur `page2.html`, `css/style.css` et `js/app.js` et validé le commit.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1015c520832ab1b5871b46a4abda)