### PR TITLE
Ajoute un menu filtre statut à côté de “Plus ancien” sur la page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5932,3 +5932,78 @@ body {
 .hidden {
   display: none !important;
 }
+
+body[data-page="site-detail"] .page2-out-filter-menu-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
+}
+
+body[data-page="site-detail"] .page2-out-filter-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  border: 1px solid rgba(31, 53, 83, 0.12);
+  background: rgba(255, 255, 255, 0.86);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color .2s ease, border-color .2s ease, box-shadow .2s ease, transform .2s ease;
+}
+
+body[data-page="site-detail"] .page2-out-filter-button__icon {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}
+
+body[data-page="site-detail"] .page2-out-filter-button:hover,
+body[data-page="site-detail"] .page2-out-filter-button:focus-visible {
+  border-color: rgba(68, 151, 255, 0.35);
+  box-shadow: 0 4px 14px rgba(31, 53, 83, 0.12);
+}
+
+body[data-page="site-detail"] .page2-out-filter-button.is-filtered {
+  background: rgba(68, 151, 255, 0.14);
+  border-color: rgba(68, 151, 255, 0.5);
+}
+
+body[data-page="site-detail"] .page2-out-filter-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 170px;
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(31, 53, 83, 0.12);
+  background: #fff;
+  box-shadow: 0 12px 30px rgba(12, 32, 58, 0.18);
+  z-index: 45;
+}
+
+body[data-page="site-detail"] .page2-out-filter-option {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 9px 10px;
+  border-radius: 8px;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+body[data-page="site-detail"] .page2-out-filter-option:hover,
+body[data-page="site-detail"] .page2-out-filter-option:focus-visible {
+  background: rgba(68, 151, 255, 0.12);
+}
+
+body[data-page="site-detail"] .page2-out-filter-option.is-active {
+  background: rgba(68, 151, 255, 0.16);
+  color: var(--brand-strong);
+}

--- a/js/app.js
+++ b/js/app.js
@@ -2850,7 +2850,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const searchReadIdsStorageKey = 'page2_search_read_ids';
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
+    const outStatusFilterButton = document.querySelector('#outStatusFilterButton');
+    const outStatusFilterMenu = document.querySelector('#outStatusFilterMenu');
+    const outStatusFilterOptions = Array.from(document.querySelectorAll('[data-out-filter]'));
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
+    let activeOutStatusFilter = 'all';
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
     let hasPendingOutScrollRestore = true;
     let selectedPurchasePhotoFile = null;
@@ -3592,11 +3596,97 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    function matchesOutDetailFilter(detail, filterKey) {
+      const isKoStatus = normalizeDetailStatut(detail?.statut) === 'K.O';
+      if (filterKey === 'ko') {
+        return isKoStatus;
+      }
+      if (isKoStatus) {
+        return filterKey === 'all';
+      }
+      const ecart = computeEcart(detail || {});
+      const qtePosee = Number(detail?.qtePosee) || 0;
+      const qteRetour = Number(detail?.qteRetour) || 0;
+      const qteRebus = Number(detail?.qteRebus) || 0;
+      const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
+      const isDone = qtePosee > 0 && ecart === 0;
+      const isAttention = hasActivity && ecart !== 0;
+      if (filterKey === 'done') {
+        return isDone;
+      }
+      if (filterKey === 'fix') {
+        return isAttention;
+      }
+      if (filterKey === 'todo') {
+        return !isDone && !isAttention;
+      }
+      return true;
+    }
+
+    function outMatchesStatusFilter(item, filterKey) {
+      if (filterKey === 'all') return true;
+      const details = detailRowsByItem[item.id] || [];
+      return details.some((detail) => matchesOutDetailFilter(detail, filterKey));
+    }
+
+    function updateOutStatusFilterCounters() {
+      if (!outStatusFilterOptions.length) {
+        return;
+      }
+      const query = itemSearchInput.value.trim().toUpperCase();
+      outStatusFilterOptions.forEach((option) => {
+        const filterKey = option.dataset.outFilter || 'all';
+        const count = currentItems.filter((item) => {
+          if (!itemMatchesDateFilter(item, selectedDateFilter)) {
+            return false;
+          }
+          const outMatches = String(item.numero || '').toUpperCase().includes(query);
+          const itemDesignations = detailDesignationsByItem[item.id] || [];
+          const queryMatches = !query || outMatches || itemDesignations.some((designation) => String(designation || '').toUpperCase().includes(query));
+          return queryMatches && outMatchesStatusFilter(item, filterKey);
+        }).length;
+        const label = option.dataset.filterLabel || option.textContent.replace(/\s*\(\d+\)\s*$/, '').trim();
+        option.dataset.filterLabel = label;
+        option.innerHTML = `<span>${label}</span><span>${count}</span>`;
+      });
+    }
+
+    function syncOutStatusFilterUi() {
+      outStatusFilterButton?.classList.toggle('is-filtered', activeOutStatusFilter !== 'all');
+      outStatusFilterOptions.forEach((option) => {
+        const isActive = option.dataset.outFilter === activeOutStatusFilter;
+        option.classList.toggle('is-active', isActive);
+        option.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      });
+    }
+
+    function setOutStatusFilter(filterKey) {
+      activeOutStatusFilter = filterKey;
+      syncOutStatusFilterUi();
+      closeOutStatusFilterMenu();
+      renderActiveTabContent();
+    }
+
+    function closeOutStatusFilterMenu() {
+      if (!outStatusFilterMenu || !outStatusFilterButton) return;
+      outStatusFilterMenu.hidden = true;
+      outStatusFilterButton.setAttribute('aria-expanded', 'false');
+    }
+
+    function openOutStatusFilterMenu() {
+      if (!outStatusFilterMenu || !outStatusFilterButton) return;
+      outStatusFilterMenu.hidden = false;
+      outStatusFilterButton.setAttribute('aria-expanded', 'true');
+    }
+
     function renderItems(options = {}) {
       const shouldFlashSearchMatches = Boolean(options?.flashSearchMatches);
       const query = itemSearchInput.value.trim().toUpperCase();
       const filteredItems = currentItems.filter((item) => {
         if (!itemMatchesDateFilter(item, selectedDateFilter)) {
+          return false;
+        }
+        if (!outMatchesStatusFilter(item, activeOutStatusFilter)) {
           return false;
         }
         if (!query) {
@@ -3611,6 +3701,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
 
       itemCount.innerHTML = `<span class="outs-number">${filteredItems.length}</span><span class="outs-label">OUT${filteredItems.length > 1 ? 'S' : ''}</span>`;
+      updateOutStatusFilterCounters();
 
       if (!filteredItems.length) {
         UiService.renderEmptyState(
@@ -3812,6 +3903,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const query = itemSearchInput.value.trim().toUpperCase();
       const purchases = currentPurchases.filter((purchase) => {
         if (!itemMatchesDateFilter({ dateCreation: purchase?.createdAt || purchase?.dateAchat || purchase?.date || purchase?.dateCreation || purchase?.dateModification }, selectedDateFilter)) {
+          return false;
+        }
+        if (!outMatchesStatusFilter(item, activeOutStatusFilter)) {
           return false;
         }
         if (!query) {
@@ -4592,6 +4686,34 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         window.localStorage.setItem(dateFilterStorageKey, selectedDateFilter);
         updateFilterChipsState();
         renderActiveTabContent();
+      });
+    }
+
+
+    if (outStatusFilterButton && outStatusFilterMenu && outStatusFilterOptions.length) {
+      syncOutStatusFilterUi();
+      outStatusFilterButton.addEventListener('click', () => {
+        if (outStatusFilterMenu.hidden) {
+          openOutStatusFilterMenu();
+        } else {
+          closeOutStatusFilterMenu();
+        }
+      });
+      outStatusFilterOptions.forEach((option) => {
+        option.addEventListener('click', () => {
+          setOutStatusFilter(option.dataset.outFilter || 'all');
+        });
+      });
+      document.addEventListener('click', (event) => {
+        if (!outStatusFilterMenu.hidden && !event.target.closest('.page2-out-filter-menu-wrap')) {
+          closeOutStatusFilterMenu();
+        }
+      });
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !outStatusFilterMenu.hidden) {
+          closeOutStatusFilterMenu();
+          outStatusFilterButton.focus();
+        }
       });
     }
 

--- a/page2.html
+++ b/page2.html
@@ -49,6 +49,18 @@
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>
             <button class="filter-chip" type="button" data-filter-chip="lastMonth">Plus ancien</button>
+            <div class="page2-out-filter-menu-wrap">
+              <button type="button" id="outStatusFilterButton" class="page2-out-filter-button" aria-label="Filtrer les OUT par statut" aria-haspopup="true" aria-expanded="false" aria-controls="outStatusFilterMenu">
+                <img src="Icon/curseurs.png" alt="" aria-hidden="true" class="page2-out-filter-button__icon" />
+              </button>
+              <div id="outStatusFilterMenu" class="page2-out-filter-menu" role="menu" hidden>
+                <button type="button" class="page2-out-filter-option is-active" data-out-filter="all" role="menuitemradio" aria-checked="true">Tous</button>
+                <button type="button" class="page2-out-filter-option" data-out-filter="todo" role="menuitemradio" aria-checked="false">À faire</button>
+                <button type="button" class="page2-out-filter-option" data-out-filter="fix" role="menuitemradio" aria-checked="false">À corriger</button>
+                <button type="button" class="page2-out-filter-option" data-out-filter="done" role="menuitemradio" aria-checked="false">Complété</button>
+                <button type="button" class="page2-out-filter-option" data-out-filter="ko" role="menuitemradio" aria-checked="false">K.O</button>
+              </div>
+            </div>
           </div>
           <label class="sr-only" for="itemDateFilter">Filtrer les résultats par date</label>
           <select id="itemDateFilter" class="visually-hidden-control" aria-label="Filtrer les résultats par date">


### PR DESCRIPTION
### Motivation
- Permettre le filtrage des OUT par statut (Tous / À faire / À corriger / Complété / K.O) directement depuis la page 2 sans modifier Page 1 ni Page 3. 
- Réutiliser l’icône existante `Icon/curseurs.png` et le même comportement de classification que Page 3 pour assurer une UX cohérente.

### Description
- Ajout du bouton d’icône et du menu dropdown à côté du chip "Plus ancien" dans `page2.html` sans créer de fichier supplémentaire. 
- Implémentation côté JS (`js/app.js`) d’un état `activeOutStatusFilter`, de la logique de filtrage qui inspecte les articles internes (`detailRowsByItem`) et de la combinaison du filtre statut avec le filtre date et la recherche. 
- Ajout de compteurs dynamiques pour chaque option du menu, recalculés en fonction du filtre date actif et de la recherche. 
- Styles ajoutés dans `css/style.css` pour rendre le bouton/menu compacts et cohérents avec le menu filtre de Page 3, y compris un état visuel `is-filtered` quand le filtre est différent de `Tous`.

### Testing
- Vérification de syntaxe JS via `node -c js/app.js` qui s’est exécutée sans erreur. 
- Vérification statique que les éléments et styles attendus sont présents (recherche des sélecteurs/éléments modifiés dans les fichiers) et que l’insertion HTML/CSS/JS a été appliquée correctement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0444c83bb0832a8f412cae9a69b72f)