### PR TITLE
Keep Page 3 filter button clickable when arriving from Page 2

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5630,7 +5630,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function setDetailFilter(filterKey) {
       activeDetailFilter = filterKey;
       syncDetailFilterUi();
-      detailFilterButton.disabled = isPage2Context;
       renderTable();
     }
 
@@ -6300,7 +6299,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (detailFilterButton && detailFilterMenu && detailFilterOptions.length) {
       syncDetailFilterUi();
-      detailFilterButton.disabled = isPage2Context;
       detailFilterButton.addEventListener('click', () => {
         if (detailFilterMenu.hidden) {
           openDetailFilterMenu();
@@ -6311,10 +6309,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       detailFilterOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          if (isPage2Context) {
-            closeDetailFilterMenu();
-            return;
-          }
           isPage2FilterBridgeActive = false;
           setDetailFilter(option.dataset.detailFilter || 'all');
           closeDetailFilterMenu();
@@ -6341,9 +6335,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       if (clearSearchBtn) {
         clearSearchBtn.disabled = true;
-      }
-      if (detailFilterButton) {
-        detailFilterButton.disabled = true;
       }
       if (detailFilterMenu) {
         detailFilterMenu.hidden = true;


### PR DESCRIPTION
### Motivation
- Allow the Page 3 filter trigger to remain clickable and open the filter menu even when the user lands on Page 3 from Page 2 with an active search/cursor filter, so the user can explicitly take control of Page 3 filters.
- Preserve existing behavior where Page 3 inherits the Page 2 filter state until the user actively picks a Page 3 option, without hiding or disabling the filter control.

### Description
- Removed the code that disabled `detailFilterButton` when `isPage2Context` and the code that explicitly disabled the button while `isPage2BridgeLocked` in `js/app.js`.
- Removed the early-return that prevented `.page3-filter-option` click handlers from running when Page 2 context was present, so clicks now clear the bridge and apply the selected filter.
- Change is isolated to `js/app.js` and preserves other behavior (Page 1/Page 2, exports and design remain unchanged).

### Testing
- No automated tests were configured for this repository, so no automated test suites were run.
- Performed automated code search/inspection to confirm the change scope is limited to `js/app.js` and verified the filter menu open/close and option click handlers remain defined and reachable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0580a6d4a4832ab4b560fb7adcc85c)