### PR TITLE
Page 3: dynamic row coloring for K.O status

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2621,6 +2621,15 @@ body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
   background: #f7faff;
 }
 
+body[data-page="item-detail"] .data-table tbody tr td {
+  transition: background-color 0.25s ease, border-color 0.25s ease;
+}
+
+body[data-page="item-detail"] .data-table tbody tr.detail-row--ko td {
+  background: #fff5f5;
+  border-bottom-color: #ffd4d4;
+}
+
 body[data-page="item-detail"] .data-table td {
   text-align: center;
   vertical-align: middle;

--- a/js/app.js
+++ b/js/app.js
@@ -5494,8 +5494,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             const ecart = computeEcart(detail);
             const ecartClassName = typeof ecart === 'number' && ecart !== 0 ? ' cell-input--ecart-alert' : '';
             const enterAnimationStyle = animateNextTableRender ? ` style="--detail-row-enter-delay:${Math.min(index, 5) * 40}ms"` : '';
+            const isKoStatus = normalizeDetailStatut(detail.statut) === 'K.O';
+            const rowClasses = [
+              animateNextTableRender ? 'detail-row-enter' : '',
+              isKoStatus ? 'detail-row--ko' : '',
+            ].filter(Boolean).join(' ');
             return `
-            <tr data-detail-id="${detail.id}" class="${animateNextTableRender ? 'detail-row-enter' : ''}"${enterAnimationStyle}>
+            <tr data-detail-id="${detail.id}" class="${rowClasses}"${enterAnimationStyle}>
               <td><span class="field-badge">${detail.champ}</span></td>
               <td><input class="cell-input cell-input--autosize cell-input--left" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
               <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
@@ -5512,10 +5517,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--compact-dynamic${ecartClassName}" data-col-key="ecart" type="number" maxlength="120" value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="observation" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" /></td>
               <td>
-                <div class="detail-status-field detail-status-field--${normalizeDetailStatut(detail.statut) === 'K.O' ? 'ko' : 'ok'}">
+                <div class="detail-status-field detail-status-field--${isKoStatus ? 'ko' : 'ok'}">
                   <select class="cell-input cell-input--compact-dynamic detail-status-select" data-col-key="statut" data-field="statut" aria-label="Statut">
-                    <option value="OK" ${normalizeDetailStatut(detail.statut) === 'OK' ? 'selected' : ''}>OK</option>
-                    <option value="K.O" ${normalizeDetailStatut(detail.statut) === 'K.O' ? 'selected' : ''}>K.O</option>
+                    <option value="OK" ${!isKoStatus ? 'selected' : ''}>OK</option>
+                    <option value="K.O" ${isKoStatus ? 'selected' : ''}>K.O</option>
                   </select>
                 </div>
               </td>
@@ -5560,9 +5565,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           });
           if (fieldName === 'statut') {
             const statusField = event.target.closest('.detail-status-field');
+            const row = event.target.closest('tr');
             if (statusField) {
               statusField.classList.toggle('detail-status-field--ok', nextValue === 'OK');
               statusField.classList.toggle('detail-status-field--ko', nextValue === 'K.O');
+            }
+            if (row) {
+              row.classList.toggle('detail-row--ko', nextValue === 'K.O');
             }
           }
           applyCompactColumnWidths();


### PR DESCRIPTION
### Motivation
- Visually indicate rows with a Firestore `statut` of `K.O` on Page 3 only so issues are immediately visible while preserving the current premium table style.
- Ensure the coloring updates instantly when the status is changed from the inline dropdown or from the add/edit form without a full reload.
- Keep behavior scoped to the item-detail page, preserve horizontal scrolling and exports, and reuse existing CSS/JS patterns where possible.

### Description
- `js/app.js`: compute `isKoStatus` when rendering rows, add a `detail-row--ko` class to rows with `K.O`, use the same boolean to initialize the row select, and toggle `detail-row--ko` immediately in the `change` handler for the `statut` field.
- `css/style.css`: add a scoped transition on table cells and a `detail-row--ko` rule that applies a very light red background (`#fff5f5`) and a soft red border-bottom color (`#ffd4d4`) to make the K.O state discreet but visible.
- Changes are strictly limited to the Page 3 table scope (`body[data-page="item-detail"]`) and do not modify Page 1/2 behavior or export functionality.

### Testing
- Performed repository-wide searches to confirm selectors and scope and to locate the render/change handlers that needed patching, and those searches completed successfully.
- Applied the code edits to `js/app.js` and `css/style.css` and inspected the produced diff to verify the intended modifications were present and correctly scoped, with no errors reported.
- Created the PR entry with the updated diff and confirmed the automated patching and verification steps completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0362cbfcb0832a8bba4ebbd2b8a005)