### PR TITLE
Ajouter astérisque requis à « Nom du site » dans le modal de création

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3806,6 +3806,14 @@ body[data-page="site-detail"] #itemDialog .required-star {
   vertical-align: baseline;
 }
 
+body[data-page="home"] #siteDialog .required-star {
+  color: #ef4444;
+  font-weight: 700;
+  font-size: 0.9em;
+  margin-left: 2px;
+  vertical-align: baseline;
+}
+
 
 body[data-page="site-detail"] #purchaseModal #purchaseDesignation,
 body[data-page="site-detail"] #purchaseModal #purchaseQty,

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
             <h2>Entrer nom du site</h2>
           </div>
           <label class="input-group input-group--site-create">
-            <span>Nom du site</span>
+            <span>Nom du site <span class="required-star" aria-hidden="true">*</span></span>
             <input id="siteNameInput" name="siteName" type="text" maxlength="25" />
             <div class="site-input-feedback-row">
               <p id="siteFormError" class="form-error" aria-live="polite"></p>


### PR DESCRIPTION
### Motivation
- Le champ « Nom du site » du modal `Entrer nom du site` doit indiquer visuellement qu’il est requis en réutilisant exactement le style des astérisques existants.
- L’ajout doit être ciblé au modal de création et ne pas impacter les autres modals du projet.

### Description
- Remplacement du label dans `index.html` pour passer de `<span>Nom du site</span>` à `<span>Nom du site <span class="required-star" aria-hidden="true">*</span></span>` dans le modal `#siteDialog`.
- Ajout d’une règle CSS ciblée `body[data-page="home"] #siteDialog .required-star` dans `css/style.css` pour réutiliser la couleur `#ef4444`, le même poids, taille et alignement que les astérisques existants.
- Les autres modals et règles CSS existantes n’ont pas été modifiées.

### Testing
- Exécution de `rg -n "Nom du site|Entrer nom du site|required-star" .` pour vérifier la présence des sélecteurs et du nouveau markup, ce test a réussi.
- Inspection de l’extrait de `index.html` via `nl -ba index.html | sed -n '102,116p'` pour confirmer l’insertion du `span.required-star`, ce test a réussi.
- Inspection de l’extrait de `css/style.css` via `nl -ba css/style.css | sed -n '3798,3815p'` pour confirmer l’ajout de la règle CSS scoped au modal, ce test a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb4ae6fa4832ab7f809fb7484200c)