### PR TITLE
Sync Page 3 detail filter with Page 2 cursor filter

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4999,7 +4999,21 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let designationInputErrorTimeoutId = null;
     let codeInputErrorStateTimeoutId = null;
     let designationInputErrorStateTimeoutId = null;
+    const cursorFilterActiveStorageKey = 'page2_cursor_filter_active';
+    const detailFilterKeyByPage2Label = {
+      'Tous': 'all',
+      'À faire': 'todo',
+      'À corriger': 'fix',
+      'Complété': 'done',
+      'K.O': 'ko',
+    };
     let activeDetailFilter = 'all';
+    try {
+      const page2ActiveFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
+      activeDetailFilter = detailFilterKeyByPage2Label[page2ActiveFilterLabel] || 'all';
+    } catch (_error) {
+      activeDetailFilter = 'all';
+    }
 
     function setDetailModalOpenState(isOpen) {
       document.body.classList.toggle('item-detail-modal-open', isOpen);


### PR DESCRIPTION
### Motivation
- Ensure Page 3 opens with the same logical status filter that was active on Page 2 by reusing the existing `localStorage` key `page2_cursor_filter_active` so the user sees only the relevant articles when opening an OUT.

### Description
- Read `page2_cursor_filter_active` from `localStorage` during Page 3 initialization and map its French label to Page 3 filter keys using `detailFilterKeyByPage2Label` (`Tous → all`, `À faire → todo`, `À corriger → fix`, `Complété → done`, `K.O → ko`).
- Initialize `activeDetailFilter` from that mapping so the detail table and filter UI reflect the Page 2 cursor filter on entry.
- Change is localized to `js/app.js` and preserves all existing Page 3 behaviors, counters, visual filter state, exports, and Page 2 logic.

### Testing
- Verified the new symbols `cursorFilterActiveStorageKey` and `detailFilterKeyByPage2Label` are present in `js/app.js` and `activeDetailFilter` is initialized from `localStorage`, and the surrounding filter UI functions (`syncDetailFilterUi`, `renderTable`) remain unchanged; checks succeeded.
- Ran code search to confirm the mapping and storage key are defined only in the intended location; search succeeded.
- Confirmed no other pages or export logic were modified; validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049c874a48832ab90f717a8822cf5f)