### PR TITLE
Fix Achat matériel rename flow: add dedicated edit modal

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2764,6 +2764,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const purchaseUnit = requireElement('purchaseUnit');
     const purchaseFormError = requireElement('purchaseFormError');
     const cancelPurchaseBtn = requireElement('cancelPurchaseBtn');
+    const editPurchaseModal = document.getElementById('editPurchaseModal');
+    const editPurchaseForm = document.getElementById('editPurchaseForm');
+    const editPurchaseNameInput = document.getElementById('editPurchaseNameInput');
+    const editPurchaseNameCounter = document.getElementById('editPurchaseNameCounter');
+    const editPurchaseFormError = document.getElementById('editPurchaseFormError');
+    const cancelEditPurchaseBtn = document.getElementById('cancelEditPurchaseBtn');
     const itemSearchInput = requireElement('itemSearchInput');
     const itemDateFilter = requireElement('itemDateFilter');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
@@ -2812,6 +2818,34 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       resetPurchaseForm();
       purchaseModal?.showModal();
       purchaseDesignation?.focus();
+    }
+
+    function updateEditPurchaseCounter() {
+      if (!editPurchaseNameInput || !editPurchaseNameCounter) return;
+      editPurchaseNameCounter.textContent = `${editPurchaseNameInput.value.length} / 25`;
+    }
+
+    function showEditPurchaseFieldError(message) {
+      if (!editPurchaseFormError) return;
+      editPurchaseFormError.textContent = message;
+      editPurchaseFormError.style.color = 'var(--danger)';
+    }
+
+    function clearEditPurchaseFieldError() {
+      if (!editPurchaseFormError) return;
+      editPurchaseFormError.textContent = '';
+      editPurchaseFormError.style.color = '';
+    }
+
+    function openEditPurchaseModal(purchase) {
+      if (!purchase || !editPurchaseModal || !editPurchaseNameInput) return;
+      selectedPurchaseId = purchase.id;
+      selectedPurchaseData = purchase;
+      editPurchaseNameInput.value = String(purchase.designation || '');
+      clearEditPurchaseFieldError();
+      updateEditPurchaseCounter();
+      editPurchaseModal.showModal();
+      window.setTimeout(() => editPurchaseNameInput.focus(), 150);
     }
 
     async function savePurchase() {
@@ -3233,6 +3267,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           ? currentPurchases.find((item) => item.id === itemId)
           : currentItems.find((item) => item.id === itemId);
         if (!targetItem) {
+          return;
+        }
+        if (isPurchaseActions) {
+          openEditPurchaseModal(targetItem);
           return;
         }
         itemForm.reset();
@@ -3850,6 +3888,33 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     cancelPurchaseBtn?.addEventListener('click', () => {
       purchaseModal?.close();
+    });
+
+    editPurchaseNameInput?.addEventListener('input', () => {
+      clearEditPurchaseFieldError();
+      updateEditPurchaseCounter();
+    });
+
+    cancelEditPurchaseBtn?.addEventListener('click', () => {
+      editPurchaseModal?.close();
+    });
+
+    editPurchaseForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!selectedPurchaseId || !editPurchaseNameInput) return;
+      const newName = String(editPurchaseNameInput.value || '').trim();
+      if (!newName) {
+        showEditPurchaseFieldError('Nom obligatoire');
+        editPurchaseNameInput.focus();
+        return;
+      }
+      await updateDoc(
+        doc(firebaseDb, 'sites', siteId, 'achatsMateriels', selectedPurchaseId),
+        { designation: newName },
+      );
+      editPurchaseModal?.close();
+      await loadPurchasesForCurrentSite();
+      setActiveSiteTab('purchases');
     });
 
     purchaseForm?.addEventListener('submit', async (event) => {

--- a/page2.html
+++ b/page2.html
@@ -189,6 +189,26 @@
         </form>
       </dialog>
 
+      <dialog id="editPurchaseModal" class="modal-card">
+        <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="editPurchaseForm">
+          <div class="modal-header">
+            <h2>Modifier l’achat matériel</h2>
+          </div>
+          <label class="input-group input-group--site-create input-group--item-create">
+            <span>Nom</span>
+            <input id="editPurchaseNameInput" type="text" maxlength="25" placeholder="Nom achat matériel" />
+            <div class="item-input-feedback-row">
+              <p id="editPurchaseFormError" class="form-error" aria-live="polite"></p>
+              <span id="editPurchaseNameCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
+            </div>
+          </label>
+          <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
+            <button type="button" class="btn btn-neutral" id="cancelEditPurchaseBtn">Annuler</button>
+            <button type="submit" class="btn btn-success" id="saveEditPurchaseBtn">Enregistrer</button>
+          </div>
+        </form>
+      </dialog>
+
       <div id="toast" class="toast" aria-live="polite"></div>
     </div>
 


### PR DESCRIPTION
### Motivation
- The purchase action sheet’s “Modifier le nom” action did not open a purchase-specific modal and was reusing the OUT/item dialog, causing no effective rename flow for achats matériels.
- Provide a dedicated, styled modal that exactly mirrors the existing OUT edit modal presentation but only for renaming purchases and without changing other modals or the bottom sheet.

### Description
- Added a new dialog markup `#editPurchaseModal` in `page2.html` that contains only the `Nom` field, a `0 / 25` counter and `Annuler` / `Enregistrer` buttons, reusing existing modal classes.
- Wired new DOM references in `js/app.js` (`editPurchaseModal`, `editPurchaseForm`, `editPurchaseNameInput`, counter and error nodes) and implemented `openEditPurchaseModal(purchase)` which pre-fills the field and focuses it.
- Updated the item action sheet handler so the purchase-specific “Modifier le nom” opens the new modal (keeps bottom sheet unchanged) and added input listener, counter update, cancel handler and submit handler.
- On save the code updates Firestore at `sites/{siteId}/achatsMateriels/{selectedPurchaseId}`, closes the modal, reloads purchases via `loadPurchasesForCurrentSite()` and activates the `purchases` tab via `setActiveSiteTab('purchases')`.

### Testing
- Ran repository checks including `git diff --check` which completed without reported problems.
- Committed the changes and created the PR; basic code-path verification performed by grepping and inspecting `page2.html` and `js/app.js` to confirm wiring (`openEditPurchaseModal`, new dialog IDs and event handlers) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb37f6d5c832aaf49847b95abc6b6)