### PR TITLE
Bloquer à 25 caractères le champ 'Nom' dans le modal Modifier l’achat matériel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2846,6 +2846,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function updateEditPurchaseCounter() {
       if (!editPurchaseNameInput || !editPurchaseNameCounter) return;
+      if (editPurchaseNameInput.value.length > 25) {
+        editPurchaseNameInput.value = editPurchaseNameInput.value.slice(0, 25);
+      }
       editPurchaseNameCounter.textContent = `${editPurchaseNameInput.value.length} / 25`;
     }
 
@@ -3957,6 +3960,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     editPurchaseNameInput?.addEventListener('input', () => {
       clearEditPurchaseFieldError();
+      if (editPurchaseNameInput.value.length > 25) {
+        editPurchaseNameInput.value = editPurchaseNameInput.value.slice(0, 25);
+      }
       updateEditPurchaseCounter();
     });
 


### PR DESCRIPTION
### Motivation
- Le compteur du champ “Nom” dans le modal « Modifier l’achat matériel » pouvait afficher et accepter plus de 25 caractères, notamment lors de collage ou préremplissage sur mobiles Android. 
- L’objectif est d’appliquer le même comportement dur que les autres inputs du projet en empêchant toute saisie ou collage au-delà de 25 caractères.

### Description
- Ajout d’un clamp côté JS dans `updateEditPurchaseCounter()` pour tronquer `editPurchaseNameInput.value` à `slice(0, 25)` avant d’afficher le compteur. 
- Ajout de la même logique de troncature dans l’`input` event handler de `editPurchaseNameInput` pour intercepter saisie et collage immédiats. 
- Vérification que l’attribut HTML natif `maxlength="25"` est présent dans `page2.html` pour fournir la protection native (clavier mobile / Android).

### Testing
- Exécution de la vérification de diff avec `git -C /workspace/Album diff -- js/app.js page2.html` qui a montré les modifications appliquées et a réussi. 
- Vérification de l’état Git avec `git -C /workspace/Album status --short` qui a confirmé les fichiers modifiés et a réussi. 
- Ajout et commit avec `git -C /workspace/Album add js/app.js && git -C /workspace/Album commit -m "Fix edit purchase name hard cap at 25 chars"` qui a réussi et a enregistré le changement dans l’historique.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff072b1530832aa4bd6f1c501acae2)