### PR TITLE
Prefill Page 3 search from Page 2 by persisting `page2_search_value`

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2874,6 +2874,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let activeStatusFilter = statusFilterKeyByLabel[storedCursorFilterLabel] || 'all';
     const readCursorFilterOuts = new Set();
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
+    try {
+      const initialPage2SearchValue = String(itemSearchInput.value || '');
+      if (initialPage2SearchValue) {
+        window.localStorage.setItem('page2_search_value', initialPage2SearchValue);
+      } else {
+        window.localStorage.removeItem('page2_search_value');
+      }
+    } catch (_error) {
+      // Ignore localStorage restrictions.
+    }
     let hasPendingOutScrollRestore = true;
     let selectedPurchasePhotoFile = null;
     let selectedPurchasePhotoPreviewUrl = '';
@@ -4745,8 +4755,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const searchValue = itemSearchInput.value;
         if (searchValue) {
           window.localStorage.setItem(searchStorageKey, searchValue);
+          window.localStorage.setItem('page2_search_value', searchValue);
         } else {
           window.localStorage.removeItem(searchStorageKey);
+          window.localStorage.removeItem('page2_search_value');
         }
         const normalizedQuery = (searchValue || '').trim().toUpperCase();
         const hasQueryChanged = normalizedQuery !== activeOutSearchQuery;


### PR DESCRIPTION
### Motivation
- Page 3 reads a `page2_search_value` from `localStorage` to prefill its search input but Page 2 did not consistently write that key, causing Page 3 to apply the filter while its search field stayed empty.

### Description
- Added an initialization sync in `js/app.js` to write `itemSearchInput.value` into `localStorage` under the key `page2_search_value` when Page 2 loads or restores the saved search.
- Updated the Page 2 search input handler (`itemSearchInput` input listener) in `js/app.js` to set or remove `page2_search_value` whenever the user types or clears the search, matching the existing `searchStorageKey` behavior.
- Change is scoped to `js/app.js` and only affects the Page 2 → Page 3 search bridge so Page 3 can prefill its search field while preserving existing filter behavior.

### Testing
- Located and validated relevant references with automated code search to confirm integration points for `page2_search_value` and `detailSearchInput`, which succeeded.
- Applied the scripted patch to `js/app.js` and verified the resulting diff shows the intended edits to persist/remove `page2_search_value`, which succeeded.
- Persisted the changes into the repository and verified the updated `js/app.js` contains the new logic for initial sync and input-time sync, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057dd151b4832a8a22446798dad739)