### PR TITLE
Harmonize purchase edit modal labels with OUT edit modal

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3772,11 +3772,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const defaultLabel = itemCreateSubmitButton?.querySelector('.btn-label-default');
       const loadingLabel = itemCreateSubmitButton?.querySelector('.btn-label-loading');
+      const isEditMode = itemDialogMode === ITEM_DIALOG_MODE_EDIT || itemDialogMode === ITEM_DIALOG_MODE_EDIT_PURCHASE;
       if (defaultLabel) {
-        defaultLabel.textContent = itemDialogMode === ITEM_DIALOG_MODE_EDIT ? 'Enregistrer' : 'Créer';
+        defaultLabel.textContent = isEditMode ? 'Enregistrer' : 'Créer';
       }
       if (loadingLabel) {
-        loadingLabel.textContent = itemDialogMode === ITEM_DIALOG_MODE_EDIT ? 'Enregistrement...' : 'Création...';
+        loadingLabel.textContent = isEditMode ? 'Enregistrement...' : 'Création...';
       }
       if (itemDialogMode === ITEM_DIALOG_MODE_EDIT) {
         itemNumberInput.setAttribute('inputmode', 'numeric');


### PR DESCRIPTION
### Motivation
- Faire en sorte que le modal de modification d’achat matériel réutilise exactement le même comportement d’action que le modal de modification OUT, notamment remplacer le libellé `Créer` par `Enregistrer` et appliquer le même texte d’état de chargement.

### Description
- Introduit un booléen partagé `isEditMode` (`ITEM_DIALOG_MODE_EDIT` ou `ITEM_DIALOG_MODE_EDIT_PURCHASE`) dans `setItemDialogMode` pour traiter les deux modes d’édition de façon identique.
- Appliqué `isEditMode` aux éléments de bouton de soumission `.btn-label-default` et `.btn-label-loading` pour afficher respectivement `Enregistrer` et `Enregistrement...` en mode édition.
- Aucune nouvelle fenêtre modale n’a été créée; le modal existant est réutilisé pour les deux cas et le préremplissage `purchase.designation` reste inchangé.

### Testing
- Aucun test automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feab7ab678832abd3f701421477f7b)