### PR TITLE
Page 2: Recompute cursor filter counters after detail rows load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3618,7 +3618,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const shouldFlashSearchMatches = Boolean(options?.flashSearchMatches);
       const query = itemSearchInput.value.trim().toUpperCase();
       const filteredItems = getFilteredOutItems(query);
-      updateItemStatusFilterCounters(query);
+      updateCursorFilterCounters();
 
       itemCount.innerHTML = `<span class="outs-number">${filteredItems.length}</span><span class="outs-label">OUT${filteredItems.length > 1 ? 'S' : ''}</span>`;
 
@@ -3750,7 +3750,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return currentItems.filter((item) => itemMatchesDateFilter(item, selectedDateFilter) && outMatchesSearch(item, query) && itemMatchesStatusFilter(item, activeStatusFilter));
     }
 
-    function updateItemStatusFilterCounters(query) {
+    function updateCursorFilterCounters() {
+      const query = itemSearchInput.value.trim().toUpperCase();
       if (!itemStatusFilterOptions.length) {
         return;
       }
@@ -4914,6 +4915,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       siteId,
       (rowsByItem) => {
         detailRowsByItem = rowsByItem;
+        if (activeSiteTab === 'outs') {
+          updateCursorFilterCounters();
+          renderItems();
+        }
       },
       () => {},
     );


### PR DESCRIPTION
### Motivation
- Fix a timing bug on Page 2 where cursor/filter counters ("À faire", "À corriger", "Complété", "K.O") briefly show `0` after a refresh because counters were computed before detail rows/articles were available.  
- Ensure counters are accurate immediately after page load and when the date tab changes without requiring user interaction.

### Description
- Added a centralized function `updateCursorFilterCounters()` that reads the active search (`itemSearchInput`), active date filter (`selectedDateFilter`) and current detail rows to compute each cursor/menu counter.  
- Replaced the previous inline call with `updateCursorFilterCounters()` in `renderItems()` to guarantee counters are recalculated whenever the OUT list is rendered.  
- Triggered `updateCursorFilterCounters()` (and re-render via `renderItems()`) from the `StorageService.subscribeDetailRows` callback so counters update after Firestore detail rows finish loading.  
- Scope: only modifies Page 2 logic in `js/app.js`; no behavior changes for other pages.

### Testing
- Searched codebase for relevant symbols with `rg` to locate affected code paths and references, which completed successfully.  
- Verified occurrences and replacements in `js/app.js` and inspected the resulting diff using `git diff`, which showed the intended function renaming/insertion.  
- Committed the change successfully (`git commit`), indicating the patch applied cleanly.  
- No automated unit tests exist in the repository for this feature; only the repository inspection and commit commands above were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04918d928c832aa375760f746821b5)