### PR TITLE
Verrouille Page 3 sur le contexte recherche/curseur de Page 2

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5068,7 +5068,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const page2CursorFilterKey = hasPage2CursorFilterContext
       ? (detailFilterKeyByPage2Label[page2CursorFilterLabel] || 'all')
       : 'all';
-    let isPage2FilterBridgeActive = hasPage2SearchContext || hasPage2CursorFilterContext;
+    const isPage2BridgeLocked = hasPage2SearchContext || hasPage2CursorFilterContext;
+    let isPage2FilterBridgeActive = isPage2BridgeLocked;
     activeDetailFilter = page2CursorFilterKey;
 
     function setDetailModalOpenState(isOpen) {
@@ -6257,7 +6258,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (detailSearchInput) {
       detailSearchInput.addEventListener('input', () => {
-        isPage2FilterBridgeActive = false;
+        if (!isPage2BridgeLocked) {
+          isPage2FilterBridgeActive = false;
+        }
         renderTable();
       });
       const toggleClearButton = () => {
@@ -6292,7 +6295,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       detailFilterOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          isPage2FilterBridgeActive = false;
+          if (!isPage2BridgeLocked) {
+            isPage2FilterBridgeActive = false;
+          }
           setDetailFilter(option.dataset.detailFilter || 'all');
           closeDetailFilterMenu();
         });
@@ -6311,6 +6316,21 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+
+    if (isPage2BridgeLocked) {
+      if (detailSearchInput) {
+        detailSearchInput.readOnly = true;
+      }
+      if (clearSearchBtn) {
+        clearSearchBtn.disabled = true;
+      }
+      if (detailFilterButton) {
+        detailFilterButton.disabled = true;
+      }
+      if (detailFilterMenu) {
+        detailFilterMenu.hidden = true;
+      }
+    }
     if (exportButton) {
       exportButton.addEventListener('click', openDetailExportDialog);
     }


### PR DESCRIPTION
### Motivation
- Empêcher Page 3 d’élargir la liste lorsqu’on arrive depuis Page 2 avec une recherche et/ou un filtre curseur actifs, pour que l’affichage respecte l’intersection `matchSearch && matchCursorFilter` sur chaque article.

### Description
- Ajout d’un flag `isPage2BridgeLocked` et initialisation de `isPage2FilterBridgeActive` depuis ce flag dans `js/app.js` pour marquer la présence d’un contexte Page 2 (recherche et/ou filtre curseur). 
- Protection des handlers de l’input recherche et des options de filtre de Page 3 pour n’autoriser la désactivation du bridge que si `isPage2BridgeLocked` est faux. 
- Désactivation/read-only de l’UI de détail (champ recherche en lecture seule, bouton effacer et bouton filtre désactivés, menu filtre masqué) quand le bridge Page 2 est verrouillé pour empêcher tout élargissement du jeu de résultats.

### Testing
- Vérification du diff avec `git -C /workspace/Album diff -- js/app.js` et inspection du patch (succès). 
- Vérification du statut `git -C /workspace/Album status --short` (succès). 
- Commit du fichier modifié via `git -C /workspace/Album commit` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0549356a28832ab322fa2cd6cbc375)