### PR TITLE
Fix Page 3 bridge filtering for Page 2 search-only navigation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5062,8 +5062,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       initialPage2SearchQuery = '';
       initialPage2CursorFilterLabel = 'Tous';
     }
-    const initialPage2CursorFilter = detailFilterKeyByPage2Label[initialPage2CursorFilterLabel] || 'all';
-    let isPage2FilterBridgeActive = Boolean(initialPage2SearchQuery) || initialPage2CursorFilter !== 'all';
+    const hasInitialPage2Search = Boolean(initialPage2SearchQuery);
+    const hasInitialPage2CursorFilter = initialPage2CursorFilterLabel !== 'Tous';
+    const initialPage2CursorFilter = hasInitialPage2CursorFilter
+      ? (detailFilterKeyByPage2Label[initialPage2CursorFilterLabel] || 'all')
+      : 'all';
+    let isPage2FilterBridgeActive = hasInitialPage2Search || hasInitialPage2CursorFilter;
     activeDetailFilter = initialPage2CursorFilter;
 
     function setDetailModalOpenState(isOpen) {
@@ -5576,8 +5580,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function getFilteredDetails(details) {
       const query = getSearchQuery();
       if (isPage2FilterBridgeActive) {
-        return details.filter((detail) => matchesSearchQuery(detail, initialPage2SearchQuery)
-          && matchesDetailFilter(detail, initialPage2CursorFilter));
+        return details.filter((detail) => {
+          const matchSearch = hasInitialPage2Search ? matchesSearchQuery(detail, initialPage2SearchQuery) : true;
+          const matchFilter = hasInitialPage2CursorFilter ? matchesDetailFilter(detail, initialPage2CursorFilter) : true;
+          return matchSearch && matchFilter;
+        });
       }
       return details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailFilter(detail, activeDetailFilter));
     }


### PR DESCRIPTION
### Motivation
- Corriger un cas où l'ouverture d'un OUT depuis Page 2 avec une recherche active mais sans filtre curseur (label `Tous`) affichait des lignes supplémentaires dans Page 3.

### Description
- Modifié `js/app.js` pour introduire des drapeaux explicites `hasInitialPage2Search` et `hasInitialPage2CursorFilter` et calculer `initialPage2CursorFilter` seulement si le curseur Page 2 est réellement actif.
- Ajusté la condition de pont (`isPage2FilterBridgeActive`) pour ne s'activer que si la recherche Page 2 ou le filtre curseur Page 2 sont effectivement présents.
- Mis à jour la fonction `getFilteredDetails` pour appliquer séparément la recherche Page 2 et le filtre curseur Page 2 : la recherche s'applique seulement si `hasInitialPage2Search` et le filtre curseur seulement si `hasInitialPage2CursorFilter`.
- L'effet est que Page 3 n'applique plus son filtre interne parasite lorsque l'on arrive depuis Page 2 avec uniquement une recherche (curseur sur `Tous`).

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d0851f6c832aa78565cd909a9197)