### PR TITLE
Page 3: afficher compteurs du menu filtre à droite des libellés

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5327,7 +5327,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       detailFilterOptions.forEach((option) => {
         const filterKey = option.dataset.detailFilter || 'all';
         const count = details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailFilter(detail, filterKey)).length;
-        option.innerHTML = `<span class="page3-filter-option__count">${count}</span><span class="page3-filter-option__label">${option.dataset.filterLabel || option.textContent.trim()}</span>`;
+        const label = option.dataset.filterLabel || option.textContent.trim();
+        option.textContent = `${label} (${count})`;
       });
     }
 


### PR DESCRIPTION
### Motivation
- Rendre l’affichage des compteurs dans le menu filtre de la Page 3 conforme au nouveau design attendu en plaçant le nombre à droite du libellé entre parenthèses (ex. `Tous (8)`).

### Description
- Modifié `js/app.js`: dans `updateDetailFilterCounters(details)` la construction HTML des options de filtre passe de deux spans séparés à un seul texte formaté `label (count)` pour chaque option de menu. 
- La valeur `label` est prise depuis `option.dataset.filterLabel` ou depuis le texte actuel de l’option afin de conserver les libellés existants.
- Le calcul des compteurs reste inchangé et continue d’utiliser la logique existante qui respecte la recherche active et les filtres appliqués.
- La modification est limitée à Page 3 et n’impacte pas le style, l’alignement général ni les autres pages/exports.

### Testing
- Aucun test automatisé spécifique à cette UI n’a été disponible dans le dépôt pour cette modification.
- Validation par inspection du diff et du fichier avec `git diff -- js/app.js`, confirmant que les lignes modifiées produisent le format attendu (`${label} (${count})`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0389459cd8832a8362d74d64c77aba)