### PR TITLE
Persister le filtre curseur de la Page 2 dans localStorage

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2849,13 +2849,29 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const searchStorageKey = `site-detail:item-search:${siteId}`;
     const searchReadIdsStorageKey = 'page2_search_read_ids';
     const cursorFilterReadOutsStorageKey = 'page2_cursor_filter_read_outs';
+    const cursorFilterActiveStorageKey = 'page2_cursor_filter_active';
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
     const itemStatusFilterButton = document.getElementById('itemStatusFilterButton');
     const itemStatusFilterMenu = document.getElementById('itemStatusFilterMenu');
     const itemStatusFilterOptions = Array.from(document.querySelectorAll('[data-item-status-filter]'));
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
-    let activeStatusFilter = 'all';
+    const statusFilterKeyByLabel = {
+      'Tous': 'all',
+      'À faire': 'todo',
+      'À corriger': 'fix',
+      'Complété': 'done',
+      'K.O': 'ko',
+    };
+    const statusFilterLabelByKey = {
+      all: 'Tous',
+      todo: 'À faire',
+      fix: 'À corriger',
+      done: 'Complété',
+      ko: 'K.O',
+    };
+    const storedCursorFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
+    let activeStatusFilter = statusFilterKeyByLabel[storedCursorFilterLabel] || 'all';
     const readCursorFilterOuts = new Set();
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
     let hasPendingOutScrollRestore = true;
@@ -3773,6 +3789,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function setItemStatusFilter(filterKey) {
       const nextFilter = filterKey || 'all';
       activeStatusFilter = nextFilter;
+      try {
+        window.localStorage.setItem(cursorFilterActiveStorageKey, statusFilterLabelByKey[activeStatusFilter] || 'Tous');
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
       if (activeStatusFilter === 'all') {
         readCursorFilterOuts.clear();
         clearCursorFilterReadIdsStorage();


### PR DESCRIPTION
### Motivation
- Le filtre curseur de la Page 2 revenait automatiquement à `Tous` après scroll, changement d’onglet date, refresh, rerender ou retour sur Page 2, il doit rester dans l’état sélectionné.

### Description
- Ajout d’une clé dédiée `page2_cursor_filter_active` (constante `cursorFilterActiveStorageKey`) stockée en `localStorage` pour Page 2 uniquement.
- Ajout d’un mapping entre labels affichés et clés internes (`statusFilterKeyByLabel` / `statusFilterLabelByKey`) et initialisation de `activeStatusFilter` depuis la valeur stockée.
- Persistance du label sélectionné dans `setItemStatusFilter` via `localStorage.setItem(cursorFilterActiveStorageKey, ...)` à chaque changement de filtre.
- Changement limité à la logique `site-detail` (Page 2) et protège contre les erreurs d’accès à `localStorage` (fallback silencieux).

### Testing
- Recherche et inspection du code affecté avec `rg` et `sed` pour valider le contexte de modification, commande exécutée avec succès.
- Modification appliquée par script et vérifiée avec `git -C /workspace/Album diff -- js/app.js`, qui affiche les insertions attendues.
- Validation de l’ajout dans l’arbre côté local avec `git -C /workspace/Album commit -m "Persist Page 2 cursor filter selection in localStorage"`, commit réussi.
- Vérification finale de l’état du dépôt avec `git -C /workspace/Album status --short` et création des méta-données de PR via `make_pr`, toutes opérations automatisées réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048ebd8ef8832ab7427e1f717eb751)