### PR TITLE
Améliore le modal "Ajouter un achat matériel" — validation, loading et layout Qte/Unité

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3773,6 +3773,85 @@ body[data-page="site-detail"] #saveEditPurchaseBtn.is-loading .btn-label-loading
   display: inline-flex;
 }
 
+body[data-page="site-detail"] #purchaseModal .purchase-form-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+body[data-page="site-detail"] #purchaseModal .quantity-group {
+  flex: 1;
+}
+
+body[data-page="site-detail"] #purchaseModal .unit-group {
+  width: 120px;
+}
+
+body[data-page="site-detail"] #purchaseModal #purchaseDesignation,
+body[data-page="site-detail"] #purchaseModal #purchaseQty,
+body[data-page="site-detail"] #purchaseModal #purchaseUnit {
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body[data-page="site-detail"] #purchaseModal #purchaseDesignation.is-error,
+body[data-page="site-detail"] #purchaseModal #purchaseDesignation.is-error:focus,
+body[data-page="site-detail"] #purchaseModal #purchaseQty.is-error,
+body[data-page="site-detail"] #purchaseModal #purchaseQty.is-error:focus,
+body[data-page="site-detail"] #purchaseModal #purchaseUnit.is-error,
+body[data-page="site-detail"] #purchaseModal #purchaseUnit.is-error:focus {
+  border-color: #e53935;
+  box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.14);
+}
+
+body[data-page="site-detail"] #purchaseModal #purchaseDesignation.is-shaking,
+body[data-page="site-detail"] #purchaseModal #purchaseDesignation.shake,
+body[data-page="site-detail"] #purchaseModal #purchaseQty.is-shaking,
+body[data-page="site-detail"] #purchaseModal #purchaseQty.shake,
+body[data-page="site-detail"] #purchaseModal #purchaseUnit.is-shaking,
+body[data-page="site-detail"] #purchaseModal #purchaseUnit.shake {
+  animation: item-number-input-shake 300ms ease-in-out 1;
+}
+
+body[data-page="site-detail"] #purchaseModal #purchaseDesignationError,
+body[data-page="site-detail"] #purchaseModal #purchaseQtyError,
+body[data-page="site-detail"] #purchaseModal #purchaseUnitError {
+  margin-top: 0.24rem;
+  min-height: 0;
+}
+
+body[data-page="site-detail"] #savePurchaseBtn {
+  position: relative;
+}
+
+body[data-page="site-detail"] #savePurchaseBtn .btn-label-loading {
+  display: none;
+}
+
+body[data-page="site-detail"] #savePurchaseBtn .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
+body[data-page="site-detail"] #savePurchaseBtn.is-loading .btn-label-default {
+  display: none;
+}
+
+body[data-page="site-detail"] #savePurchaseBtn.is-loading .btn-loading-spinner,
+body[data-page="site-detail"] #savePurchaseBtn.is-loading .btn-label-loading {
+  display: inline-flex;
+}
+
+@media (max-width: 520px) {
+  body[data-page="site-detail"] #purchaseModal .unit-group {
+    width: 104px;
+  }
+}
+
 body[data-page="site-detail"] #itemDialog.edit-out-modal .magasin-group {
   display: none !important;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -2763,7 +2763,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const purchaseQty = requireElement('purchaseQty');
     const purchaseUnit = requireElement('purchaseUnit');
     const purchaseFormError = requireElement('purchaseFormError');
+    const purchaseDesignationError = requireElement('purchaseDesignationError');
+    const purchaseQtyError = requireElement('purchaseQtyError');
+    const purchaseUnitError = requireElement('purchaseUnitError');
     const cancelPurchaseBtn = requireElement('cancelPurchaseBtn');
+    const savePurchaseBtn = requireElement('savePurchaseBtn');
     const editPurchaseModal = document.getElementById('editPurchaseModal');
     const editPurchaseForm = document.getElementById('editPurchaseForm');
     const editPurchaseNameInput = document.getElementById('editPurchaseNameInput');
@@ -2806,13 +2810,32 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (purchaseFormError) {
         purchaseFormError.textContent = '';
       }
