### PR TITLE
Aligne le style du modal "Modifier le nom OUT" sur "Modifier l’achat matériel"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3718,7 +3718,8 @@ body[data-page="site-detail"] #itemDialog #itemNumberInput.is-shaking {
 
 body[data-page="site-detail"] #itemDialog .input-group--item-create .input-char-counter,
 body[data-page="site-detail"] #purchaseModal .input-group--item-create .input-char-counter,
-body[data-page="site-detail"] #editPurchaseModal .input-group--item-create .input-char-counter {
+body[data-page="site-detail"] #editPurchaseModal .input-group--item-create .input-char-counter,
+body[data-page="site-detail"] #editOutNameModal .input-group--item-create .input-char-counter {
   width: auto;
   text-align: right;
   margin-top: 0;
@@ -3731,7 +3732,8 @@ body[data-page="site-detail"] #editPurchaseModal .input-group--item-create .inpu
 
 body[data-page="site-detail"] #itemDialog .item-input-feedback-row,
 body[data-page="site-detail"] #purchaseModal .item-input-feedback-row,
-body[data-page="site-detail"] #editPurchaseModal .item-input-feedback-row {
+body[data-page="site-detail"] #editPurchaseModal .item-input-feedback-row,
+body[data-page="site-detail"] #editOutNameModal .item-input-feedback-row {
   width: 100%;
   margin-top: 0.24rem;
   display: flex;
@@ -3742,7 +3744,8 @@ body[data-page="site-detail"] #editPurchaseModal .item-input-feedback-row {
 
 body[data-page="site-detail"] #itemDialog #itemFormError,
 body[data-page="site-detail"] #purchaseModal #purchaseDesignationError,
-body[data-page="site-detail"] #editPurchaseModal #editPurchaseFormError {
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseFormError,
+body[data-page="site-detail"] #editOutNameModal #editOutNameFormError {
   width: auto;
   margin-top: 0;
   text-align: left;
@@ -3756,20 +3759,27 @@ body[data-page="site-detail"] #itemDialog .modal-actions--item-create {
   margin-top: 0.62rem;
 }
 
-body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput {
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput,
+body[data-page="site-detail"] #editOutNameModal #editOutNameInput {
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.input-error,
 body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.input-error:focus,
 body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.is-error,
-body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.is-error:focus {
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.is-error:focus,
+body[data-page="site-detail"] #editOutNameModal #editOutNameInput.input-error,
+body[data-page="site-detail"] #editOutNameModal #editOutNameInput.input-error:focus,
+body[data-page="site-detail"] #editOutNameModal #editOutNameInput.is-error,
+body[data-page="site-detail"] #editOutNameModal #editOutNameInput.is-error:focus {
   border-color: #e53935;
   box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.14);
 }
 
 body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.is-shaking,
-body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.shake {
+body[data-page="site-detail"] #editPurchaseModal #editPurchaseNameInput.shake,
+body[data-page="site-detail"] #editOutNameModal #editOutNameInput.is-shaking,
+body[data-page="site-detail"] #editOutNameModal #editOutNameInput.shake {
   animation: item-number-input-shake 300ms ease-in-out 1;
 }
 
@@ -3797,6 +3807,34 @@ body[data-page="site-detail"] #saveEditPurchaseBtn.is-loading .btn-label-default
 
 body[data-page="site-detail"] #saveEditPurchaseBtn.is-loading .btn-loading-spinner,
 body[data-page="site-detail"] #saveEditPurchaseBtn.is-loading .btn-label-loading {
+  display: inline-flex;
+}
+
+
+body[data-page="site-detail"] #saveEditOutNameBtn {
+  position: relative;
+}
+
+body[data-page="site-detail"] #saveEditOutNameBtn .btn-label-loading {
+  display: none;
+}
+
+body[data-page="site-detail"] #saveEditOutNameBtn .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
+body[data-page="site-detail"] #saveEditOutNameBtn.is-loading .btn-label-default {
+  display: none;
+}
+
+body[data-page="site-detail"] #saveEditOutNameBtn.is-loading .btn-loading-spinner,
+body[data-page="site-detail"] #saveEditOutNameBtn.is-loading .btn-label-loading {
   display: inline-flex;
 }
 


### PR DESCRIPTION
### Motivation
- Corriger l'apparence du modal `#editOutNameModal` pour qu'il ait exactement le même rendu que le modal `#editPurchaseModal` (alignement, largeur, padding, bordures, ombre, overlay, position verticale, taille de l'input, style du compteur, emplacement du message d'erreur, et actions bouton).

### Description
- Ajouté les mêmes règles CSS de retour/compteur/erreur pour `#editOutNameModal` en étendant les sélecteurs existants dans `css/style.css` pour réutiliser le style du modal d'achat.
- Appliqué les mêmes règles de comportement d'erreur et d'animation (`is-error`, `is-shaking`, `shake`) à l'input `#editOutNameInput` pour obtenir le même visuel que l'input d'achat.
- Ajouté le style d'état de chargement pour `#saveEditOutNameBtn` (masquage du label par défaut, affichage du spinner/label de chargement) afin d'éviter le libellé cassé/répété `EnregistrerEnregistrement`.
- Modifications limitées à `css/style.css` et ciblées uniquement sur le modal `Modifier le nom OUT` sans toucher au HTML ni aux autres modals ou à la logique du modal achat.

### Testing
- Localisé les modals et éléments concernés avec `rg` et confirmé la présence des IDs `#editOutNameModal` et `#editPurchaseModal` (succès).
- Inspecté la zone modifiée de `css/style.css` avec `nl`/`sed` et confirmé l'ajout des sélecteurs pour `#editOutNameModal` et des règles de `#saveEditOutNameBtn` (succès).
- Vérifié l'état du working tree pour s'assurer que seule la feuille de style `css/style.css` a été modifiée (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0155980de8832a82e768fd82ec627c)