### PR TITLE
Page 3: change counter label from "Articles affichés" to "Articles"

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5764,7 +5764,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         countLabel.textContent = filteredCount > 1 ? 'Articles' : 'Article';
         return;
       }
-      countLabel.textContent = `${filteredCount > 1 ? 'Articles' : 'Article'} affiché${filteredCount > 1 ? 's' : ''} / ${totalCount}`;
+      countLabel.textContent = `${filteredCount > 1 ? 'Articles' : 'Article'} / ${totalCount}`;
     }
 
     function exportDetails(fileNameOverride) {


### PR DESCRIPTION
### Motivation
- Replace the verbose "Articles affichés" label on Page 3 with the shorter "Articles" while preserving all counting, filtering, and styling behavior.

### Description
- Updated the `updateCount` function in `js/app.js` to set `countLabel.textContent` to ``${filteredCount > 1 ? 'Articles' : 'Article'} / ${totalCount}`` when filtered and total counts differ, making only a text change.

### Testing
- Verified the change and file contents with `rg -n` and `nl -ba js/app.js | sed -n '5758,5772p'`, and committed the change with `git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e10feb54832a83176baa0850c3c5)