### PR TITLE
Ajouter filtre statut OUT (icône curseurs) sur Page 2 à côté du chip "Plus ancien"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4281,8 +4281,16 @@ body[data-page="site-detail"] .tab-content.hidden {
 
 body[data-page="site-detail"] .filter-chip-group {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.5rem;
+  align-items: center;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+
+body[data-page="site-detail"] .filter-chip-group::-webkit-scrollbar {
+  display: none;
 }
 
 body[data-page="site-detail"] .filter-chip {
@@ -4294,6 +4302,77 @@ body[data-page="site-detail"] .filter-chip {
   font-size: 0.86rem;
   font-weight: 600;
   transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+  transition: transform 0.18s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-button:hover,
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-button:focus-visible {
+  transform: translateY(-1px);
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-button.is-filtered {
+  background: #e8f1ff;
+  border-color: #b6cbef;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-button__icon {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+  opacity: 0.82;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 170px;
+  border-radius: 14px;
+  border: 1px solid #dbe5f1;
+  background: #fff;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14);
+  padding: 6px;
+  z-index: 30;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-option {
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+  font-size: 0.92rem;
+  color: #334155;
+  padding: 8px 10px;
+  transition: background-color 0.18s ease, color 0.18s ease;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-option:hover,
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-option:focus-visible {
+  background: #f2f7ff;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-option.is-active {
+  background: #e7f0ff;
+  color: #1d4ed8;
+  font-weight: 600;
 }
 
 body[data-page="site-detail"] .filter-chip:hover {

--- a/js/app.js
+++ b/js/app.js
@@ -264,6 +264,33 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return String(value || '').trim().toUpperCase() === 'K.O' ? 'K.O' : 'OK';
   }
 
+  function matchesDetailStatusFilter(detail, filterKey) {
+    const isKoStatus = normalizeDetailStatut(detail?.statut) === 'K.O';
+    if (filterKey === 'ko') {
+      return isKoStatus;
+    }
+    if (isKoStatus) {
+      return filterKey === 'all';
+    }
+    const ecart = computeEcart(detail);
+    const qtePosee = Number(detail?.qtePosee) || 0;
+    const qteRetour = Number(detail?.qteRetour) || 0;
+    const qteRebus = Number(detail?.qteRebus) || 0;
+    const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
+    const isDone = qtePosee > 0 && ecart === 0;
+    const isAttention = hasActivity && ecart !== 0;
+    if (filterKey === 'done') {
+      return isDone;
+    }
+    if (filterKey === 'fix') {
+      return isAttention;
+    }
+    if (filterKey === 'todo') {
+      return !isDone && !isAttention;
+    }
+    return true;
+  }
+
   function setupZoomableDetailTable() {
     const tableContainer = requireElement('detailTableContainer');
     const tableWrapper = requireElement('detailTableWrapper');
@@ -2850,7 +2877,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const searchReadIdsStorageKey = 'page2_search_read_ids';
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
+    const outStatusFilterButton = document.querySelector('#outStatusFilterButton');
+    const outStatusFilterMenu = document.querySelector('#outStatusFilterMenu');
+    const outStatusFilterOptions = Array.from(document.querySelectorAll('[data-out-status-filter]'));
+    outStatusFilterOptions.forEach((option) => {
+      option.dataset.filterLabel = option.textContent.trim();
+    });
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
+    let selectedOutStatusFilter = 'all';
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
     let hasPendingOutScrollRestore = true;
     let selectedPurchasePhotoFile = null;
@@ -3595,8 +3629,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function renderItems(options = {}) {
       const shouldFlashSearchMatches = Boolean(options?.flashSearchMatches);
       const query = itemSearchInput.value.trim().toUpperCase();
+      updateOutStatusFilterCounters();
       const filteredItems = currentItems.filter((item) => {
         if (!itemMatchesDateFilter(item, selectedDateFilter)) {
+          return false;
+        }
+        if (!matchesOutStatusFilter(item, selectedOutStatusFilter)) {
           return false;
         }
         if (!query) {
@@ -3678,6 +3716,74 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
 
       restoreOutPageScrollPosition();
+    }
+
+    function matchesOutStatusFilter(item, filterKey) {
+      if (filterKey === 'all') {
+        return true;
+      }
+      const details = detailRowsByItem[item.id] || [];
+      return details.some((detail) => matchesDetailStatusFilter(detail, filterKey));
+    }
+
+    function updateOutStatusFilterCounters() {
+      if (!outStatusFilterOptions.length) {
+        return;
+      }
+      const query = itemSearchInput.value.trim().toUpperCase();
+      outStatusFilterOptions.forEach((option) => {
+        const filterKey = option.dataset.outStatusFilter || 'all';
+        const count = currentItems.filter((item) => {
+          if (!itemMatchesDateFilter(item, selectedDateFilter)) {
+            return false;
+          }
+          if (!matchesOutStatusFilter(item, filterKey)) {
+            return false;
+          }
+          if (!query) {
+            return true;
+          }
+          const outMatches = String(item.numero || '').toUpperCase().includes(query);
+          if (outMatches) {
+            return true;
+          }
+          const itemDesignations = detailDesignationsByItem[item.id] || [];
+          return itemDesignations.some((designation) => String(designation || '').toUpperCase().includes(query));
+        }).length;
+        const label = option.dataset.filterLabel || option.textContent.trim();
+        option.textContent = `${label} (${count})`;
+      });
+    }
+
+    function syncOutStatusFilterUi() {
+      outStatusFilterButton?.classList.toggle('is-filtered', selectedOutStatusFilter !== 'all');
+      outStatusFilterOptions.forEach((option) => {
+        const isActive = option.dataset.outStatusFilter === selectedOutStatusFilter;
+        option.classList.toggle('is-active', isActive);
+        option.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      });
+    }
+
+    function setOutStatusFilter(filterKey) {
+      selectedOutStatusFilter = filterKey;
+      syncOutStatusFilterUi();
+      renderActiveTabContent();
+    }
+
+    function closeOutStatusFilterMenu() {
+      if (!outStatusFilterMenu || !outStatusFilterButton) {
+        return;
+      }
+      outStatusFilterMenu.hidden = true;
+      outStatusFilterButton.setAttribute('aria-expanded', 'false');
+    }
+
+    function openOutStatusFilterMenu() {
+      if (!outStatusFilterMenu || !outStatusFilterButton) {
+        return;
+      }
+      outStatusFilterMenu.hidden = false;
+      outStatusFilterButton.setAttribute('aria-expanded', 'true');
     }
 
     const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
@@ -4595,6 +4701,33 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    if (outStatusFilterButton && outStatusFilterMenu && outStatusFilterOptions.length) {
+      syncOutStatusFilterUi();
+      outStatusFilterButton.addEventListener('click', () => {
+        if (outStatusFilterMenu.hidden) {
+          openOutStatusFilterMenu();
+          return;
+        }
+        closeOutStatusFilterMenu();
+      });
+      outStatusFilterOptions.forEach((option) => {
+        option.addEventListener('click', () => {
+          setOutStatusFilter(option.dataset.outStatusFilter || 'all');
+          closeOutStatusFilterMenu();
+        });
+      });
+      document.addEventListener('click', (event) => {
+        if (!outStatusFilterMenu.hidden && !event.target.closest('.page2-filter-menu-wrap')) {
+          closeOutStatusFilterMenu();
+        }
+      });
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !outStatusFilterMenu.hidden) {
+          closeOutStatusFilterMenu();
+        }
+      });
+    }
+
     itemForm.addEventListener('submit', async (event) => {
       event.preventDefault();
       if (itemCreateSubmitButton.disabled) {
@@ -5284,7 +5417,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return !query || String(detail.designation || '').toLowerCase().includes(query);
     }
 
-    function matchesDetailFilter(detail, filterKey) {
+    function matchesDetailStatusFilter(detail, filterKey) {
       const isKoStatus = normalizeDetailStatut(detail.statut) === 'K.O';
       if (filterKey === 'ko') {
         return isKoStatus;
@@ -5315,7 +5448,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function getFilteredDetails(details) {
       const query = getSearchQuery();
-      return details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailFilter(detail, activeDetailFilter));
+      return details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailStatusFilter(detail, activeDetailFilter));
     }
 
     function updateDetailFilterCounters(details) {
@@ -5326,7 +5459,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const query = getSearchQuery();
       detailFilterOptions.forEach((option) => {
         const filterKey = option.dataset.detailFilter || 'all';
-        const count = details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailFilter(detail, filterKey)).length;
+        const count = details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailStatusFilter(detail, filterKey)).length;
         const label = option.dataset.filterLabel || option.textContent.trim();
         option.textContent = `${label} (${count})`;
       });

--- a/page2.html
+++ b/page2.html
@@ -49,6 +49,18 @@
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>
             <button class="filter-chip" type="button" data-filter-chip="lastMonth">Plus ancien</button>
+            <div class="page2-filter-menu-wrap">
+              <button type="button" id="outStatusFilterButton" class="page3-filter-button" aria-label="Filtrer les OUT" aria-haspopup="true" aria-expanded="false" aria-controls="outStatusFilterMenu">
+                <img src="Icon/curseurs.png" alt="" aria-hidden="true" class="page3-filter-button__icon" />
+              </button>
+              <div id="outStatusFilterMenu" class="page3-filter-menu" role="menu" hidden>
+                <button type="button" class="page3-filter-option is-active" data-out-status-filter="all" role="menuitemradio" aria-checked="true">Tous</button>
+                <button type="button" class="page3-filter-option" data-out-status-filter="todo" role="menuitemradio" aria-checked="false">À faire</button>
+                <button type="button" class="page3-filter-option" data-out-status-filter="fix" role="menuitemradio" aria-checked="false">À corriger</button>
+                <button type="button" class="page3-filter-option" data-out-status-filter="done" role="menuitemradio" aria-checked="false">Complété</button>
+                <button type="button" class="page3-filter-option" data-out-status-filter="ko" role="menuitemradio" aria-checked="false">K.O</button>
+              </div>
+            </div>
           </div>
           <label class="sr-only" for="itemDateFilter">Filtrer les résultats par date</label>
           <select id="itemDateFilter" class="visually-hidden-control" aria-label="Filtrer les résultats par date">


### PR DESCRIPTION
### Motivation
- Fournir sur Page 2 le même filtrage d’état que Page 3 pour pouvoir combiner filtre date + statut OUT sans modifier Page 1 ni Page 3.

### Description
- Ajout de l’icône bouton (`Icon/curseurs.png`) dans la barre des chips Page 2 et insertion d’un menu dropdown compact avec les options `Tous`, `À faire`, `À corriger`, `Complété` et `K.O` dans `page2.html`.
- Implémentation côté client (`js/app.js`) d’un filtre de statut qui analyse les articles internes de chaque OUT (réutilisation de la logique de classification de Page 3 : priorité K.O, puis done/fix/todo) et inclut un OUT si au moins un article correspond.
- Compteurs dynamiques ajoutés au menu (affichés entre parenthèses) et calculés en respectant la recherche active et le filtre de date sélectionné; le filtre `Tous` est actif par défaut et le bouton prend un fond doux quand un filtre ≠ `Tous` est actif.
- Ajustements CSS (`css/style.css`) pour aligner l’icône avec les chips existants et réutiliser le style et le comportement visuel du menu de Page 3 sans créer de fichiers nouveaux.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03f953e578832aa7469e6282cac21c)