### PR TITLE
Corrige compteurs du menu filtre sur Page 3 pour compter tous les articles

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5609,10 +5609,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
 
-      const query = getSearchQuery();
       detailFilterOptions.forEach((option) => {
         const filterKey = option.dataset.detailFilter || 'all';
-        const count = details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailFilter(detail, filterKey)).length;
+        const count = details.filter((detail) => matchesDetailFilter(detail, filterKey)).length;
         const label = option.dataset.filterLabel || option.textContent.trim();
         option.textContent = `${label} (${count})`;
       });


### PR DESCRIPTION
### Motivation
- Sur Page 3, le compteur du menu filtre "Tous" (et les compteurs de statut) était calculé en réutilisant la recherche active, affichant par exemple "Tous (1)" alors que l’OUT contient 6 articles ; il doit refléter le total réel des articles de l’OUT.

### Description
- Dans `js/app.js`, la fonction `updateDetailFilterCounters(details)` a été mise à jour pour calculer chaque compteur en utilisant uniquement `matchesDetailFilter(detail, filterKey)` sur la liste complète `details` (suppression du filtrage par la requête de recherche), garantissant que "Tous" affiche `allArticles.length` et que les compteurs de statut sont basés sur tous les détails.

### Testing
- Aucun test automatisé n’est présent dans le dépôt; la modification a été validée localement par inspection du code et vérification du diff pour confirmer que les compteurs du menu filtre utilisent désormais l’ensemble des détails de l’OUT.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05836fc7d0832aac4ce5a319bb2f1c)