### PR TITLE
Fix OUT rename modal layering after action sheet close

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3353,6 +3353,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         });
 
       itemActionState.closeSheet = closeSheet;
+      const openOutEditModal = (targetItem) => {
+        itemForm.reset();
+        clearItemFormError();
+        clearItemNumberErrorState();
+        hasBlockingItemNumberError = false;
+        itemCreateSubmitButton.disabled = false;
+        itemCreateSubmitButton.classList.remove('is-loading');
+        setItemDialogMode(ITEM_DIALOG_MODE_EDIT, targetItem);
+        itemDialog.showModal();
+        itemNumberInput.focus();
+      };
       editNameButton.onclick = async () => {
         await closeSheet();
         const targetItem = isPurchaseActions
@@ -3365,15 +3376,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           openEditPurchaseModal(targetItem);
           return;
         }
-        itemForm.reset();
-        clearItemFormError();
-        clearItemNumberErrorState();
-        hasBlockingItemNumberError = false;
-        itemCreateSubmitButton.disabled = false;
-        itemCreateSubmitButton.classList.remove('is-loading');
-        setItemDialogMode(isPurchaseActions ? ITEM_DIALOG_MODE_EDIT_PURCHASE : ITEM_DIALOG_MODE_EDIT, targetItem);
-        itemDialog.showModal();
-        itemNumberInput.focus();
+
+        // Sécurise l'ordre de transition: fermeture complète du bottom-sheet avant ouverture du modal.
+        document.body.classList.remove('sidebar-open');
+        overlay.classList.remove('is-open');
+        overlay.hidden = true;
+        window.setTimeout(() => {
+          openOutEditModal(targetItem);
+        }, 30);
       };
       deleteButton.onclick = async () => {
         deleteButton.disabled = true;


### PR DESCRIPTION
### Motivation
- The `Modifier le nom` flow could open the OUT edit modal behind the bottom sheet or overlay due to overlapping transitions and residual sheet state, causing z-index/overlay blocking and click/touch issues.
- The fix must ensure the action sheet is fully closed and its active classes removed before the OUT edit modal is shown, without changing visual design or other flows.

### Description
- Updated `js/app.js` to add a dedicated helper `openOutEditModal` that encapsulates the modal setup and `itemDialog.showModal()` call.
- Refactored the `editNameButton.onclick` handler to `await closeSheet()`, then remove residual UI state (`document.body.classList.remove('sidebar-open')`, `overlay.classList.remove('is-open')`, `overlay.hidden = true`) and open the modal after a short `setTimeout(…, 30)` to avoid animation/race overlap.
- Kept the purchase-edit and delete flows functionally unchanged and did not modify global design or other modals.

### Testing
- Ran static syntax check with `node --check js/app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014eafedc0832aacce365c2cd5854d)