### PR TITLE
Bloquer l'édition des lignes K.O sur Page 3 (détails)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3173,6 +3173,13 @@ body[data-page="item-detail"] .detail-status-select {
   background-position: 0.65rem 50%;
 }
 
+body[data-page="item-detail"] .cell-input.cell-input--soft-disabled,
+body[data-page="item-detail"] .cell-textarea.cell-input--soft-disabled {
+  opacity: 0.72;
+  background: #f5f7fa;
+  cursor: not-allowed;
+}
+
 .cell-input-measurer {
   position: absolute;
   visibility: hidden;

--- a/js/app.js
+++ b/js/app.js
@@ -5474,6 +5474,23 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    function setRowKoInteractionState(row, isKoStatus) {
+      if (!row) {
+        return;
+      }
+
+      const editableFields = row.querySelectorAll('[data-field]');
+      editableFields.forEach((field) => {
+        const fieldName = field.dataset.field;
+        const shouldDisable = !canEditDetails || (isKoStatus && fieldName !== 'statut');
+        field.disabled = shouldDisable;
+        field.readOnly = shouldDisable && field.tagName === 'INPUT';
+        field.tabIndex = shouldDisable ? -1 : 0;
+        field.classList.toggle('cell-input--soft-disabled', shouldDisable);
+        field.setAttribute('aria-disabled', shouldDisable ? 'true' : 'false');
+      });
+    }
+
     function renderTable() {
       if (!currentItem) {
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
@@ -5538,20 +5555,24 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         .join('');
       animateNextTableRender = false;
 
-      detailTableBody.querySelectorAll('[data-field]').forEach((field) => {
-        if (!canEditDetails) {
-          field.disabled = true;
-        }
-        if (!canEditDetails) {
-          return;
-        }
+      detailTableBody.querySelectorAll('tr[data-detail-id]').forEach((row) => {
+        const statusSelect = row.querySelector('[data-field="statut"]');
+        const isKoStatus = normalizeDetailStatut(statusSelect?.value) === 'K.O';
+        setRowKoInteractionState(row, isKoStatus);
+      });
 
+      detailTableBody.querySelectorAll('[data-field]').forEach((field) => {
         field.addEventListener('change', async (event) => {
           const row = event.target.closest('tr');
           const fieldName = event.target.dataset.field;
           const currentDetail = currentDetails.find((detail) => detail.id === row.dataset.detailId);
 
           if (!currentDetail) {
+            return;
+          }
+
+          const isKoRow = normalizeDetailStatut(currentDetail.statut) === 'K.O';
+          if (fieldName !== 'statut' && isKoRow) {
             return;
           }
 
@@ -5572,6 +5593,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             }
             if (row) {
               row.classList.toggle('detail-row--ko', nextValue === 'K.O');
+              setRowKoInteractionState(row, nextValue === 'K.O');
             }
           }
           applyCompactColumnWidths();
@@ -5579,6 +5601,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
         if (field.classList.contains('cell-input--compact-dynamic')) {
           field.addEventListener('input', () => {
+            if (field.disabled) {
+              return;
+            }
             if (field.value.length > 120) {
               field.value = field.value.slice(0, 120);
             }


### PR DESCRIPTION
### Motivation
- Corriger le comportement des lignes avec statut `K.O` sur la Page 3 afin que tous les champs restent visibles mais non modifiables, sauf le champ `Statut`.
- Appliquer l’état immédiatement côté client lors des basculements `OK ↔ K.O` sans attendre un refresh Firestore.
- Empêcher toute mise à jour Firestore depuis des champs désactivés tout en conservant l'affichage et le scroll du tableau.

### Description
- Ajout de `setRowKoInteractionState(row, isKoStatus)` dans `js/app.js` pour activer/désactiver les champs d'une ligne, gérer `tabIndex`, `aria-disabled` et appliquer la classe visuelle de désactivation.
- Le rendu de la table appelle désormais `setRowKoInteractionState` pour chaque ligne après insertion du HTML afin d'appliquer l'état immédiatement selon le `Statut` courant.
- Le handler de `change` refuse les modifications venant de champs non-`statut` si la ligne est en `K.O`, et le changement de `statut` met à jour instantanément la classe de ligne et l'état d'interaction.
- Ajout d'un style CSS `.cell-input--soft-disabled` dans `css/style.css` pour opacité réduite, fond clair et curseur `not-allowed` sans modifier le design global; fichiers modifiés: `js/app.js`, `css/style.css`.

### Testing
- Exécution de `git -C /workspace/Album status --short` a réussi et a listé les fichiers modifiés.
- Exécution de `git -C /workspace/Album diff -- js/app.js css/style.css` a réussi et a montré le diff attendu.
- Validation par `git -C /workspace/Album add ... && git -C /workspace/Album commit -m "Fix KO row edit locking on page 3 details table"` a réussi et a committé les modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0367b1f7b4832abaf0b7c824695231)