### PR TITLE
Persister et restaurer la recherche OUT (page 2)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3685,7 +3685,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       outsTabContent?.classList.toggle('hidden', safeTabName !== 'outs');
       purchasesTabContent?.classList.toggle('hidden', safeTabName !== 'purchases');
       itemSearchInput.placeholder = safeTabName === 'outs' ? OUT_SEARCH_PLACEHOLDER : PURCHASE_SEARCH_PLACEHOLDER;
-      itemSearchInput.value = '';
+      itemSearchInput.value = safeTabName === 'outs'
+        ? (window.localStorage.getItem(searchStorageKey) || '')
+        : '';
       updateFabByActiveTab(safeTabName);
       updateHeaderExportButton(safeTabName);
       renderActiveTabContent();
@@ -4189,7 +4191,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     itemSearchInput.addEventListener('input', () => {
-      window.localStorage.setItem(searchStorageKey, itemSearchInput.value);
+      if (activeSiteTab === 'outs') {
+        const searchValue = itemSearchInput.value;
+        if (searchValue) {
+          window.localStorage.setItem(searchStorageKey, searchValue);
+        } else {
+          window.localStorage.removeItem(searchStorageKey);
+        }
+      }
       renderActiveTabContent();
     });
 


### PR DESCRIPTION
### Motivation
- Conserver automatiquement la valeur saisie dans le champ de recherche OUT afin qu’elle survive à un rechargement et soit réappliquée au filtre sans modifier le design ou les animations existants.

### Description
- Lors du basculement vers l’onglet OUT, `setActiveSiteTab` restaure la valeur depuis la clé `searchStorageKey` (scopée par `siteId`) en la réinjectant dans `itemSearchInput`.
- L’écouteur `itemSearchInput.addEventListener('input', ...)` a été mis à jour pour n’écrire la valeur dans `localStorage` que lorsque l’onglet actif est `outs` et pour supprimer la clé lorsque le champ devient vide (y compris via le bouton natif `X`).
- Le flux de rendu reste inchangé en appelant toujours `renderActiveTabContent()` sur chaque saisie, garantissant la réapplication automatique du filtre après restauration.

### Testing
- Vérification du diff et des lignes modifiées avec `rg`/`sed` pour valider l’emplacement des changements, et ces inspections ont réussi.
- Contrôle de l’état Git avec `git status --short` puis commit via `git add` + `git commit`, et le commit s’est effectué avec succès.
- Comportement validé via lecture du code (restauration depuis `localStorage`, suppression automatique quand vide, et appel à `renderActiveTabContent()`), sans tests unitaires automatisés supplémentaires exécutés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004d4f0fb0832a9f5445aeffa028c9)