### PR TITLE
Ajouter compteur 25c et limites (qty 9999) au modal « Ajouter un achat matériel »

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3693,6 +3693,7 @@ body[data-page="site-detail"] #itemDialog #itemNumberInput.is-shaking {
 }
 
 body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-counter,
+body[data-page="site-detail"] #purchaseModal .input-group--item-create .input-char-counter,
 body[data-page="site-detail"] #editPurchaseModal .input-group--item-create .input-char-counter {
   width: auto;
   text-align: right;
@@ -3705,6 +3706,7 @@ body[data-page="site-detail"] #editPurchaseModal .input-group--item-create .inpu
 }
 
 body[data-page="site-detail"] #itemDialog .item-input-feedback-row,
+body[data-page="site-detail"] #purchaseModal .item-input-feedback-row,
 body[data-page="site-detail"] #editPurchaseModal .item-input-feedback-row {
   width: 100%;
   margin-top: 0.24rem;
@@ -3715,6 +3717,7 @@ body[data-page="site-detail"] #editPurchaseModal .item-input-feedback-row {
 }
 
 body[data-page="site-detail"] #itemDialog #itemFormError,
+body[data-page="site-detail"] #purchaseModal #purchaseDesignationError,
 body[data-page="site-detail"] #editPurchaseModal #editPurchaseFormError {
   width: auto;
   margin-top: 0;

--- a/js/app.js
+++ b/js/app.js
@@ -2760,6 +2760,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const purchaseModal = requireElement('purchaseModal');
     const purchaseForm = requireElement('purchaseForm');
     const purchaseDesignation = requireElement('purchaseDesignation');
+    const purchaseDesignationCounter = requireElement('purchaseDesignationCounter');
     const purchaseQty = requireElement('purchaseQty');
     const purchaseUnit = requireElement('purchaseUnit');
     const purchaseFormError = requireElement('purchaseFormError');
@@ -2840,8 +2841,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function openCreatePurchaseModal() {
       resetPurchaseForm();
+      updatePurchaseDesignationCounter();
       purchaseModal?.showModal();
       purchaseDesignation?.focus();
+    }
+
+    function updatePurchaseDesignationCounter() {
+      if (!purchaseDesignation || !purchaseDesignationCounter) return;
+      if (purchaseDesignation.value.length > 25) {
+        purchaseDesignation.value = purchaseDesignation.value.slice(0, 25);
+      }
+      purchaseDesignationCounter.textContent = `${purchaseDesignation.value.length} / 25`;
     }
 
     function updateEditPurchaseCounter() {
@@ -3939,12 +3949,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     });
 
     purchaseDesignation?.addEventListener('input', () => {
+      if (purchaseDesignation.value.length > 25) {
+        purchaseDesignation.value = purchaseDesignation.value.slice(0, 25);
+      }
+      updatePurchaseDesignationCounter();
       if (String(purchaseDesignation.value || '').trim()) {
         clearPurchaseFieldError(purchaseDesignation, purchaseDesignationError);
       }
     });
 
     purchaseQty?.addEventListener('input', () => {
+      if (parseInt(purchaseQty.value, 10) > 9999) {
+        purchaseQty.value = 9999;
+      }
       const qty = Number(purchaseQty.value);
       if (qty > 0) {
         clearPurchaseFieldError(purchaseQty, purchaseQtyError);
@@ -3998,6 +4015,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       event.preventDefault();
       await savePurchase();
     });
+
+    updatePurchaseDesignationCounter();
 
     itemStoreSelect?.addEventListener('change', () => {
       updateItemStoreOtherVisibility();

--- a/page2.html
+++ b/page2.html
@@ -166,15 +166,18 @@
             <h2>Ajouter un achat matériel</h2>
           </div>
           <p class="modal-helper-text">Renseignez les informations de l’achat.</p>
-          <label class="input-group input-group--site-create">
+          <label class="input-group input-group--site-create input-group--item-create">
             <span>Désignation</span>
-            <input id="purchaseDesignation" type="text" placeholder="Ex : Câble cuivre" />
-            <p id="purchaseDesignationError" class="form-error form-error--field" aria-live="polite"></p>
+            <input id="purchaseDesignation" type="text" maxlength="25" placeholder="Ex : Câble cuivre" />
+            <div class="item-input-feedback-row">
+              <p id="purchaseDesignationError" class="form-error form-error--field" aria-live="polite"></p>
+              <span id="purchaseDesignationCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
+            </div>
           </label>
           <div class="form-row purchase-form-row">
             <label class="input-group input-group--site-create quantity-group">
               <span>Quantité</span>
-              <input id="purchaseQty" type="number" min="1" placeholder="Ex : 10" />
+              <input id="purchaseQty" type="number" min="1" max="9999" placeholder="Ex : 10" />
               <p id="purchaseQtyError" class="form-error form-error--field" aria-live="polite"></p>
             </label>
             <label class="input-group input-group--site-create unit-group">


### PR DESCRIPTION
### Motivation
- Le champ `Désignation` du modal doit utiliser le même compteur de caractères que les autres modals et être physiquement limité à 25 caractères.
- Le champ `Quantité` doit être limité entre `1` et `9999` pour éviter des saisies/colles de valeurs impossibles.
- Conserver l’UX existante (bordure rouge, animation shake, bouton loading) sans modifier les autres modals ni le style global.

### Description
- HTML: ajout de `maxlength="25"` sur `#purchaseDesignation`, ajout de la classe `input-group--item-create` et insertion de la rangée feedback contenant le compteur `#purchaseDesignationCounter`, et ajout de `max="9999"` sur `#purchaseQty` (fichier `page2.html`).
- JS: ajout de la référence `purchaseDesignationCounter` et de la fonction `updatePurchaseDesignationCounter()` qui tronque la saisie à 25 caractères et met à jour le compteur; appel du compteur à l'ouverture du modal, à l'`input` et à l'initialisation; ajout d'un clamp côté JS pour forcer `purchaseQty` à `9999` si la valeur saisie dépasse la limite (fichier `js/app.js`).
- CSS: extension des sélecteurs existants du compteur/feedback pour inclure `#purchaseModal` afin d'assurer le même rendu (taille, alignement, spacing) que les autres modals (fichier `css/style.css`).

### Testing
- Exécution d'une recherche automatique avec `rg -n "purchaseDesignationCounter|max=\"9999\"|maxlength=\"25\"|updatePurchaseDesignationCounter|parseInt\(purchaseQty" page2.html js/app.js css/style.css` a trouvé toutes les occurrences attendues avec succès.
- Inspection automatique des extraits de fichiers (HTML/JS/CSS) a confirmé la présence des modifications (compteur, attributs `maxlength`/`max`, et nouvelle fonction JS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0a882500832ab6aa36d76f29a01d)