### PR TITLE
Improve unread OUT card visibility styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4203,8 +4203,10 @@ body[data-page="site-detail"] .list-card.list-card--search-flash {
 }
 
 body[data-page="site-detail"] .list-card.list-card--search-unread {
-  background: #f8fbff;
-  border-color: rgba(52, 152, 219, 0.18);
+  background: #edf6ff;
+  border: 1px solid rgba(52, 152, 219, 0.22);
+  box-shadow: 0 4px 12px rgba(52, 152, 219, 0.08);
+  transition: all 0.25s ease;
 }
 
 body[data-page="site-detail"] .list-card.list-card--search-unread::after {


### PR DESCRIPTION
### Motivation
- Increase visibility of the temporary "unread" state on page 2 (`site-detail`) while preserving a sober, premium and modern appearance without using an aggressive dark blue.

### Description
- Updated `css/style.css` for the `.list-card.list-card--search-unread` selector to set `background: #edf6ff`, `border: 1px solid rgba(52,152,219,0.22)`, `box-shadow: 0 4px 12px rgba(52,152,219,0.08)` and `transition: all 0.25s ease`, keeping the `::after` blue indicator and making no changes to read/unread logic or `localStorage`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02af7def50832a8a60fc49a3b436d8)