### PR TITLE
Restreint l’affichage des onglets OUT/Achat matériel aux admins

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3564,6 +3564,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     );
     const siteDetailFabStack = document.querySelector('body[data-page="site-detail"] .site-detail-fab-stack');
     const siteTabButtons = Array.from(document.querySelectorAll('.bottom-nav-item'));
+    const bottomNavigation = document.querySelector('.bottom-navigation');
     const outsTabContent = document.getElementById('outsTabContent');
     const purchasesTabContent = document.getElementById('purchasesTabContent');
     const purchasesTabButton = document.querySelector('[data-tab="purchases"]');
@@ -3611,6 +3612,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function updateTabsByRole() {
       isAdminTabAllowed = Boolean(permissions?.isAdmin);
+      siteTabButtons.forEach((tabButton) => {
+        tabButton.classList.toggle('hidden', !isAdminTabAllowed);
+      });
+      if (bottomNavigation) {
+        bottomNavigation.classList.toggle('hidden', !isAdminTabAllowed);
+      }
       if (purchasesTabButton) {
         purchasesTabButton.classList.toggle('hidden', !isAdminTabAllowed);
       }


### PR DESCRIPTION
### Motivation
- Restreindre l’affichage des boutons de navigation bas (OUT / Achat matériel) pour qu’ils s’affichent uniquement pour les utilisateurs avec le rôle Admin sans modifier le contenu, le design, la position ou les animations.

### Description
- Mise à jour de `js/app.js` : ajout d’une référence au conteneur `.bottom-navigation` et modification de `updateTabsByRole()` pour masquer/afficher tous les boutons `.bottom-nav-item` et le conteneur de navigation bas selon `permissions?.isAdmin`, en conservant le fallback qui force l’onglet actif sur `outs` pour les non-admin.

### Testing
- Aucun test automatisé exécuté; les changements ont été inspectés via `git diff` et validés par un commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a015f4cbaf8832a985f4ee320d380d9)