### PR TITLE
Page2: aligner le compteur "X Articles" avec le filtre curseur actif

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3640,6 +3640,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         previousLabel = currentLabel;
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
+        const detailCountForCard = getOutDetailCountForActiveFilter(item.id);
         const isCursorFilterActive = activeStatusFilter !== 'all' && !query;
         const isSearchUnread = query && !readSearchResults.has(String(item.id));
         const isCursorFilterUnread = isCursorFilterActive && !readCursorFilterOuts.has(String(item.id));
@@ -3650,7 +3651,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <button class="list-card__button" type="button" data-item-open="${item.id}">
                 <h3 class="list-card__title">${escapeHtml(item.numero)}</h3>
                 <div class="list-card__meta">
-                  <span class="list-card__meta-item list-card__meta-item--article"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span class="outs-count"><span class="outs-number">${detailCountsByItem[item.id] || 0}</span><span class="outs-label">Article${(detailCountsByItem[item.id] || 0) > 1 ? 's' : ''}</span></span></span>
+                  <span class="list-card__meta-item list-card__meta-item--article"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span class="outs-count"><span class="outs-number">${detailCountForCard}</span><span class="outs-label">Article${detailCountForCard > 1 ? 's' : ''}</span></span></span>
                   <span class="list-card__meta-item"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Créé le ${escapeHtml(createdLabel)}</span></span>
                   <span class="list-card__meta-item"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>${escapeHtml(createdBy)}</span></span>
                 </div>
@@ -3744,6 +3745,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const detailRows = detailRowsByItem[item.id] || [];
       return detailRows.some((detail) => matchesStatusClassification(detail, filterKey));
+    }
+
+    function getOutDetailCountForActiveFilter(itemId) {
+      const detailRows = detailRowsByItem[itemId] || [];
+      if (activeStatusFilter === 'all') {
+        return Number(detailCountsByItem[itemId] || 0);
+      }
+      return detailRows.reduce((count, detail) => count + (matchesStatusClassification(detail, activeStatusFilter) ? 1 : 0), 0);
     }
 
     function getFilteredOutItems(query) {


### PR DESCRIPTION
### Motivation
- Faire en sorte que le compteur affiché dans chaque carte OUT sur la Page 2 respecte le filtre curseur actif (`Tous`, `À faire`, `À corriger`, `Complété`, `K.O`) sans changer la logique d’affichage ni les autres filtres ou pages.

### Description
- Ajout de la fonction `getOutDetailCountForActiveFilter(itemId)` dans `js/app.js` pour calculer le nombre d’articles d’un OUT selon `activeStatusFilter`.
- Remplacement de l’usage direct de `detailCountsByItem[item.id]` par `detailCountForCard` (valeur calculée via la nouvelle fonction) lors du rendu des cartes OUT dans `renderItems`.
- Le comportement en mode `Tous` reste inchangé et retourne le total d’articles de l’OUT; aucune autre logique (visibilité des OUT, recherche, filtres date, lu/non lu, compteurs du menu filtre, pages 1/3, exports) n’a été modifiée.
- Tous les changements sont contenus dans le fichier `js/app.js`.

### Testing
- Exécution de la vérification de syntaxe avec `node --check js/app.js` qui a réussi.
- Le fichier modifié a été validé localement et le diff contient uniquement l’ajout de la fonction et le remplacement de l’affichage du compteur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a034ac9c832a9fd706632e7d6657)