### PR TITLE
Fix Page 3 auto search/filter timing after Page 2 navigation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5052,7 +5052,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       'K.O': 'ko',
     };
     let activeDetailFilter = 'all';
-    const initialPage2SearchQuery = String(searchParams.get('search') || '').trim().toLowerCase();
+    const page2SearchStorageKey = 'page2_search_value';
+    const initialPage2SearchQuery = (() => {
+      try {
+        return String(window.localStorage.getItem(page2SearchStorageKey) || '').trim().toLowerCase();
+      } catch (_error) {
+        return '';
+      }
+    })();
     try {
       const page2ActiveFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
       activeDetailFilter = detailFilterKeyByPage2Label[page2ActiveFilterLabel] || 'all';
@@ -5618,6 +5625,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
 
+      if (!hasResolvedInitialDetails || filteredCount === null || totalCount === null) {
+        countNumber.textContent = '...';
+        countLabel.textContent = 'Chargement...';
+        return;
+      }
+
       countNumber.textContent = String(filteredCount);
       if (filteredCount === totalCount) {
         countLabel.textContent = filteredCount > 1 ? 'Articles' : 'Article';
@@ -5838,6 +5851,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function renderTable() {
+      if (!hasResolvedInitialDetails) {
+        updateCount(null, null);
+        detailTableBody.innerHTML = `<tr><td colspan="14"><div class="empty-state">Chargement...</div></td></tr>`;
+        return;
+      }
+
       if (!currentItem) {
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
         return;
@@ -6343,6 +6362,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       isDetailSkeletonVisible = false;
       detailTableBody.innerHTML = '';
     }
+
+    updateCount(null, null);
 
     detailSkeletonTimerId = window.setTimeout(() => {
       showDetailTableSkeleton();


### PR DESCRIPTION
### Motivation
- Page 3 could apply the saved Page 2 search + cursor filter before Firestore details finished loading and show a premature empty state (`0 Articles`).
- The saved search was read from the URL query instead of reliably reading the actual `localStorage` value used by Page 2, causing mismatch in some navigation flows.
- The goal is to ensure Page 3 waits for the real details load and then applies the same filtering logic as Page 2 so the correct rows and counts are shown.

### Description
- Read the saved Page 2 search value from `localStorage` using the key `page2_search_value` and use it as the initial query (`js/app.js`).
- Prevent rendering/applying filters while initial details are unresolved by gating `renderTable()` with `hasResolvedInitialDetails` so Page 3 shows a loading state until details arrive (`js/app.js`).
- Update `updateCount()` to display a loading state (`'...'` / `'Chargement...'`) when details are not yet resolved, preventing a transient `0 Articles` display (`js/app.js`).
- Initialize the loading counter early at page start to avoid flashes and keep the existing Page 2→Page 3 filter label mapping intact (`Tous`, `À faire`, `À corriger`, `Complété`, `K.O`).

### Testing
- Ran a JavaScript syntax check: `node --check js/app.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c6ac6678832a9d4e383652a6a3f4)