### PR TITLE
Page2: isoler l'état lu/non-lu du filtre curseur dans `localStorage`

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2848,6 +2848,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const dateFilterStorageKey = `site-detail:item-date-filter:${siteId}`;
     const searchStorageKey = `site-detail:item-search:${siteId}`;
     const searchReadIdsStorageKey = 'page2_search_read_ids';
+    const cursorFilterReadOutsStorageKey = 'page2_cursor_filter_read_outs';
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
     const itemStatusFilterButton = document.getElementById('itemStatusFilterButton');
@@ -3623,7 +3624,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         previousLabel = currentLabel;
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
-        const isCursorFilterActive = activeStatusFilter !== 'all';
+        const isCursorFilterActive = activeStatusFilter !== 'all' && !query;
         const isSearchUnread = query && !readSearchResults.has(String(item.id));
         const isCursorFilterUnread = isCursorFilterActive && !readCursorFilterOuts.has(String(item.id));
         const unreadClassName = (isCursorFilterUnread || isSearchUnread) ? ' list-card--search-unread' : '';
@@ -3662,8 +3663,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             readSearchResults.add(openedItemId);
             persistSearchReadIdsToStorage(readSearchResults);
           }
-          if (activeStatusFilter !== 'all') {
+          if (activeStatusFilter !== 'all' && !query) {
             readCursorFilterOuts.add(openedItemId);
+            persistCursorFilterReadIdsToStorage(readCursorFilterOuts);
           }
           const card = button.closest('.list-card');
           card?.classList.remove('list-card--search-unread');
@@ -3772,8 +3774,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const nextFilter = filterKey || 'all';
       if (nextFilter !== activeStatusFilter) {
         readCursorFilterOuts.clear();
+        clearCursorFilterReadIdsStorage();
+        if (nextFilter !== 'all') {
+          readCursorFilterReadIdsFromStorage().forEach((id) => readCursorFilterOuts.add(id));
+        }
       }
       activeStatusFilter = nextFilter;
+      if (activeStatusFilter === 'all') {
+        readCursorFilterOuts.clear();
+        clearCursorFilterReadIdsStorage();
+      }
       syncItemStatusFilterUi();
       renderItems();
     }
@@ -3836,6 +3846,36 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
     }
 
+    function readCursorFilterReadIdsFromStorage() {
+      try {
+        const rawValue = window.localStorage.getItem(cursorFilterReadOutsStorageKey);
+        const parsed = JSON.parse(rawValue || '[]');
+        if (!Array.isArray(parsed)) {
+          return new Set();
+        }
+        return new Set(parsed.map((value) => String(value || '')).filter(Boolean));
+      } catch (_error) {
+        return new Set();
+      }
+    }
+
+    function persistCursorFilterReadIdsToStorage(readIdsSet) {
+      try {
+        window.localStorage.setItem(cursorFilterReadOutsStorageKey, JSON.stringify(Array.from(readIdsSet)));
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
+    function clearCursorFilterReadIdsStorage() {
+      try {
+        window.localStorage.removeItem(cursorFilterReadOutsStorageKey);
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
+    readCursorFilterReadIdsFromStorage().forEach((id) => readCursorFilterOuts.add(id));
     const readSearchResults = readSearchReadIdsFromStorage();
 
     function isFirebaseUserAuthenticated(user) {


### PR DESCRIPTION
### Motivation

- Séparer le suivi lu/non lu du filtre bouton curseur de la logique de recherche existante pour Page 2 en respectant les restrictions fonctionnelles (ne pas toucher Page 1/3, filtres date, exports ni Firestore).
- Permettre un mode lu/non lu spécifique au filtre curseur qui persiste entre visites tant que le filtre n'est pas réinitialisé.

### Description

- Ajout d'une constante `cursorFilterReadOutsStorageKey = 'page2_cursor_filter_read_outs'` et d'un ensemble mémoire `readCursorFilterOuts` pour stocker les IDs lus en mode curseur dans `js/app.js`.
- Implémentation des helpers `readCursorFilterReadIdsFromStorage`, `persistCursorFilterReadIdsToStorage` et `clearCursorFilterReadIdsStorage` pour charger, persister et vider la clé `page2_cursor_filter_read_outs` sans modifier la clé de recherche `page2_search_read_ids`.
- Marquage d'un OUT comme lu dans la clé curseur uniquement quand un filtre curseur est actif et aucune recherche n'est en cours, et persistance immédiate via `persistCursorFilterReadIdsToStorage` lors du clic sur un OUT.
- Réinitialisation du mode curseur lors du changement de filtre (y compris retour à `Tous`) en vidant le `Set` et en appelant `localStorage.removeItem('page2_cursor_filter_read_outs')`, tout en conservant le comportement lu/non lu du champ recherche inchangé.

### Testing

- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04876f407c832aa7ace7cd8103d5e5)