### PR TITLE
Refactor purchase card internal layout to label/value rows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4923,6 +4923,44 @@ body[data-page="site-detail"] .list-card__meta-item span {
   line-height: 1.32;
 }
 
+body[data-page="site-detail"] .purchase-card__meta {
+  display: grid;
+  gap: 0.48rem;
+}
+
+body[data-page="site-detail"] .purchase-info-row {
+  display: grid;
+  grid-template-columns: minmax(7.9rem, auto) minmax(0, 1fr);
+  align-items: start;
+  column-gap: 0.7rem;
+}
+
+body[data-page="site-detail"] .purchase-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  min-width: 0;
+  color: #4b5563;
+}
+
+body[data-page="site-detail"] .purchase-label .icon {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+body[data-page="site-detail"] .purchase-label span {
+  font-weight: 600;
+}
+
+body[data-page="site-detail"] .purchase-value {
+  min-width: 0;
+  color: #111827;
+  overflow-wrap: anywhere;
+  line-height: 1.32;
+}
+
 body[data-page="site-detail"] .list-separator {
   width: min(100%, var(--content-max-width));
   margin-inline: auto;

--- a/js/app.js
+++ b/js/app.js
@@ -3469,10 +3469,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <article class="list-card purchase-card">
             <div class="list-card__button">
               <h3 class="list-card__title">${escapeHtml(purchase?.designation || '-')}</h3>
-              <div class="list-card__meta">
-                <span class="list-card__meta-item"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>${Number(purchase?.qty || 0)} ${escapeHtml(purchase?.unit || 'Pcs')}</span></span>
-                <span class="list-card__meta-item"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Créé le ${escapeHtml(formatPurchaseDateLabel(purchase))}</span></span>
-                <span class="list-card__meta-item"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>${escapeHtml(purchase?.createdBy || 'Utilisateur')}</span></span>
+              <div class="list-card__meta purchase-card__meta" role="list" aria-label="Informations achat matériel">
+                <div class="purchase-info-row" role="listitem">
+                  <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
+                  <div class="purchase-value">${Number(purchase?.qty || 0)} ${escapeHtml(purchase?.unit || 'Pcs')}</div>
+                </div>
+                <div class="purchase-info-row" role="listitem">
+                  <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date</span></div>
+                  <div class="purchase-value">${escapeHtml(formatPurchaseDateLabel(purchase))}</div>
+                </div>
+                <div class="purchase-info-row" role="listitem">
+                  <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Utilisateur</span></div>
+                  <div class="purchase-value">${escapeHtml(purchase?.createdBy || 'Utilisateur')}</div>
+                </div>
               </div>
             </div>
           </article>


### PR DESCRIPTION
### Motivation
- Improve readability and visual hierarchy of the "Achat matériel" cards by replacing the raw vertical meta list with a compact label/value layout while keeping the card shell and project design unchanged.

### Description
- Replaced the previous inline meta spans with semantic rows in `js/app.js`, adding `purchase-info-row`, `purchase-label`, and `purchase-value` elements for `Quantité`, `Date`, and `Utilisateur`.
- Added scoped CSS rules in `css/style.css` under `body[data-page="site-detail"]` to display the info as a two-column grid and align labels and values consistently without changing card radius, shadow, left blue border, or colors.
- Marked the new structure with ARIA roles (`role="list"` and `role="listitem"`) to preserve accessibility while keeping the material title at the top.
- Did not modify OUT cards, Firestore logic, filters, bottom navigation, or existing animations.

### Testing
- No automated tests were added or executed for this presentational change.
- Verified changes by inspecting the generated diff and committing the updates to `js/app.js` and `css/style.css` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe95373630832a9ee7ac27a4ff31d1)