### PR TITLE
Harmoniser le modal “Modifier l’achat matériel” : compteur, erreur et état loading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3726,6 +3726,50 @@ body[data-page="site-detail"] #itemDialog .modal-actions--item-create {
   margin-top: 0.62rem;
 }
 
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput {
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.input-error,
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.input-error:focus,
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.is-error,
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.is-error:focus {
+  border-color: #e53935;
+  box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.14);
+}
+
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.is-shaking,
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.shake {
+  animation: item-number-input-shake 300ms ease-in-out 1;
+}
+
+body[data-page="site-detail"] #saveEditPurchaseBtn {
+  position: relative;
+}
+
+body[data-page="site-detail"] #saveEditPurchaseBtn .btn-label-loading {
+  display: none;
+}
+
+body[data-page="site-detail"] #saveEditPurchaseBtn .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
+body[data-page="site-detail"] #saveEditPurchaseBtn.is-loading .btn-label-default {
+  display: none;
+}
+
+body[data-page="site-detail"] #saveEditPurchaseBtn.is-loading .btn-loading-spinner,
+body[data-page="site-detail"] #saveEditPurchaseBtn.is-loading .btn-label-loading {
+  display: inline-flex;
+}
+
 body[data-page="site-detail"] #itemDialog.edit-out-modal .magasin-group {
   display: none !important;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -2770,6 +2770,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const editPurchaseNameCounter = document.getElementById('editPurchaseNameCounter');
     const editPurchaseFormError = document.getElementById('editPurchaseFormError');
     const cancelEditPurchaseBtn = document.getElementById('cancelEditPurchaseBtn');
+    const saveEditPurchaseBtn = document.getElementById('saveEditPurchaseBtn');
     const itemSearchInput = requireElement('itemSearchInput');
     const itemDateFilter = requireElement('itemDateFilter');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
@@ -2829,12 +2830,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!editPurchaseFormError) return;
       editPurchaseFormError.textContent = message;
       editPurchaseFormError.style.color = 'var(--danger)';
+      editPurchaseNameInput?.classList.remove('is-shaking');
+      void editPurchaseNameInput?.offsetWidth;
+      editPurchaseNameInput?.classList.add('input-error', 'is-error', 'is-shaking', 'shake');
     }
 
     function clearEditPurchaseFieldError() {
       if (!editPurchaseFormError) return;
       editPurchaseFormError.textContent = '';
       editPurchaseFormError.style.color = '';
+      editPurchaseNameInput?.classList.remove('input-error', 'is-error', 'is-shaking', 'shake');
+    }
+
+    function setEditPurchaseSubmitLoadingState(isLoading) {
+      if (!saveEditPurchaseBtn) return;
+      saveEditPurchaseBtn.disabled = isLoading;
+      saveEditPurchaseBtn.classList.toggle('is-loading', isLoading);
     }
 
     function openEditPurchaseModal(purchase) {
@@ -3908,13 +3919,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         editPurchaseNameInput.focus();
         return;
       }
-      await updateDoc(
-        doc(firebaseDb, 'sites', siteId, 'achatsMateriels', selectedPurchaseId),
-        { designation: newName },
-      );
-      editPurchaseModal?.close();
-      await loadPurchasesForCurrentSite();
-      setActiveSiteTab('purchases');
+      clearEditPurchaseFieldError();
+      setEditPurchaseSubmitLoadingState(true);
+      try {
+        await updateDoc(
+          doc(firebaseDb, 'sites', siteId, 'achatsMateriels', selectedPurchaseId),
+          { designation: newName },
+        );
+        editPurchaseModal?.close();
+        await loadPurchasesForCurrentSite();
+        setActiveSiteTab('purchases');
+      } finally {
+        setEditPurchaseSubmitLoadingState(false);
+      }
     });
 
     purchaseForm?.addEventListener('submit', async (event) => {

--- a/page2.html
+++ b/page2.html
@@ -198,13 +198,17 @@
             <span>Nom</span>
             <input id="editPurchaseNameInput" type="text" maxlength="25" placeholder="Nom achat matériel" />
             <div class="item-input-feedback-row">
-              <p id="editPurchaseFormError" class="form-error" aria-live="polite"></p>
+              <p id="editPurchaseFormError" class="form-error error-message" aria-live="polite"></p>
               <span id="editPurchaseNameCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
             </div>
           </label>
           <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
             <button type="button" class="btn btn-neutral" id="cancelEditPurchaseBtn">Annuler</button>
-            <button type="submit" class="btn btn-success" id="saveEditPurchaseBtn">Enregistrer</button>
+            <button type="submit" class="btn btn-success" id="saveEditPurchaseBtn">
+              <span class="btn-label-default">Enregistrer</span>
+              <span class="btn-loading-spinner" aria-hidden="true"></span>
+              <span class="btn-label-loading" aria-hidden="true">Enregistrement...</span>
+            </button>
           </div>
         </form>
       </dialog>


### PR DESCRIPTION
### Motivation
- Aligner le comportement visuel du modal `editPurchaseModal` sur les autres modals existants : compteur à droite, message d’erreur à gauche, bordure rouge + shake, et état loading du bouton lors de l’enregistrement.
- Réutiliser les classes et patterns existants (`input-error`, `error-message`, `shake`, `is-loading`) pour éviter de créer du CSS ou des composants nouveaux.

### Description
- Mise à jour du markup dans `page2.html` pour ajouter la classe `error-message` sur l’élément d’erreur et réutiliser le pattern de bouton (ajout de `btn-loading-spinner`, `btn-label-loading`, `btn-label-default`) sur `#saveEditPurchaseBtn`.
- Ajout de wiring JS dans `js/app.js` pour gérer l’erreur de champ vide via `showEditPurchaseFieldError`/`clearEditPurchaseFieldError` en appliquant les classes `input-error`, `is-error`, `is-shaking`, `shake` et en conservant le focus et l’animation rejouable.
- Ajout de la fonction `setEditPurchaseSubmitLoadingState(isLoading)` qui désactive le bouton `#saveEditPurchaseBtn` et bascule la classe `is-loading` pour empêcher le double clic et afficher l’état loading.
- Encapsulation de l’appel Firestore `updateDoc(...)` dans un `try/finally` pour activer l’état loading pendant l’opération et le désactiver ensuite, sans bloquer le reste de l’UI.
- Ajout de styles ciblés dans `css/style.css` (scopés sur `#editPurchaseModal` et `#saveEditPurchaseBtn`) pour reprendre exactement le rendu d’erreur (bordure/ombre rouge), l’animation `shake` et l’affichage du spinner de bouton existant.

### Testing
- Aucun test automatisé spécifique n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb7a33d2c832ab67ffd0f23126a38)