### PR TITLE
Fix combined search + cursor filter behavior from Page 2 to Page 3

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3640,7 +3640,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         previousLabel = currentLabel;
         const createdBy = resolveActorLabel(item?.createdBy, userNamesById, item?.createdByName);
         const createdLabel = buildDateAndTimeLabel(item?.dateCreation || item?.dateModification);
-        const detailCountForCard = getOutDetailCountForActiveFilter(item.id);
+        const detailCountForCard = getOutDetailCountForActiveFilter(item.id, query);
         const isCursorFilterActive = activeStatusFilter !== 'all' && !query;
         const isSearchUnread = query && !readSearchResults.has(String(item.id));
         const isCursorFilterUnread = isCursorFilterActive && !readCursorFilterOuts.has(String(item.id));
@@ -3686,7 +3686,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           }
           const card = button.closest('.list-card');
           card?.classList.remove('list-card--search-unread');
-          UiService.navigate(`page3.html?siteId=${encodeURIComponent(siteId)}&itemId=${encodeURIComponent(button.dataset.itemOpen)}`);
+          UiService.navigate(`page3.html?siteId=${encodeURIComponent(siteId)}&itemId=${encodeURIComponent(button.dataset.itemOpen)}&search=${encodeURIComponent(query)}`);
         });
       });
 
@@ -3756,17 +3756,23 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return designation.includes(query) || code.includes(query);
     }
 
-    function itemMatchesCombinedSearchAndStatus(item, query, filterKey) {
-      const detailRows = detailRowsByItem[item.id] || [];
-      return detailRows.some((detail) => detailMatchesOutSearch(detail, query) && matchesStatusClassification(detail, filterKey));
+    function detailMatchesOutCombinedFilters(detail, query, filterKey) {
+      const matchSearch = detailMatchesOutSearch(detail, query);
+      const matchFilter = matchesStatusClassification(detail, filterKey);
+      return matchSearch && matchFilter;
     }
 
-    function getOutDetailCountForActiveFilter(itemId) {
+    function itemMatchesCombinedSearchAndStatus(item, query, filterKey) {
+      const detailRows = detailRowsByItem[item.id] || [];
+      return detailRows.some((detail) => detailMatchesOutCombinedFilters(detail, query, filterKey));
+    }
+
+    function getOutDetailCountForActiveFilter(itemId, query) {
       const detailRows = detailRowsByItem[itemId] || [];
-      if (activeStatusFilter === 'all') {
+      if (activeStatusFilter === 'all' && !query) {
         return Number(detailCountsByItem[itemId] || 0);
       }
-      return detailRows.reduce((count, detail) => count + (matchesStatusClassification(detail, activeStatusFilter) ? 1 : 0), 0);
+      return detailRows.reduce((count, detail) => count + (detailMatchesOutCombinedFilters(detail, query, activeStatusFilter) ? 1 : 0), 0);
     }
 
     function getFilteredOutItems(query) {
@@ -5046,6 +5052,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       'K.O': 'ko',
     };
     let activeDetailFilter = 'all';
+    const initialPage2SearchQuery = String(searchParams.get('search') || '').trim().toLowerCase();
     try {
       const page2ActiveFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
       activeDetailFilter = detailFilterKeyByPage2Label[page2ActiveFilterLabel] || 'all';
@@ -6230,7 +6237,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         renderTable();
         detailSearchInput.focus();
       });
-      detailSearchInput.value = '';
+      detailSearchInput.value = initialPage2SearchQuery;
       toggleClearButton();
     }
 


### PR DESCRIPTION
### Motivation
- Page 2 article counts and Page 3 detail rows were inconsistent when a search and a cursor/status filter were both active, causing OUT cards to report a larger article count than the rows visible after opening the card.
- The intent is that an article is shown only when it matches both the active search and the active cursor filter, and this same predicate must be used for counts on Page 2 and rows on Page 3.

### Description
- Added a combined predicate `detailMatchesOutCombinedFilters(detail, query, filterKey)` to centralize the rule that a detail must match the search AND the status classification.
- Made `getOutDetailCountForActiveFilter(itemId, query)` use the combined predicate so per-card article counts on Page 2 respect the same search+filter combination.
- Updated Page 2 rendering to pass the active search `query` into the detail-count function and to include `&search=` in the navigation URL when opening Page 3.
- Initialized Page 3 search input from the received `search` URL parameter so the detail table is filtered immediately with the same search + cursor filter context.

### Testing
- Ran `node --check js/app.js` to validate the modified file syntax, which completed successfully.
- Verified the patch was applied and committed (`git add` + `git commit`) without errors.
- Confirmed the updated behavior manually in code paths by inspecting the changes to `js/app.js` and ensuring the combined predicate is used for both counting and rendering (no automated unit tests were present to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c380aac8832a9bbdd4e31b1d92f2)