### PR TITLE
Ajout du champ « Statut » sur la Page 3 (UI, stockage et exports)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3145,6 +3145,28 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   min-width: 100px;
 }
 
+body[data-page="item-detail"] .detail-status-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+body[data-page="item-detail"] .detail-status-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #16a34a;
+  display: inline-block;
+}
+
+body[data-page="item-detail"] .detail-status-field--ko .detail-status-dot {
+  background: #dc2626;
+}
+
+body[data-page="item-detail"] .detail-status-select {
+  min-width: 76px;
+}
+
 .cell-input-measurer {
   position: absolute;
   visibility: hidden;

--- a/js/app.js
+++ b/js/app.js
@@ -260,6 +260,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return `${day}/${month}/${year}`;
   }
 
+  function normalizeDetailStatut(value) {
+    return String(value || '').trim().toUpperCase() === 'K.O' ? 'K.O' : 'OK';
+  }
+
   function setupZoomableDetailTable() {
     const tableContainer = requireElement('detailTableContainer');
     const tableWrapper = requireElement('detailTableWrapper');
@@ -526,6 +530,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td>${escapeHtml(formatExcelCellValue(formatReturnDate(detail.dateRetour)))}</td>
               <td>${escapeHtml(formatExcelCellValue(computeEcart(detail)))}</td>
               <td>${escapeHtml(formatExcelCellValue(detail.observation))}</td>
+              <td>${escapeHtml(formatExcelCellValue(normalizeDetailStatut(detail.statut)))}</td>
             </tr>
           `,
       )
@@ -556,6 +561,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <th>Date de retour</th>
           <th>Ecart</th>
           <th>Observation</th>
+          <th>Statut</th>
         </tr>
       </thead>
       <tbody>${rows}</tbody>
@@ -580,6 +586,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <td>${escapeHtml(formatExcelCellValue(formatReturnDate(row.dateRetour)))}</td>
             <td>${escapeHtml(formatExcelCellValue(computeEcart(row)))}</td>
             <td>${escapeHtml(formatExcelCellValue(row.observation))}</td>
+            <td>${escapeHtml(formatExcelCellValue(normalizeDetailStatut(row.statut)))}</td>
           </tr>
         `,
       )
@@ -610,6 +617,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <th>Date de retour</th>
           <th>Ecart</th>
           <th>Remarque</th>
+          <th>Statut</th>
         </tr>
       </thead>
       <tbody>${bodyRows}</tbody>
@@ -3163,6 +3171,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           qteRetour: detail.qteRetour,
           dateRetour: detail.dateRetour || '',
           observation: detail.observation,
+          statut: normalizeDetailStatut(detail.statut),
         })),
       );
     }
@@ -4818,6 +4827,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       detailForm.reset();
       requireElement('uniteInput').value = 'm';
+      requireElement('statutInput').value = 'OK';
       setDetailFormSavingState(false);
       clearDetailFormError();
       clearDetailRequiredFieldErrors();
@@ -5474,7 +5484,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       updateCount(filteredDetails.length, currentDetails.length);
 
       if (!filteredDetails.length) {
-        detailTableBody.innerHTML = `<tr><td colspan="13"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
+        detailTableBody.innerHTML = `<tr><td colspan="14"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
         return;
       }
 
@@ -5501,6 +5511,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="dateRetour" data-field="dateRetour" type="date" value="${escapeHtml(detail.dateRetour || '')}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic${ecartClassName}" data-col-key="ecart" type="number" maxlength="120" value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="observation" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" /></td>
+              <td>
+                <div class="detail-status-field detail-status-field--${normalizeDetailStatut(detail.statut) === 'K.O' ? 'ko' : 'ok'}">
+                  <span class="detail-status-dot" aria-hidden="true"></span>
+                  <select class="cell-input cell-input--compact-dynamic detail-status-select" data-col-key="statut" data-field="statut" aria-label="Statut">
+                    <option value="OK" ${normalizeDetailStatut(detail.statut) === 'OK' ? 'selected' : ''}>OK</option>
+                    <option value="K.O" ${normalizeDetailStatut(detail.statut) === 'K.O' ? 'selected' : ''}>K.O</option>
+                  </select>
+                </div>
+              </td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateCreation)}</span></td>
               <td><span class="meta-value">${UiService.formatDate(detail.dateModification)}</span></td>
               <td>
@@ -5532,7 +5551,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             return;
           }
 
-          const nextValue = event.target.value;
+          const nextValue = fieldName === 'statut' ? normalizeDetailStatut(event.target.value) : event.target.value;
           if (String(currentDetail[fieldName] ?? '') === String(nextValue ?? '')) {
             return;
           }
@@ -5540,6 +5559,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           await StorageService.updateDetail(siteId, itemId, row.dataset.detailId, {
             [fieldName]: nextValue,
           });
+          if (fieldName === 'statut') {
+            const statusField = event.target.closest('.detail-status-field');
+            if (statusField) {
+              statusField.classList.toggle('detail-status-field--ok', nextValue === 'OK');
+              statusField.classList.toggle('detail-status-field--ko', nextValue === 'K.O');
+            }
+          }
           applyCompactColumnWidths();
         });
 
@@ -5589,6 +5615,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         dateRetour: 140,
         ecart: 48,
         observation: 48,
