### PR TITLE
Page2: compteurs du filtre curseur basés sur les articles (pas sur les OUT)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3758,7 +3758,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const scopeItems = currentItems.filter((item) => itemMatchesDateFilter(item, selectedDateFilter) && outMatchesSearch(item, query));
       itemStatusFilterOptions.forEach((option) => {
         const filterKey = option.dataset.itemStatusFilter || 'all';
-        const count = scopeItems.filter((item) => itemMatchesStatusFilter(item, filterKey)).length;
+        const count = scopeItems.reduce((total, item) => {
+          const detailRows = detailRowsByItem[item.id] || [];
+          const matchingDetails = detailRows.filter((detail) => matchesStatusClassification(detail, filterKey));
+          return total + matchingDetails.length;
+        }, 0);
         const countNode = option.querySelector('.page2-filter-option__count');
         if (countNode) {
           countNode.textContent = String(count);


### PR DESCRIPTION
### Motivation
- Sur la Page 2, les compteurs du menu filtre (bouton curseur) doivent afficher le nombre total d’articles/lignes correspondant à chaque statut et non plus le nombre de cartes OUT.
- Maintenir le reste du comportement existant (filtrage visuel des OUT, recherche, filtres date, localStorage, mode lu/non lu, design et navigation).

### Description
- Modifié `js/app.js` dans la fonction `updateCursorFilterCounters` pour agréger les lignes d’articles en parcourant `detailRowsByItem` et en additionnant les détails qui correspondent au statut via `matchesStatusClassification` au lieu de compter les OUT.
- La sélection des `scopeItems` reste basée sur la recherche (`itemSearchInput`) et le filtre date (`selectedDateFilter`), de sorte que les compteurs respectent ces filtres actifs.
- Aucun changement à la logique d’affichage des cartes OUT, ni aux pages 1/3, aux exports, au design du menu ou à la logique d’ouverture/fermeture du menu.

### Testing
- Examen du diff avec `git status --short && git diff -- js/app.js` — commande exécutée avec succès.
- Validation de l’application du patch et enregistrement via `git add` et `git commit` — commande exécutée avec succès.
- Aucun test automatisé unitaire/CI supplémentaire n’a été ajouté; la modification s’exécute via le flux existant qui appelle `updateCursorFilterCounters` pour recalculer les compteurs en temps réel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04950e2d54832abaee7b6c3ad325dd)