### PR TITLE
Normalize numeric blanks to 0 in Excel exports (Page 2 & 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -514,6 +514,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return value;
   }
 
+  function normalizeExportNumber(value) {
+    if (
+      value === ''
+      || value === null
+      || value === undefined
+      || value === '-'
+      || Number.isNaN(Number(value))
+    ) {
+      return 0;
+    }
+    return Number(value);
+  }
+
   function buildDetailExcelContent(title, details) {
     const rows = details
       .map(
@@ -524,11 +537,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td>${escapeHtml(formatExcelCellValue(detail.designation))}</td>
               <td>${escapeHtml(formatExcelCellValue(detail.qteSortie))}</td>
               <td>${escapeHtml(formatExcelCellValue(detail.unite))}</td>
-              <td>${escapeHtml(formatExcelCellValue(detail.qtePosee))}</td>
-              <td>${escapeHtml(formatExcelCellValue(detail.qteRebus))}</td>
-              <td>${escapeHtml(formatExcelCellValue(detail.qteRetour))}</td>
+              <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(detail.qtePosee)))}</td>
+              <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(detail.qteRebus)))}</td>
+              <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(detail.qteRetour)))}</td>
               <td>${escapeHtml(formatExcelCellValue(formatReturnDate(detail.dateRetour)))}</td>
-              <td>${escapeHtml(formatExcelCellValue(computeEcart(detail)))}</td>
+              <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(computeEcart(detail))))}</td>
               <td>${escapeHtml(formatExcelCellValue(detail.observation))}</td>
               <td>${escapeHtml(formatExcelCellValue(normalizeDetailStatut(detail.statut)))}</td>
             </tr>
@@ -620,11 +633,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <td>${escapeHtml(formatExcelCellValue(row.designation))}</td>
             <td>${escapeHtml(formatExcelCellValue(row.qteSortie))}</td>
             <td>${escapeHtml(formatExcelCellValue(row.unite))}</td>
-            <td>${escapeHtml(formatExcelCellValue(row.qtePosee))}</td>
-            <td>${escapeHtml(formatExcelCellValue(row.qteRebus))}</td>
-            <td>${escapeHtml(formatExcelCellValue(row.qteRetour))}</td>
+            <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(row.qtePosee)))}</td>
+            <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(row.qteRebus)))}</td>
+            <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(row.qteRetour)))}</td>
             <td>${escapeHtml(formatExcelCellValue(formatReturnDate(row.dateRetour)))}</td>
-            <td>${escapeHtml(formatExcelCellValue(computeEcart(row)))}</td>
+            <td>${escapeHtml(formatExcelCellValue(normalizeExportNumber(computeEcart(row))))}</td>
             <td>${escapeHtml(formatExcelCellValue(row.observation))}</td>
             <td>${escapeHtml(formatExcelCellValue(normalizeDetailStatut(row.statut)))}</td>
           </tr>


### PR DESCRIPTION
### Motivation
- Ensure exported Excel files never contain empty or `-` values in numeric columns `Qté posée`, `Qté Rebus`, `Qté Retour` and `Ecart` for Page 2 and Page 3 while leaving UI, Firestore and filters unchanged.
- Match the requested behavior where empty, `null`, `undefined`, `NaN` or `"-"` become `0` only in the Excel output.

### Description
- Added `normalizeExportNumber(value)` in `js/app.js` which returns `0` for `''`, `null`, `undefined`, `'-'` or `NaN`, otherwise returns `Number(value)`.
- Applied `normalizeExportNumber(...)` when building Page 3 export rows in `buildDetailExcelContent` for `qtePosee`, `qteRebus`, `qteRetour` and `computeEcart(detail)` so the Excel cells contain `0` when appropriate.
- Applied the same normalization in Page 2 export `buildSiteExcelContent` for `qtePosee`, `qteRebus`, `qteRetour` and `computeEcart(row)`; left `formatExcelCellValue` behavior for text/date columns unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060eb334b0832a809f4a4f459f70f9)