### PR TITLE
Fix Page 3 status visual alignment in detail table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3148,23 +3148,20 @@ body[data-page="item-detail"] #designationInput.is-shaking {
 body[data-page="item-detail"] .detail-status-field {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  --detail-status-color: #16a34a;
 }
 
-body[data-page="item-detail"] .detail-status-dot {
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: #16a34a;
-  display: inline-block;
-}
-
-body[data-page="item-detail"] .detail-status-field--ko .detail-status-dot {
-  background: #dc2626;
+body[data-page="item-detail"] .detail-status-field--ko {
+  --detail-status-color: #dc2626;
 }
 
 body[data-page="item-detail"] .detail-status-select {
   min-width: 76px;
+  padding-left: 1.45rem;
+  background-image: radial-gradient(circle at center, var(--detail-status-color) 0 60%, transparent 61%);
+  background-repeat: no-repeat;
+  background-size: 0.55rem 0.55rem;
+  background-position: 0.65rem 50%;
 }
 
 .cell-input-measurer {

--- a/js/app.js
+++ b/js/app.js
@@ -5513,7 +5513,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="observation" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" /></td>
               <td>
                 <div class="detail-status-field detail-status-field--${normalizeDetailStatut(detail.statut) === 'K.O' ? 'ko' : 'ok'}">
-                  <span class="detail-status-dot" aria-hidden="true"></span>
                   <select class="cell-input cell-input--compact-dynamic detail-status-select" data-col-key="statut" data-field="statut" aria-label="Statut">
                     <option value="OK" ${normalizeDetailStatut(detail.statut) === 'OK' ? 'selected' : ''}>OK</option>
                     <option value="K.O" ${normalizeDetailStatut(detail.statut) === 'K.O' ? 'selected' : ''}>K.O</option>


### PR DESCRIPTION
### Motivation
- Corriger l’alignement visuel de la colonne « Statut » sur Page 3 en plaçant le petit point coloré à l’intérieur du même conteneur visuel que le libellé et le select pour un rendu compact et centré verticalement.
- Conserver le comportement dynamique existant (changement de point en temps réel selon la valeur `OK` / `K.O`) et ne toucher ni aux exports ni aux autres pages ou fonctions.

### Description
- Supprimé l’élément `<span class="detail-status-dot">` externe du template de ligne et laissé uniquement le `select` dans le même conteneur (`js/app.js`).
- Ajouté une variable CSS `--detail-status-color` pilotée par la classe de conteneur `detail-status-field--ko` et dessin du point directement dans le `select` via `background-image: radial-gradient(...)` pour que le point apparaisse à gauche du libellé et reste dans la cellule (`css/style.css`).
- Ajusté l’espacement intérieur du `select` avec `padding-left` et fixé la taille/position du point pour conserver les dimensions et le style compact actuels du champ.
- Limité au sélecteur `body[data-page="item-detail"]` afin d’impacter uniquement Page 3 et de ne pas modifier d’autres colonnes ou pages.

### Testing
- Exécuté `git diff --check` pour valider l’absence d’erreurs de diff et l’opération a réussi.
- Aucune suite de tests unitaires automatisés disponible pour cette zone, vérification manuelle du template/CSS et inspection des fichiers modifiés réalisée avec des recherches par motif (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033efa87f4832aacaa1e3306c833b8)