### PR TITLE
Page 3: ensure detail table rows follow active search + selected filter

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5074,15 +5074,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       page2SearchValue = '';
       page2CursorFilterLabel = 'Tous';
     }
-    const normalizedPage2SearchValue = page2SearchValue.toLowerCase();
-    const hasPage2SearchContext = Boolean(page2SearchValue);
     const hasPage2CursorFilterContext = page2CursorFilterLabel !== 'Tous';
-    const isPage2Context = hasPage2SearchContext || hasPage2CursorFilterContext;
     const page2CursorFilterKey = hasPage2CursorFilterContext
       ? (detailFilterKeyByPage2Label[page2CursorFilterLabel] || 'all')
       : 'all';
-    const isPage2BridgeLocked = isPage2Context;
-    let isPage2FilterBridgeActive = isPage2Context;
     activeDetailFilter = page2CursorFilterKey;
 
     function setDetailModalOpenState(isOpen) {
@@ -5594,13 +5589,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function getFilteredDetails(details) {
       const query = getSearchQuery();
-      if (isPage2FilterBridgeActive) {
-        return details.filter((detail) => {
-          const matchSearch = hasPage2SearchContext ? matchesSearchQuery(detail, normalizedPage2SearchValue) : true;
-          const matchFilter = hasPage2CursorFilterContext ? matchesDetailFilter(detail, page2CursorFilterKey) : true;
-          return matchSearch && matchFilter;
-        });
-      }
       return details.filter((detail) => matchesSearchQuery(detail, query) && matchesDetailFilter(detail, activeDetailFilter));
     }
 
@@ -6270,9 +6258,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (detailSearchInput) {
       detailSearchInput.addEventListener('input', () => {
-        if (!isPage2Context) {
-          isPage2FilterBridgeActive = false;
-        }
         renderTable();
       });
       const toggleClearButton = () => {
@@ -6292,7 +6277,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         detailSearchInput.focus();
       });
       detailSearchInput.value = page2SearchValue;
-      detailSearchInput.readOnly = isPage2Context;
       toggleClearButton();
     }
 
@@ -6308,7 +6292,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       detailFilterOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          isPage2FilterBridgeActive = false;
           setDetailFilter(option.dataset.detailFilter || 'all');
           closeDetailFilterMenu();
         });
@@ -6327,18 +6310,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
-
-    if (isPage2BridgeLocked) {
-      if (detailSearchInput) {
-        detailSearchInput.readOnly = true;
-      }
-      if (clearSearchBtn) {
-        clearSearchBtn.disabled = true;
-      }
-      if (detailFilterMenu) {
-        detailFilterMenu.hidden = true;
-      }
-    }
     if (exportButton) {
       exportButton.addEventListener('click', openDetailExportDialog);
     }


### PR DESCRIPTION
### Motivation
- Fix Page 3 inconsistency where filter counters were computed over all details but the table rows could be driven by a stale Page‑2 bridge context, causing missing/incomplete rows for `search + filter` combinations. 

### Description
- Remove the Page‑2 bridge/lock logic and any alternate branch in Page 3 that bypassed the local `search + active filter` flow in `js/app.js` (item detail section). 
- Make `getFilteredDetails()` always compute visible rows using `matchesSearchQuery(detail, query)` AND `matchesDetailFilter(detail, activeDetailFilter)`. 
- Preserve filter counters calculation using the full details set via `updateDetailFilterCounters(currentDetails)` so menu counts remain based on all OUT articles. 
- Keep only Page 3 changes in `js/app.js` and do not alter Page 1 / Page 2 behavior or module exports.

### Testing
- Ran repository checks and inspected the change with `git diff -- js/app.js` which showed the intended deletions and replacements, and the diff was as expected (succeeded). 
- Committed the change with `git commit -m "Fix page 3 detail table filtering from search and active filter"` which completed successfully. 
- Performed code searches (`rg`, `sed`) to verify removal of the bridge/lock variables and related read‑only/disabled UI code paths, which returned the expected results (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0585300668832aa45ae4c9df0d8b3d)