### PR TITLE
Page 3 : Corrige classification automatique “Complété” (Rebus/Retour)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5669,6 +5669,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return designation.includes(normalizedQuery) || code.includes(normalizedQuery);
     }
 
+    function isDetailCompleted(detail) {
+      const qteSortie = Number(detail?.qteSortie) || 0;
+      const qtePosee = Number(detail?.qtePosee) || 0;
+      const qteRetour = Number(detail?.qteRetour) || 0;
+      const qteRebus = Number(detail?.qteRebus) || 0;
+      const ecart = computeEcart(detail);
+
+      return (qtePosee > 0 && ecart === 0)
+        || qteSortie === qteRebus
+        || qteSortie === qteRetour;
+    }
+
     function matchesDetailFilter(detail, filterKey) {
       const isKoStatus = normalizeDetailStatut(detail.statut) === 'K.O';
       if (filterKey === 'ko') {
@@ -5683,7 +5695,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const qteRetour = Number(detail?.qteRetour) || 0;
       const qteRebus = Number(detail?.qteRebus) || 0;
       const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
-      const isDone = qtePosee > 0 && ecart === 0;
+      const isDone = isDetailCompleted(detail);
       const isAttention = hasActivity && ecart !== 0;
 
       if (filterKey === 'done') {
@@ -5971,13 +5983,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
 
       const isKoStatus = normalizeDetailStatut(row.querySelector('[data-field="statut"]')?.value) === 'K.O';
+      const qteSortie = Number(row.querySelector('[data-field="qteSortie"]')?.value ?? 0);
       const qtePosee = Number(row.querySelector('[data-field="qtePosee"]')?.value ?? 0);
       const qteRetour = Number(row.querySelector('[data-field="qteRetour"]')?.value ?? 0);
       const qteRebus = Number(row.querySelector('[data-field="qteRebus"]')?.value ?? 0);
       const ecart = Number(row.querySelector('[data-col-key="ecart"]')?.value ?? 0);
       const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
+      const isDone = (qtePosee > 0 && ecart === 0)
+        || qteSortie === qteRebus
+        || qteSortie === qteRetour;
 
-      row.classList.toggle('detail-row--done', !isKoStatus && qtePosee > 0 && ecart === 0);
+      row.classList.toggle('detail-row--done', !isKoStatus && isDone);
       row.classList.toggle('detail-row--attention', !isKoStatus && hasActivity && ecart !== 0);
     }
 


### PR DESCRIPTION
### Motivation
- Corriger le classement automatique “Complété” sur la Page 3 qui n’incluait pas les cas où `Qté Sortie` == `Qté Rebus` ou `Qté Sortie` == `Qté Retour` et laissait les lignes seulement dans “Tous”.

### Description
- Ajout d’une fonction `isDetailCompleted(detail)` qui retourne true si `Qté posée > 0 && Ecart === 0` OU `Qté Sortie === Qté Rebus` OU `Qté Sortie === Qté Retour`, en convertissant les valeurs via `Number(...) || 0` pour traiter les champs vides comme `0`.
- Remplacement de la condition de “Complété” dans `matchesDetailFilter` pour utiliser `isDetailCompleted(detail)`, en conservant la priorité `K.O` inchangée.
- Alignement de l’état sémantique de la ligne (`applyDetailRowSemanticState`) pour appliquer immédiatement la classe `detail-row--done` (couleur verte) selon la même logique de complétion pendant l’édition.
- Modification limitée au fichier `js/app.js` et restreinte à la logique de la Page 3, sans toucher Page 1/Page 2, exports ni design.

### Testing
- Aucun test automatisé disponible dans le dépôt pour ce comportement, donc aucun test automatisé exécuté.
- Validation par inspection du diff de `js/app.js` et vérification que la nouvelle fonction `isDetailCompleted` est utilisée par le filtre et par l’état sémantique de ligne.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f9231ce0832abc5a375edc3adaea)