### PR TITLE
Masque les champs « Magasin » dans le modal « Modifier l’achat matériel »

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3794,7 +3794,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         itemNumberInput.setAttribute('pattern', '[0-9]*');
         itemNumberInput.placeholder = 'Exemple : 26050200';
       }
-      itemStoreSelect?.closest('.input-group')?.toggleAttribute('hidden', itemDialogMode !== ITEM_DIALOG_MODE_CREATE);
+      const isCreateMode = itemDialogMode === ITEM_DIALOG_MODE_CREATE;
+      itemStoreSelect?.closest('.input-group')?.toggleAttribute('hidden', !isCreateMode);
+      if (!isCreateMode) {
+        hideItemStoreOtherField({ immediate: true });
+      }
+      itemStoreOtherGroup?.toggleAttribute('hidden', !isCreateMode);
       updateItemNumberCounter();
     }
 


### PR DESCRIPTION
### Motivation
- Faire en sorte que le modal `Modifier l’achat matériel` n’affiche que le champ `Nom` (et son compteur + boutons), en retirant le champ `Magasin` et l’option `-- Sélectionner --` uniquement pour le mode modification d’un achat matériel.
- Conserver le modal de création et tous les styles/animations/overlay/paddings/boutons inchangés.

### Description
- Modifie la logique de `setItemDialogMode` dans `js/app.js` pour introduire une variable `isCreateMode` basée sur `ITEM_DIALOG_MODE_CREATE` et n’afficher le `itemStoreSelect` que lorsque `isCreateMode` est vrai.
- Appelle `hideItemStoreOtherField({ immediate: true })` hors mode création pour s’assurer que le champ « Préciser le magasin » est caché immédiatement.
- Bascule également la visibilité de `itemStoreOtherGroup` via `toggleAttribute('hidden', !isCreateMode)` afin que le groupe complémentaire soit masqué en modification.

### Testing
- Aucune suite de tests automatisés n’a été exécutée pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feae180380832a905dec584b157c5d)