### PR TITLE
Amélioration du formatage de la grille exportée (Pages 2 & 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -542,12 +542,52 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     <meta charset="UTF-8" />
     <title>${escapeHtml(title)}</title>
     <style>
-      table { border-collapse: collapse; width: 100%; }
-      th, td { border: 1px solid #cfd8e3; padding: 8px; text-align: center; vertical-align: middle; }
+      table { border-collapse: collapse; width: 100%; table-layout: fixed; }
+      th, td {
+        border: 1px solid #cfd8e3;
+        padding: 8px 10px;
+        vertical-align: middle;
+        white-space: normal;
+        word-break: break-word;
+      }
+      th {
+        font-weight: 700;
+        background: #f3f6fa;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        text-align: left;
+      }
+      td { text-align: left; }
+      td:nth-child(4),
+      td:nth-child(6),
+      td:nth-child(7),
+      td:nth-child(8),
+      td:nth-child(10) {
+        text-align: right;
+      }
+      td:nth-child(5),
+      td:nth-child(12) {
+        text-align: center;
+      }
     </style>
   </head>
   <body>
     <table>
+      <colgroup>
+        <col style="width: 18ch;" />
+        <col style="width: 18ch;" />
+        <col style="width: 40ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 10ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 22ch;" />
+        <col style="width: 12ch;" />
+        <col style="width: 30ch;" />
+        <col style="width: 12ch;" />
+      </colgroup>
       <thead>
         <tr>
           <th>#</th>
@@ -598,12 +638,52 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     <meta charset="UTF-8" />
     <title>${escapeHtml(title)}</title>
     <style>
-      table { border-collapse: collapse; width: 100%; }
-      th, td { border: 1px solid #cfd8e3; padding: 8px; text-align: center; vertical-align: middle; }
+      table { border-collapse: collapse; width: 100%; table-layout: fixed; }
+      th, td {
+        border: 1px solid #cfd8e3;
+        padding: 8px 10px;
+        vertical-align: middle;
+        white-space: normal;
+        word-break: break-word;
+      }
+      th {
+        font-weight: 700;
+        background: #f3f6fa;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        text-align: left;
+      }
+      td { text-align: left; }
+      td:nth-child(4),
+      td:nth-child(6),
+      td:nth-child(7),
+      td:nth-child(8),
+      td:nth-child(10) {
+        text-align: right;
+      }
+      td:nth-child(5),
+      td:nth-child(12) {
+        text-align: center;
+      }
     </style>
   </head>
   <body>
     <table>
+      <colgroup>
+        <col style="width: 18ch;" />
+        <col style="width: 18ch;" />
+        <col style="width: 40ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 10ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 14ch;" />
+        <col style="width: 22ch;" />
+        <col style="width: 12ch;" />
+        <col style="width: 30ch;" />
+        <col style="width: 12ch;" />
+      </colgroup>
       <thead>
         <tr>
           <th>OUT</th>


### PR DESCRIPTION
### Motivation
- Résoudre les colonnes trop serrées et les chevauchements visuels dans les fichiers exportés pour améliorer la lecture dans Excel / Google Sheets / mobile sans toucher aux données ni à la logique d’export. 

### Description
- Modifié les builders d’export HTML `buildDetailExcelContent` et `buildSiteExcelContent` dans `js/app.js` pour n’affecter que la présentation du fichier exporté. 
- Ajout d’un style de table amélioré (`table-layout: fixed`, padding augmenté, `white-space: normal`, `word-break: break-word`) et maintien de bordures fines. 
- Ajout d’un `<colgroup>` avec largeurs fixes correspondant aux largeurs conseillées (OUT/Code 18ch, Désignation 40ch, Qté 14ch, Unité 10ch, Date 22ch, Écart 12ch, Remarque 30ch, Statut 12ch). 
- Renforcement visuel des en-têtes (fond, gras, sticky quand supporté) et règles d’alignement (nombres à droite, texte à gauche, unité/statut centrés). 

### Testing
- Examiné le fichier modifié avec `nl -ba /workspace/Album/js/app.js | sed -n '520,700p'` pour vérifier l’intégration du nouveau HTML/CSS et la présence des `<colgroup>`; la vérification a réussi. 
- Vérifié l’état git avec `git -C /workspace/Album status --short` et commité la modif avec `git -C /workspace/Album commit -m "Improve Page 2/3 export grid formatting"`; l’opération a réussi. 
- Aucune modification de la logique d’export, des données exportées ou des noms de fichiers n’a été introduite, et aucune suite de tests unitaires automatiques n’a été modifiée ou ajoutée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a059dafc420832a98e41d855dbdef1c)