### PR TITLE
Corrige l'affichage date/heure des Achats matériels (utilise le format OUT)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -137,7 +137,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     if (!dateValue) {
       return '--';
     }
-    const parsedDate = new Date(dateValue);
+    let normalizedDateValue = dateValue;
+    if (typeof dateValue?.toDate === 'function') {
+      normalizedDateValue = dateValue.toDate();
+    } else if (dateValue instanceof Date) {
+      normalizedDateValue = dateValue;
+    } else if (typeof dateValue?.seconds === 'number') {
+      normalizedDateValue = new Date(dateValue.seconds * 1000);
+    }
+    const parsedDate = new Date(normalizedDateValue);
     if (Number.isNaN(parsedDate.getTime())) {
       return '--';
     }


### PR DESCRIPTION
### Motivation
- Les cards « Achat matériel » affichaient « Créé le -- » car `createdAt` retourné par Firestore n'était pas correctement interprété par la fonction de formatage existante utilisée par les OUT. 
- L'objectif est d'utiliser exactement la même logique de formatage que les cards OUT sans introduire de nouvelle fonction et en conservant le flux d'enregistrement existant.

### Description
- Adaptation de `buildDateAndTimeLabel` dans `js/app.js` pour normaliser les valeurs `createdAt` en prenant en charge les `Timestamp` Firestore via `toDate()` et la forme `{ seconds }`, tout en préservant le comportement pour `Date`, `number` et `string` inputs.
- Aucune nouvelle fonction ajoutée et les purchases continuent d'appeler `formatPurchaseDateLabel(...)` qui délègue vers `buildDateAndTimeLabel`, garantissant le même format visuel `dd/mm/yyyy · hh:mm` que les OUT.
- Le flux d'enregistrement reste inchangé et continue d'utiliser `createdAt: serverTimestamp()` puis de recharger les achats via `loadPurchasesForCurrentSite()` pour s'assurer que le timestamp serveur est disponible avant affichage.

### Testing
- Vérification du diff de `js/app.js` confirmant les insertions de normalisation du `dateValue` et la présence du parsing final avec `new Date(...)`, réussite. 
- Inspection des usages montrant que `formatPurchaseDateLabel` délègue bien à `buildDateAndTimeLabel`, réussite.
- Actions de dépôt (enregistrement des modifications et création des métadonnées de PR) exécutées avec succès; aucun test unitaire automatisé n'a été exécuté dans ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe26d1d2c8832abb7554a3313ca48a)