### PR TITLE
Fix edit purchase modal footer alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3692,7 +3692,8 @@ body[data-page="site-detail"] #itemDialog #itemNumberInput.is-shaking {
   }
 }
 
-body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-counter {
+body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-counter,
+body[data-page="site-detail"] #editPurchaseModal .input-group--item-create .input-char-counter {
   width: auto;
   text-align: right;
   margin-top: 0;
@@ -3703,7 +3704,8 @@ body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-
   opacity: 1;
 }
 
-body[data-page="site-detail"] #itemDialog .item-input-feedback-row {
+body[data-page="site-detail"] #itemDialog .item-input-feedback-row,
+body[data-page="site-detail"] #editPurchaseModal .item-input-feedback-row {
   width: 100%;
   margin-top: 0.24rem;
   display: flex;
@@ -3712,7 +3714,8 @@ body[data-page="site-detail"] #itemDialog .item-input-feedback-row {
   gap: 0.5rem;
 }
 
-body[data-page="site-detail"] #itemDialog #itemFormError {
+body[data-page="site-detail"] #itemDialog #itemFormError,
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseFormError {
   width: auto;
   margin-top: 0;
   text-align: left;


### PR DESCRIPTION
### Motivation
- Corriger l’alignement du compteur `0 / 25` et du message d’erreur dans le modal `Modifier l’achat matériel` en réutilisant la même structure que le modal OUT pour garantir message à gauche, compteur à droite et alignement vertical centré.

### Description
- Étendu les sélecteurs CSS existants dans `css/style.css` pour inclure `#editPurchaseModal` afin que `.input-char-counter`, `.item-input-feedback-row` et `#editPurchaseFormError` héritent du même comportement flex (`space-between`, `align-items:center`) que `#itemDialog`.

### Testing
- Exécuté les vérifications de diff et d’état avec `git diff -- css/style.css` et `git status --short`, et appliqué la modification avec `git commit -m "Fix edit purchase modal footer alignment"`, toutes réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69febae1ac5c832a95a8c2a51d7303dd)