### PR TITLE
Page 3 — ajouter bouton filtre et menu popup pour le tableau

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2387,6 +2387,89 @@ body[data-page="item-detail"] .search-panel .input-group {
   position: relative;
 }
 
+body[data-page="item-detail"] .page3-search-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+body[data-page="item-detail"] .page3-search-filter-bar .input-group {
+  flex: 1;
+  min-width: 0;
+}
+
+body[data-page="item-detail"] .page3-filter-menu-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+body[data-page="item-detail"] .page3-filter-button {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  transition: transform 0.18s ease, box-shadow 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+body[data-page="item-detail"] .page3-filter-button:hover,
+body[data-page="item-detail"] .page3-filter-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
+}
+
+body[data-page="item-detail"] .page3-filter-button.is-filtered {
+  background: #e8f1ff;
+  border-color: #b6cbef;
+}
+
+body[data-page="item-detail"] .page3-filter-button__icon {
+  width: 17px;
+  height: 17px;
+  object-fit: contain;
+  opacity: 0.82;
+}
+
+body[data-page="item-detail"] .page3-filter-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 150px;
+  border-radius: 14px;
+  border: 1px solid #dbe5f1;
+  background: #fff;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14);
+  padding: 6px;
+  z-index: 30;
+}
+
+body[data-page="item-detail"] .page3-filter-option {
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+  font-size: 0.92rem;
+  color: #334155;
+  padding: 8px 10px;
+  transition: background-color 0.18s ease, color 0.18s ease;
+}
+
+body[data-page="item-detail"] .page3-filter-option:hover,
+body[data-page="item-detail"] .page3-filter-option:focus-visible {
+  background: #f2f7ff;
+}
+
+body[data-page="item-detail"] .page3-filter-option.is-active {
+  background: #e7f0ff;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
 body[data-page="item-detail"] .search-input__icon-wrap {
   position: absolute;
   left: 0.85rem;

--- a/js/app.js
+++ b/js/app.js
@@ -4770,6 +4770,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const detailTableBody = requireElement('detailTableBody');
     const detailSearchInput = requireElement('detailSearchInput');
     const clearSearchBtn = document.querySelector('#clearSearchBtn');
+    const detailFilterButton = document.querySelector('#detailFilterButton');
+    const detailFilterMenu = document.querySelector('#detailFilterMenu');
+    const detailFilterOptions = Array.from(document.querySelectorAll('[data-detail-filter]'));
     const exportButton = requireElement('exportDetailsButton');
     const detailExportDialog = requireElement('detailExportDialog');
     const detailExportForm = requireElement('detailExportForm');
@@ -4804,6 +4807,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let designationInputErrorTimeoutId = null;
     let codeInputErrorStateTimeoutId = null;
     let designationInputErrorStateTimeoutId = null;
+    let activeDetailFilter = 'all';
 
     function setDetailModalOpenState(isOpen) {
       document.body.classList.toggle('item-detail-modal-open', isOpen);
@@ -5275,10 +5279,70 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function getFilteredDetails(details) {
       const query = getSearchQuery();
-      if (!query) {
-        return details;
+      return details.filter((detail) => {
+        const designationMatch = !query || String(detail.designation || '').toLowerCase().includes(query);
+        if (!designationMatch) {
+          return false;
+        }
+
+        const isKoStatus = normalizeDetailStatut(detail.statut) === 'K.O';
+        if (activeDetailFilter === 'ko') {
+          return isKoStatus;
+        }
+        if (isKoStatus) {
+          return activeDetailFilter === 'all';
+        }
+
+        const ecart = computeEcart(detail);
+        const qtePosee = Number(detail?.qtePosee) || 0;
+        const qteRetour = Number(detail?.qteRetour) || 0;
+        const qteRebus = Number(detail?.qteRebus) || 0;
+        const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
+        const isDone = qtePosee > 0 && ecart === 0;
+        const isAttention = hasActivity && ecart !== 0;
+
+        if (activeDetailFilter === 'done') {
+          return isDone;
+        }
+        if (activeDetailFilter === 'fix') {
+          return isAttention;
+        }
+        if (activeDetailFilter === 'todo') {
+          return !isDone && !isAttention;
+        }
+        return true;
+      });
+    }
+
+    function syncDetailFilterUi() {
+      detailFilterButton?.classList.toggle('is-filtered', activeDetailFilter !== 'all');
+      detailFilterOptions.forEach((option) => {
+        const isActive = option.dataset.detailFilter === activeDetailFilter;
+        option.classList.toggle('is-active', isActive);
+        option.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      });
+    }
+
+    function setDetailFilter(filterKey) {
+      activeDetailFilter = filterKey;
+      syncDetailFilterUi();
+      renderTable();
+    }
+
+    function closeDetailFilterMenu() {
+      if (!detailFilterMenu || !detailFilterButton) {
+        return;
       }
-      return details.filter((detail) => String(detail.designation || '').toLowerCase().includes(query));
+      detailFilterMenu.hidden = true;
+      detailFilterButton.setAttribute('aria-expanded', 'false');
+    }
+
+    function openDetailFilterMenu() {
+      if (!detailFilterMenu || !detailFilterButton) {
+        return;
+      }
+      detailFilterMenu.hidden = false;
+      detailFilterButton.setAttribute('aria-expanded', 'true');
     }
 
     function updateCount(filteredCount, totalCount) {
@@ -5908,6 +5972,36 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
       detailSearchInput.value = '';
       toggleClearButton();
+    }
+
+    if (detailFilterButton && detailFilterMenu && detailFilterOptions.length) {
+      syncDetailFilterUi();
+      detailFilterButton.addEventListener('click', () => {
+        if (detailFilterMenu.hidden) {
+          openDetailFilterMenu();
+          return;
+        }
+        closeDetailFilterMenu();
+      });
+
+      detailFilterOptions.forEach((option) => {
+        option.addEventListener('click', () => {
+          setDetailFilter(option.dataset.detailFilter || 'all');
+          closeDetailFilterMenu();
+        });
+      });
+
+      document.addEventListener('click', (event) => {
+        if (!detailFilterMenu.hidden && !event.target.closest('.page3-filter-menu-wrap')) {
+          closeDetailFilterMenu();
+        }
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !detailFilterMenu.hidden) {
+          closeDetailFilterMenu();
+        }
+      });
     }
 
     if (exportButton) {

--- a/page3.html
+++ b/page3.html
@@ -42,7 +42,7 @@
 
             <div id="detailStore" class="store-info magasin-block page3-info-row">Magasin : Non défini</div>
           </div>
-          <div class="search-panel search-panel--inline">
+          <div class="search-panel search-panel--inline page3-search-filter-bar">
             <label class="input-group">
               <span class="search-input__icon-wrap" aria-hidden="true">
                 <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
@@ -50,6 +50,18 @@
               <input id="detailSearchInput" class="search-input" type="text" placeholder="Entrer votre recherche..." autocomplete="off" />
               <button id="clearSearchBtn" class="clear-search-btn" type="button" aria-label="Effacer la recherche">×</button>
             </label>
+            <div class="page3-filter-menu-wrap">
+              <button type="button" id="detailFilterButton" class="page3-filter-button" aria-label="Filtrer le tableau" aria-haspopup="true" aria-expanded="false" aria-controls="detailFilterMenu">
+                <img src="Icon/filtre.png" alt="" aria-hidden="true" class="page3-filter-button__icon" />
+              </button>
+              <div id="detailFilterMenu" class="page3-filter-menu" role="menu" hidden>
+                <button type="button" class="page3-filter-option is-active" data-detail-filter="all" role="menuitemradio" aria-checked="true">Tous</button>
+                <button type="button" class="page3-filter-option" data-detail-filter="todo" role="menuitemradio" aria-checked="false">À faire</button>
+                <button type="button" class="page3-filter-option" data-detail-filter="fix" role="menuitemradio" aria-checked="false">À corriger</button>
+                <button type="button" class="page3-filter-option" data-detail-filter="done" role="menuitemradio" aria-checked="false">Effectué</button>
+                <button type="button" class="page3-filter-option" data-detail-filter="ko" role="menuitemradio" aria-checked="false">K.O</button>
+              </div>
+            </div>
           </div>
           <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>
             <span class="auth-required-card__icon" aria-hidden="true">i</span>


### PR DESCRIPTION
### Motivation
- Ajouter un bouton filtre compact à droite du champ de recherche sur Page 3 pour permettre le filtrage rapide des lignes sans créer de nouveaux fichiers. 
- Réutiliser l’icône existante `Icon/filtre.png` et conserver le style et le comportement actuels du tableau (scroll, exports, priorité K.O). 

### Description
- Ajout du markup du bouton et du menu popup dans `page3.html` juste à côté du champ de recherche, avec les options `Tous`, `À faire`, `À corriger`, `Effectué`, `K.O` (par défaut `Tous`).
- Ajout de styles Page‑3 spécifiques dans `css/style.css` pour aligner le champ et l’icône sur une seule ligne, rendre le bouton rond/professionnel, et styler le menu popup et l’état actif discret.
- Intégration côté client dans `js/app.js` : nouvel état `activeDetailFilter`, intégration de la logique de filtrage dans `getFilteredDetails` (combinaison recherche + filtre), gestion du comportement K.O prioritaire sans modifier la sémantique existante des lignes, et ajout des interactions du menu (ouverture/fermeture, clic extérieur, `Esc`, mise à jour visuelle du bouton et des options actives).
- Aucune modification effectuée sur Page 1 ou Page 2, aucun nouveau fichier ajouté, et aucun changement aux exports ou au scroll horizontal du tableau.

### Testing
- Exécution d’une vérification de syntaxe JS via `node --check js/app.js`, qui a réussi sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0382511240832a80d5575ea058f7fa)