### PR TITLE
Ajouter un filtre de lignes dans la modal d’export Excel (Page 2)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2873,6 +2873,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const siteExportDialog = requireElement('siteExportDialog');
     const siteExportForm = requireElement('siteExportForm');
     const siteExportFileNameInput = requireElement('siteExportFileNameInput');
+    const siteExportLineFilterSelect = requireElement('siteExportLineFilterSelect');
     const siteExportFileNameError = requireElement('siteExportFileNameError');
     const siteExportSubmitButton = requireElement('siteExportSubmitButton');
     const siteExportCancelButton = requireElement('siteExportCancelButton');
@@ -3288,7 +3289,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       );
     }
 
-    async function exportItems(fileNameOverride) {
+    async function exportItems(fileNameOverride, lineFilterOverride) {
       if (!currentSite) {
         UiService.navigate('index.html');
         return;
@@ -3308,7 +3309,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
 
-      const sortedRows = [...rows].sort((a, b) => {
+      const selectedLineFilter = String(lineFilterOverride || siteExportLineFilterSelect?.value || 'all').trim() || 'all';
+      const filteredRows = rows.filter((row) => matchesStatusClassification(row, selectedLineFilter));
+      if (!filteredRows.length) {
+        UiService.showToast('Aucune donnée');
+        return;
+      }
+
+      const sortedRows = [...filteredRows].sort((a, b) => {
         const designationA = String(a?.designation || '').trim();
         const designationB = String(b?.designation || '').trim();
 
@@ -3384,6 +3392,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const defaultName = currentSite?.nom ? `SUIVI MATERIEL . ${currentSite.nom}` : 'export-materiel';
       siteExportFileNameInput.value = sanitizeExportFileName(defaultName);
+      if (siteExportLineFilterSelect) {
+        siteExportLineFilterSelect.value = '';
+      }
       if (siteExportFileNameError) {
         siteExportFileNameError.textContent = '';
       }
@@ -4841,10 +4852,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           updateSiteExportSubmitState();
           return;
         }
+        const selectedLineFilter = String(siteExportLineFilterSelect?.value || 'all').trim() || 'all';
         siteExportSubmitButton.disabled = true;
         siteExportSubmitButton.classList.add('is-loading');
         try {
-          await exportItems(fileName);
+          await exportItems(fileName, selectedLineFilter);
           closeSiteExportDialog();
         } catch (_error) {
           siteExportSubmitButton.disabled = false;

--- a/page2.html
+++ b/page2.html
@@ -162,6 +162,17 @@
               <input id="siteExportFileNameInput" name="siteExportFileName" type="text" placeholder="Ex : export-materiel" autocomplete="off" />
             </div>
           </label>
+          <label class="input-group input-group--site-create">
+            <span>Filtrer les lignes</span>
+            <select id="siteExportLineFilterSelect" name="siteExportLineFilter">
+              <option value="">-- Sélectionner --</option>
+              <option value="all">Tous</option>
+              <option value="todo">En attente</option>
+              <option value="fix">À corriger</option>
+              <option value="done">Terminés</option>
+              <option value="ko">K.O</option>
+            </select>
+          </label>
           <p id="siteExportFileNameError" class="form-error" aria-live="polite"></p>
           <div class="modal-actions modal-actions--split modal-actions--site-create">
             <button type="button" id="siteExportCancelButton" class="btn btn-neutral">Annuler</button>


### PR DESCRIPTION
### Motivation
- Permettre à l’utilisateur de filtrer les lignes/articles incluses dans l’export Excel de la Page 2 selon leur état (Tous, En attente, À corriger, Terminés, K.O) sans modifier l’affichage de la page ni les autres pages.

### Description
- Ajout d’un champ `select` `#siteExportLineFilterSelect` dans la modal `#siteExportDialog` de `page2.html` avec les options demandées et un état vide par défaut (sélection non obligatoire). 
- Lecture du nouveau champ côté client dans `js/app.js` lors de l’initialisation de la Page 2 via `siteExportLineFilterSelect`. 
- `exportItems(...)` accepte désormais un paramètre de filtre de lignes et applique la restriction des lignes avant la génération du fichier Excel en réutilisant la logique existante de classification (`matchesStatusClassification`). 
- Si aucune sélection n’est faite, le comportement retombe sur `all` (Tous), le filtre est réinitialisé lors de l’ouverture de la modal et le champ `Nom du fichier` reste inchangé.

### Testing
- Vérification statique du code: recherche des références et inspection des diffs pour s’assurer que `siteExportLineFilterSelect` est ajouté et consommé dans `js/app.js` (recherches/visualisation des fichiers modifiés). 
- Test d’intégration manuel automatisé léger: soumission de la modal déclenchant `exportItems` avec le filtre sélectionné, et comportement attendu observé quand le filtre retourne aucune ligne (toast d’erreur).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060707cd58832a9ee9cd0e12a27190)