### PR TITLE
Ajouter le champ optionnel « Magasin » au modal d'achat matériel

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -188,6 +188,10 @@
               <p id="purchaseUnitError" class="form-error form-error--field" aria-live="polite"></p>
             </label>
           </div>
+          <label class="input-group input-group--site-create">
+            <span>Magasin</span>
+            <input id="purchaseStore" type="text" placeholder="Ex : Titan I" />
+          </label>
           <p id="purchaseFormError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelPurchaseBtn" class="btn btn-neutral" type="button">Annuler</button>


### PR DESCRIPTION
### Motivation
- Ajouter un champ texte non obligatoire « Magasin » au formulaire « Ajouter un achat matériel » pour pouvoir saisir le magasin fournisseur sans modifier le reste du modal.

### Description
- Ajout d'un `label` utilisant `input-group input-group--site-create` contenant un `input` `id="purchaseStore"` avec `placeholder="Ex : Titan I"` placé sous la ligne Quantité/Unité et avant les boutons d'action, sans modifier les autres champs, validations ni boutons.

### Testing
- Exécuté `git status --short` puis `git add page2.html && git commit -m "Add optional Magasin field to purchase modal"` et la commande de commit a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e03bd5c4832a834881a243ea7f1c)