### PR TITLE
Hide header export button when 'Achat matériel' tab is active

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2750,7 +2750,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const itemNumberCounter = requireElement('itemNumberCounter');
     const itemFormError = requireElement('itemFormError');
     const itemCreateSubmitButton = requireElement('itemCreateSubmitButton');
-    const openExportItems = requireElement('openExportItems');
+    const openExportItems = requireElement('headerExportBtn');
     const siteExportDialog = requireElement('siteExportDialog');
     const siteExportForm = requireElement('siteExportForm');
     const siteExportFileNameInput = requireElement('siteExportFileNameInput');
@@ -3667,6 +3667,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
     }
 
+
+    function updateHeaderExportButton(tabName) {
+      const exportBtn = document.querySelector('#headerExportBtn');
+      if (!exportBtn) {
+        return;
+      }
+      exportBtn.classList.toggle('hidden', tabName === 'purchases');
+    }
+
     function setActiveSiteTab(tabName) {
       const safeTabName = tabName === 'purchases' && isAdminTabAllowed ? 'purchases' : 'outs';
       activeSiteTab = safeTabName;
@@ -3678,6 +3687,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       itemSearchInput.placeholder = safeTabName === 'outs' ? OUT_SEARCH_PLACEHOLDER : PURCHASE_SEARCH_PLACEHOLDER;
       itemSearchInput.value = '';
       updateFabByActiveTab(safeTabName);
+      updateHeaderExportButton(safeTabName);
       renderActiveTabContent();
     }
 

--- a/page2.html
+++ b/page2.html
@@ -17,7 +17,7 @@
           <div id="itemCount" class="site-detail-subtitle outs-count page2-header-subtitle"><span class="outs-number">0</span><span class="outs-label">OUTS</span></div>
         </div>
         <div class="app-header__side app-header__side--right">
-          <button class="btn-export-header" type="button" id="openExportItems" aria-label="Exporter">
+          <button class="btn-export-header" type="button" id="headerExportBtn" aria-label="Exporter">
             <img src="Icon/Exporter.png" alt="" aria-hidden="true" />
           </button>
         </div>


### PR DESCRIPTION
### Motivation
- Cacher le bouton « Exporter » du header uniquement lorsque l’onglet `Achat matériel` (internally `purchases`) est actif tout en ne supprimant pas le bouton ni en modifiant son style.
- Réutiliser la classe existante `hidden` pour la visibilité afin de rester compatible avec le reste de l’application.

### Description
- Ajout de `id="headerExportBtn"` sur le bouton exporteur dans `page2.html` pour pouvoir le cibler depuis le JS.
- Mise à jour de la récupération JS pour cibler `headerExportBtn` (`const openExportItems = requireElement('headerExportBtn');`) dans `js/app.js`.
- Ajout de la fonction `updateHeaderExportButton(tabName)` qui applique `exportBtn.classList.toggle('hidden', tabName === 'purchases');` et ne touche pas au style du bouton.
- Appel de `updateHeaderExportButton(safeTabName)` depuis `setActiveSiteTab` pour cacher/afficher automatiquement le bouton lors du changement d’onglet.

### Testing
- Aucune suite de tests automatisés n’a été exécutée pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff72770b9c832aa60dc065d8e09a4b)