### PR TITLE
Page2: intégrer lu/non lu pour le filtre curseur OUT

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2855,6 +2855,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const itemStatusFilterOptions = Array.from(document.querySelectorAll('[data-item-status-filter]'));
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
     let activeStatusFilter = 'all';
+    const readCursorFilterOuts = new Set();
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
     let hasPendingOutScrollRestore = true;
     let selectedPurchasePhotoFile = null;
@@ -3622,8 +3623,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         previousLabel = currentLabel;
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
+        const isCursorFilterActive = activeStatusFilter !== 'all';
+        const isSearchUnread = query && !readSearchResults.has(String(item.id));
+        const isCursorFilterUnread = isCursorFilterActive && !readCursorFilterOuts.has(String(item.id));
+        const unreadClassName = (isCursorFilterUnread || isSearchUnread) ? ' list-card--search-unread' : '';
         htmlParts.push(`
-            <article class="list-card${query && !readSearchResults.has(String(item.id)) ? " list-card--search-unread" : ""}" data-search-match="true" data-item-id="${escapeHtml(item.id)}">
+            <article class="list-card${unreadClassName}" data-search-match="true" data-item-id="${escapeHtml(item.id)}">
               ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-item-menu="${item.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
@@ -3652,12 +3657,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       itemList.querySelectorAll('[data-item-open]').forEach((button) => {
         button.addEventListener('click', () => {
+          const openedItemId = String(button.dataset.itemOpen || '');
           if (query) {
-            readSearchResults.add(String(button.dataset.itemOpen || ''));
+            readSearchResults.add(openedItemId);
             persistSearchReadIdsToStorage(readSearchResults);
-            const card = button.closest('.list-card');
-            card?.classList.remove('list-card--search-unread');
           }
+          if (activeStatusFilter !== 'all') {
+            readCursorFilterOuts.add(openedItemId);
+          }
+          const card = button.closest('.list-card');
+          card?.classList.remove('list-card--search-unread');
           UiService.navigate(`page3.html?siteId=${encodeURIComponent(siteId)}&itemId=${encodeURIComponent(button.dataset.itemOpen)}`);
         });
       });
@@ -3760,7 +3769,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function setItemStatusFilter(filterKey) {
-      activeStatusFilter = filterKey || 'all';
+      const nextFilter = filterKey || 'all';
+      if (nextFilter !== activeStatusFilter) {
+        readCursorFilterOuts.clear();
+      }
+      activeStatusFilter = nextFilter;
       syncItemStatusFilterUi();
       renderItems();
     }


### PR DESCRIPTION
### Motivation
- Permettre que le mode lu/non lu s’applique aussi aux résultats affichés quand un filtre curseur (Tous/À faire/À corriger/Complété/K.O) est actif sur la Page 2.
- Conserver le comportement existant de la recherche (lu/non lu stocké en `localStorage`) et éviter d’impacter Page 1 et Page 3 ou le design.
- Offrir une mémoire temporaire par filtre curseur pour marquer les OUT ouverts comme lus tant que le même filtre reste actif et réinitialiser cet état au changement de filtre.

### Description
- Ajout d’une mémoire temporaire `readCursorFilterOuts = new Set()` dans `js/app.js` pour suivre les OUT lus dans le contexte du filtre curseur.
- Ajustement du rendu dans `renderItems` pour combiner l’état non-lu de la recherche et l’état non-lu du filtre curseur via la classe CSS existante `list-card--search-unread`.
- Au clic sur un OUT, l’ID est ajouté à `readCursorFilterOuts` quand un filtre curseur autre que `all` est actif, et la carte est immédiatement rendue en lu.
- `setItemStatusFilter` vide `readCursorFilterOuts` si le filtre change (y compris retour à `Tous`) puis relance le rendu; aucune classe CSS ni design n’ont été modifiés.

### Testing
- Vérification de syntaxe JavaScript effectuée avec `node --check js/app.js` et réussie.
- Validation du changement dans l’arbre Git (ajout et commit de `js/app.js`) réalisée avec `git add` + `git commit` sans erreur.
- Aucun test automatisé supplémentaire disponible; changement limité et localisé au fichier `js/app.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0484bff5a8832a9d6315ea93cabaee)