### PR TITLE
Ajout photo optionnelle Cloudinary pour achats matériels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5144,6 +5144,34 @@ body[data-page="site-detail"] .purchase-card__meta {
   gap: 0.48rem;
 }
 
+body[data-page="site-detail"] .purchase-card__content {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+body[data-page="site-detail"] .purchase-card__media {
+  width: 72px;
+  height: 72px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  font-size: 1.7rem;
+  flex-shrink: 0;
+}
+
+body[data-page="site-detail"] .purchase-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
 body[data-page="site-detail"] .purchase-info-row {
   display: grid;
   grid-template-columns: minmax(7.9rem, auto) minmax(0, 1fr);
@@ -5175,6 +5203,22 @@ body[data-page="site-detail"] .purchase-value {
   color: #111827;
   overflow-wrap: anywhere;
   line-height: 1.32;
+}
+
+body[data-page="site-detail"] .purchase-photo-preview {
+  margin-top: 0.2rem;
+  width: 90px;
+  height: 90px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+}
+
+body[data-page="site-detail"] .purchase-photo-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 
 body[data-page="site-detail"] .list-separator {

--- a/js/app.js
+++ b/js/app.js
@@ -2795,6 +2795,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const purchaseQty = requireElement('purchaseQty');
     const purchaseUnit = requireElement('purchaseUnit');
     const purchaseStore = requireElement('purchaseStore');
+    const purchasePhotoInput = requireElement('purchasePhotoInput');
+    const purchasePhotoPreviewWrap = requireElement('purchasePhotoPreviewWrap');
+    const purchasePhotoPreview = requireElement('purchasePhotoPreview');
     const purchaseFormError = requireElement('purchaseFormError');
     const purchaseDesignationError = requireElement('purchaseDesignationError');
     const purchaseQtyError = requireElement('purchaseQtyError');
@@ -2841,6 +2844,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
     let hasPendingOutScrollRestore = true;
+    let selectedPurchasePhotoFile = null;
+    let selectedPurchasePhotoPreviewUrl = '';
 
     function persistOutPageScrollPosition() {
       if (activeSiteTab !== 'outs') {
@@ -2887,6 +2892,47 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       clearPurchaseFieldError(purchaseDesignation, purchaseDesignationError);
       clearPurchaseFieldError(purchaseQty, purchaseQtyError);
       clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
+      selectedPurchasePhotoFile = null;
+      if (selectedPurchasePhotoPreviewUrl) {
+        URL.revokeObjectURL(selectedPurchasePhotoPreviewUrl);
+        selectedPurchasePhotoPreviewUrl = '';
+      }
+      if (purchasePhotoPreview) {
+        purchasePhotoPreview.src = '';
+      }
+      purchasePhotoPreviewWrap?.classList.add('hidden');
+    }
+
+    function getCloudinaryUploadConfig() {
+      const cloudinaryConfig = window.APP_CONFIG?.cloudinary || window.CLOUDINARY_CONFIG || {};
+      const cloudName = String(cloudinaryConfig.cloudName || '').trim();
+      const uploadPreset = String(cloudinaryConfig.uploadPreset || '').trim();
+      if (!cloudName || !uploadPreset) {
+        throw new Error('cloudinary_config_missing');
+      }
+      return { cloudName, uploadPreset, folder: String(cloudinaryConfig.folder || '').trim() };
+    }
+
+    async function uploadPurchaseImageToCloudinary(file) {
+      if (!file) {
+        return '';
+      }
+      const { cloudName, uploadPreset, folder } = getCloudinaryUploadConfig();
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('upload_preset', uploadPreset);
+      if (folder) {
+        formData.append('folder', folder);
+      }
+      const response = await fetch(`https://api.cloudinary.com/v1_1/${encodeURIComponent(cloudName)}/image/upload`, {
+        method: 'POST',
+        body: formData,
+      });
+      if (!response.ok) {
+        throw new Error('cloudinary_upload_failed');
+      }
+      const payload = await response.json();
+      return String(payload?.secure_url || '').trim();
     }
 
     function showPurchaseFieldError(field, errorElement, message) {
@@ -3040,6 +3086,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const currentUserEmail = String(firebaseAuth.currentUser?.email || '').trim();
       setPurchaseSubmitLoadingState(true);
       try {
+        const imageUrl = selectedPurchasePhotoFile ? await uploadPurchaseImageToCloudinary(selectedPurchasePhotoFile) : '';
         await addDoc(
           collection(firebaseDb, 'sites', siteId, 'achatsMateriels'),
           {
@@ -3048,6 +3095,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             unit,
             store,
             magasin: store,
+            imageUrl,
             createdAt: serverTimestamp(),
             createdBy: currentUserName || 'Utilisateur',
             createdByEmail: currentUserEmail || '',
@@ -3717,25 +3765,34 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <article class="list-card purchase-card">
             ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-purchase-menu="${purchase.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
             <div class="list-card__button">
-              <h3 class="list-card__title">${escapeHtml(purchase?.designation || '-')}</h3>
-              <div class="list-card__meta purchase-card__meta" role="list" aria-label="Informations achat matériel">
-                <div class="purchase-info-row" role="listitem">
-                  <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
-                  <div class="purchase-value">${Number(purchase?.qty || 0)} ${escapeHtml(purchase?.unit || 'Pcs')}</div>
+              <div class="purchase-card__content">
+                <div class="purchase-card__media" aria-hidden="true">
+                  ${String(purchase?.imageUrl || '').trim()
+                    ? `<img src="${escapeHtml(purchase.imageUrl)}" alt="Photo achat matériel" />`
+                    : '🖼️'}
                 </div>
-                ${purchaseStore ? `
-                <div class="purchase-info-row" role="listitem">
-                  <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
-                  <div class="purchase-value">${escapeHtml(purchaseStore)}</div>
-                </div>
-                ` : ''}
-                <div class="purchase-info-row" role="listitem">
-                  <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date</span></div>
-                  <div class="purchase-value">${escapeHtml(formatPurchaseDateLabel(purchase))}</div>
-                </div>
-                <div class="purchase-info-row" role="listitem">
-                  <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Utilisateur</span></div>
-                  <div class="purchase-value">${escapeHtml(purchase?.createdBy || 'Utilisateur')}</div>
+                <div>
+                  <h3 class="list-card__title">${escapeHtml(purchase?.designation || '-')}</h3>
+                  <div class="list-card__meta purchase-card__meta" role="list" aria-label="Informations achat matériel">
+                    <div class="purchase-info-row" role="listitem">
+                      <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
+                      <div class="purchase-value">${Number(purchase?.qty || 0)} ${escapeHtml(purchase?.unit || 'Pcs')}</div>
+                    </div>
+                    ${purchaseStore ? `
+                    <div class="purchase-info-row" role="listitem">
+                      <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
+                      <div class="purchase-value">${escapeHtml(purchaseStore)}</div>
+                    </div>
+                    ` : ''}
+                    <div class="purchase-info-row" role="listitem">
+                      <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date</span></div>
+                      <div class="purchase-value">${escapeHtml(formatPurchaseDateLabel(purchase))}</div>
+                    </div>
+                    <div class="purchase-info-row" role="listitem">
+                      <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Utilisateur</span></div>
+                      <div class="purchase-value">${escapeHtml(purchase?.createdBy || 'Utilisateur')}</div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -4122,6 +4179,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (['Pcs', 'm'].includes(unit)) {
         clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
       }
+    });
+    purchasePhotoInput?.addEventListener('change', () => {
+      const file = purchasePhotoInput.files?.[0] || null;
+      selectedPurchasePhotoFile = file;
+      if (selectedPurchasePhotoPreviewUrl) {
+        URL.revokeObjectURL(selectedPurchasePhotoPreviewUrl);
+        selectedPurchasePhotoPreviewUrl = '';
+      }
+      if (!file) {
+        purchasePhotoPreviewWrap?.classList.add('hidden');
+        if (purchasePhotoPreview) {
+          purchasePhotoPreview.src = '';
+        }
+        return;
+      }
+      selectedPurchasePhotoPreviewUrl = URL.createObjectURL(file);
+      if (purchasePhotoPreview) {
+        purchasePhotoPreview.src = selectedPurchasePhotoPreviewUrl;
+      }
+      purchasePhotoPreviewWrap?.classList.remove('hidden');
     });
 
     editPurchaseNameInput?.addEventListener('input', () => {

--- a/page2.html
+++ b/page2.html
@@ -192,6 +192,13 @@
             <span>Magasin</span>
             <input id="purchaseStore" type="text" placeholder="Ex : Titan I" />
           </label>
+          <label class="input-group input-group--site-create">
+            <span>Photo</span>
+            <input id="purchasePhotoInput" type="file" accept="image/*" />
+          </label>
+          <div id="purchasePhotoPreviewWrap" class="purchase-photo-preview hidden" aria-live="polite">
+            <img id="purchasePhotoPreview" alt="Aperçu de la photo sélectionnée" />
+          </div>
           <p id="purchaseFormError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button id="cancelPurchaseBtn" class="btn btn-neutral" type="button">Annuler</button>


### PR DESCRIPTION
### Motivation
- Permettre l’ajout d’une photo optionnelle lors de la création d’un “Achat matériel” et l’afficher proprement dans la card correspondante.
- Uploader automatiquement l’image vers Cloudinary en réutilisant la configuration Cloudinary déjà présente dans le projet et ne stocker que le lien (`imageUrl`) dans Firestore.
- Conserver le comportement existant du formulaire et des cards quand aucune image n’est fournie (fallback emoji). 

### Description
- UI : ajout d’un champ `input[type=file] accept="image/*"` et d’une zone d’aperçu dans le modal “Ajouter un achat matériel”.
- Logique JS : gestion de la sélection (preview via `URL.createObjectURL`), nettoyage (`URL.revokeObjectURL`), upload asynchrone vers Cloudinary via `fetch`+`FormData` en lisant la config depuis `window.APP_CONFIG.cloudinary` ou `window.CLOUDINARY_CONFIG`, et enregistrement du `secure_url` dans le champ `imageUrl` du document Firestore.
- Affichage : refonte légère du rendu des cards `purchase-card` pour insérer un bloc média à gauche affichant l’image (`object-fit: cover`, border-radius) ou l’emoji `🖼️` si `imageUrl` absent, tout en conservant quantité/magasin/date/utilisateur et les comportements existants.
- Styles : ajout de règles CSS compactes pour garantir alignement vertical, responsive mobile et éviter la déformation de l’image.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ec427b80832a82e5e807c404f1ce)