### PR TITLE
Keep FAB visible on page 2 (site-detail) during scroll

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4490,26 +4490,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (siteDetailFabStack) {
       const siteDetailScrollContainer = document.querySelector('body[data-page="site-detail"] .page-content');
-      let siteDetailScrollTimerId = null;
-      const SCROLL_IDLE_DELAY_MS = 180;
-
-      const setFabStackScrollingState = (isScrolling) => {
-        siteDetailFabStack.classList.toggle('is-scroll-hidden', isScrolling);
-      };
-
-      const handleSiteDetailScroll = () => {
-        persistOutPageScrollPosition();
-        setFabStackScrollingState(true);
-        if (siteDetailScrollTimerId) {
-          window.clearTimeout(siteDetailScrollTimerId);
-        }
-        siteDetailScrollTimerId = window.setTimeout(() => {
-          setFabStackScrollingState(false);
-          siteDetailScrollTimerId = null;
-        }, SCROLL_IDLE_DELAY_MS);
-      };
-
-      siteDetailScrollContainer?.addEventListener('scroll', handleSiteDetailScroll, { passive: true });
+      siteDetailFabStack.classList.remove('is-scroll-hidden');
+      siteDetailScrollContainer?.addEventListener('scroll', persistOutPageScrollPosition, { passive: true });
     }
 
     itemSearchInput.addEventListener('input', () => {


### PR DESCRIPTION
### Motivation
- The blue FAB on page 2 (`data-page="site-detail"`) was being hidden while scrolling via JS that toggled an `is-scroll-hidden` state, and the intent is to keep the FAB always visible on that page. 
- The change must be scoped to page 2 only and must not alter the FAB position, size, design, or click action.

### Description
- Removed the scroll-hide logic in `js/app.js` that toggled `is-scroll-hidden` and the associated idle timer. 
- Explicitly remove any existing `is-scroll-hidden` state at initialization with `siteDetailFabStack.classList.remove('is-scroll-hidden')`. 
- Retained a scroll listener only to call `persistOutPageScrollPosition` so scroll position persistence remains while the FAB visibility is no longer affected. 
- The modification is limited to the `body[data-page="site-detail"]` handling in `js/app.js` and does not touch CSS or other pages.

### Testing
- Located FAB-related code with `rg` and inspected `js/app.js` to confirm the old toggling logic was removed and the `is-scroll-hidden` removal was added (succeeded). 
- Applied the patch and reviewed the resulting `js/app.js` diff to ensure only the intended lines were changed (succeeded). 
- No automated unit test suite was available in the repository, so no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a70db824832ab908222a658a6402)