### PR TITLE
Page 2: separate localStorage key for read OUT search results

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2839,6 +2839,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     };
     const dateFilterStorageKey = `site-detail:item-date-filter:${siteId}`;
     const searchStorageKey = `site-detail:item-search:${siteId}`;
+    const searchReadIdsStorageKey = 'page2_search_read_ids';
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
@@ -3652,6 +3653,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         button.addEventListener('click', () => {
           if (query) {
             readSearchResults.add(String(button.dataset.itemOpen || ''));
+            persistSearchReadIdsToStorage(readSearchResults);
             const card = button.closest('.list-card');
             card?.classList.remove('list-card--search-unread');
           }
@@ -3698,7 +3700,36 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let itemDialogMode = ITEM_DIALOG_MODE_CREATE;
     let editingItemId = null;
     let activeOutSearchQuery = (itemSearchInput.value || "").trim().toUpperCase();
-    const readSearchResults = new Set();
+    function readSearchReadIdsFromStorage() {
+      try {
+        const rawValue = window.localStorage.getItem(searchReadIdsStorageKey);
+        const parsed = JSON.parse(rawValue || '[]');
+        if (!Array.isArray(parsed)) {
+          return new Set();
+        }
+        return new Set(parsed.map((value) => String(value || '')).filter(Boolean));
+      } catch (_error) {
+        return new Set();
+      }
+    }
+
+    function persistSearchReadIdsToStorage(readIdsSet) {
+      try {
+        window.localStorage.setItem(searchReadIdsStorageKey, JSON.stringify(Array.from(readIdsSet)));
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
+    function clearSearchReadIdsStorage() {
+      try {
+        window.localStorage.removeItem(searchReadIdsStorageKey);
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
+    const readSearchResults = readSearchReadIdsFromStorage();
 
     function isFirebaseUserAuthenticated(user) {
       return Boolean(user?.uid);
@@ -3934,6 +3965,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         activeOutSearchQuery = normalizedQuery;
         if (!normalizedQuery) {
           readSearchResults.clear();
+          clearSearchReadIdsStorage();
+        } else {
+          readSearchResults.clear();
+          readSearchReadIdsFromStorage().forEach((id) => readSearchResults.add(id));
         }
       }
       saveActiveSiteTab(safeTabName);
@@ -4504,9 +4539,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           window.localStorage.removeItem(searchStorageKey);
         }
         const normalizedQuery = (searchValue || '').trim().toUpperCase();
+        const hasQueryChanged = normalizedQuery !== activeOutSearchQuery;
         activeOutSearchQuery = normalizedQuery;
         if (!normalizedQuery) {
           readSearchResults.clear();
+          clearSearchReadIdsStorage();
+        } else if (hasQueryChanged) {
+          readSearchResults.clear();
+          clearSearchReadIdsStorage();
         }
       }
       renderActiveTabContent({


### PR DESCRIPTION
### Motivation

- Preserve the existing search text persistence while adding a transient, separate store for marking search results as read during an active search. 
- Ensure search-result read/unread state does not leak into the saved search text and resets when the search is cleared or changed. 
- Reuse existing CSS classes for `lu`/`non lu` rendering and avoid changing date filter behavior.

### Description

- Added a new storage key constant `searchReadIdsStorageKey = 'page2_search_read_ids'` and helper functions `readSearchReadIdsFromStorage`, `persistSearchReadIdsToStorage`, and `clearSearchReadIdsStorage` to manage a JSON array of read IDs. 
- Initialize `readSearchResults` from the new storage key and persist an ID when a search result card is clicked by calling `persistSearchReadIdsToStorage(readSearchResults)`, while removing the `list-card--search-unread` class immediately. 
- On tab activation and on search input changes, load or clear the in-memory `readSearchResults` and call `removeItem` on the storage key when the search becomes empty or the query changes. 
- Kept the existing `site-detail:item-search:${siteId}` key and all date filter logic untouched, and reused the existing unread/read CSS behavior already present in the UI rendering code.

### Testing

- Ran `node --check js/app.js` to validate there are no syntax errors and the file parses successfully (passed). 
- Verified the app code loads the new helpers and that `readSearchResults` persists and clears by exercising the search input behavior in the running UI (smoke verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fe6aac4c832a954380054cf3e3f8)