### PR TITLE
Bloquer à 25 caractères le champ « Modifier l’achat matériel »

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2845,8 +2845,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function updateEditPurchaseCounter() {
-      if (!editPurchaseNameInput || !editPurchaseNameCounter) return;
-      editPurchaseNameCounter.textContent = `${editPurchaseNameInput.value.length} / 25`;
+      updateInputCharCounter(editPurchaseNameInput, editPurchaseNameCounter);
     }
 
     function showEditPurchaseFieldError(message) {
@@ -3958,6 +3957,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     editPurchaseNameInput?.addEventListener('input', () => {
       clearEditPurchaseFieldError();
       updateEditPurchaseCounter();
+    });
+
+    editPurchaseNameInput?.addEventListener('beforeinput', (event) => {
+      enforceMaxLengthOnBeforeInput(event, editPurchaseNameInput);
+    });
+
+    editPurchaseNameInput?.addEventListener('paste', (event) => {
+      enforceMaxLengthOnPaste(event, editPurchaseNameInput, editPurchaseNameCounter);
     });
 
     cancelEditPurchaseBtn?.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Le compteur affichait `37 / 25` mais la saisie n’était pas réellement limitée à 25 caractères, ce qui différait du comportement des autres modals du projet.
- L’objectif est de réutiliser la logique commune existante pour appliquer une coupure réelle à `maxlength` sans changer l’UI ni l’animation.

### Description
- Remplacé le calcul local dans `updateEditPurchaseCounter()` par un appel à `updateInputCharCounter(editPurchaseNameInput, editPurchaseNameCounter)` pour réutiliser la logique centrale de gestion du compteur et du `maxlength`.
- Ajouté un handler `beforeinput` sur `editPurchaseNameInput` qui appelle `enforceMaxLengthOnBeforeInput(...)` pour empêcher la frappe au-delà de la limite.
- Ajouté un handler `paste` sur `editPurchaseNameInput` qui appelle `enforceMaxLengthOnPaste(...)` pour empêcher/trimmer les collages dépassant la limite.
- Aucune modification visuelle n’a été effectuée afin de conserver l’animation, le style et le compteur existants.

### Testing
- Aucune suite de tests automatisés spécifique n’existe pour ce changement, aucun test automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff01f5bee0832ab095c5cc6c50262f)