### PR TITLE
Aligner auto-resize des colonnes Qté/Ecart avec le comportement Remarque (page 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5173,13 +5173,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
               <td>
                 <div class="qte-sortie-field">
-                  <input class="cell-input cell-input--detail-fluid" data-col-fluid="qteSortie" data-min-ch="4" data-max-ch="13" data-field="qteSortie" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="13" value="${escapeHtml(detail.qteSortie)}" />
+                  <input class="cell-input cell-input--autosize cell-input--detail-fluid" data-col-fluid="qteSortie" data-min-ch="4" data-max-ch="120" data-field="qteSortie" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="120" value="${escapeHtml(detail.qteSortie)}" />
                   <span class="meta-value meta-value--inline">${escapeHtml(detail.unite)}</span>
                 </div>
               </td>
-              <td><input class="cell-input cell-input--detail-fluid" data-col-fluid="qtePosee" data-min-ch="4" data-max-ch="13" data-field="qtePosee" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="13" value="${escapeHtml(detail.qtePosee)}" /></td>
-              <td><input class="cell-input cell-input--detail-fluid" data-col-fluid="qteRetour" data-min-ch="4" data-max-ch="13" data-field="qteRetour" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="13" value="${escapeHtml(detail.qteRetour)}" /></td>
-              <td><input class="cell-input cell-input--detail-fluid${ecartClassName}" data-col-fluid="ecart" data-min-ch="4" data-max-ch="13" type="text" inputmode="numeric" pattern="[0-9-]*" maxlength="13" value="${escapeHtml(ecart)}" readonly aria-label="Ecart" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--detail-fluid" data-col-fluid="qtePosee" data-min-ch="4" data-max-ch="120" data-field="qtePosee" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="120" value="${escapeHtml(detail.qtePosee)}" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--detail-fluid" data-col-fluid="qteRetour" data-min-ch="4" data-max-ch="120" data-field="qteRetour" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="120" value="${escapeHtml(detail.qteRetour)}" /></td>
+              <td><input class="cell-input cell-input--autosize cell-input--detail-fluid${ecartClassName}" data-col-fluid="ecart" data-min-ch="4" data-max-ch="120" type="text" inputmode="numeric" pattern="[0-9-]*" maxlength="120" value="${escapeHtml(ecart)}" readonly aria-label="Ecart" /></td>
               <td><input class="cell-input cell-input--autosize cell-input--detail-fluid" data-col-fluid="observation" data-min-ch="8" data-max-ch="120" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" size="${Math.max(String(detail.observation || '').length + 1, 14)}" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>


### PR DESCRIPTION
### Motivation
- Rendre l’affichage et la saisie des colonnes **Qté Sortie**, **Qté posée**, **Qté Retour** et **Ecart** identiques au comportement déjà en place pour **Remarque**, afin d’assurer un auto-redimensionnement cohérent et l’affichage immédiat de tout le texte saisi.

### Description
- Ajout de la classe `cell-input--autosize` aux champs `qteSortie`, `qtePosee`, `qteRetour` et `ecart` dans le rendu du tableau de la page 3 (`js/app.js`).
- Augmentation de `data-max-ch` de `13` à `120` pour ces quatre champs afin de permettre `maxlength="120"` et l’affichage complet pendant la saisie.
- Conservation des attributs métier existants (`inputmode`, `pattern`, `readonly` pour `ecart`) et réutilisation de la logique de recalcul de largeur partagée (`refreshDetailFluidColumns`) pour aligner toutes les cellules d’une même colonne.
- Aucune modification effectuée sur la colonne Remarque, les autres colonnes, la structure du tableau, les calculs ou validations métier existants.

### Testing
- Exécution de la commande de diff `git diff -- js/app.js` pour inspecter les modifications, qui a montré uniquement les quatre champs ciblés (succès). 
- Recherche des sélecteurs modifiés avec `rg -n "data-col-fluid=\"qteSortie\"|data-col-fluid=\"qtePosee\"|data-col-fluid=\"qteRetour\"|data-col-fluid=\"ecart\"" js/app.js` pour valider les changements (succès).
- Ajout et commit via `git add js/app.js && git commit -m "Harmonize fluid input behavior for quantity and ecart columns"` pour enregistrer la modification (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc6b2f8d4832a849abd9abab8af9c)