### PR TITLE
Page 2: exiger que recherche + filtre curseur matchent sur la même ligne détail

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3747,6 +3747,20 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return detailRows.some((detail) => matchesStatusClassification(detail, filterKey));
     }
 
+    function detailMatchesOutSearch(detail, query) {
+      if (!query) {
+        return true;
+      }
+      const designation = String(detail?.designation || '').toUpperCase();
+      const code = String(detail?.code || '').toUpperCase();
+      return designation.includes(query) || code.includes(query);
+    }
+
+    function itemMatchesCombinedSearchAndStatus(item, query, filterKey) {
+      const detailRows = detailRowsByItem[item.id] || [];
+      return detailRows.some((detail) => detailMatchesOutSearch(detail, query) && matchesStatusClassification(detail, filterKey));
+    }
+
     function getOutDetailCountForActiveFilter(itemId) {
       const detailRows = detailRowsByItem[itemId] || [];
       if (activeStatusFilter === 'all') {
@@ -3756,7 +3770,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function getFilteredOutItems(query) {
-      return currentItems.filter((item) => itemMatchesDateFilter(item, selectedDateFilter) && outMatchesSearch(item, query) && itemMatchesStatusFilter(item, activeStatusFilter));
+      return currentItems.filter((item) => {
+        if (!itemMatchesDateFilter(item, selectedDateFilter)) {
+          return false;
+        }
+        if (activeStatusFilter === 'all') {
+          return outMatchesSearch(item, query);
+        }
+        if (!query) {
+          return itemMatchesStatusFilter(item, activeStatusFilter);
+        }
+        const outMatches = String(item.numero || '').toUpperCase().includes(query);
+        if (outMatches) {
+          return itemMatchesStatusFilter(item, activeStatusFilter);
+        }
+        return itemMatchesCombinedSearchAndStatus(item, query, activeStatusFilter);
+      });
     }
 
     function updateCursorFilterCounters() {


### PR DESCRIPTION
### Motivation
- Page 2 affichait un OUT quand une ligne détail satisfaisait la recherche et une autre ligne détail du même OUT satisfaisait le filtre curseur, ce qui produisait des faux positifs.
- L'objectif est de n'afficher un OUT que lorsqu'au moins une même ligne détail respecte simultanément la recherche et le filtre curseur actif.

### Description
- Ajout de la fonction `detailMatchesOutSearch(detail, query)` pour tester la recherche au niveau détail via la `designation` ou le `code`.
- Ajout de la fonction `itemMatchesCombinedSearchAndStatus(item, query, filterKey)` pour vérifier l'intersection « même détail » entre recherche et classification de statut.
- Modification de `getFilteredOutItems(query)` pour préserver les comportements existants (filtre `all`, recherche vide + filtre actif, match sur numéro d'OUT) et appliquer l'intersection stricte détail-level dans le cas combiné recherche + curseur.

### Testing
- Aucun test automatique n'a été trouvé ni exécuté (`npm test` ou suite de tests JS absents), donc aucune exécution de tests automatisés n'a eu lieu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04bddaaa94832a91a55943158f5b70)