### PR TITLE
Ajout du filtre de statut sur la Page 2 (icône curseurs)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3757,6 +3757,103 @@ body[data-page="site-detail"] .search-panel--site .input-group {
   position: relative;
 }
 
+body[data-page="site-detail"] .page2-search-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+body[data-page="site-detail"] .page2-search-filter-bar .input-group {
+  flex: 1;
+  min-width: 0;
+}
+
+body[data-page="site-detail"] .page2-filter-menu-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+body[data-page="site-detail"] .page2-filter-button {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  transition: transform 0.18s ease, box-shadow 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+body[data-page="site-detail"] .page2-filter-button:hover,
+body[data-page="site-detail"] .page2-filter-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
+}
+
+body[data-page="site-detail"] .page2-filter-button.is-filtered {
+  background: #e8f1ff;
+  border-color: #b6cbef;
+}
+
+body[data-page="site-detail"] .page2-filter-button__icon {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+  opacity: 0.82;
+}
+
+body[data-page="site-detail"] .page2-filter-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 172px;
+  border-radius: 14px;
+  border: 1px solid #dbe5f1;
+  background: #fff;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14);
+  padding: 6px;
+  z-index: 30;
+}
+
+body[data-page="site-detail"] .page2-filter-option {
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: #334155;
+  padding: 8px 10px;
+  transition: background-color 0.18s ease, color 0.18s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.92rem;
+}
+
+body[data-page="site-detail"] .page2-filter-option__label {
+  color: inherit;
+}
+
+body[data-page="site-detail"] .page2-filter-option__count {
+  min-width: 1.5em;
+  text-align: right;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+body[data-page="site-detail"] .page2-filter-option:hover,
+body[data-page="site-detail"] .page2-filter-option:focus-visible {
+  background: #f2f7ff;
+}
+
+body[data-page="site-detail"] .page2-filter-option.is-active {
+  background: #e7f0ff;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
 body[data-page="site-detail"] .site-search-icon-wrap {
   position: absolute;
   left: 0.95rem;

--- a/js/app.js
+++ b/js/app.js
@@ -2850,7 +2850,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const searchReadIdsStorageKey = 'page2_search_read_ids';
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
+    const itemStatusFilterButton = document.getElementById('itemStatusFilterButton');
+    const itemStatusFilterMenu = document.getElementById('itemStatusFilterMenu');
+    const itemStatusFilterOptions = Array.from(document.querySelectorAll('[data-item-status-filter]'));
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
+    let activeStatusFilter = 'all';
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
     let hasPendingOutScrollRestore = true;
     let selectedPurchasePhotoFile = null;
@@ -3595,20 +3599,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function renderItems(options = {}) {
       const shouldFlashSearchMatches = Boolean(options?.flashSearchMatches);
       const query = itemSearchInput.value.trim().toUpperCase();
-      const filteredItems = currentItems.filter((item) => {
-        if (!itemMatchesDateFilter(item, selectedDateFilter)) {
-          return false;
-        }
-        if (!query) {
-          return true;
-        }
-        const outMatches = String(item.numero || '').toUpperCase().includes(query);
-        if (outMatches) {
-          return true;
-        }
-        const itemDesignations = detailDesignationsByItem[item.id] || [];
-        return itemDesignations.some((designation) => String(designation || '').toUpperCase().includes(query));
-      });
+      const filteredItems = getFilteredOutItems(query);
+      updateItemStatusFilterCounters(query);
 
       itemCount.innerHTML = `<span class="outs-number">${filteredItems.length}</span><span class="outs-label">OUT${filteredItems.length > 1 ? 'S' : ''}</span>`;
 
@@ -3678,6 +3670,99 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
 
       restoreOutPageScrollPosition();
+    }
+
+    function outMatchesSearch(item, query) {
+      if (!query) {
+        return true;
+      }
+      const outMatches = String(item.numero || '').toUpperCase().includes(query);
+      if (outMatches) {
+        return true;
+      }
+      const itemDesignations = detailDesignationsByItem[item.id] || [];
+      return itemDesignations.some((designation) => String(designation || '').toUpperCase().includes(query));
+    }
+
+    function matchesStatusClassification(detail, filterKey) {
+      const isKoStatus = normalizeDetailStatut(detail.statut) === 'K.O';
+      if (filterKey === 'ko') {
+        return isKoStatus;
+      }
+      if (isKoStatus) {
+        return filterKey === 'all';
+      }
+      const ecart = computeEcart(detail);
+      const qtePosee = Number(detail?.qtePosee) || 0;
+      const qteRetour = Number(detail?.qteRetour) || 0;
+      const qteRebus = Number(detail?.qteRebus) || 0;
+      const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
+      const isDone = qtePosee > 0 && ecart === 0;
+      const isAttention = hasActivity && ecart !== 0;
+      if (filterKey === 'done') {
+        return isDone;
+      }
+      if (filterKey === 'fix') {
+        return isAttention;
+      }
+      if (filterKey === 'todo') {
+        return !isDone && !isAttention;
+      }
+      return true;
+    }
+
+    function itemMatchesStatusFilter(item, filterKey) {
+      if (filterKey === 'all') {
+        return true;
+      }
+      const detailRows = detailRowsByItem[item.id] || [];
+      return detailRows.some((detail) => matchesStatusClassification(detail, filterKey));
+    }
+
+    function getFilteredOutItems(query) {
+      return currentItems.filter((item) => itemMatchesDateFilter(item, selectedDateFilter) && outMatchesSearch(item, query) && itemMatchesStatusFilter(item, activeStatusFilter));
+    }
+
+    function updateItemStatusFilterCounters(query) {
+      if (!itemStatusFilterOptions.length) {
+        return;
+      }
+      const scopeItems = currentItems.filter((item) => itemMatchesDateFilter(item, selectedDateFilter) && outMatchesSearch(item, query));
+      itemStatusFilterOptions.forEach((option) => {
+        const filterKey = option.dataset.itemStatusFilter || 'all';
+        const count = scopeItems.filter((item) => itemMatchesStatusFilter(item, filterKey)).length;
+        const countNode = option.querySelector('.page2-filter-option__count');
+        if (countNode) {
+          countNode.textContent = String(count);
+        }
+      });
+    }
+
+    function syncItemStatusFilterUi() {
+      itemStatusFilterButton?.classList.toggle('is-filtered', activeStatusFilter !== 'all');
+      itemStatusFilterOptions.forEach((option) => {
+        const isActive = option.dataset.itemStatusFilter === activeStatusFilter;
+        option.classList.toggle('is-active', isActive);
+        option.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      });
+    }
+
+    function closeItemStatusFilterMenu() {
+      if (!itemStatusFilterMenu || !itemStatusFilterButton) return;
+      itemStatusFilterMenu.hidden = true;
+      itemStatusFilterButton.setAttribute('aria-expanded', 'false');
+    }
+
+    function openItemStatusFilterMenu() {
+      if (!itemStatusFilterMenu || !itemStatusFilterButton) return;
+      itemStatusFilterMenu.hidden = false;
+      itemStatusFilterButton.setAttribute('aria-expanded', 'true');
+    }
+
+    function setItemStatusFilter(filterKey) {
+      activeStatusFilter = filterKey || 'all';
+      syncItemStatusFilterUi();
+      renderItems();
     }
 
     const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
@@ -4562,6 +4647,34 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         flashSearchMatches: isOutSearchInput,
       });
     });
