### PR TITLE
Corrige l’upload Cloudinary pour la page Achat matériel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2913,8 +2913,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return {
         cloudName,
         uploadPreset,
-        uploadUrl: `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
-        folder: String(cloudinaryConfig.folder || '').trim(),
+        uploadUrl: 'https://api.cloudinary.com/v1_1/dskw13nem/image/upload',
       };
     }
 
@@ -2922,22 +2921,50 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!file) {
         return '';
       }
-      const { uploadPreset, uploadUrl, folder } = getCloudinaryUploadConfig();
+      const { uploadPreset, uploadUrl } = getCloudinaryUploadConfig();
       const formData = new FormData();
       formData.append('file', file);
       formData.append('upload_preset', uploadPreset);
-      if (folder) {
-        formData.append('folder', folder);
+      let response;
+      let responsePayload = null;
+      try {
+        response = await fetch(uploadUrl, {
+          method: 'POST',
+          body: formData,
+        });
+        try {
+          responsePayload = await response.clone().json();
+        } catch (_parseError) {
+          responsePayload = await response.text();
+        }
+      } catch (error) {
+        console.log('[Cloudinary upload] échec', {
+          status: null,
+          errorMessage: error?.message || String(error),
+          cloudinaryResponse: null,
+        });
+        throw error;
       }
-      const response = await fetch(uploadUrl, {
-        method: 'POST',
-        body: formData,
-      });
       if (!response.ok) {
-        throw new Error('cloudinary_upload_failed');
+        const uploadError = new Error('cloudinary_upload_failed');
+        console.log('[Cloudinary upload] échec', {
+          status: response.status,
+          errorMessage: uploadError.message,
+          cloudinaryResponse: responsePayload,
+        });
+        throw uploadError;
       }
-      const payload = await response.json();
-      return String(payload?.secure_url || '').trim();
+      const secureUrl = String(responsePayload?.secure_url || '').trim();
+      if (!secureUrl) {
+        const uploadError = new Error('cloudinary_secure_url_missing');
+        console.log('[Cloudinary upload] échec', {
+          status: response.status,
+          errorMessage: uploadError.message,
+          cloudinaryResponse: responsePayload,
+        });
+        throw uploadError;
+      }
+      return secureUrl;
     }
 
     function showPurchaseFieldError(field, errorElement, message) {


### PR DESCRIPTION
### Motivation
- Corriger l’erreur qui empêchait l’enregistrement d’un achat lorsque l’utilisateur sélectionnait une image en clarifiant et en durcissant le flux d’upload Cloudinary.
- S’assurer que l’upload respecte la configuration obligatoire Cloudinary (`cloud_name = "dskw13nem"` et URL `https://api.cloudinary.com/v1_1/dskw13nem/image/upload`).
- Fournir des logs explicites pour diagnostiquer les échecs d’upload (statut HTTP, message d’erreur et réponse Cloudinary). 

### Description
- Mise à jour de `js/app.js` pour retourner `uploadUrl: 'https://api.cloudinary.com/v1_1/dskw13nem/image/upload'` depuis `getCloudinaryUploadConfig()` afin d’imposer l’endpoint requis.
- Le `FormData` n’envoie désormais que `file` et `upload_preset` comme requis par la configuration, et l’ajout optionnel du `folder` a été retiré pour éviter des envois non désirés.
- Amélioration du flux d’upload dans `uploadPurchaseImageToCloudinary()` avec gestion des erreurs réseau, tentative de parsing JSON de la réponse (fallback texte) et logs clairs en cas d’échec contenant `status`, `errorMessage` et `cloudinaryResponse`.
- Validation explicite de la présence de `secure_url` dans la réponse Cloudinary et génération d’une erreur et d’un log clair si ce champ est absent, puis renvoi du `secure_url` pour sauvegarde dans Firestore (`imageUrl`).

### Testing
- Aucun test automatisé ajouté ni exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f4388804832a9db3b2befcaf78bc)