### PR TITLE
Page 2: hide OUT cards with 0 matching articles when search + cursor filter are active

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3777,12 +3777,28 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return detailRows.some((detail) => detailMatchesOutCombinedFilters(detail, query, filterKey));
     }
 
+    function getMatchingDetailCountForItem(item, searchText, filterKey) {
+      const query = String(searchText || '').trim().toUpperCase();
+      const normalizedFilterKey = filterKey || 'all';
+      const detailRows = detailRowsByItem[item.id] || [];
+      return detailRows.reduce((count, detail) => {
+        const outMatchesQuery = query ? String(item.numero || '').toUpperCase().includes(query) : false;
+        const matchSearch = !query || outMatchesQuery ? true : detailMatchesOutSearch(detail, query);
+        const matchFilter = matchesStatusClassification(detail, normalizedFilterKey);
+        return count + (matchSearch && matchFilter ? 1 : 0);
+      }, 0);
+    }
+
     function getOutDetailCountForActiveFilter(itemId, query) {
       const detailRows = detailRowsByItem[itemId] || [];
       if (activeStatusFilter === 'all' && !query) {
         return Number(detailCountsByItem[itemId] || 0);
       }
-      return detailRows.reduce((count, detail) => count + (detailMatchesOutCombinedFilters(detail, query, activeStatusFilter) ? 1 : 0), 0);
+      const item = currentItems.find((entry) => String(entry?.id) === String(itemId));
+      if (!item) {
+        return detailRows.reduce((count, detail) => count + (detailMatchesOutCombinedFilters(detail, query, activeStatusFilter) ? 1 : 0), 0);
+      }
+      return getMatchingDetailCountForItem(item, query, activeStatusFilter);
     }
 
     function getMatchingOutArticles(articleList, searchText, cursorFilter) {
@@ -3795,10 +3811,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           if (!query) {
             matchFilter = itemMatchesStatusFilter(item, filterKey);
           } else {
-            const outMatches = String(item.numero || '').toUpperCase().includes(query);
-            matchFilter = outMatches
-              ? itemMatchesStatusFilter(item, filterKey)
-              : itemMatchesCombinedSearchAndStatus(item, query, filterKey);
+            matchFilter = getMatchingDetailCountForItem(item, query, filterKey) > 0;
           }
         }
         return itemMatchesDateFilter(item, selectedDateFilter) && matchSearch && matchFilter;
@@ -3820,13 +3833,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           return total;
         }
 
-        const detailRows = detailRowsByItem[item.id] || [];
-        const matchingDetailCount = detailRows.reduce((count, detail) => {
-          const outMatchesQuery = query ? String(item.numero || '').toUpperCase().includes(query) : false;
-          const matchSearch = !query || outMatchesQuery ? true : detailMatchesOutSearch(detail, query);
-          const matchFilter = matchesStatusClassification(detail, normalizedFilterKey);
-          return count + (matchSearch && matchFilter ? 1 : 0);
-        }, 0);
+        const matchingDetailCount = getMatchingDetailCountForItem(item, query, normalizedFilterKey);
 
         return total + matchingDetailCount;
       }, 0);


### PR DESCRIPTION
### Motivation
- Prevent OUT cards from remaining visible on Page 2 when a combined search and non-`Tous` cursor filter produces zero matching articles for that OUT. 
- Align the visibility logic with the same article-count calculation used by the card counters so the UI shows only OUTs with at least one matching article. 
- Preserve existing filter behavior, counters, exports and page designs while fixing the mismatch between count and visibility.

### Description
- Added a shared helper `getMatchingDetailCountForItem(item, searchText, filterKey)` in `js/app.js` that computes the number of detail/articles matching the exact combined criteria (search + cursor filter). 
- Updated `getMatchingOutArticles(...)` to use the new helper so that when a search is present and the cursor filter is not `all`, an OUT is kept only if `getMatchingDetailCountForItem(...) > 0`. 
- Rewired `getOutDetailCountForActiveFilter(...)` and `getTotalMatchingDetailCount(...)` to reuse the same helper so counts and visibility come from a single source of truth. 
- Change is isolated to `js/app.js` and does not modify Page 1, Page 3, exports, filters semantics, or UI design.

### Testing
- Ran `node --check js/app.js` to validate the updated script and it completed successfully. 
- Static inspection of the generated diff and runtime checks confirmed the new helper is used by the filtering and counting code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a059696fe50832ab6588713bb60d484)