### PR TITLE
Page 2 OUT: fond blanc temporaire pour résultats de recherche non consultés

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4202,6 +4202,12 @@ body[data-page="site-detail"] .list-card.list-card--search-flash {
   background-color: #eef6ff;
 }
 
+body[data-page="site-detail"] .list-card.list-card--search-unread {
+  background-color: #ffffff;
+  border-color: #c6d8f4;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.1);
+}
+
 body[data-page="site-detail"] .list-card::before {
   content: "";
   position: absolute;

--- a/js/app.js
+++ b/js/app.js
@@ -3621,7 +3621,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
         htmlParts.push(`
-            <article class="list-card" data-search-match="true">
+            <article class="list-card${query && !viewedOutSearchResultIds.has(String(item.id)) ? " list-card--search-unread" : ""}" data-search-match="true" data-item-id="${escapeHtml(item.id)}">
               ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-item-menu="${item.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
@@ -3650,6 +3650,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       itemList.querySelectorAll('[data-item-open]').forEach((button) => {
         button.addEventListener('click', () => {
+          if (query) {
+            viewedOutSearchResultIds.add(String(button.dataset.itemOpen || ''));
+            const card = button.closest('.list-card');
+            card?.classList.remove('list-card--search-unread');
+          }
           UiService.navigate(`page3.html?siteId=${encodeURIComponent(siteId)}&itemId=${encodeURIComponent(button.dataset.itemOpen)}`);
         });
       });
@@ -3691,6 +3696,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const ITEM_DIALOG_MODE_EDIT_PURCHASE = 'edit_purchase';
     let itemDialogMode = ITEM_DIALOG_MODE_CREATE;
     let editingItemId = null;
+    let activeOutSearchQuery = (itemSearchInput.value || "").trim().toUpperCase();
+    let viewedOutSearchResultIds = new Set();
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -3903,6 +3910,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       itemSearchInput.value = safeTabName === 'outs'
         ? (window.localStorage.getItem(searchStorageKey) || '')
         : '';
+      if (safeTabName === 'outs') {
+        const normalizedQuery = (itemSearchInput.value || '').trim().toUpperCase();
+        if (normalizedQuery !== activeOutSearchQuery) {
+          activeOutSearchQuery = normalizedQuery;
+          viewedOutSearchResultIds = new Set();
+        }
+      }
       updateFabByActiveTab(safeTabName);
       updateHeaderExportButton(safeTabName);
       renderActiveTabContent();
@@ -4480,6 +4494,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           window.localStorage.setItem(searchStorageKey, searchValue);
         } else {
           window.localStorage.removeItem(searchStorageKey);
+        }
+        const normalizedQuery = (searchValue || '').trim().toUpperCase();
+        if (normalizedQuery !== activeOutSearchQuery) {
+          activeOutSearchQuery = normalizedQuery;
+          viewedOutSearchResultIds = new Set();
         }
       }
       renderActiveTabContent({


### PR DESCRIPTION
### Motivation
- Permettre aux utilisateurs de distinguer visuellement, pendant une recherche sur la page 2 (onglet OUT), les résultats qui n'ont pas encore été ouverts en leur appliquant un fond blanc temporaire indiquant « non lu ». 
- Respecter les contraintes existantes en n'altérant ni la structure des cards, ni les filtres, ni la clé/localStorage de recherche, et en conservant les animations/transitions actuelles.

### Description
- `js/app.js` : ajout de deux états locaux `activeOutSearchQuery` et `viewedOutSearchResultIds`, application conditionnelle de la classe `list-card--search-unread` lors du rendu des résultats OUT, suppression de la classe et mémorisation de l'ID au clic, et réinitialisation de l'état à chaque changement de requête ou lors du retour sur l'onglet OUT. 
- `css/style.css` : ajout de la règle `body[data-page="site-detail"] .list-card.list-card--search-unread` pour donner le fond blanc et un léger accent visuel sans modifier les transitions existantes. 
- Modifications limitées à la page 2 (site-detail / OUT) et conçues pour ne pas toucher à la structure HTML des cards, aux filtres ni au stockage local existant.

### Testing
- Examen du diff des fichiers modifiés via `git diff -- js/app.js css/style.css` pour valider les changements attendus (succès). 
- Vérification de l'état du workspace avec `git status --short` pour s'assurer qu'il ne reste pas de modifications non prises en compte (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02193c7cb8832a8924d9ade6b43b4a)