### PR TITLE
Fix page2 OUT search read/unread reset behavior

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3652,7 +3652,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         button.addEventListener('click', () => {
           if (query) {
             viewedOutSearchResultIds.add(String(button.dataset.itemOpen || ''));
-            persistSeenOutResultsForQuery(activeOutSearchQuery);
             const card = button.closest('.list-card');
             card?.classList.remove('list-card--search-unread');
           }
@@ -3701,44 +3700,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let activeOutSearchQuery = (itemSearchInput.value || "").trim().toUpperCase();
     let viewedOutSearchResultIds = new Set();
 
-    function buildOutSearchSeenStorageKey(queryValue) {
-      return `search_seen_${queryValue}`;
+    function resetSeenOutResults() {
+      viewedOutSearchResultIds = new Set();
     }
 
-    function loadSeenOutResultsForQuery(queryValue) {
-      if (!queryValue) {
-        return new Set();
-      }
-      try {
-        const rawValue = window.localStorage.getItem(buildOutSearchSeenStorageKey(queryValue));
-        if (!rawValue) {
-          return new Set();
-        }
-        const parsedValue = JSON.parse(rawValue);
-        if (!Array.isArray(parsedValue)) {
-          return new Set();
-        }
-        return new Set(parsedValue.map((value) => String(value || '')));
-      } catch (_error) {
-        return new Set();
-      }
-    }
-
-    function persistSeenOutResultsForQuery(queryValue) {
-      if (!queryValue) {
-        return;
-      }
-      try {
-        window.localStorage.setItem(
-          buildOutSearchSeenStorageKey(queryValue),
-          JSON.stringify(Array.from(viewedOutSearchResultIds)),
-        );
-      } catch (_error) {
-        // Ignore localStorage restrictions.
-      }
-    }
-
-    viewedOutSearchResultIds = loadSeenOutResultsForQuery(activeOutSearchQuery);
+    resetSeenOutResults();
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -3973,7 +3939,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const normalizedQuery = (itemSearchInput.value || '').trim().toUpperCase();
         if (normalizedQuery !== activeOutSearchQuery) {
           activeOutSearchQuery = normalizedQuery;
-          viewedOutSearchResultIds = loadSeenOutResultsForQuery(normalizedQuery);
+          resetSeenOutResults();
         }
       }
       saveActiveSiteTab(safeTabName);
@@ -4546,7 +4512,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const normalizedQuery = (searchValue || '').trim().toUpperCase();
         if (normalizedQuery !== activeOutSearchQuery) {
           activeOutSearchQuery = normalizedQuery;
-          viewedOutSearchResultIds = loadSeenOutResultsForQuery(normalizedQuery);
+          resetSeenOutResults();
         }
       }
       renderActiveTabContent({


### PR DESCRIPTION
### Motivation
- Fix the incorrect persistence of search "seen" state for OUT results on page 2 so read/unread is session-only and resets when the search is cleared or changed.
- Ensure clicking a card only marks it seen for the current live search session and that no durable state is stored in `localStorage` for seen results.

### Description
- Removed the old `localStorage`-based functions for search seen state and replaced them with an in-memory helper `resetSeenOutResults()` that clears `viewedOutSearchResultIds`.
- Stop persisting seen IDs on card click by removing the `persistSeenOutResultsForQuery` call; clicks now only update the in-memory `viewedOutSearchResultIds` and the card DOM class.
- Call `resetSeenOutResults()` whenever the OUT search query changes (including when cleared) and when switching back to the OUT tab if the query differs, so repeated searches after clearing start with all results unread.
- Change is limited to `js/app.js` and only affects page 2 OUT search behavior; no design/CSS changes were made.

### Testing
- Verified code changes with a pattern search using `rg` to confirm removal of the old storage functions and references, and the command succeeded.
- Committed the change with `git commit` which completed successfully and produced the new short SHA.
- Rendered/inspected the modified `js/app.js` regions with `sed`/`nl` to confirm the new `resetSeenOutResults()` usage and the removal of `localStorage` persistence; these inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b83b84f0832abb93c1b13a621870)