### PR TITLE
Fix missing purchase date separators with Firestore timestamps

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -161,7 +161,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   }
 
   function parseDateValue(value) {
-    const parsed = new Date(value);
+    if (!value) {
+      return null;
+    }
+    let normalizedValue = value;
+    if (typeof value?.toDate === 'function') {
+      normalizedValue = value.toDate();
+    } else if (typeof value?.seconds === 'number') {
+      normalizedValue = new Date(value.seconds * 1000);
+    }
+    const parsed = new Date(normalizedValue);
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
 


### PR DESCRIPTION
### Motivation
- Restore the period separators ("Aujourd’hui / Hier / Plus ancien") in the Achat matériel list by ensuring dates coming from Firestore/remote sources are parsed correctly so existing grouping logic can detect the correct period labels.

### Description
- Update `parseDateValue` in `js/app.js` to return `null` for empty values, convert Firestore `Timestamp` objects via `toDate()`, support `{ seconds }` timestamp-like objects, and otherwise fall back to normal `Date` parsing so `resolveItemPeriodLabel` and `itemMatchesDateFilter` can work as intended.

### Testing
- No automated tests were added or executed for this small parsing fix; change is confined to `js/app.js` and intended to immediately restore the existing separator rendering logic when run in the application.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe91d0fd74832a961d6d4e8b67ae0e)