### PR TITLE
Fix page 3 inputs: auto-resize and maxlength for quantities and Remarque

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5112,8 +5112,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const content = String(input.value ?? input.placeholder ?? '').trim();
       const minChars = Number(input.dataset.minCh || 4);
-      const maxChars = Number(input.dataset.maxCh || 28);
-      const nextChars = Math.min(Math.max(content.length + 1, minChars), maxChars);
+      const maxChars = Number(input.dataset.maxCh || 120);
+      const safeContentLength = Math.max(content.length, 1);
+      const nextChars = Math.min(Math.max(safeContentLength + 1, minChars), maxChars + 1);
       input.style.width = `${nextChars}ch`;
       input.dataset.length = String(content.length);
     }
@@ -5156,14 +5157,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
               <td>
                 <div class="qte-sortie-field">
-                  <input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="10" data-field="qteSortie" type="number" min="0" step="1" value="${escapeHtml(detail.qteSortie)}" />
+                  <input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="8" data-field="qteSortie" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="8" value="${escapeHtml(detail.qteSortie)}" />
                   <span class="meta-value meta-value--inline">${escapeHtml(detail.unite)}</span>
                 </div>
               </td>
-              <td><input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="10" data-field="qtePosee" type="number" min="0" step="1" value="${detail.qtePosee}" /></td>
-              <td><input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="10" data-field="qteRetour" type="number" min="0" step="1" value="${detail.qteRetour}" /></td>
-              <td><input class="cell-input cell-input--detail-fluid${ecartClassName}" data-min-ch="4" data-max-ch="10" type="number" value="${ecart}" readonly aria-label="Ecart" /></td>
-              <td><input class="cell-input cell-input--autosize cell-input--detail-fluid" data-min-ch="8" data-max-ch="34" data-field="observation" type="text" value="${escapeHtml(detail.observation)}" size="${Math.max(String(detail.observation || '').length + 1, 14)}" /></td>
+              <td><input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="8" data-field="qtePosee" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="8" value="${escapeHtml(detail.qtePosee)}" /></td>
+              <td><input class="cell-input cell-input--detail-fluid" data-min-ch="4" data-max-ch="8" data-field="qteRetour" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="8" value="${escapeHtml(detail.qteRetour)}" /></td>
+              <td><input class="cell-input cell-input--detail-fluid${ecartClassName}" data-min-ch="4" data-max-ch="8" type="text" inputmode="numeric" pattern="[0-9-]*" maxlength="8" value="${escapeHtml(ecart)}" readonly aria-label="Ecart" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--detail-fluid" data-min-ch="8" data-max-ch="120" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" size="${Math.max(String(detail.observation || '').length + 1, 14)}" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td>


### PR DESCRIPTION
### Motivation
- Ensure full visibility of entered values in the page 3 "Tableau des données" for the five specified columns so 8-digit quantities and up to 120-character remarks are never truncated.  
- Enforce the requested input length limits (`8` for quantities/écart, `120` for `Remarque`) while keeping the current visual style and table horizontal scrolling.  
- Apply the fix only to the five columns: `Qté Sortie`, `Qté posée`, `Qté retour`, `Ecart`, and `Remarque`.

### Description
- Converted the quantity and ecart inputs to `type="text"` with `inputmode="numeric"`, `pattern` and added `maxlength="8"` for `qteSortie`, `qtePosee`, `qteRetour`, and `Ecart` to ensure HTML `maxlength` is honored while keeping numeric keyboard behavior on mobile.  
- Added `maxlength="120"` and increased `data-max-ch` to `120` for the `observation` (`Remarque`) field so remarks can display up to 120 characters.  
- Improved auto-resize logic in `applyDetailColumnAutoWidth` to read the `data-max-ch` value (default `120`), use a safe content length and recalculate width on each `input`/`change`, producing a smooth transition and keeping fields compact when short.  
- Changes are limited to `js/app.js` (table row input markup and auto-width logic) and preserve existing CSS classes, borders, radii, colors, typography, transitions and table layout so horizontal scrolling and design remain unchanged.

### Testing
- Searched and inspected relevant files with `rg` and `sed` to confirm targets and context, and those inspections completed successfully.  
- Applied the targeted source edits via a small scripted patch (`python` one-liner) and verified the updated attributes with `rg`, which returned the expected lines.  
- Committed the change with `git commit` and reviewed the resulting file segment with `nl` to confirm the new input markup and auto-width function, and all commands succeeded.  
- The only modified file is `js/app.js` and all automated verification steps listed above completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffbf8c0f68832ab6c0bc5ab824f36f)