### PR TITLE
Fix compact input sizing for page 3 quantity and remark columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3133,11 +3133,16 @@ body[data-page="item-detail"] #designationInput.is-shaking {
 
 .cell-input--compact-dynamic {
   width: auto;
-  min-width: 3.5rem;
+  min-width: 48px;
   max-width: none;
+  padding: 0.7rem 0.75rem;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: clip;
+}
+
+.cell-input--compact-dynamic[data-col-key="observation"] {
+  min-width: 100px;
 }
 
 .cell-input-measurer {

--- a/js/app.js
+++ b/js/app.js
@@ -5218,18 +5218,27 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       measurer.className = 'cell-input-measurer';
       document.body.appendChild(measurer);
 
-      columns.forEach((inputs) => {
-        let maxWidth = 0;
+      const minWidthByColumn = {
+        qteSortie: 48,
+        qtePosee: 48,
+        qteRetour: 48,
+        ecart: 48,
+        observation: 100,
+      };
+
+      columns.forEach((inputs, key) => {
+        let maxWidth = minWidthByColumn[key] || 48;
 
         inputs.forEach((input) => {
           const computed = window.getComputedStyle(input);
           measurer.style.font = computed.font;
-          measurer.textContent = String(input.value ?? '').trim() || '0';
+          measurer.style.letterSpacing = computed.letterSpacing;
+          measurer.textContent = String(input.value ?? '');
           const contentWidth = Math.ceil(measurer.getBoundingClientRect().width);
           const horizontalPadding = parseFloat(computed.paddingLeft) + parseFloat(computed.paddingRight);
           const horizontalBorder = parseFloat(computed.borderLeftWidth) + parseFloat(computed.borderRightWidth);
-          const minWidth = parseFloat(computed.minWidth) || 0;
-          const width = Math.max(minWidth, contentWidth + horizontalPadding + horizontalBorder + 8);
+          const minWidth = Math.max(parseFloat(computed.minWidth) || 0, minWidthByColumn[key] || 48);
+          const width = Math.max(minWidth, contentWidth + horizontalPadding + horizontalBorder + 10);
           maxWidth = Math.max(maxWidth, width);
         });
 


### PR DESCRIPTION
### Motivation
- The page 3 data table inputs for `Qté Sortie`, `Qté posée`, `Qté retour`, `Ecart` and `Remarque` were rendering overly wide after edits, producing unprofessional, full-column inputs by default. 
- Inputs must start compact and expand only to fit longer content while keeping all inputs in a column matched to the largest cell in that column. 
- Changes must not touch numeric/business logic, other columns, or the overall table design and scrolling behavior.

### Description
- Tightened the default CSS for `.cell-input--compact-dynamic` by setting a practical `min-width` and controlled horizontal padding so short values render as compact inputs. 
- Added a column-specific CSS rule for the remark input via `.cell-input--compact-dynamic[data-col-key="observation"]` to give `Remarque` a larger initial minimum width. 
- Reworked `applyCompactColumnWidths()` to use a `minWidthByColumn` map (for `qteSortie`, `qtePosee`, `qteRetour`, `ecart`, `observation`) and to compute widths from measured content plus padding/border so inputs expand only as needed while all cells in a column adopt the largest computed width. 
- Preserved existing styles (border-radius, height, colors), table-level horizontal scrolling, and all numeric/compute functions unchanged.

### Testing
- Ran repository-wide searches to locate usages of `cell-input--compact-dynamic` and the page 3 table to ensure the change is scoped to the intended inputs, and the search completed successfully. 
- Generated and inspected diffs for `css/style.css` and `js/app.js` to verify the new CSS and the updated `applyCompactColumnWidths()` behavior, and the diffs matched the intended changes. 
- There is no dedicated automated unit test suite for this UI change in the repository, so no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00049907e0832abb5ca415b3dd5459)