### PR TITLE
Add required asterisks to Nouveau numéro OUT modal labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3798,6 +3798,15 @@ body[data-page="site-detail"] #purchaseModal .required-star {
   vertical-align: baseline;
 }
 
+body[data-page="site-detail"] #itemDialog .required-star {
+  color: #ef4444;
+  font-weight: 700;
+  font-size: 0.9em;
+  margin-left: 2px;
+  vertical-align: baseline;
+}
+
+
 body[data-page="site-detail"] #purchaseModal #purchaseDesignation,
 body[data-page="site-detail"] #purchaseModal #purchaseQty,
 body[data-page="site-detail"] #purchaseModal #purchaseUnit {

--- a/page2.html
+++ b/page2.html
@@ -96,7 +96,7 @@
             <h2>Nouveau numéro OUT</h2>
           </div>
           <label class="input-group input-group--site-create input-group--item-create">
-            <span>Numéro OUT</span>
+            <span>Numéro OUT <span class="required-star" aria-hidden="true">*</span></span>
             <input
               id="itemNumberInput"
               name="itemNumber"
@@ -113,7 +113,7 @@
             </div>
           </label>
           <label class="input-group input-group--site-create input-group--item-create magasin-group">
-            <span class="magasin-label">Magasin</span>
+            <span class="magasin-label">Magasin <span class="required-star" aria-hidden="true">*</span></span>
             <select id="itemStoreSelect" name="itemStore">
               <option value="">-- Sélectionner --</option>
               <option value="TIT I">TITAN I</option>


### PR DESCRIPTION
### Motivation
- Make the required fields in the "Nouveau numéro OUT" modal visually consistent with other required fields by adding the red asterisk to the `Numéro OUT` and `Magasin` labels.
- Reuse the existing `required-star` styling so the new indicators match color, weight, size and alignment used elsewhere in the project.

### Description
- Inserted `<span class="required-star" aria-hidden="true">*</span>` next to `Numéro OUT` and `Magasin` labels in `page2.html` inside the `#itemDialog` modal.
- Added a scoped CSS rule `body[data-page="site-detail"] #itemDialog .required-star` in `css/style.css` to match the existing required-star appearance (`color: #ef4444; font-weight: 700; font-size: 0.9em; margin-left: 2px; vertical-align: baseline;`) without affecting other modals.

### Testing
- Ran `rg -n "Numéro OUT|Magasin|Nouveau numéro OUT|required-star" /workspace/Album` to confirm occurrences and the new markup, which succeeded.
- Verified the changes with `git -C /workspace/Album diff -- page2.html css/style.css`, which showed the intended modifications.
- Staged and committed the two files with `git -C /workspace/Album add page2.html css/style.css && git -C /workspace/Album commit -m "Add required stars to OUT number modal labels"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb2dafaf0832aaf33a6a7bdfd5cf3)