### PR TITLE
Add red required asterisks to Désignation and Quantité labels in purchase modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3790,6 +3790,14 @@ body[data-page="site-detail"] #purchaseModal .unit-group {
   width: 120px;
 }
 
+body[data-page="site-detail"] #purchaseModal .required-star {
+  color: #c95e68;
+  font-size: 0.9em;
+  margin-left: 2px;
+  font-weight: 700;
+  vertical-align: baseline;
+}
+
 body[data-page="site-detail"] #purchaseModal #purchaseDesignation,
 body[data-page="site-detail"] #purchaseModal #purchaseQty,
 body[data-page="site-detail"] #purchaseModal #purchaseUnit {

--- a/page2.html
+++ b/page2.html
@@ -167,7 +167,7 @@
           </div>
           <p class="modal-helper-text">Renseignez les informations de l’achat.</p>
           <label class="input-group input-group--site-create input-group--item-create">
-            <span>Désignation</span>
+            <span>Désignation <span class="required-star" aria-hidden="true">*</span></span>
             <input id="purchaseDesignation" type="text" maxlength="25" placeholder="Ex : Câble cuivre" />
             <div class="item-input-feedback-row">
               <p id="purchaseDesignationError" class="form-error form-error--field" aria-live="polite"></p>
@@ -176,7 +176,7 @@
           </label>
           <div class="form-row purchase-form-row">
             <label class="input-group input-group--site-create quantity-group">
-              <span>Quantité</span>
+              <span>Quantité <span class="required-star" aria-hidden="true">*</span></span>
               <input id="purchaseQty" type="number" min="1" max="9999" placeholder="Ex : 10" />
               <p id="purchaseQtyError" class="form-error form-error--field" aria-live="polite"></p>
             </label>


### PR DESCRIPTION
### Motivation
- Indicate that the purchase form fields "Désignation" and "Quantité" are required by adding a small red asterisk while preserving existing label styles and text sizing.

### Description
- Inserted a `<span class="required-star" aria-hidden="true">*</span>` next to the "Désignation" and "Quantité" label text in `page2.html` and added a scoped CSS rule `body[data-page="site-detail"] #purchaseModal .required-star { color: #c95e68; font-size: 0.9em; margin-left: 2px; font-weight: 700; vertical-align: baseline; }` to `css/style.css` so the asterisk uses the same red tone and stays small and vertically aligned.

### Testing
- Ran `cd /workspace/Album && git status --short && git diff -- page2.html css/style.css` and `cd /workspace/Album && git add page2.html css/style.css && git commit -m "Add required red asterisks to designation and quantity labels"`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffaf6485e0832a94875f4de6eabde4)