### PR TITLE
Persist Page 2 cursor filter read state; only reset on `Tous`

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3772,13 +3772,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function setItemStatusFilter(filterKey) {
       const nextFilter = filterKey || 'all';
-      if (nextFilter !== activeStatusFilter) {
-        readCursorFilterOuts.clear();
-        clearCursorFilterReadIdsStorage();
-        if (nextFilter !== 'all') {
-          readCursorFilterReadIdsFromStorage().forEach((id) => readCursorFilterOuts.add(id));
-        }
-      }
       activeStatusFilter = nextFilter;
       if (activeStatusFilter === 'all') {
         readCursorFilterOuts.clear();


### PR DESCRIPTION
### Motivation
- Ensure Page 2 cursor-filtered read/unread state is persisted in `localStorage` (`page2_cursor_filter_read_outs`) when switching between active status filters and only cleared when the user explicitly selects `Tous`.

### Description
- Update `setItemStatusFilter` in `js/app.js` to stop clearing `readCursorFilterOuts` and `page2_cursor_filter_read_outs` when switching between active filters (`À faire`, `À corriger`, `Complété`, `K.O`), keeping the existing clear behavior only for `activeStatusFilter === 'all'`.

### Testing
- Ran `node --check js/app.js` to validate syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048b807548832a8cb0fadfd91e3d34)