### PR TITLE
Fix Page 2 OUT filter button click handling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4346,6 +4346,15 @@ body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-button__icon
   opacity: 0.82;
 }
 
+
+body[data-page="site-detail"] #outStatusFilterBtn {
+  pointer-events: auto;
+  z-index: 20;
+}
+
+body[data-page="site-detail"] #outStatusFilterBtn .page3-filter-button__icon {
+  pointer-events: none;
+}
 body[data-page="site-detail"] .page2-filter-menu-wrap .page3-filter-menu {
   position: absolute;
   top: calc(100% + 8px);

--- a/js/app.js
+++ b/js/app.js
@@ -2877,7 +2877,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const searchReadIdsStorageKey = 'page2_search_read_ids';
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
-    const outStatusFilterButton = document.querySelector('#outStatusFilterButton');
+    const outStatusFilterButton = document.querySelector('#outStatusFilterBtn');
     const outStatusFilterMenu = document.querySelector('#outStatusFilterMenu');
     const outStatusFilterOptions = Array.from(document.querySelectorAll('[data-out-status-filter]'));
     outStatusFilterOptions.forEach((option) => {
@@ -4703,18 +4703,24 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (outStatusFilterButton && outStatusFilterMenu && outStatusFilterOptions.length) {
       syncOutStatusFilterUi();
-      outStatusFilterButton.addEventListener('click', () => {
-        if (outStatusFilterMenu.hidden) {
-          openOutStatusFilterMenu();
+      const outStatusFilterContainer = outStatusFilterButton.closest('.page2-filter-menu-wrap');
+      outStatusFilterContainer?.addEventListener('click', (event) => {
+        const filterButton = event.target.closest('#outStatusFilterBtn');
+        if (filterButton) {
+          event.stopPropagation();
+          if (outStatusFilterMenu.hidden) {
+            openOutStatusFilterMenu();
+            return;
+          }
+          closeOutStatusFilterMenu();
           return;
         }
+        const filterOption = event.target.closest('[data-out-status-filter]');
+        if (!filterOption) {
+          return;
+        }
+        setOutStatusFilter(filterOption.dataset.outStatusFilter || 'all');
         closeOutStatusFilterMenu();
-      });
-      outStatusFilterOptions.forEach((option) => {
-        option.addEventListener('click', () => {
-          setOutStatusFilter(option.dataset.outStatusFilter || 'all');
-          closeOutStatusFilterMenu();
-        });
       });
       document.addEventListener('click', (event) => {
         if (!outStatusFilterMenu.hidden && !event.target.closest('.page2-filter-menu-wrap')) {

--- a/page2.html
+++ b/page2.html
@@ -50,7 +50,7 @@
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>
             <button class="filter-chip" type="button" data-filter-chip="lastMonth">Plus ancien</button>
             <div class="page2-filter-menu-wrap">
-              <button type="button" id="outStatusFilterButton" class="page3-filter-button" aria-label="Filtrer les OUT" aria-haspopup="true" aria-expanded="false" aria-controls="outStatusFilterMenu">
+              <button type="button" id="outStatusFilterBtn" class="page3-filter-button" aria-label="Filtrer les OUT" aria-haspopup="true" aria-expanded="false" aria-controls="outStatusFilterMenu">
                 <img src="Icon/curseurs.png" alt="" aria-hidden="true" class="page3-filter-button__icon" />
               </button>
               <div id="outStatusFilterMenu" class="page3-filter-menu" role="menu" hidden>


### PR DESCRIPTION
### Motivation
- Corriger Page 2 pour que l’icône `Icon/curseurs.png` soit portée par un vrai bouton cliquable et que le menu de filtre s’ouvre/ferme correctement au clic.
- Rendre le listener robuste lorsque la barre de filtres est (re)générée dynamiquement pour éviter que le clic soit perdu ou bloqué.

### Description
- Remplacé l’ID du bouton filtre dans `page2.html` par `id="outStatusFilterBtn"` et conservé l’image `Icon/curseurs.png` à l’intérieur du bouton.
- Mis à jour la sélection DOM dans `js/app.js` pour utiliser `document.querySelector('#outStatusFilterBtn')` et remplacé l’attache directe du `click` par une gestion par délégation d’événements sur `.page2-filter-menu-wrap` pour capturer à la fois le clic sur le bouton et la sélection d’options.
- Conservé la logique d’ouverture/fermeture (`openOutStatusFilterMenu` / `closeOutStatusFilterMenu`) et les fermetures au clic extérieur et à la touche `Escape` pour un comportement identique à Page 3.
- Ajouté des règles CSS dans `css/style.css` pour garantir la cliquabilité (`pointer-events: auto; z-index: 20;`) sur `#outStatusFilterBtn` et `pointer-events: none;` sur l’icône afin d’éviter l’interception du clic par l’image.

### Testing
- Exécuté une recherche de références (`rg`) pour vérifier et corriger les sélecteurs utilisés et confirmer que les modifications s’appliquent uniquement à Page 2 (succès).
- Lancé `git diff --check` pour valider les modifications de style/format (succès).
- Validé la création du commit avec `git commit` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03fe7fb3d0832ab23d8e2a91bb9442)