### PR TITLE
Page 2 : afficher le total d'articles correspondants dans les compteurs du filtre curseur

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3809,6 +3809,29 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return getMatchingOutArticles(currentItems, query, activeStatusFilter);
     }
 
+    function getTotalMatchingDetailCount(searchText, filterKey) {
+      const query = String(searchText || '').trim().toUpperCase();
+      const normalizedFilterKey = filterKey || 'all';
+      return currentItems.reduce((total, item) => {
+        if (!itemMatchesDateFilter(item, selectedDateFilter)) {
+          return total;
+        }
+        if (!outMatchesSearch(item, query)) {
+          return total;
+        }
+
+        const detailRows = detailRowsByItem[item.id] || [];
+        const matchingDetailCount = detailRows.reduce((count, detail) => {
+          const outMatchesQuery = query ? String(item.numero || '').toUpperCase().includes(query) : false;
+          const matchSearch = !query || outMatchesQuery ? true : detailMatchesOutSearch(detail, query);
+          const matchFilter = matchesStatusClassification(detail, normalizedFilterKey);
+          return count + (matchSearch && matchFilter ? 1 : 0);
+        }, 0);
+
+        return total + matchingDetailCount;
+      }, 0);
+    }
+
     function updateCursorFilterCounters() {
       const query = itemSearchInput.value;
       if (!itemStatusFilterOptions.length) {
@@ -3816,7 +3839,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       itemStatusFilterOptions.forEach((option) => {
         const filterKey = option.dataset.itemStatusFilter || 'all';
-        const count = getMatchingOutArticles(currentItems, query, filterKey).length;
+        const count = getTotalMatchingDetailCount(query, filterKey);
         const countNode = option.querySelector('.page2-filter-option__count');
         if (countNode) {
           countNode.textContent = String(count);


### PR DESCRIPTION
### Motivation
- Le menu filtre de la Page 2 affichait le nombre de cartes OUT correspondantes au lieu du nombre total de lignes/articles correspondants, ce qui ne reflétait pas le comptage attendu.

### Description
- Ajout de la fonction `getTotalMatchingDetailCount(searchText, filterKey)` dans `js/app.js` pour agréger le nombre de lignes/articles correspondant à la recherche/filtre/date sur tous les OUT visibles.
- Mise à jour de `updateCursorFilterCounters()` pour utiliser `getTotalMatchingDetailCount` au lieu de `getMatchingOutArticles(...).length`, garantissant que les compteurs affichent le total d'articles et non le nombre de cartes OUT.

### Testing
- Aucun test automatisé spécifique à l'interface n'était présent ; une validation automatisée de type smoke a confirmé que `js/app.js` contient la nouvelle fonction `getTotalMatchingDetailCount` et que `updateCursorFilterCounters` l'utilise sans erreurs de syntaxe.
- Aucune erreur détectée lors des vérifications automatisées exécutées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0593fa5db8832aaa85fd2f3b5d86b1)