### PR TITLE
Corrige l’alignement du bouton filtre (Page 2) dans la rangée de chips

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4313,6 +4313,7 @@ body[data-page="site-detail"] .filter-chip.is-active {
   color: #fff;
 }
 
+
 body[data-page="site-detail"] .list-separator {
   margin: 0.55rem 0 0.25rem;
 }
@@ -6016,4 +6017,21 @@ body[data-page="site-detail"] .page2-out-filter-option:focus-visible {
 body[data-page="site-detail"] .page2-out-filter-option.is-active {
   background: rgba(68, 151, 255, 0.16);
   color: var(--brand-strong);
+}
+
+body[data-page="site-detail"] .filters-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: nowrap;
+}
+
+body[data-page="site-detail"] .filters-row .page2-out-filter-menu-wrap {
+  margin-left: 0;
+}
+
+body[data-page="site-detail"] .filters-row .page2-out-filter-button {
+  width: 34px;
+  height: 34px;
+  min-width: 34px;
 }

--- a/page2.html
+++ b/page2.html
@@ -44,7 +44,7 @@
               <span aria-hidden="true">›</span>
             </button>
           </section>
-          <div class="filter-chip-group filters" role="group" aria-label="Filtrer les résultats par date">
+          <div class="filter-chip-group filters filters-row" role="group" aria-label="Filtrer les résultats par date">
             <button class="filter-chip" type="button" data-filter-chip="all">Tous</button>
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>


### PR DESCRIPTION
### Motivation
- Le bouton filtre sur Page 2 sautait à la ligne et avait une taille/décalage différents des chips, rompant l’alignement horizontal et l’uniformité visuelle.

### Description
- Ajout de la classe `filters-row` au conteneur des filtres dans `page2.html` pour regrouper les chips et le bouton filtre dans un même contexte de layout.
- Ajout de règles scoped dans `css/style.css` pour `body[data-page="site-detail"] .filters-row` avec `display:flex`, `align-items:center`, `gap:12px` et `flex-wrap:nowrap` afin d’empêcher les retours à la ligne.
- Ajustement du wrapper et des dimensions du bouton filtre via `filters-row` overrides pour supprimer le décalage gauche et aligner la hauteur/verticale avec les chips.

### Testing
- Vérification que la classe et les règles CSS ont été appliquées avec `rg -n "filters-row|page2-out-filter-button" page2.html css/style.css` et inspection des extraits avec `nl`/`sed`, ce qui confirme les modifications attendues.
- Toutes les vérifications automatisées exécutées ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0449a4944c832ab7c47f5216c08938)