+      clearPurchaseFieldError(purchaseDesignation, purchaseDesignationError);
+      clearPurchaseFieldError(purchaseQty, purchaseQtyError);
+      clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
     }
 
-    function showPurchaseFieldError(field, message) {
-      if (purchaseFormError) {
-        purchaseFormError.textContent = message;
+    function showPurchaseFieldError(field, errorElement, message) {
+      if (errorElement) {
+        errorElement.textContent = message;
       }
+      field?.classList.remove('input-error', 'is-error', 'is-shaking', 'shake');
+      void field?.offsetWidth;
+      field?.classList.add('input-error', 'is-error', 'is-shaking', 'shake');
       field?.focus();
+    }
+
+    function clearPurchaseFieldError(field, errorElement) {
+      if (errorElement) {
+        errorElement.textContent = '';
+      }
+      field?.classList.remove('input-error', 'is-error', 'is-shaking', 'shake');
+    }
+
+    function setPurchaseSubmitLoadingState(isLoading) {
+      if (!savePurchaseBtn) return;
+      savePurchaseBtn.disabled = isLoading;
+      savePurchaseBtn.classList.toggle('is-loading', isLoading);
     }
 
     function openCreatePurchaseModal() {
@@ -2860,19 +2883,25 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     async function savePurchase() {
+      clearPurchaseFieldError(purchaseDesignation, purchaseDesignationError);
+      clearPurchaseFieldError(purchaseQty, purchaseQtyError);
+      clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
+      if (purchaseFormError) {
+        purchaseFormError.textContent = '';
+      }
       const designation = String(purchaseDesignation?.value || '').trim();
       const qty = Number(purchaseQty?.value);
       const unit = String(purchaseUnit?.value || '').trim();
       if (!designation) {
-        showPurchaseFieldError(purchaseDesignation, 'Désignation obligatoire');
+        showPurchaseFieldError(purchaseDesignation, purchaseDesignationError, 'Désignation obligatoire');
         return;
       }
       if (!qty || qty <= 0) {
-        showPurchaseFieldError(purchaseQty, 'Quantité invalide');
+        showPurchaseFieldError(purchaseQty, purchaseQtyError, 'Quantité invalide');
         return;
       }
-      if (!unit) {
-        showPurchaseFieldError(purchaseUnit, 'Unité obligatoire');
+      if (!['Pcs', 'm'].includes(unit)) {
+        showPurchaseFieldError(purchaseUnit, purchaseUnitError, 'Unité invalide');
         return;
       }
       const currentUserName = String(
@@ -2882,6 +2911,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         || '',
       ).trim();
       const currentUserEmail = String(firebaseAuth.currentUser?.email || '').trim();
+      setPurchaseSubmitLoadingState(true);
       try {
         await addDoc(
           collection(firebaseDb, 'sites', siteId, 'achatsMateriels'),
@@ -2900,7 +2930,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         resetPurchaseForm();
         await loadPurchasesForCurrentSite();
       } catch (_error) {
-        showPurchaseFieldError(purchaseDesignation, 'Erreur lors de l’enregistrement de l’achat');
+        if (purchaseFormError) {
+          purchaseFormError.textContent = 'Erreur lors de l’enregistrement de l’achat';
+        }
+      } finally {
+        setPurchaseSubmitLoadingState(false);
       }
     }
 
@@ -3899,6 +3933,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     cancelPurchaseBtn?.addEventListener('click', () => {
       purchaseModal?.close();
+    });
+
+    purchaseDesignation?.addEventListener('input', () => {
+      if (String(purchaseDesignation.value || '').trim()) {
+        clearPurchaseFieldError(purchaseDesignation, purchaseDesignationError);
+      }
+    });
+
+    purchaseQty?.addEventListener('input', () => {
+      const qty = Number(purchaseQty.value);
+      if (qty > 0) {
+        clearPurchaseFieldError(purchaseQty, purchaseQtyError);
+      }
+    });
+
+    purchaseUnit?.addEventListener('change', () => {
+      const unit = String(purchaseUnit.value || '').trim();
+      if (['Pcs', 'm'].includes(unit)) {
+        clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
+      }
     });
 
     editPurchaseNameInput?.addEventListener('input', () => {

--- a/page2.html
+++ b/page2.html
@@ -169,22 +169,31 @@
           <label class="input-group input-group--site-create">
             <span>Désignation</span>
             <input id="purchaseDesignation" type="text" placeholder="Ex : Câble cuivre" />
+            <p id="purchaseDesignationError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
-          <label class="input-group input-group--site-create">
-            <span>Quantité</span>
-            <input id="purchaseQty" type="number" min="1" placeholder="Ex : 10" />
-          </label>
-          <label class="input-group input-group--site-create">
-            <span>Unité</span>
-            <select id="purchaseUnit">
-              <option value="Pcs">Pcs</option>
-              <option value="m">m</option>
-            </select>
-          </label>
+          <div class="form-row purchase-form-row">
+            <label class="input-group input-group--site-create quantity-group">
+              <span>Quantité</span>
+              <input id="purchaseQty" type="number" min="1" placeholder="Ex : 10" />
+              <p id="purchaseQtyError" class="form-error form-error--field" aria-live="polite"></p>
+            </label>
+            <label class="input-group input-group--site-create unit-group">
+              <span>Unité</span>
+              <select id="purchaseUnit">
+                <option value="Pcs">Pcs</option>
+                <option value="m">m</option>
+              </select>
+              <p id="purchaseUnitError" class="form-error form-error--field" aria-live="polite"></p>
+            </label>
+          </div>
           <p id="purchaseFormError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelPurchaseBtn" class="btn btn-neutral" type="button">Annuler</button>
-            <button id="savePurchaseBtn" class="btn btn-success" type="submit">Enregistrer</button>
+            <button id="savePurchaseBtn" class="btn btn-success" type="submit">
+              <span class="btn-label-default">Enregistrer</span>
+              <span class="btn-loading-spinner" aria-hidden="true"></span>
+              <span class="btn-label-loading" aria-hidden="true">Enregistrement...</span>
+            </button>
           </div>
         </form>
       </dialog>


### PR DESCRIPTION
### Motivation
- Rendre le modal `Ajouter un achat matériel` cohérent avec les autres modals en ajoutant une validation champ par champ et les retours visuels existants (bordure rouge + shake).
- Empêcher les doubles soumissions et afficher un état visuel pendant l’enregistrement pour améliorer l’expérience utilisateur.
- Aligner `Quantité` et `Unité` sur la même ligne pour gagner en lisibilité et respecter la maquette mobile sans casser les styles globaux.

### Description
- Reconfiguration HTML du `#purchaseModal` dans `page2.html` pour ajouter des éléments d’erreur dédiés `purchaseDesignationError`, `purchaseQtyError`, `purchaseUnitError`, regrouper `Quantité` et `Unité` dans une `div.form-row` et intégrer les labels/spinner de loading au bouton `#savePurchaseBtn`.
- Ajout de helpers JS dans `js/app.js` pour afficher/effacer les erreurs par champ (`showPurchaseFieldError`, `clearPurchaseFieldError`), validation stricte (Désignation non vide, Quantité > 0, Unité dans `Pcs` ou `m`), et suppression automatique de l’erreur au premier input/change.
- Gestion de l’état de soumission dans `js/app.js` via `setPurchaseSubmitLoadingState` pour désactiver le bouton, appliquer la classe `is-loading`, empêcher le double-clic et restaurer l’état dans le `finally`.
- Ajout de règles CSS ciblées dans `css/style.css` pour la ligne `Quantité / Unité` (`.purchase-form-row`, `.quantity-group`, `.unit-group`), réutilisation de l’animation de shake et du style d’erreur existants, et styles de loading pour `#savePurchaseBtn` avec adaptation mobile.
- Les modifications sont strictement localisées au modal d’ajout d’achat matériel et réutilisent les classes/animations existantes sans toucher les autres modals ou comportements globaux.

### Testing
- Vérifications statiques (contrôle d’espaces/conflicts de diff) exécutées et sans erreur détectée.
- Aucune suite de tests unitaires ou end-to-end automatique supplémentaire disponible dans le projet pour ces changements UI, modifications limitées à HTML/CSS/JS et testées par inspection et parcours local du flux d’ajout d’achat (ouverture modal, validation, correction, enregistrement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69febf7ef884832a810ef62e80a335d4)