### PR TITLE
Update filter menu labels on Page 2 and Page 3

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -43,9 +43,9 @@
               </button>
               <div id="itemStatusFilterMenu" class="page2-filter-menu" role="menu" hidden>
                 <button type="button" class="page2-filter-option is-active" data-item-status-filter="all" role="menuitemradio" aria-checked="true"><span class="page2-filter-option__label">Tous</span><span class="page2-filter-option__count">0</span></button>
-                <button type="button" class="page2-filter-option" data-item-status-filter="todo" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">À faire</span><span class="page2-filter-option__count">0</span></button>
+                <button type="button" class="page2-filter-option" data-item-status-filter="todo" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">En attente</span><span class="page2-filter-option__count">0</span></button>
                 <button type="button" class="page2-filter-option" data-item-status-filter="fix" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">À corriger</span><span class="page2-filter-option__count">0</span></button>
-                <button type="button" class="page2-filter-option" data-item-status-filter="done" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">Complété</span><span class="page2-filter-option__count">0</span></button>
+                <button type="button" class="page2-filter-option" data-item-status-filter="done" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">Terminés</span><span class="page2-filter-option__count">0</span></button>
                 <button type="button" class="page2-filter-option" data-item-status-filter="ko" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">K.O</span><span class="page2-filter-option__count">0</span></button>
               </div>
             </div>

--- a/page3.html
+++ b/page3.html
@@ -56,9 +56,9 @@
               </button>
               <div id="detailFilterMenu" class="page3-filter-menu" role="menu" hidden>
                 <button type="button" class="page3-filter-option is-active" data-detail-filter="all" role="menuitemradio" aria-checked="true"><span class="page3-filter-option__label">Tous</span><span class="page3-filter-option__count">0</span></button>
-                <button type="button" class="page3-filter-option" data-detail-filter="todo" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">À faire</span><span class="page3-filter-option__count">0</span></button>
+                <button type="button" class="page3-filter-option" data-detail-filter="todo" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">En attente</span><span class="page3-filter-option__count">0</span></button>
                 <button type="button" class="page3-filter-option" data-detail-filter="fix" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">À corriger</span><span class="page3-filter-option__count">0</span></button>
-                <button type="button" class="page3-filter-option" data-detail-filter="done" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">Effectué</span><span class="page3-filter-option__count">0</span></button>
+                <button type="button" class="page3-filter-option" data-detail-filter="done" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">Terminés</span><span class="page3-filter-option__count">0</span></button>
                 <button type="button" class="page3-filter-option" data-detail-filter="ko" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">K.O</span><span class="page3-filter-option__count">0</span></button>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Update the displayed filter labels on Page 2 and Page 3 to the new French terms while preserving all existing filter behavior, counts, styles and exports.

### Description
- Replace label text in `page2.html` and `page3.html`: `À faire` → `En attente` and `Complété`/`Effectué` → `Terminés`, without changing any JavaScript logic, filter keys, counters, colors, classification conditions, exports, or Page 1.

### Testing
- Verified the change with `rg -n "À faire|Complété|Effectué|Tous|K.O|corriger|filtre" page2.html page3.html js/app.js js/ui.js css/style.css` and ran the automated replacement script to update the two HTML files, confirming the new labels are present and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0603b34ce8832a99f348afd02e3662)