### PR TITLE
Renforce le mode vu/non lu pendant la recherche OUT

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3621,7 +3621,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
         htmlParts.push(`
-            <article class="list-card${query && !viewedOutSearchResultIds.has(String(item.id)) ? " list-card--search-unread" : ""}" data-search-match="true" data-item-id="${escapeHtml(item.id)}">
+            <article class="list-card${query && isOutSearchReadModeActive && !viewedOutSearchResultIds.has(String(item.id)) ? " list-card--search-unread" : ""}" data-search-match="true" data-item-id="${escapeHtml(item.id)}">
               ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-item-menu="${item.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
@@ -3650,7 +3650,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       itemList.querySelectorAll('[data-item-open]').forEach((button) => {
         button.addEventListener('click', () => {
-          if (query) {
+          if (query && isOutSearchReadModeActive) {
             viewedOutSearchResultIds.add(String(button.dataset.itemOpen || ''));
             const card = button.closest('.list-card');
             card?.classList.remove('list-card--search-unread');
@@ -3698,13 +3698,23 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let itemDialogMode = ITEM_DIALOG_MODE_CREATE;
     let editingItemId = null;
     let activeOutSearchQuery = (itemSearchInput.value || "").trim().toUpperCase();
+    let isOutSearchReadModeActive = Boolean(activeOutSearchQuery);
     let viewedOutSearchResultIds = new Set();
 
     function resetSeenOutResults() {
       viewedOutSearchResultIds = new Set();
     }
 
-    resetSeenOutResults();
+    function setOutSearchReadMode(isActive) {
+      isOutSearchReadModeActive = Boolean(isActive);
+      if (!isOutSearchReadModeActive) {
+        resetSeenOutResults();
+      }
+    }
+
+    if (isOutSearchReadModeActive) {
+      resetSeenOutResults();
+    }
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -3937,10 +3947,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         : '';
       if (safeTabName === 'outs') {
         const normalizedQuery = (itemSearchInput.value || '').trim().toUpperCase();
-        if (normalizedQuery !== activeOutSearchQuery) {
-          activeOutSearchQuery = normalizedQuery;
-          resetSeenOutResults();
-        }
+        activeOutSearchQuery = normalizedQuery;
+        setOutSearchReadMode(Boolean(normalizedQuery));
       }
       saveActiveSiteTab(safeTabName);
       if (safeTabName === 'outs') {
@@ -4510,9 +4518,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           window.localStorage.removeItem(searchStorageKey);
         }
         const normalizedQuery = (searchValue || '').trim().toUpperCase();
-        if (normalizedQuery !== activeOutSearchQuery) {
-          activeOutSearchQuery = normalizedQuery;
+        const hadActiveSearch = Boolean(activeOutSearchQuery);
+        activeOutSearchQuery = normalizedQuery;
+        const hasActiveSearch = Boolean(normalizedQuery);
+        if (!hadActiveSearch && hasActiveSearch) {
+          setOutSearchReadMode(true);
           resetSeenOutResults();
+        } else if (!hasActiveSearch) {
+          setOutSearchReadMode(false);
         }
       }
       renderActiveTabContent({


### PR DESCRIPTION
### Motivation
- Garantir que le mode “vu / non lu” s’active automatiquement quand la recherche OUT est non vide et soit réinitialisé uniquement quand la recherche redevient vide, sans affecter les autres interactions (scroll, filtres, modals, navigation). 

### Description
- Ajout de l’état `isOutSearchReadModeActive` et du helper `setOutSearchReadMode` pour piloter l’entrée/sortie du mode lecture et centraliser le reset des résultats vus. 
- Le rendu des cartes utilise désormais la condition `query && isOutSearchReadModeActive && !viewedOutSearchResultIds.has(...)` pour appliquer la classe `list-card--search-unread`. 
- Au clic sur une card, seule la card cliquée est marquée comme vue via `viewedOutSearchResultIds.add(...)` et suppression immédiate de la classe `list-card--search-unread` sans réinitialiser les autres cartes. 
- Le handler d’`input` pour la recherche met à jour `activeOutSearchQuery` et active/désactive le mode de lecture seulement lors des transitions vides→non vide ou non vide→vide (via `setOutSearchReadMode`), et `setActiveSiteTab` initialise aussi correctement ce mode selon la recherche sauvegardée. 

### Testing
- Vérification de syntaxe de `js/app.js` avec `node -c js/app.js` (succès). 
- Contrôle d’état git avec `git status --short` (modification attendue de `js/app.js`). 
- Commit du changement (`git commit`) exécuté avec message de PR (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f579b840832ab19d06d482126fbd)