### PR TITLE
Preserve Page 2 context in Page 3 to prevent auto-filter switching

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5065,11 +5065,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const normalizedPage2SearchValue = page2SearchValue.toLowerCase();
     const hasPage2SearchContext = Boolean(page2SearchValue);
     const hasPage2CursorFilterContext = page2CursorFilterLabel !== 'Tous';
+    const isPage2Context = hasPage2SearchContext || hasPage2CursorFilterContext;
     const page2CursorFilterKey = hasPage2CursorFilterContext
       ? (detailFilterKeyByPage2Label[page2CursorFilterLabel] || 'all')
       : 'all';
-    const isPage2BridgeLocked = hasPage2SearchContext || hasPage2CursorFilterContext;
-    let isPage2FilterBridgeActive = isPage2BridgeLocked;
+    const isPage2BridgeLocked = isPage2Context;
+    let isPage2FilterBridgeActive = isPage2Context;
     activeDetailFilter = page2CursorFilterKey;
 
     function setDetailModalOpenState(isOpen) {
@@ -5617,6 +5618,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function setDetailFilter(filterKey) {
       activeDetailFilter = filterKey;
       syncDetailFilterUi();
+      detailFilterButton.disabled = isPage2Context;
       renderTable();
     }
 
@@ -6258,7 +6260,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (detailSearchInput) {
       detailSearchInput.addEventListener('input', () => {
-        if (!isPage2BridgeLocked) {
+        if (!isPage2Context) {
           isPage2FilterBridgeActive = false;
         }
         renderTable();
@@ -6280,11 +6282,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         detailSearchInput.focus();
       });
       detailSearchInput.value = page2SearchValue;
+      detailSearchInput.readOnly = isPage2Context;
       toggleClearButton();
     }
 
     if (detailFilterButton && detailFilterMenu && detailFilterOptions.length) {
       syncDetailFilterUi();
+      detailFilterButton.disabled = isPage2Context;
       detailFilterButton.addEventListener('click', () => {
         if (detailFilterMenu.hidden) {
           openDetailFilterMenu();
@@ -6295,9 +6299,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       detailFilterOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          if (!isPage2BridgeLocked) {
-            isPage2FilterBridgeActive = false;
+          if (isPage2Context) {
+            closeDetailFilterMenu();
+            return;
           }
+          isPage2FilterBridgeActive = false;
           setDetailFilter(option.dataset.detailFilter || 'all');
           closeDetailFilterMenu();
         });


### PR DESCRIPTION
### Motivation
- Corriger un bug où Page 3 bascule automatiquement son filtre interne quand on y arrive depuis Page 2 avec une recherche ou un filtre curseur actifs, élargissant inutilement les résultats.
- Garantir que Page 3 conserve strictement le contexte transmis (recherche Page 2 + filtre curseur Page 2) et n’autorise aucun changement de filtre sans action utilisateur explicite hors de ce mode.

### Description
- Ajout d’un drapeau `isPage2Context` calculé depuis les clés `page2_search_value` et `page2_cursor_filter_active` dans `js/app.js` et utilisation de ce drapeau pour verrouiller le pont de filtrage Page2→Page3.
- Conservé `isPage2FilterBridgeActive` activé par défaut quand `isPage2Context` est vrai, pour appliquer la recherche et le filtre Page 2 lors du rendu des détails.
- Bloqué les interactions susceptibles d’élargir les résultats en mode contexte en rendant `detailSearchInput` en `readOnly`, en désactivant `detailFilterButton` et en ignorant les clics d’options de filtre quand `isPage2Context` est actif.

### Testing
- Aucun test automatisé n’a été exécuté pour ce patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a054b7a53b0832aa92c94420c3ff3b1)