### PR TITLE
Aligner la gestion du filtre statut de la Page 2 sur le pattern de la Page 3

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4707,7 +4707,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const filterButton = event.target.closest('#outStatusFilterBtn');
         if (filterButton) {
           event.preventDefault();
-          event.stopPropagation();
           if (outStatusFilterMenu.hidden) {
             openOutStatusFilterMenu();
             return;
@@ -4717,14 +4716,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         }
 
         const filterOption = event.target.closest('[data-out-status-filter]');
-        if (filterOption && event.target.closest('#outStatusFilterMenu')) {
+        if (filterOption && event.target.closest('.page2-filter-menu-wrap')) {
           event.preventDefault();
           setOutStatusFilter(filterOption.dataset.outStatusFilter || 'all');
           closeOutStatusFilterMenu();
           return;
         }
 
-        if (!outStatusFilterMenu.hidden && !event.target.closest('#outStatusFilterMenu')) {
+        if (!outStatusFilterMenu.hidden && !event.target.closest('.page2-filter-menu-wrap')) {
           closeOutStatusFilterMenu();
         }
       });


### PR DESCRIPTION
### Motivation
- La logique du filtre de statut sur la Page 2 ne ciblait pas correctement les clics d’option et les clics hors menu, entraînant la perte du comportement quand la barre de filtres est reconstruite ; l’objectif est d’appliquer la même délégation fiable utilisée sur la Page 3.

### Description
- Dans `js/app.js` j’ai adapté le gestionnaire d’événements du filtre Page 2 pour utiliser `closest()` autour du wrapper `.page2-filter-menu-wrap` au lieu de tester directement l’ID du menu, et j’ai supprimé `event.stopPropagation()` sur le bouton pour rester cohérent avec le pattern de Page 3.

### Testing
- Exécuté `git diff -- js/app.js` pour valider le delta de fichier (succès).  
- Tentative d’exécuter `node -e "new Function(require('fs').readFileSync('js/app.js','utf8'))"` a échoué de façon attendue car `js/app.js` est un module ES (`import`), donc ce check d’exécution n’est pas applicable (échec attendu).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04046578f4832a8db94c86488c4735)