### PR TITLE
Afficher le Magasin dans la card Achat matériel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3701,6 +3701,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const htmlParts = [];
       let previousLabel = null;
       purchases.forEach((purchase) => {
+        const purchaseStore = String(purchase?.store || purchase?.magasin || '').trim();
         const currentLabel = resolveItemPeriodLabel({
           dateCreation: purchase?.createdAt || purchase?.dateAchat || purchase?.date || purchase?.dateCreation || purchase?.dateModification,
         });
@@ -3718,6 +3719,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
                   <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
                   <div class="purchase-value">${Number(purchase?.qty || 0)} ${escapeHtml(purchase?.unit || 'Pcs')}</div>
                 </div>
+                ${purchaseStore ? `
+                <div class="purchase-info-row" role="listitem">
+                  <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
+                  <div class="purchase-value">${escapeHtml(purchaseStore)}</div>
+                </div>
+                ` : ''}
                 <div class="purchase-info-row" role="listitem">
                   <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date</span></div>
                   <div class="purchase-value">${escapeHtml(formatPurchaseDateLabel(purchase))}</div>


### PR DESCRIPTION
### Motivation
- Permettre l’affichage du champ « Magasin » directement dans la card d’un achat matériel afin que l’information soit visible sans ouvrir le modal de détail.

### Description
- Normalise la valeur du magasin avec `purchase.store || purchase.magasin` puis `trim()` et stocke le résultat dans `purchaseStore` dans `renderPurchases`.
- Insère une `purchase-info-row` conditionnelle affichée uniquement si `purchaseStore` n’est pas vide, placée entre la ligne `Quantité` et la ligne `Date`.
- Utilise l’emoji discret `🏪` avec la classe `icon` et réutilise les classes `purchase-info-row`, `purchase-label` et `purchase-value` pour conserver alignement, taille et spacing existants.
- Aucun autre champ, le modal ou le design global des cards n’a été modifié.

### Testing
- Aucune suite de tests automatisés n’a été exécutée pour ce changement (modification front-end locale mineure); validation visuelle et revue du diff effectuées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e38f934c832aa6db4d001b8c2e01)