### PR TITLE
Fix Cloudinary upload configuration for Achat matériel (use cloud dskw13nem)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2905,26 +2905,31 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function getCloudinaryUploadConfig() {
       const cloudinaryConfig = window.APP_CONFIG?.cloudinary || window.CLOUDINARY_CONFIG || {};
-      const cloudName = String(cloudinaryConfig.cloudName || '').trim();
-      const uploadPreset = String(cloudinaryConfig.uploadPreset || '').trim();
-      if (!cloudName || !uploadPreset) {
+      const cloudName = 'dskw13nem';
+      const uploadPreset = String(cloudinaryConfig.uploadPreset || cloudinaryConfig.upload_preset || '').trim();
+      if (!uploadPreset) {
         throw new Error('cloudinary_config_missing');
       }
-      return { cloudName, uploadPreset, folder: String(cloudinaryConfig.folder || '').trim() };
+      return {
+        cloudName,
+        uploadPreset,
+        uploadUrl: `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
+        folder: String(cloudinaryConfig.folder || '').trim(),
+      };
     }
 
     async function uploadPurchaseImageToCloudinary(file) {
       if (!file) {
         return '';
       }
-      const { cloudName, uploadPreset, folder } = getCloudinaryUploadConfig();
+      const { uploadPreset, uploadUrl, folder } = getCloudinaryUploadConfig();
       const formData = new FormData();
       formData.append('file', file);
       formData.append('upload_preset', uploadPreset);
       if (folder) {
         formData.append('folder', folder);
       }
-      const response = await fetch(`https://api.cloudinary.com/v1_1/${encodeURIComponent(cloudName)}/image/upload`, {
+      const response = await fetch(uploadUrl, {
         method: 'POST',
         body: formData,
       });


### PR DESCRIPTION
### Motivation
- Fix image save failures in the “Achat matériel” flow by ensuring the correct Cloudinary cloud name and upload endpoint are used so image uploads succeed and `secure_url` can be stored in Firestore.

### Description
- Force the Cloudinary `cloudName` to the exact value `dskw13nem`, accept either `uploadPreset` or `upload_preset` from config, and expose a fixed `uploadUrl` of `https://api.cloudinary.com/v1_1/dskw13nem/image/upload` in `js/app.js` via `getCloudinaryUploadConfig()`.
- Use the new `uploadUrl` in `uploadPurchaseImageToCloudinary()` while preserving the `FormData` fields `file` and `upload_preset` and the existing behavior of returning the Cloudinary `secure_url`.

### Testing
- Ran code searches with `rg` to locate Cloudinary usage and verified updated code in `js/app.js` (search succeeded).
- Inspected the patch diff to confirm `cloudName` is hardcoded to `dskw13nem`, `upload_preset` handling is preserved, and upload now uses the fixed `uploadUrl` (`git diff`/inspection succeeded).
- Ran a quick Node parse check which failed due to browser ESM `import` statements (expected in this environment) and did not affect the applied change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f13b165c832a87afa13af8aa2116)