### PR TITLE
Add professional temporary seen/unseen state for OUT search results

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4195,7 +4195,7 @@ body[data-page="site-detail"] .list-card {
   border-radius: 18px;
   box-shadow: 0 8px 22px rgba(15, 23, 42, 0.07);
   overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.45s ease;
+  transition: all 0.25s ease;
 }
 
 body[data-page="site-detail"] .list-card.list-card--search-flash {
@@ -4203,9 +4203,20 @@ body[data-page="site-detail"] .list-card.list-card--search-flash {
 }
 
 body[data-page="site-detail"] .list-card.list-card--search-unread {
-  background-color: #ffffff;
-  border-color: #c6d8f4;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.1);
+  background: #f8fbff;
+  border-color: rgba(52, 152, 219, 0.18);
+}
+
+body[data-page="site-detail"] .list-card.list-card--search-unread::after {
+  content: "";
+  position: absolute;
+  top: 11px;
+  right: 12px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(52, 152, 219, 0.9);
+  box-shadow: 0 0 0 2px rgba(248, 251, 255, 0.95);
 }
 
 body[data-page="site-detail"] .list-card::before {

--- a/js/app.js
+++ b/js/app.js
@@ -3652,6 +3652,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         button.addEventListener('click', () => {
           if (query) {
             viewedOutSearchResultIds.add(String(button.dataset.itemOpen || ''));
+            persistSeenOutResultsForQuery(activeOutSearchQuery);
             const card = button.closest('.list-card');
             card?.classList.remove('list-card--search-unread');
           }
@@ -3699,6 +3700,45 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let editingItemId = null;
     let activeOutSearchQuery = (itemSearchInput.value || "").trim().toUpperCase();
     let viewedOutSearchResultIds = new Set();
+
+    function buildOutSearchSeenStorageKey(queryValue) {
+      return `search_seen_${queryValue}`;
+    }
+
+    function loadSeenOutResultsForQuery(queryValue) {
+      if (!queryValue) {
+        return new Set();
+      }
+      try {
+        const rawValue = window.localStorage.getItem(buildOutSearchSeenStorageKey(queryValue));
+        if (!rawValue) {
+          return new Set();
+        }
+        const parsedValue = JSON.parse(rawValue);
+        if (!Array.isArray(parsedValue)) {
+          return new Set();
+        }
+        return new Set(parsedValue.map((value) => String(value || '')));
+      } catch (_error) {
+        return new Set();
+      }
+    }
+
+    function persistSeenOutResultsForQuery(queryValue) {
+      if (!queryValue) {
+        return;
+      }
+      try {
+        window.localStorage.setItem(
+          buildOutSearchSeenStorageKey(queryValue),
+          JSON.stringify(Array.from(viewedOutSearchResultIds)),
+        );
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
+    viewedOutSearchResultIds = loadSeenOutResultsForQuery(activeOutSearchQuery);
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -3933,7 +3973,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const normalizedQuery = (itemSearchInput.value || '').trim().toUpperCase();
         if (normalizedQuery !== activeOutSearchQuery) {
           activeOutSearchQuery = normalizedQuery;
-          viewedOutSearchResultIds = new Set();
+          viewedOutSearchResultIds = loadSeenOutResultsForQuery(normalizedQuery);
         }
       }
       saveActiveSiteTab(safeTabName);
@@ -4506,7 +4546,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const normalizedQuery = (searchValue || '').trim().toUpperCase();
         if (normalizedQuery !== activeOutSearchQuery) {
           activeOutSearchQuery = normalizedQuery;
-          viewedOutSearchResultIds = new Set();
+          viewedOutSearchResultIds = loadSeenOutResultsForQuery(normalizedQuery);
         }
       }
       renderActiveTabContent({


### PR DESCRIPTION
### Motivation
- Implémenter un état visuel temporaire “vu / non vu” pendant la recherche OUT sur la page 2 pour améliorer l’UX (résultats trouvés doivent être visuellement distingués jusqu’à consultation). 
- Conserver la solution purement visuelle et locale sans toucher à Firestore, aux filtres, aux animations existantes ni à la structure des données.

### Description
- Ajout de helpers dans `js/app.js` : `buildOutSearchSeenStorageKey`, `loadSeenOutResultsForQuery`, et `persistSeenOutResultsForQuery` pour gérer la persistance par requête via `localStorage` (clé `search_seen_<QUERY>`).
- Lors d’un clic sur une card (`[data-item-open]`) la card est immédiatement marquée comme vue en ajoutant son id à `viewedOutSearchResultIds` et en appelant `persistSeenOutResultsForQuery(activeOutSearchQuery)`, puis la classe visuelle `list-card--search-unread` est retirée pour CETTE card seulement.
- À chaque changement de texte de recherche ou au retour sur l’onglet OUT on recharge l’état vu/non vu pour la requête courante via `loadSeenOutResultsForQuery` pour isoler l’état par requête.
- Modifications CSS dans `css/style.css` : `transition: all 0.25s ease;`, style « non vu » sobre `background: #f8fbff; border-color: rgba(52,152,219,0.18);` et ajout d’un petit indicateur point bleu en haut à droite via `::after` pour les cards non lues.

### Testing
- Exécution de `node --check js/app.js` pour vérifier l’absence d’erreurs de syntaxe JavaScript et confirmation de succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02aa96084c832a9e2d9fcb10806421)