### PR TITLE
Ajout de la colonne « Date de retour » sur la page 3 et dans les exports Excel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -248,6 +248,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return qteSortie - (qtePosee + qteRetour + qteRebus);
   }
 
+  function formatReturnDate(dateValue) {
+    const normalized = String(dateValue || '').trim();
+    if (!normalized) {
+      return '';
+    }
+    const [year, month, day] = normalized.split('-');
+    if (!year || !month || !day) {
+      return '';
+    }
+    return `${day}/${month}/${year}`;
+  }
+
   function setupZoomableDetailTable() {
     const tableContainer = requireElement('detailTableContainer');
     const tableWrapper = requireElement('detailTableWrapper');
@@ -501,6 +513,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td>${escapeHtml(detail.qtePosee)}</td>
               <td>${escapeHtml(detail.qteRebus)}</td>
               <td>${escapeHtml(detail.qteRetour)}</td>
+              <td>${escapeHtml(formatReturnDate(detail.dateRetour))}</td>
               <td>${escapeHtml(computeEcart(detail))}</td>
               <td>${escapeHtml(detail.observation)}</td>
             </tr>
@@ -530,6 +543,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <th>Qté posée</th>
           <th>Qté Rebus</th>
           <th>Qté Retour</th>
+          <th>Date de retour</th>
           <th>Ecart</th>
           <th>Observation</th>
         </tr>
@@ -553,6 +567,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <td>${escapeHtml(row.qtePosee)}</td>
             <td>${escapeHtml(row.qteRebus)}</td>
             <td>${escapeHtml(row.qteRetour)}</td>
+            <td>${escapeHtml(formatReturnDate(row.dateRetour))}</td>
             <td>${escapeHtml(computeEcart(row))}</td>
             <td>${escapeHtml(row.observation)}</td>
           </tr>
@@ -582,6 +597,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <th>Qté posée</th>
           <th>Qté Rebus</th>
           <th>Qté Retour</th>
+          <th>Date de retour</th>
           <th>Ecart</th>
           <th>Remarque</th>
         </tr>
@@ -3074,6 +3090,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           qtePosee: detail.qtePosee,
           qteRebus: detail.qteRebus,
           qteRetour: detail.qteRetour,
+          dateRetour: detail.dateRetour || '',
           observation: detail.observation,
         })),
       );
@@ -5268,7 +5285,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       updateCount(filteredDetails.length, currentDetails.length);
 
       if (!filteredDetails.length) {
-        detailTableBody.innerHTML = `<tr><td colspan="12"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
+        detailTableBody.innerHTML = `<tr><td colspan="13"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
         return;
       }
 
@@ -5292,6 +5309,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qtePosee" data-field="qtePosee" type="number" min="0" step="1" maxlength="120" value="${detail.qtePosee}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRebus" data-field="qteRebus" type="number" min="0" step="1" maxlength="120" value="${detail.qteRebus ?? 0}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRetour" data-field="qteRetour" type="number" min="0" step="1" maxlength="120" value="${detail.qteRetour}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="dateRetour" data-field="dateRetour" type="date" value="${escapeHtml(detail.dateRetour || '')}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic${ecartClassName}" data-col-key="ecart" type="number" maxlength="120" value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="observation" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" /></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
@@ -5379,6 +5397,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         qtePosee: 48,
         qteRebus: 0,
         qteRetour: 48,
+        dateRetour: 140,
         ecart: 48,
         observation: 48,
       };

--- a/js/storage.js
+++ b/js/storage.js
@@ -587,6 +587,14 @@ function sanitizeNumber(value) {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
 
+function sanitizeReturnDate(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    return '';
+  }
+  return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : '';
+}
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -1387,6 +1395,7 @@ async function createDetail(siteId, itemId, payload) {
     unite: sanitizeText(payload.unite || 'm', false) || 'm',
     qteHorsBtrs: '',
     qteRetour: 0,
+    dateRetour: '',
     qtePosee: 0,
     qteRebus: 0,
     observation: '',
@@ -1451,6 +1460,10 @@ async function updateDetail(siteId, itemId, detailId, changes) {
   if ('observation' in changes) {
     nextValues.observation = sanitizeText(changes.observation, false);
     syncedChanges.observation = nextValues.observation;
+  }
+  if ('dateRetour' in changes) {
+    nextValues.dateRetour = sanitizeReturnDate(changes.dateRetour);
+    syncedChanges.dateRetour = nextValues.dateRetour;
   }
   nextValues.dateModification = nowIso();
   syncedChanges.dateModification = nextValues.dateModification;
@@ -1606,6 +1619,7 @@ function normalizeImportPayload(payload) {
           unite: sanitizeText(detail.unite || 'm', false) || 'm',
           qteHorsBtrs: '',
           qteRetour: sanitizeNumber(detail.qteRetour),
+          dateRetour: sanitizeReturnDate(detail.dateRetour),
           qtePosee: sanitizeNumber(detail.qtePosee),
           qteRebus: sanitizeNumber(detail.qteRebus),
           observation: sanitizeText(detail.observation, false),

--- a/page3.html
+++ b/page3.html
@@ -71,6 +71,7 @@
                   <th>Qté posée</th>
                   <th>Qté Rebus</th>
                   <th>Qté Retour</th>
+                  <th>Date de retour</th>
                   <th>Ecart</th>
                   <th>Remarque</th>
                   <th>Date de création</th>


### PR DESCRIPTION
### Motivation
- Ajouter un champ `Date de retour` par ligne dans le « Tableau des données » (page 3) et l’inclure obligatoirement dans les exports Excel de la page 2 et page 3, sans modifier les autres colonnes ni les calculs existants.
- Le champ doit être un sélecteur de date, persistant après actualisation et affiché au format `jj/mm/aaaa` dans les exports.

### Description
- `page3.html` : ajout de l’en-tête de colonne `Date de retour` immédiatement après `Qté Retour` pour conserver l’ordre demandé.
- `js/app.js` : rendu d’un champ `type="date"` par ligne (`data-field="dateRetour"`) et conservation du style existant, ajustement du `colspan` de l’état vide, ajout de `formatReturnDate` pour produire `jj/mm/aaaa` dans les exports, et inclusion de `dateRetour` dans les templates Excel (`buildDetailExcelContent` et `buildSiteExcelContent`) et dans les lignes construites pour l’export.
- `js/storage.js` : ajout de `sanitizeReturnDate` pour valider le format `yyyy-mm-dd`, initialisation de `dateRetour` à la création d’une ligne, gestion de `dateRetour` lors de `updateDetail` et prise en charge lors de la normalisation d’import.
- Intégration complète sans modification des autres colonnes ni des calculs existants (le calcul d’écart reste inchangé) et réutilisation du flux existant de sauvegarde (`StorageService.updateDetail`) via les `data-field` pour persistance.

### Testing
- Aucun test automatisé n’a été exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ae522090832ab77838d8bf8b528d)