### PR TITLE
Fix Page 2 search read/unread state persistence

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3621,7 +3621,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
         htmlParts.push(`
-            <article class="list-card${query && isOutSearchReadModeActive && !viewedOutSearchResultIds.has(String(item.id)) ? " list-card--search-unread" : ""}" data-search-match="true" data-item-id="${escapeHtml(item.id)}">
+            <article class="list-card${query && !readSearchResults.has(String(item.id)) ? " list-card--search-unread" : ""}" data-search-match="true" data-item-id="${escapeHtml(item.id)}">
               ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-item-menu="${item.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
@@ -3650,8 +3650,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       itemList.querySelectorAll('[data-item-open]').forEach((button) => {
         button.addEventListener('click', () => {
-          if (query && isOutSearchReadModeActive) {
-            viewedOutSearchResultIds.add(String(button.dataset.itemOpen || ''));
+          if (query) {
+            readSearchResults.add(String(button.dataset.itemOpen || ''));
             const card = button.closest('.list-card');
             card?.classList.remove('list-card--search-unread');
           }
@@ -3698,23 +3698,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let itemDialogMode = ITEM_DIALOG_MODE_CREATE;
     let editingItemId = null;
     let activeOutSearchQuery = (itemSearchInput.value || "").trim().toUpperCase();
-    let isOutSearchReadModeActive = Boolean(activeOutSearchQuery);
-    let viewedOutSearchResultIds = new Set();
-
-    function resetSeenOutResults() {
-      viewedOutSearchResultIds = new Set();
-    }
-
-    function setOutSearchReadMode(isActive) {
-      isOutSearchReadModeActive = Boolean(isActive);
-      if (!isOutSearchReadModeActive) {
-        resetSeenOutResults();
-      }
-    }
-
-    if (isOutSearchReadModeActive) {
-      resetSeenOutResults();
-    }
+    const readSearchResults = new Set();
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -3948,7 +3932,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (safeTabName === 'outs') {
         const normalizedQuery = (itemSearchInput.value || '').trim().toUpperCase();
         activeOutSearchQuery = normalizedQuery;
-        setOutSearchReadMode(Boolean(normalizedQuery));
+        if (!normalizedQuery) {
+          readSearchResults.clear();
+        }
       }
       saveActiveSiteTab(safeTabName);
       if (safeTabName === 'outs') {
@@ -4518,14 +4504,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           window.localStorage.removeItem(searchStorageKey);
         }
         const normalizedQuery = (searchValue || '').trim().toUpperCase();
-        const hadActiveSearch = Boolean(activeOutSearchQuery);
         activeOutSearchQuery = normalizedQuery;
-        const hasActiveSearch = Boolean(normalizedQuery);
-        if (!hadActiveSearch && hasActiveSearch) {
-          setOutSearchReadMode(true);
-          resetSeenOutResults();
-        } else if (!hasActiveSearch) {
-          setOutSearchReadMode(false);
+        if (!normalizedQuery) {
+          readSearchResults.clear();
         }
       }
       renderActiveTabContent({


### PR DESCRIPTION
### Motivation
- Corriger la logique LU / NON LU en mode recherche sur la Page 2 pour respecter le comportement attendu : résultats démarrent NON LU, cliquer un résultat le marque LU uniquement pour la recherche courante, et tout revient NON LU seulement quand le champ recherche est vidé.

### Description
- Introduit une mémoire temporaire en RAM `readSearchResults = new Set()` pour tracer les résultats lus pendant une recherche.
- Lors du rendu des cartes de recherche, la classe `list-card--search-unread` est appliquée lorsque `query && !readSearchResults.has(String(item.id))` (au lieu de l'ancienne logique basée sur des flags/globaux supprimés).
- Au clic sur un résultat de recherche on ajoute son ID à `readSearchResults` et on retire immédiatement la classe `list-card--search-unread` sur la carte cliquée afin de la marquer LU sans affecter les autres résultats.
- Le `Set` est vidé uniquement lorsque le champ de recherche devient vide (gestion dans le gestionnaire `input` et au changement d'onglet), assurant la préservation de l'état LU/NON LU pendant la durée de la recherche active.

### Testing
- Exécuté `node --check js/app.js` pour une vérification statique de fichiers JavaScript, sans erreur (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fa90949c832a8176fbd71fc22782)