### PR TITLE
Ajoute mise en évidence temporaire des résultats de recherche OUT (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4195,7 +4195,11 @@ body[data-page="site-detail"] .list-card {
   border-radius: 18px;
   box-shadow: 0 8px 22px rgba(15, 23, 42, 0.07);
   overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.45s ease;
+}
+
+body[data-page="site-detail"] .list-card.list-card--search-flash {
+  background-color: #eef6ff;
 }
 
 body[data-page="site-detail"] .list-card::before {

--- a/js/app.js
+++ b/js/app.js
@@ -3136,7 +3136,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       } catch (_error) {
         userNamesById = {};
       }
-      renderItems();
+      renderItems(options);
     }
 
     function formatSiteExportUnit(unit) {
@@ -3582,7 +3582,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
-    function renderItems() {
+    function renderItems(options = {}) {
+      const shouldFlashSearchMatches = Boolean(options?.flashSearchMatches);
       const query = itemSearchInput.value.trim().toUpperCase();
       const filteredItems = currentItems.filter((item) => {
         if (!itemMatchesDateFilter(item, selectedDateFilter)) {
@@ -3620,7 +3621,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
         htmlParts.push(`
-            <article class="list-card">
+            <article class="list-card" data-search-match="true">
               ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-item-menu="${item.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
@@ -3634,6 +3635,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           `);
       });
       itemList.innerHTML = htmlParts.join('');
+
+      if (query && shouldFlashSearchMatches) {
+        const matchedCards = itemList.querySelectorAll('[data-search-match="true"]');
+        matchedCards.forEach((card) => {
+          card.classList.remove('list-card--search-flash');
+          void card.offsetWidth;
+          card.classList.add('list-card--search-flash');
+          window.setTimeout(() => {
+            card.classList.remove('list-card--search-flash');
+          }, 1800);
+        });
+      }
 
       itemList.querySelectorAll('[data-item-open]').forEach((button) => {
         button.addEventListener('click', () => {
@@ -3838,7 +3851,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       renderPurchases();
     }
 
-    function renderActiveTabContent() {
+    function renderActiveTabContent(options = {}) {
       if (activeSiteTab === 'purchases') {
         renderPurchases();
         return;
@@ -4460,7 +4473,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     itemSearchInput.addEventListener('input', () => {
-      if (activeSiteTab === 'outs') {
+      const isOutSearchInput = activeSiteTab === 'outs';
+      if (isOutSearchInput) {
         const searchValue = itemSearchInput.value;
         if (searchValue) {
           window.localStorage.setItem(searchStorageKey, searchValue);
@@ -4468,7 +4482,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           window.localStorage.removeItem(searchStorageKey);
         }
       }
-      renderActiveTabContent();
+      renderActiveTabContent({
+        flashSearchMatches: isOutSearchInput,
+      });
     });
 
     if (itemDateFilter) {


### PR DESCRIPTION
### Motivation
- Rendre plus visible pour l’utilisateur quels OUT / articles correspondent à la recherche en appliquant un surlignage temporaire sur la page 2 (site-detail / OUT). 
- L’effet doit être subtil, non permanent et se relancer à chaque saisie sans modifier le design ou le comportement des autres pages.

### Description
- `js/app.js` : `renderItems` accepte désormais une option `options = { flashSearchMatches }` et marque les cards rendues par la recherche avec `data-search-match="true"` afin d’identifier les correspondances. 
- `js/app.js` : quand `flashSearchMatches` est vrai et qu’il y a une requête, les cards correspondantes reçoivent la classe `list-card--search-flash` puis la perdent automatiquement après ~1,8s (relance à chaque saisie). 
- `js/app.js` : le handler `input` de `itemSearchInput` envoie `flashSearchMatches: true` uniquement si l’onglet actif est `outs`, ce qui garantit que l’effet s’applique uniquement à la page 2 OUT. 
- `css/style.css` : ajout d’une transition `background-color` sur les cards de `body[data-page="site-detail"]` et définition de la classe `list-card--search-flash` avec un fond bleu très clair (`#eef6ff`) pour un effet subtil et professionnel.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021522aff4832a8884b1ef64adc56b)