### PR TITLE
Fix Page 2 filter row overflow and search width containment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6035,3 +6035,50 @@ body[data-page="site-detail"] .filters-row .page2-out-filter-button {
   height: 34px;
   min-width: 34px;
 }
+
+/* Page 2 overflow containment fixes (search + filters row) */
+body[data-page="site-detail"] .page2-search-wrap {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  padding-inline: 24px;
+}
+
+body[data-page="site-detail"] .page2-search-wrap input {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+body[data-page="site-detail"] .page2-filters-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+  padding-inline: 24px;
+  box-sizing: border-box;
+  -webkit-overflow-scrolling: touch;
+}
+
+body[data-page="site-detail"] .page2-filters-row::-webkit-scrollbar {
+  display: none;
+}
+
+body[data-page="site-detail"] .page2-filters-row > * {
+  flex: 0 0 auto;
+}
+
+body[data-page="site-detail"] .out-status-filter-btn,
+body[data-page="site-detail"] .page2-out-filter-button {
+  flex: 0 0 auto;
+  width: 52px;
+  height: 52px;
+  min-width: 52px;
+}
+
+body[data-page="site-detail"] {
+  overflow-x: hidden;
+}

--- a/page2.html
+++ b/page2.html
@@ -25,7 +25,7 @@
 
       <main class="page-content main-content">
           <section class="search-panel search-panel--site surface-card section">
-          <label class="input-group">
+          <label class="input-group page2-search-wrap">
             <span class="sr-only">Rechercher (OUT ou article)</span>
             <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
             <input
@@ -44,7 +44,7 @@
               <span aria-hidden="true">›</span>
             </button>
           </section>
-          <div class="filter-chip-group filters filters-row" role="group" aria-label="Filtrer les résultats par date">
+          <div class="filter-chip-group filters filters-row page2-filters-row" role="group" aria-label="Filtrer les résultats par date">
             <button class="filter-chip" type="button" data-filter-chip="all">Tous</button>
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>


### PR DESCRIPTION
### Motivation
- Prevent horizontal overflow and misalignment in the Page 2 search/filters area so the global page never scrolls horizontally and the filter row behaves predictably.

### Description
- Added `page2-search-wrap` to the search wrapper and `page2-filters-row` to the filters container in `page2.html` so styles target Page 2 only.
- Appended CSS rules in `css/style.css` to constrain the search input (`width/max-width/box-sizing`), make the filters row horizontally scrollable only (`overflow-x: auto`) and hide its scrollbar, and ensure children do not shrink (`flex: 0 0 auto`).
- Increased the filters cursor/status button sizing and made it non-shrinking (`width/height/min-width: 52px`) so the icon stays aligned with chips.
- Added a global Page 2 horizontal overflow guard via `body[data-page="site-detail"] { overflow-x: hidden; }` to prevent page-level horizontal scrolling.

### Testing
- Verified the working tree and inspected the diff with `git status --short` and `git diff -- page2.html css/style.css` to confirm only the intended changes were introduced, which succeeded.
- Opened the modified files with `nl -ba page2.html` and `nl -ba css/style.css` to confirm the new classes and CSS block were present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044e0963fc832ab1e4d62283f1ed9b)