### PR TITLE
Remove "Créer un OUT" label next to page 2 FAB

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -85,7 +85,6 @@
 
       <div class="site-detail-fab-stack" aria-hidden="false">
         <div class="site-detail-fab-row" data-fab-row="create">
-          <span class="site-detail-fab-label fab-label site-detail-fab-label--create">Créer un OUT</span>
           <button id="openCreateItem" class="fab" type="button" aria-label="Ajouter un numéro OUT">+</button>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Remove the small text label "Créer un OUT" next to the blue FAB on page 2 so the floating "+" button appears alone while preserving its position, size, animations and behavior.

### Description
- Deleted the `<span class="site-detail-fab-label fab-label site-detail-fab-label--create">Créer un OUT</span>` from `page2.html`, leaving the `button#openCreateItem` FAB unchanged.

### Testing
- Ran the inline `python` update script to remove the label and inspected `page2.html` to confirm the span was removed and the `#openCreateItem` button remains; verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0164b80870832aae98e45ee5b4e4c7)