+        statut: 84,
       };
 
       columns.forEach((inputs, key) => {
@@ -5642,6 +5669,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           designation: designationInput.value,
           qteSortie: requireElement('qteSortieInput').value,
           unite: requireElement('uniteInput').value,
+          statut: requireElement('statutInput')?.value || 'OK',
         });
         if (!result?.ok) {
           showDetailFormError(
@@ -5653,6 +5681,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         }
         detailForm.reset();
         requireElement('uniteInput').value = 'm';
+        requireElement('statutInput').value = 'OK';
         updateDetailInputCounters();
         hideCodeSuggestions();
         clearDetailFormError();

--- a/js/storage.js
+++ b/js/storage.js
@@ -595,6 +595,10 @@ function sanitizeReturnDate(value) {
   return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : '';
 }
 
+function sanitizeDetailStatut(value) {
+  return String(value || '').trim().toUpperCase() === 'K.O' ? 'K.O' : 'OK';
+}
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -1399,6 +1403,7 @@ async function createDetail(siteId, itemId, payload) {
     qtePosee: 0,
     qteRebus: 0,
     observation: '',
+    statut: sanitizeDetailStatut(payload.statut),
     ownerId: state.userId,
     createdBy: state.userId,
     dateCreation: timestamp,
@@ -1464,6 +1469,10 @@ async function updateDetail(siteId, itemId, detailId, changes) {
   if ('dateRetour' in changes) {
     nextValues.dateRetour = sanitizeReturnDate(changes.dateRetour);
     syncedChanges.dateRetour = nextValues.dateRetour;
+  }
+  if ('statut' in changes) {
+    nextValues.statut = sanitizeDetailStatut(changes.statut);
+    syncedChanges.statut = nextValues.statut;
   }
   nextValues.dateModification = nowIso();
   syncedChanges.dateModification = nextValues.dateModification;
@@ -1623,6 +1632,7 @@ function normalizeImportPayload(payload) {
           qtePosee: sanitizeNumber(detail.qtePosee),
           qteRebus: sanitizeNumber(detail.qteRebus),
           observation: sanitizeText(detail.observation, false),
+          statut: sanitizeDetailStatut(detail.statut),
           ownerId: state.userId,
           createdBy: state.userId,
           dateCreation: detail.dateCreation || nowIso(),

--- a/page3.html
+++ b/page3.html
@@ -74,6 +74,7 @@
                   <th>Date de retour</th>
                   <th>Ecart</th>
                   <th>Remarque</th>
+                  <th>Statut</th>
                   <th>Date de création</th>
                   <th>Date de modification</th>
                   <th>Action</th>
@@ -130,6 +131,13 @@
                   </select>
                 </label>
               </div>
+              <label class="input-group detail-form-field">
+                <span>Statut</span>
+                <select id="statutInput" name="statut">
+                  <option value="OK" selected>OK</option>
+                  <option value="K.O">K.O</option>
+                </select>
+              </label>
               <div class="form-footer">
                 <p id="detailFormError" class="form-error" aria-live="polite"></p>
                 <div class="detail-form-actions">


### PR DESCRIPTION
### Motivation
- Ajouter un champ non obligatoire `Statut` (deux valeurs : `OK` / `K.O`) pour chaque article de la Page 3, avec `OK` comme valeur par défaut et compatibilité avec les anciennes données.
- Permettre l'édition directe du statut depuis le tableau et la persistance dans Firestore sans impacter les autres pages ni la structure globale du projet.

### Description
- Interface: ajout d'un `<select id="statutInput">` dans le formulaire d'ajout/modification de `page3.html` et insertion de la colonne `Statut` entre `Remarque` et `Date de création` dans le tableau.
- Comportement UI: rendu d'une pastille discrète (point vert/rouge) + libellé et édition inline via un `select` dans chaque ligne du tableau, avec mise à jour visuelle immédiate après modification.
- Stockage/Validation: ajout de `sanitizeDetailStatut()` dans `js/storage.js` et `normalizeDetailStatut()` dans `js/app.js`, intégration du champ `statut` dans `createDetail`, `updateDetail` et lors de l'import pour garantir le fallback `OK` si absent.
- Exports: ajout de la colonne `Statut` (texte `OK` / `K.O`, sans pastille) dans l'export Page 3 (`buildDetailExcelContent`) et dans l'export Page 2 (`buildSiteExcelContent` / `buildSiteExportRows`).
- Style: ajout de styles discrets dans `css/style.css` pour la pastille et l'alignement du `select` afin de respecter le style existant; ajustement du `colspan` et des largeurs compactes dans `js/app.js`.
- Fichiers modifiés : `page3.html`, `js/app.js`, `js/storage.js`, `css/style.css`.

### Testing
- Vérification syntaxique JavaScript effectuée avec `node --check js/app.js` et `node --check js/storage.js`, les deux commandes ont réussi.
- Contrôles de packaging/état : `git status` / `git show --stat` exécutés pour valider le diff et le commit; commit créé avec message lié à l'ajout du champ `Statut`.
- Aucun test unitaire automatisé supplémentaire présent dans le projet; vérifier en environnement d'exécution la création, modification, recherche et export des articles pour valider le comportement runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0338d3e62c832a80ded6a28ba23578)