### PR TITLE
Fix Cloudinary upload in Achat matériel (use unsigned preset Suivi_matériel)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2904,15 +2904,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function getCloudinaryUploadConfig() {
-      const cloudinaryConfig = window.APP_CONFIG?.cloudinary || window.CLOUDINARY_CONFIG || {};
-      const cloudName = 'dskw13nem';
-      const uploadPreset = String(cloudinaryConfig.uploadPreset || cloudinaryConfig.upload_preset || '').trim();
-      if (!uploadPreset) {
-        throw new Error('cloudinary_config_missing');
-      }
       return {
-        cloudName,
-        uploadPreset,
+        uploadPreset: 'Suivi_matériel',
         uploadUrl: 'https://api.cloudinary.com/v1_1/dskw13nem/image/upload',
       };
     }
@@ -2925,46 +2918,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const formData = new FormData();
       formData.append('file', file);
       formData.append('upload_preset', uploadPreset);
-      let response;
-      let responsePayload = null;
-      try {
-        response = await fetch(uploadUrl, {
-          method: 'POST',
-          body: formData,
-        });
-        try {
-          responsePayload = await response.clone().json();
-        } catch (_parseError) {
-          responsePayload = await response.text();
-        }
-      } catch (error) {
-        console.log('[Cloudinary upload] échec', {
-          status: null,
-          errorMessage: error?.message || String(error),
-          cloudinaryResponse: null,
-        });
-        throw error;
-      }
+
+      const response = await fetch(uploadUrl, {
+        method: 'POST',
+        body: formData,
+      });
+
+      const data = await response.json();
+
       if (!response.ok) {
-        const uploadError = new Error('cloudinary_upload_failed');
-        console.log('[Cloudinary upload] échec', {
-          status: response.status,
-          errorMessage: uploadError.message,
-          cloudinaryResponse: responsePayload,
-        });
-        throw uploadError;
+        console.error('Erreur Cloudinary :', data);
+        throw new Error(data.error?.message || 'Upload Cloudinary échoué');
       }
-      const secureUrl = String(responsePayload?.secure_url || '').trim();
-      if (!secureUrl) {
-        const uploadError = new Error('cloudinary_secure_url_missing');
-        console.log('[Cloudinary upload] échec', {
-          status: response.status,
-          errorMessage: uploadError.message,
-          cloudinaryResponse: responsePayload,
-        });
-        throw uploadError;
+
+      const imageUrl = String(data?.secure_url || '').trim();
+      if (!imageUrl) {
+        console.error('Erreur Cloudinary :', data);
+        throw new Error('Upload Cloudinary échoué');
       }
-      return secureUrl;
+
+      return imageUrl;
     }
 
     function showPurchaseFieldError(field, errorElement, message) {
@@ -3119,21 +3092,24 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       setPurchaseSubmitLoadingState(true);
       try {
         const imageUrl = selectedPurchasePhotoFile ? await uploadPurchaseImageToCloudinary(selectedPurchasePhotoFile) : '';
+        const purchasePayload = {
+          designation,
+          qty,
+          unit,
+          store,
+          magasin: store,
+          createdAt: serverTimestamp(),
+          createdBy: currentUserName || 'Utilisateur',
+          createdByEmail: currentUserEmail || '',
+          siteId,
+          siteName: currentSite?.nom || '',
+        };
+        if (imageUrl) {
+          purchasePayload.imageUrl = imageUrl;
+        }
         await addDoc(
           collection(firebaseDb, 'sites', siteId, 'achatsMateriels'),
-          {
-            designation,
-            qty,
-            unit,
-            store,
-            magasin: store,
-            imageUrl,
-            createdAt: serverTimestamp(),
-            createdBy: currentUserName || 'Utilisateur',
-            createdByEmail: currentUserEmail || '',
-            siteId,
-            siteName: currentSite?.nom || '',
-          },
+          purchasePayload,
         );
         purchaseModal?.close();
         resetPurchaseForm();


### PR DESCRIPTION
### Motivation
- Garantir l’upload Cloudinary pour les « Achat matériel » avec la configuration exacte demandée : preset signé `Suivi_matériel` (accent conservé) en mode unsigned et URL `https://api.cloudinary.com/v1_1/dskw13nem/image/upload`. 
- Afficher l’erreur Cloudinary complète en console et ne pas bloquer l’enregistrement d’un achat quand aucune image n’est sélectionnée.

### Description
- Remplace la lecture dynamique de la config Cloudinary par une configuration verrouillée dans `getCloudinaryUploadConfig()` qui retourne `uploadPreset: 'Suivi_matériel'` et `uploadUrl: 'https://api.cloudinary.com/v1_1/dskw13nem/image/upload'`.
- Met à jour `uploadPurchaseImageToCloudinary(file)` pour construire un `FormData` avec `file` et exactement `upload_preset`, effectuer un `fetch` POST vers l’URL fournie, parser la réponse JSON, logger l’objet d’erreur via `console.error('Erreur Cloudinary :', data)` si `response.ok` est faux, et lancer `new Error(data.error?.message || 'Upload Cloudinary échoué')`.
- Retourne et utilise `data.secure_url` comme `imageUrl` et vérifie sa présence; en cas d’absence déclenche une erreur et logue la réponse.
- Modifie la création du document Firestore pour n’ajouter `imageUrl` au payload que si une image a bien été uploadée, et laisse l’enregistrement possible sans image (aucun changement de design ou des autres champs). 

### Testing
- Exécuté `rg -n "Cloudinary|upload_preset|Suivi_matériel|image/upload|imageUrl|achatsMateriels" js/app.js` pour vérifier les occurrences et la présence du preset exact, et la recherche a réussi.
- Inspecté le diff via `git -C /workspace/Album diff -- js/app.js` pour valider les changements attendus et la sortie a montré le remplacement attendu.
- Ajouté et enregistré les modifications avec `git -C /workspace/Album add js/app.js` et `git -C /workspace/Album commit -m "Fix Cloudinary upload preset and optional purchase image handling"`, et le commit a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0210358420832a90c72a4064427a1e)