### PR TITLE
Page 3: coloration automatique des lignes selon Qté posée / Ecart

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2630,6 +2630,16 @@ body[data-page="item-detail"] .data-table tbody tr.detail-row--ko td {
   border-bottom-color: #ffd4d4;
 }
 
+body[data-page="item-detail"] .data-table tbody tr.detail-row--done td {
+  background: #f0fdf4;
+  border-bottom-color: #bbf7d0;
+}
+
+body[data-page="item-detail"] .data-table tbody tr.detail-row--attention td {
+  background: #fffbeb;
+  border-bottom-color: #fde68a;
+}
+
 body[data-page="item-detail"] .data-table td {
   text-align: center;
   vertical-align: middle;

--- a/js/app.js
+++ b/js/app.js
@@ -5491,6 +5491,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    function applyDetailRowSemanticState(row) {
+      if (!row) {
+        return;
+      }
+
+      const isKoStatus = normalizeDetailStatut(row.querySelector('[data-field="statut"]')?.value) === 'K.O';
+      const qtePosee = Number(row.querySelector('[data-field="qtePosee"]')?.value ?? 0);
+      const ecart = Number(row.querySelector('[data-col-key="ecart"]')?.value ?? 0);
+
+      row.classList.toggle('detail-row--done', !isKoStatus && qtePosee > 0 && ecart === 0);
+      row.classList.toggle('detail-row--attention', !isKoStatus && qtePosee === 0 && ecart !== 0);
+    }
+
     function renderTable() {
       if (!currentItem) {
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
@@ -5559,6 +5572,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const statusSelect = row.querySelector('[data-field="statut"]');
         const isKoStatus = normalizeDetailStatut(statusSelect?.value) === 'K.O';
         setRowKoInteractionState(row, isKoStatus);
+        applyDetailRowSemanticState(row);
       });
 
       detailTableBody.querySelectorAll('[data-field]').forEach((field) => {
@@ -5594,7 +5608,20 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             if (row) {
               row.classList.toggle('detail-row--ko', nextValue === 'K.O');
               setRowKoInteractionState(row, nextValue === 'K.O');
+              applyDetailRowSemanticState(row);
             }
+          }
+          if (fieldName === 'qtePosee' || fieldName === 'qteSortie' || fieldName === 'qteRebus' || fieldName === 'qteRetour') {
+            const ecartField = row.querySelector('[data-col-key="ecart"]');
+            if (ecartField) {
+              const nextEcart = computeEcart({
+                ...currentDetail,
+                [fieldName]: nextValue,
+              });
+              ecartField.value = Number.isFinite(nextEcart) ? String(nextEcart) : '0';
+              ecartField.classList.toggle('cell-input--ecart-alert', typeof nextEcart === 'number' && nextEcart !== 0);
+            }
+            applyDetailRowSemanticState(row);
           }
           applyCompactColumnWidths();
         });
@@ -5606,6 +5633,24 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             }
             if (field.value.length > 120) {
               field.value = field.value.slice(0, 120);
+            }
+            if (field.dataset.field === 'qtePosee' || field.dataset.field === 'qteSortie' || field.dataset.field === 'qteRebus' || field.dataset.field === 'qteRetour' || field.dataset.field === 'statut') {
+              const row = field.closest('tr');
+              if (row) {
+                if (field.dataset.field !== 'statut') {
+                  const qteSortie = Number(row.querySelector('[data-field="qteSortie"]')?.value ?? 0);
+                  const qtePosee = Number(row.querySelector('[data-field="qtePosee"]')?.value ?? 0);
+                  const qteRebus = Number(row.querySelector('[data-field="qteRebus"]')?.value ?? 0);
+                  const qteRetour = Number(row.querySelector('[data-field="qteRetour"]')?.value ?? 0);
+                  const ecart = qteSortie - qtePosee - qteRebus - qteRetour;
+                  const ecartField = row.querySelector('[data-col-key="ecart"]');
+                  if (ecartField) {
+                    ecartField.value = String(ecart);
+                    ecartField.classList.toggle('cell-input--ecart-alert', ecart !== 0);
+                  }
+                }
+                applyDetailRowSemanticState(row);
+              }
             }
             applyCompactColumnWidths();
           });


### PR DESCRIPTION
### Motivation
- Implémenter sur la Page 3 une coloration automatique des lignes du tableau selon les règles métier (vert doux si `Qté posée > 0` et `Ecart = 0`, jaune doux si `Qté posée = 0` et `Ecart != 0`), mise à jour immédiate à la saisie, tout en conservant la priorité du statut `K.O` et sans toucher aux pages 1/2 ni aux exports.

### Description
- Ajout de la fonction `applyDetailRowSemanticState(row)` dans `js/app.js` qui bascule les classes `detail-row--done` et `detail-row--attention` en tenant compte du `statut`, `qtePosee` et de la valeur `ecart` (K.O reste prioritaire). 
- Mise à jour des handlers pour appeler cette fonction au rendu initial de chaque ligne, sur `change` après persistance, et pendant `input` pour un feedback immédiat, et recalcul instantané de la cellule `Ecart` côté UI quand les quantités changent. 
- Ajout de styles CSS dans `css/style.css` pour `detail-row--done` (fond `#f0fdf4`, bordure `#bbf7d0`) et `detail-row--attention` (fond `#fffbeb`, bordure `#fde68a`) appliqués à toute la ligne du tableau.

### Testing
- Exécution de recherches de code avec `rg -n "Page 3|Qté posée|Ecart|K.O|KO|statut|export" -S .` pour valider le périmètre des changements, succès. 
- Inspection des plages modifiées avec `nl ... | sed` pour vérifier l’insertion des modifications dans `js/app.js` et `css/style.css`, succès. 
- Application du patch via `apply_patch` et vérification que `js/app.js` et `css/style.css` ont bien été mis à jour sans erreur, succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036f8f38cc832aa470082b84a55072)