### PR TITLE
Fix Page 2 filter icon sizing and containment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5940,23 +5940,33 @@ body[data-page="site-detail"] .page2-out-filter-menu-wrap {
   margin-left: 4px;
 }
 
-body[data-page="site-detail"] .page2-out-filter-button {
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
+body[data-page="site-detail"] .page2-out-filter-button,
+body[data-page="site-detail"] .out-status-filter-btn {
+  width: 48px;
+  height: 48px;
+  min-width: 48px;
+  border-radius: 50%;
   border: 1px solid rgba(31, 53, 83, 0.12);
   background: rgba(255, 255, 255, 0.86);
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+  position: relative;
+  flex-shrink: 0;
   cursor: pointer;
   transition: background-color .2s ease, border-color .2s ease, box-shadow .2s ease, transform .2s ease;
 }
 
 body[data-page="site-detail"] .page2-out-filter-button__icon {
-  width: 16px;
-  height: 16px;
+  width: 17px;
+  height: 17px;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
+  display: block;
+  pointer-events: none;
+  opacity: 0.82;
 }
 
 body[data-page="site-detail"] .page2-out-filter-button:hover,


### PR DESCRIPTION
### Motivation
- Page 2 filter icon (`Icon/curseurs.png`) was overflowing its button, growing huge and intercepting clicks, so the visual and interaction must match Page 3 and stay contained in the round button.

### Description
- Updated `css/style.css` under the `body[data-page="site-detail"]` scope to normalize the Page 2 filter button by setting fixed round dimensions (`width: 48px; height: 48px; min-width: 48px; border-radius: 50%`), `overflow: hidden`, `position: relative` and `flex-shrink: 0` so the icon cannot escape the container.
- Added compatibility selector `.out-status-filter-btn` alongside `.page2-out-filter-button` so the same rules apply where that class is used.
- Adjusted icon rules for `.page2-out-filter-button__icon` to match Page 3: `width: 17px; height: 17px; max-width: 100%; max-height: 100%; object-fit: contain; display: block; pointer-events: none; opacity: 0.82` to avoid deformation and click interception.
- Change is limited to Page 2 via the `body[data-page="site-detail"]` selector and modifies `css/style.css` only.

### Testing
- Located relevant selectors with `rg` and inspected the updated stylesheet region using `sed`/`nl` to confirm the new rules are present in `css/style.css`, which succeeded.
- Verified the icon sizing/containment rules match the Page 3 pattern by comparing the new icon properties to the Page 3 rules, which succeeded.
- Ran a workspace file status check and local inspection to ensure `css/style.css` reflects the change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044785fc78832a8be0a0465399b355)