+
+    if (itemStatusFilterButton && itemStatusFilterMenu && itemStatusFilterOptions.length) {
+      syncItemStatusFilterUi();
+      itemStatusFilterButton.addEventListener('click', () => {
+        if (itemStatusFilterMenu.hidden) {
+          openItemStatusFilterMenu();
+        } else {
+          closeItemStatusFilterMenu();
+        }
+      });
+      itemStatusFilterOptions.forEach((option) => {
+        option.addEventListener('click', () => {
+          setItemStatusFilter(option.dataset.itemStatusFilter || 'all');
+          closeItemStatusFilterMenu();
+        });
+      });
+      document.addEventListener('click', (event) => {
+        if (!itemStatusFilterMenu.hidden && !event.target.closest('.page2-filter-menu-wrap')) {
+          closeItemStatusFilterMenu();
+        }
+      });
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !itemStatusFilterMenu.hidden) {
+          closeItemStatusFilterMenu();
+          itemStatusFilterButton.focus();
+        }
+      });
+    }
 
     if (itemDateFilter) {
       if (!itemDateFilter.querySelector(`option[value="${selectedDateFilter}"]`)) {

--- a/page2.html
+++ b/page2.html
@@ -25,17 +25,31 @@
 
       <main class="page-content main-content">
           <section class="search-panel search-panel--site surface-card section">
-          <label class="input-group">
-            <span class="sr-only">Rechercher (OUT ou article)</span>
-            <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
-            <input
-              id="itemSearchInput"
-              class="search-input"
-              type="search"
-              placeholder="Rechercher (OUT ou article)"
-              autocomplete="off"
-            />
-          </label>
+          <div class="page2-search-filter-bar">
+            <label class="input-group">
+              <span class="sr-only">Rechercher (OUT ou article)</span>
+              <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
+              <input
+                id="itemSearchInput"
+                class="search-input"
+                type="search"
+                placeholder="Rechercher (OUT ou article)"
+                autocomplete="off"
+              />
+            </label>
+            <div class="page2-filter-menu-wrap">
+              <button type="button" id="itemStatusFilterButton" class="page2-filter-button" aria-label="Filtrer les OUT par statut" aria-haspopup="true" aria-expanded="false" aria-controls="itemStatusFilterMenu">
+                <img src="Icon/curseurs.png" alt="" aria-hidden="true" class="page2-filter-button__icon" />
+              </button>
+              <div id="itemStatusFilterMenu" class="page2-filter-menu" role="menu" hidden>
+                <button type="button" class="page2-filter-option is-active" data-item-status-filter="all" role="menuitemradio" aria-checked="true"><span class="page2-filter-option__label">Tous</span><span class="page2-filter-option__count">0</span></button>
+                <button type="button" class="page2-filter-option" data-item-status-filter="todo" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">À faire</span><span class="page2-filter-option__count">0</span></button>
+                <button type="button" class="page2-filter-option" data-item-status-filter="fix" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">À corriger</span><span class="page2-filter-option__count">0</span></button>
+                <button type="button" class="page2-filter-option" data-item-status-filter="done" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">Complété</span><span class="page2-filter-option__count">0</span></button>
+                <button type="button" class="page2-filter-option" data-item-status-filter="ko" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">K.O</span><span class="page2-filter-option__count">0</span></button>
+              </div>
+            </div>
+          </div>
           <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>
             <span class="auth-required-card__icon" aria-hidden="true">i</span>
             <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>


### PR DESCRIPTION
### Motivation
- Permettre de filtrer la liste des OUT sur la Page 2 par statut (Tous / À faire / À corriger / Complété / K.O) via une icône située à droite du champ de recherche, en reprenant exactement la logique de classification déjà utilisée sur la Page 3.

### Description
- Ajout d’un composant UI dans `page2.html` : conteneur `page2-search-filter-bar` contenant le champ `#itemSearchInput` et le bouton `#itemStatusFilterButton` affichant `Icon/curseurs.png`, plus le menu `#itemStatusFilterMenu` avec les options et compteurs intégrés.
- Ajout de classes CSS dans `css/style.css` pour conserver le style du champ de recherche, aligner l’icône sur la même ligne, positionner le menu sous l’icône et appliquer l’état visuel `is-filtered` quand le filtre actif n’est pas `all`.
- Implémentation JavaScript dans `js/app.js` : nouvel état `activeStatusFilter`, fonctions `getFilteredOutItems`, `matchesStatusClassification`, `itemMatchesStatusFilter`, `updateItemStatusFilterCounters`, `syncItemStatusFilterUi`, `setItemStatusFilter` et gestion d’ouverture/fermeture du menu (clic bouton, clic extérieur, Échap); la logique de classification reprend `normalizeDetailStatut`, `computeEcart` et les mêmes règles `K.O` / `done` / `fix` / `todo` utilisées sur Page 3 afin d’assurer une cohérence complète.
- La combinaison des filtres est respectée : recherche (`#itemSearchInput`), filtre date (`itemDateFilter` / chips) et filtre statut sont appliqués conjointement, et un OUT est inclus dès qu’au moins un de ses articles correspond au filtre statut sélectionné.

### Testing
- Vérification syntaxique JavaScript avec `node --check js/app.js` qui a réussi.
- Contrôles manuels locaux : ouverture/fermeture du menu par clic, fermeture au clic extérieur et à `Escape`, et recalcul des compteurs lors de la saisie de recherche et du changement de filtre date (vérifié en local).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048187e61c832abb94a10decc5a2d8)