### PR TITLE
Page 2 : délégation d’événements pour l’ouverture du menu filtre OUT

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4703,10 +4703,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (outStatusFilterButton && outStatusFilterMenu && outStatusFilterOptions.length) {
       syncOutStatusFilterUi();
-      const outStatusFilterContainer = outStatusFilterButton.closest('.page2-filter-menu-wrap');
-      outStatusFilterContainer?.addEventListener('click', (event) => {
+      document.addEventListener('click', (event) => {
         const filterButton = event.target.closest('#outStatusFilterBtn');
         if (filterButton) {
+          event.preventDefault();
           event.stopPropagation();
           if (outStatusFilterMenu.hidden) {
             openOutStatusFilterMenu();
@@ -4715,15 +4715,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           closeOutStatusFilterMenu();
           return;
         }
+
         const filterOption = event.target.closest('[data-out-status-filter]');
-        if (!filterOption) {
+        if (filterOption && event.target.closest('#outStatusFilterMenu')) {
+          event.preventDefault();
+          setOutStatusFilter(filterOption.dataset.outStatusFilter || 'all');
+          closeOutStatusFilterMenu();
           return;
         }
-        setOutStatusFilter(filterOption.dataset.outStatusFilter || 'all');
-        closeOutStatusFilterMenu();
-      });
-      document.addEventListener('click', (event) => {
-        if (!outStatusFilterMenu.hidden && !event.target.closest('.page2-filter-menu-wrap')) {
+
+        if (!outStatusFilterMenu.hidden && !event.target.closest('#outStatusFilterMenu')) {
           closeOutStatusFilterMenu();
         }
       });


### PR DESCRIPTION
### Motivation
- Le bouton filtre `#outStatusFilterBtn` était visible sur la Page 2 mais le menu ne s’ouvrait pas de manière fiable, probablement parce que le listener était attaché à un conteneur susceptible d’être recréé pendant le rendu ou parce que le menu n’était pas correctement ciblé lors des clics.
- Il fallait une approche robuste qui capte les clics même si le bouton/menu sont re-rendus ou déplacés dans le DOM.

### Description
- Remplacement de l’écouteur local attaché au conteneur par un gestionnaire délégué au niveau `document` dans `js/app.js` (zone autour de `L4704-L4730`).
- Les clics sur le bouton sont détectés via `event.target.closest('#outStatusFilterBtn')` et traités avec `preventDefault()` + `stopPropagation()` pour ouvrir/fermer le menu avec `openOutStatusFilterMenu()` / `closeOutStatusFilterMenu()`.
- La sélection d’une option est gérée par délégation uniquement si le clic provient de `#outStatusFilterMenu`, puis appelle `setOutStatusFilter(...)` et ferme le menu.
- La fermeture au clic extérieur et la gestion de la touche `Escape` ont été conservées et fiabilisées par des vérifications de contenance ciblées sur `#outStatusFilterMenu`.

### Testing
- Examiné le diff généré avec `git diff -- js/app.js` pour valider les modifications de code, commande exécutée avec succès.
- Enregistré la modification avec `git commit` pour vérifier l’intégration locale, commande exécutée avec succès.
- Inspecté les lignes modifiées via `nl`/`sed` pour confirmer l’emplacement et le contenu du nouveau gestionnaire, commande exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0401a86458832aad743c7a734a6f43)