### PR TITLE
Afficher et persister le champ `Magasin` dans les cards d'achat matériel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2794,6 +2794,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const purchaseDesignationCounter = requireElement('purchaseDesignationCounter');
     const purchaseQty = requireElement('purchaseQty');
     const purchaseUnit = requireElement('purchaseUnit');
+    const purchaseStore = requireElement('purchaseStore');
     const purchaseFormError = requireElement('purchaseFormError');
     const purchaseDesignationError = requireElement('purchaseDesignationError');
     const purchaseQtyError = requireElement('purchaseQtyError');
@@ -3017,6 +3018,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const designation = String(purchaseDesignation?.value || '').trim();
       const qty = Number(purchaseQty?.value);
       const unit = String(purchaseUnit?.value || '').trim();
+      const store = String(purchaseStore?.value || '').trim();
       if (!designation) {
         showPurchaseFieldError(purchaseDesignation, purchaseDesignationError, 'Désignation obligatoire');
         return;
@@ -3044,6 +3046,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             designation,
             qty,
             unit,
+            store,
+            magasin: store,
             createdAt: serverTimestamp(),
             createdBy: currentUserName || 'Utilisateur',
             createdByEmail: currentUserEmail || '',


### PR DESCRIPTION
### Motivation
- Les cards d’« Achat matériel » prévoyaient déjà l’affichage d’une ligne « Magasin » mais la valeur n’était pas persistée lors de la création, donc la ligne n’apparaissait pas dans les cards.

### Description
- Ajout de la référence DOM `purchaseStore` et lecture de sa valeur dans la fonction `savePurchase()` pour prendre en compte le champ du formulaire.
- Persistance de la valeur sous les deux clés `store` et `magasin` lors de l’appel à `addDoc()` afin de rester compatible avec les formats historiques sans modifier le rendu ni le design des cards.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` et sortie OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e7564818832aa1c4f1841b33b5e2)