### PR TITLE
Ajout colonne Qté Rebus (page 3) et prise en compte dans Ecart et exports

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -239,12 +239,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const qteSortie = Number(detail?.qteSortie) || 0;
     const qtePosee = Number(detail?.qtePosee) || 0;
     const qteRetour = Number(detail?.qteRetour) || 0;
+    const qteRebus = Number(detail?.qteRebus) || 0;
 
-    if (qtePosee === 0 && qteRetour === 0) {
+    if (qtePosee === 0 && qteRetour === 0 && qteRebus === 0) {
       return '';
     }
 
-    return qteSortie - (qtePosee + qteRetour);
+    return qteSortie - (qtePosee + qteRetour + qteRebus);
   }
 
   function setupZoomableDetailTable() {
@@ -498,6 +499,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td>${escapeHtml(detail.qteSortie)}</td>
               <td>${escapeHtml(detail.unite)}</td>
               <td>${escapeHtml(detail.qtePosee)}</td>
+              <td>${escapeHtml(detail.qteRebus)}</td>
               <td>${escapeHtml(detail.qteRetour)}</td>
               <td>${escapeHtml(computeEcart(detail))}</td>
               <td>${escapeHtml(detail.observation)}</td>
@@ -526,6 +528,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <th>Qté Sortie</th>
           <th>Unité</th>
           <th>Qté posée</th>
+          <th>Qté Rebus</th>
           <th>Qté Retour</th>
           <th>Ecart</th>
           <th>Observation</th>
@@ -548,6 +551,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <td>${escapeHtml(row.qteSortie)}</td>
             <td>${escapeHtml(row.unite)}</td>
             <td>${escapeHtml(row.qtePosee)}</td>
+            <td>${escapeHtml(row.qteRebus)}</td>
             <td>${escapeHtml(row.qteRetour)}</td>
             <td>${escapeHtml(computeEcart(row))}</td>
             <td>${escapeHtml(row.observation)}</td>
@@ -576,6 +580,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <th>Qté Sortie</th>
           <th>Unité</th>
           <th>Qté posée</th>
+          <th>Qté Rebus</th>
           <th>Qté Retour</th>
           <th>Ecart</th>
           <th>Remarque</th>
@@ -3067,6 +3072,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           qteSortie: detail.qteSortie,
           unite: formatSiteExportUnit(detail.unite),
           qtePosee: detail.qtePosee,
+          qteRebus: detail.qteRebus,
           qteRetour: detail.qteRetour,
           observation: detail.observation,
         })),
@@ -5262,7 +5268,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       updateCount(filteredDetails.length, currentDetails.length);
 
       if (!filteredDetails.length) {
-        detailTableBody.innerHTML = `<tr><td colspan="11"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
+        detailTableBody.innerHTML = `<tr><td colspan="12"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
         return;
       }
 
@@ -5284,6 +5290,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
                 </div>
               </td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qtePosee" data-field="qtePosee" type="number" min="0" step="1" maxlength="120" value="${detail.qtePosee}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRebus" data-field="qteRebus" type="number" min="0" step="1" maxlength="120" value="${detail.qteRebus ?? 0}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRetour" data-field="qteRetour" type="number" min="0" step="1" maxlength="120" value="${detail.qteRetour}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic${ecartClassName}" data-col-key="ecart" type="number" maxlength="120" value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="observation" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" /></td>
@@ -5370,6 +5377,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const minWidthByColumn = {
         qteSortie: 48,
         qtePosee: 48,
+        qteRebus: 0,
         qteRetour: 48,
         ecart: 48,
         observation: 48,

--- a/js/storage.js
+++ b/js/storage.js
@@ -1388,6 +1388,7 @@ async function createDetail(siteId, itemId, payload) {
     qteHorsBtrs: '',
     qteRetour: 0,
     qtePosee: 0,
+    qteRebus: 0,
     observation: '',
     ownerId: state.userId,
     createdBy: state.userId,
@@ -1442,6 +1443,10 @@ async function updateDetail(siteId, itemId, detailId, changes) {
   if ('qtePosee' in changes) {
     nextValues.qtePosee = sanitizeNumber(changes.qtePosee);
     syncedChanges.qtePosee = nextValues.qtePosee;
+  }
+  if ('qteRebus' in changes) {
+    nextValues.qteRebus = sanitizeNumber(changes.qteRebus);
+    syncedChanges.qteRebus = nextValues.qteRebus;
   }
   if ('observation' in changes) {
     nextValues.observation = sanitizeText(changes.observation, false);
@@ -1602,6 +1607,7 @@ function normalizeImportPayload(payload) {
           qteHorsBtrs: '',
           qteRetour: sanitizeNumber(detail.qteRetour),
           qtePosee: sanitizeNumber(detail.qtePosee),
+          qteRebus: sanitizeNumber(detail.qteRebus),
           observation: sanitizeText(detail.observation, false),
           ownerId: state.userId,
           createdBy: state.userId,

--- a/page3.html
+++ b/page3.html
@@ -69,6 +69,7 @@
                   <th>Désignation</th>
                   <th>Qté Sortie</th>
                   <th>Qté posée</th>
+                  <th>Qté Rebus</th>
                   <th>Qté Retour</th>
                   <th>Ecart</th>
                   <th>Remarque</th>


### PR DESCRIPTION
### Motivation
- Ajouter une nouvelle colonne de quantité « Qté Rebus » au tableau de la page 3 et l'intégrer au calcul d'`Ecart` et aux exports sans modifier les autres colonnes ni le design global.

### Description
- Ajout de l'en-tête `Qté Rebus` entre `Qté posée` et `Qté Retour` dans `page3.html` et insertion d'un input éditable avec les mêmes classes et comportement que les autres colonnes quantitatives dans `js/app.js`.
- Mise à jour de la fonction `computeEcart(detail)` pour appliquer la formule `Qté Sortie - (Qté posée + Qté retour + Qté rebus)` et garder l'affichage vide quand toutes les quantités sont à 0.
- Propagation de la nouvelle propriété `qteRebus` dans les routines de stockage/création/mise à jour/import (`js/storage.js`) pour assurer la persistance et la cohérence des données.
- Inclusion de `qteRebus` dans les exports Excel de détail et site (`buildDetailExcelContent`, `buildSiteExcelContent`) et dans le mapping des lignes d'export (`buildSiteExportRows`) et ajustement du `colspan` d'état vide du tableau.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` et `node --check js/storage.js`, les deux vérifications ont réussi.
- Tests automatiques d'export et rendu : génération des templates d'export modifiés (détail/site) inspectée via les fonctions `buildDetailExcelContent` et `buildSiteExcelContent` (vérification manuelle du contenu HTML généré).
- Vérification rapide du commit avec `git status` et création du commit décrivant l'ajout (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a52b96e8832aba482617b15727b3)