### PR TITLE
Prevent internal scrolling in page 3 quantity inputs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3136,6 +3136,14 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   transition: width 180ms ease, min-width 180ms ease;
 }
 
+.cell-input--detail-fluid[data-col-fluid="qteSortie"],
+.cell-input--detail-fluid[data-col-fluid="qtePosee"],
+.cell-input--detail-fluid[data-col-fluid="qteRetour"],
+.cell-input--detail-fluid[data-col-fluid="ecart"] {
+  overflow: visible;
+  text-overflow: clip;
+}
+
 .cell-input--designation {
   min-width: 20ch;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -5120,7 +5120,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         '[data-col-fluid="qtePosee"]',
         '[data-col-fluid="qteRetour"]',
         '[data-col-fluid="ecart"]',
-        '[data-col-fluid="observation"]',
       ];
       columnSelectors.forEach((selector) => {
         const inputs = Array.from(scope.querySelectorAll(selector)).filter((item) => item instanceof HTMLInputElement);


### PR DESCRIPTION
### Motivation
- Éliminer le scroll interne et la coupure de texte dans les champs des colonnes `Qté Sortie`, `Qté posée`, `Qté Retour` et `Ecart` pour que toute valeur saisie soit immédiatement visible et que la largeur s’ajuste dynamiquement.

### Description
- Retiré la colonne `Remarque` du groupe recalculé dans `refreshDetailFluidColumns` afin que seules les 4 colonnes ciblées soient synchronisées (`js/app.js`).
- Ajouté une règle CSS ciblée pour `.cell-input--detail-fluid[data-col-fluid="qteSortie"]`, `.cell-input--detail-fluid[data-col-fluid="qtePosee"]`, `.cell-input--detail-fluid[data-col-fluid="qteRetour"]` et `.cell-input--detail-fluid[data-col-fluid="ecart"]` pour forcer `overflow: visible` et `text-overflow: clip` et empêcher le scroll/coupe interne (`css/style.css`).
- Conservé le mécanisme existant de recalcul sur `input`/`change` qui ajuste la largeur à la taille du contenu et maintien la largeur commune par colonne basée sur le champ le plus large, sans toucher aux fonctions numériques ni au calcul d'`Ecart`.

### Testing
- Aucun test automatisé n'a été exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc9bf0398832a862c3e67146be6bc)