### PR TITLE
Preserve OUT page scroll position after refresh

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2797,9 +2797,43 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     };
     const dateFilterStorageKey = `site-detail:item-date-filter:${siteId}`;
     const searchStorageKey = `site-detail:item-search:${siteId}`;
+    const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
+    let hasPendingOutScrollRestore = true;
+
+    function persistOutPageScrollPosition() {
+      if (activeSiteTab !== 'outs') {
+        return;
+      }
+      try {
+        window.localStorage.setItem(outPageScrollStorageKey, String(Math.max(0, Math.round(window.scrollY || 0))));
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
+    function restoreOutPageScrollPosition() {
+      if (!hasPendingOutScrollRestore || activeSiteTab !== 'outs') {
+        return;
+      }
+      hasPendingOutScrollRestore = false;
+      let savedScrollY = 0;
+      try {
+        savedScrollY = Number.parseInt(window.localStorage.getItem(outPageScrollStorageKey) || '0', 10);
+      } catch (_error) {
+        savedScrollY = 0;
+      }
+      if (!Number.isFinite(savedScrollY) || savedScrollY <= 0) {
+        return;
+      }
+      window.requestAnimationFrame(() => {
+        window.setTimeout(() => {
+          window.scrollTo(0, savedScrollY);
+        }, 40);
+      });
+    }
 
     siteTitle.textContent = currentSite ? currentSite.nom : 'Chargement...';
 
@@ -3470,6 +3504,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           openItemActionSheet(button.dataset.itemMenu);
         });
       });
+
+      restoreOutPageScrollPosition();
     }
 
     const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
@@ -4177,6 +4213,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       };
 
       const handleSiteDetailScroll = () => {
+        persistOutPageScrollPosition();
         setFabStackScrollingState(true);
         if (siteDetailScrollTimerId) {
           window.clearTimeout(siteDetailScrollTimerId);


### PR DESCRIPTION
### Motivation
- When the user scrolls the OUT list on page 2 and refreshes, they should return to the same position instead of being reset to the top.
- Persisting and restoring the scroll position must be limited to the OUT tab and must not affect page 1 or page 3.

### Description
- Added scroll persistence to `js/app.js` using a dedicated `localStorage` key `outPageScrollY` and a `hasPendingOutScrollRestore` guard.
- Save logic is invoked from the site detail scroll handler so the value is updated only while scrolling and only when the active tab is `outs` (`persistOutPageScrollPosition`).
- Restore logic (`restoreOutPageScrollPosition`) runs after the OUT list is rendered and uses `requestAnimationFrame` + a short `setTimeout(40)` before calling `window.scrollTo(0, savedScrollY)` to avoid visual jumps; the restore call is triggered from the items rendering path. 
- Scope is limited to `initSiteDetailPage`/OUT-tab behaviour and preserves the existing search persistence flow unchanged.

### Testing
- Ran `git diff -- js/app.js` to inspect the produced change, which showed the added functions and hooks, and it succeeded. 
- Committed the change with `git add js/app.js && git commit -m "Preserve OUT page scroll position after reload"`, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0052c4a01c832aa4bf3132a94fdb02)