### PR TITLE
Page 3 : inputs des colonnes Qté Sortie/Posée/Retour/Ecart/Remarque en auto-resize

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3130,6 +3130,13 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   min-width: fit-content;
 }
 
+.cell-input--detail-fluid {
+  width: auto;
+  min-width: 4ch;
+  max-width: min(34ch, 42vw);
+  transition: width 180ms ease, min-width 180ms ease, max-width 180ms ease;
+}
+
 .cell-input--designation {
   min-width: 20ch;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -5103,6 +5103,32 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    function applyDetailColumnAutoWidth(input) {
+      if (!input || !(input instanceof HTMLInputElement)) {
+        return;
+      }
+      if (!input.classList.contains('cell-input--detail-fluid')) {
+        return;
+      }
+      const content = String(input.value ?? input.placeholder ?? '').trim();
+      const minChars = Number(input.dataset.minCh || 4);
+      const maxChars = Number(input.dataset.maxCh || 28);
+      const nextChars = Math.min(Math.max(content.length + 1, minChars), maxChars);
+      input.style.width = `${nextChars}ch`;
+      input.dataset.length = String(content.length);
+    }
+
+    function bindDetailColumnAutoWidth(input) {
+      if (!input || input.dataset.autowidthBound === 'true') {
+        return;
+      }
+      input.dataset.autowidthBound = 'true';
+      const refresh = () => applyDetailColumnAutoWidth(input);
+      input.addEventListener('input', refresh);
+      input.addEventListener('change', refresh);
+      refresh();
+    }
+
     function renderTable() {
       if (!currentItem) {
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
@@ -5130,14 +5156,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
               <td>
                 <div class="qte-sortie-field">
-                  <input class="cell-input" data-field="qteSortie" type="number" min="0" step="1" value="${escapeHtml(detail.qteSortie)}" />
+                  <input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="10" data-field="qteSortie" type="number" min="0" step="1" value="${escapeHtml(detail.qteSortie)}" />
                   <span class="meta-value meta-value--inline">${escapeHtml(detail.unite)}</span>
                 </div>
               </td>
-              <td><input class="cell-input" data-field="qtePosee" type="number" min="0" step="1" value="${detail.qtePosee}" /></td>
-              <td><input class="cell-input" data-field="qteRetour" type="number" min="0" step="1" value="${detail.qteRetour}" /></td>
-              <td><input class="cell-input${ecartClassName}" type="number" value="${ecart}" readonly aria-label="Ecart" /></td>
-              <td><input class="cell-input cell-input--autosize" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" size="${Math.max(String(detail.observation || '').length + 1, 14)}" /></td>
+              <td><input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="10" data-field="qtePosee" type="number" min="0" step="1" value="${detail.qtePosee}" /></td>
+              <td><input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="10" data-field="qteRetour" type="number" min="0" step="1" value="${detail.qteRetour}" /></td>
+              <td><input class="cell-input cell-input--detail-fluid${ecartClassName}" data-min-ch="4" data-max-ch="10" type="number" value="${ecart}" readonly aria-label="Ecart" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--detail-fluid" data-min-ch="8" data-max-ch="34" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" size="${Math.max(String(detail.observation || '').length + 1, 14)}" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td>
@@ -5151,6 +5177,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         )
         .join('');
       animateNextTableRender = false;
+
+      detailTableBody.querySelectorAll('.cell-input--detail-fluid').forEach((field) => {
+        bindDetailColumnAutoWidth(field);
+      });
 
       detailTableBody.querySelectorAll('[data-field]').forEach((field) => {
         if (!canEditDetails) {


### PR DESCRIPTION
### Motivation
- Rendre les champs de saisie des 5 colonnes du tableau de la page 3 (`Qté Sortie`, `Qté posée`, `Qté retour`, `Ecart`, `Remarque`) adaptatifs à leur contenu tout en conservant le style visuel existant et sans impacter les autres colonnes.

### Description
- Ajout d’une classe CSS dédiée `cell-input--detail-fluid` pour ces 5 champs avec `width: auto`, `min-width` en `ch`, `max-width` bornée (`min(34ch, 42vw)`) et une `transition` fluide pour les changements de largeur afin d’assurer un rendu premium et responsive.
- Ajout de deux fonctions JS : `applyDetailColumnAutoWidth(input)` qui calcule la largeur en `ch` depuis la longueur du contenu et `bindDetailColumnAutoWidth(input)` qui attache des listeners `input`/`change` et déclenche un rafraîchissement initial pour la croissance progressive lors de la saisie.
- Seuls les inputs des colonnes ciblées ont été modifiés dans le rendu (`renderTable()`), via l’ajout de la classe `cell-input--detail-fluid` et des attributs `data-min-ch`/`data-max-ch`; aucun autre style de `.cell-input` (border-radius, hauteur, couleurs, bordures, police, alignement) n’a été altéré.
- Le binding auto-width est exécuté après chaque rendu du tableau pour garantir que les nouveaux éléments reçoivent les écouteurs sans duplication.

### Testing
- Aucun test automatisé n’est présent dans le dépôt pour cette fonctionnalité.
- Vérifications locales : recherche des usages concernés via `rg`, inspection des fichiers modifiés (`js/app.js`, `css/style.css`) et chargement local de la page pour valider que les champs ciblés passent d’un rendu compact (`"0"`) à plus large (`"25"`) et s’agrandissent pour une remarque longue (`"Remarque test longue"`) avec transition fluide et contraintes min/max respectées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffba6773b4832a9b3ccce0c41dab2d)