### PR TITLE
Corrige le sous-titre du header après actualisation en restaurant l'onglet actif

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3685,6 +3685,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let activeSiteTab = 'outs';
     const PURCHASE_SEARCH_PLACEHOLDER = 'Rechercher un achat matériel';
     const OUT_SEARCH_PLACEHOLDER = 'Rechercher (OUT ou article)';
+    const activeTabStorageKey = `siteDetailActiveTab:${siteId || 'default'}`;
     let itemFormErrorTimeoutId = null;
     let itemNumberErrorClearTimer = null;
     let itemAvailabilityDebounceTimer = null;
@@ -3751,6 +3752,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       `;
     }
 
+    function getSavedActiveSiteTab() {
+      try {
+        return window.localStorage.getItem(activeTabStorageKey);
+      } catch (_error) {
+        return null;
+      }
+    }
+
+    function saveActiveSiteTab(tabName) {
+      try {
+        window.localStorage.setItem(activeTabStorageKey, tabName);
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
     function renderPurchases() {
       const query = itemSearchInput.value.trim().toUpperCase();
       const purchases = currentPurchases.filter((purchase) => {
@@ -3764,7 +3781,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           .some((value) => String(value || '').toUpperCase().includes(query));
       });
 
-      itemCount.innerHTML = `<span class="outs-number">${purchases.length}</span><span class="outs-label">${purchases.length > 1 ? 'Achats' : 'Achat'}</span>`;
+      if (activeSiteTab === 'purchases') {
+        itemCount.innerHTML = `<span class="outs-number">${purchases.length}</span><span class="outs-label">${purchases.length > 1 ? 'Achats' : 'Achat'}</span>`;
+      }
 
       if (!purchasesList) {
         console.error('#purchasesList introuvable');
@@ -3916,6 +3935,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           activeOutSearchQuery = normalizedQuery;
           viewedOutSearchResultIds = new Set();
         }
+      }
+      saveActiveSiteTab(safeTabName);
+      if (safeTabName === 'outs') {
+        itemCount.innerHTML = `<span class="outs-number">0</span><span class="outs-label">OUTS</span>`;
+      } else {
+        itemCount.innerHTML = `<span class="outs-number">0</span><span class="outs-label">Achat</span>`;
       }
       updateFabByActiveTab(safeTabName);
       updateHeaderExportButton(safeTabName);
@@ -4142,8 +4167,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
     updateTabsByRole();
+    const savedActiveTab = getSavedActiveSiteTab();
+    setActiveSiteTab(savedActiveTab === 'purchases' ? 'purchases' : 'outs');
     loadPurchasesForCurrentSite();
-    setActiveSiteTab('outs');
     siteTabButtons.forEach((tab) => {
       tab.addEventListener('click', async () => {
         const targetTab = tab.dataset.tab;


### PR DESCRIPTION
### Motivation
- À l’actualisation la valeur du sous-titre pouvait afficher des compteurs `Achat` même lorsque l’onglet actif devait être `OUT`, car le préchargement des achats mettait à jour le compteur partagé avant que l’onglet actif soit restauré.

### Description
- Ajout d’une clé site-scopée de `localStorage` `siteDetailActiveTab:<siteId>` et des helpers `getSavedActiveSiteTab()` / `saveActiveSiteTab()` dans `js/app.js` pour lire/écrire l’onglet actif de manière sûre.
- Restauration de l’onglet sauvegardé au chargement et appel de `setActiveSiteTab()` avant le préchargement des achats afin d’afficher immédiatement le bon sous-titre (`0 OUTS` ou `0 Achat`).
- Protection de `renderPurchases()` pour n’écrire le sous-titre `Achats` que si l’onglet actif est réellement `purchases`, évitant ainsi l’écrasement du libellé lorsqu’on est sur `outs`.
- Persistance de l’onglet à chaque changement via `saveActiveSiteTab()` et mise à jour immédiate du sous-titre dans `setActiveSiteTab()` sans modifier l’UI/design existant.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a194c804832a885414f93b344315)