### PR TITLE
Allow editing Page 3 numeric fields without forcing 0 during typing

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6189,9 +6189,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             if (field.value.length > 120) {
               field.value = field.value.slice(0, 120);
             }
-            if ((field.dataset.field === 'qtePosee' || field.dataset.field === 'qteRebus' || field.dataset.field === 'qteRetour') && String(field.value).trim() === '') {
-              field.value = '0';
-            }
             if (field.dataset.field === 'qtePosee' || field.dataset.field === 'qteSortie' || field.dataset.field === 'qteRebus' || field.dataset.field === 'qteRetour' || field.dataset.field === 'statut') {
               const row = field.closest('tr');
               if (row) {


### PR DESCRIPTION
### Motivation
- Corriger le comportement sur Page 3 où les champs numériques (`Qté posée`, `Qté Rebus`, `Qté Retour`, `Ecart`) étaient remis à "0" immédiatement pendant la saisie, empêchant de supprimer temporairement la valeur pour taper une nouvelle valeur.

### Description
- Supprimé la coercition à `0` lors de l'événement `input` pour les champs `qtePosee`, `qteRebus` et `qteRetour` dans `js/app.js`, tout en conservant la normalisation existante au moment du `change`/`blur` et avant sauvegarde; le recalcul de l'`ecart`, la coloration des lignes et les filtres restent inchangés.

### Testing
- Aucun test automatisé n'a été exécuté pour ce petit correctif; la modification se limite à `js/app.js` et vise uniquement la saisie/modification des champs numériques sur Page 3.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0613763458832a96cd6fb9bd7b38c2)