### PR TITLE
Fix immediate Ecart recalculation on Page 3 edits

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -235,16 +235,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return null;
   }
 
-  function computeEcart(detail) {
-    const qteSortie = Number(detail?.qteSortie) || 0;
-    const qtePosee = Number(detail?.qtePosee) || 0;
-    const qteRetour = Number(detail?.qteRetour) || 0;
-    const qteRebus = Number(detail?.qteRebus) || 0;
-
-    if (qtePosee === 0 && qteRetour === 0 && qteRebus === 0) {
-      return '';
+  function toNumber(value) {
+    if (value === '' || value === null || value === undefined || value === '-') {
+      return 0;
     }
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
 
+  function computeEcart(detail) {
+    const qteSortie = toNumber(detail?.qteSortie);
+    const qtePosee = toNumber(detail?.qtePosee);
+    const qteRetour = toNumber(detail?.qteRetour);
+    const qteRebus = toNumber(detail?.qteRebus);
     return qteSortie - (qtePosee + qteRetour + qteRebus);
   }
 
@@ -6008,11 +6011,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
 
       const isKoStatus = normalizeDetailStatut(row.querySelector('[data-field="statut"]')?.value) === 'K.O';
-      const qteSortie = Number(row.querySelector('[data-field="qteSortie"]')?.value ?? 0);
-      const qtePosee = Number(row.querySelector('[data-field="qtePosee"]')?.value ?? 0);
-      const qteRetour = Number(row.querySelector('[data-field="qteRetour"]')?.value ?? 0);
-      const qteRebus = Number(row.querySelector('[data-field="qteRebus"]')?.value ?? 0);
-      const ecart = Number(row.querySelector('[data-col-key="ecart"]')?.value ?? 0);
+      const qteSortie = toNumber(row.querySelector('[data-field="qteSortie"]')?.value);
+      const qtePosee = toNumber(row.querySelector('[data-field="qtePosee"]')?.value);
+      const qteRetour = toNumber(row.querySelector('[data-field="qteRetour"]')?.value);
+      const qteRebus = toNumber(row.querySelector('[data-field="qteRebus"]')?.value);
+      const ecart = toNumber(row.querySelector('[data-col-key="ecart"]')?.value);
       const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
       const isDone = (qtePosee > 0 && ecart === 0)
         || qteSortie === qteRebus
@@ -6023,8 +6026,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function sanitizeNumericDisplayValue(value) {
-      const numericValue = Number(value);
+      const numericValue = toNumber(value);
       return Number.isFinite(numericValue) ? String(numericValue) : '0';
+    }
+
+    function syncRowEcart(row) {
+      if (!row) {
+        return 0;
+      }
+      const ecartField = row.querySelector('[data-col-key="ecart"]');
+      const nextEcart = computeEcart({
+        qteSortie: row.querySelector('[data-field="qteSortie"]')?.value,
+        qtePosee: row.querySelector('[data-field="qtePosee"]')?.value,
+        qteRebus: row.querySelector('[data-field="qteRebus"]')?.value,
+        qteRetour: row.querySelector('[data-field="qteRetour"]')?.value,
+      });
+      if (ecartField) {
+        ecartField.value = String(nextEcart);
+        ecartField.classList.toggle('cell-input--ecart-alert', nextEcart !== 0);
+      }
+      return nextEcart;
     }
 
     function normalizeDetailNumericCells(row) {
@@ -6140,7 +6161,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             return;
           }
 
-          const shouldForceNumericZero = fieldName === 'qtePosee' || fieldName === 'qteRebus' || fieldName === 'qteRetour';
+          const shouldForceNumericZero = fieldName === 'qtePosee' || fieldName === 'qteRebus' || fieldName === 'qteRetour' || fieldName === 'qteSortie';
           if (shouldForceNumericZero && String(event.target.value).trim() === '') {
             event.target.value = '0';
           }
@@ -6150,9 +6171,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             return;
           }
 
-          await StorageService.updateDetail(siteId, itemId, row.dataset.detailId, {
-            [fieldName]: nextValue,
-          });
+          const payload = { [fieldName]: nextValue };
+          if (fieldName === 'qtePosee' || fieldName === 'qteSortie' || fieldName === 'qteRebus' || fieldName === 'qteRetour') {
+            payload.ecart = syncRowEcart(row);
+          }
+          await StorageService.updateDetail(siteId, itemId, row.dataset.detailId, payload);
           if (fieldName === 'statut') {
             const statusField = event.target.closest('.detail-status-field');
             const row = event.target.closest('tr');
@@ -6167,15 +6190,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             }
           }
           if (fieldName === 'qtePosee' || fieldName === 'qteSortie' || fieldName === 'qteRebus' || fieldName === 'qteRetour') {
-            const ecartField = row.querySelector('[data-col-key="ecart"]');
-            if (ecartField) {
-              const nextEcart = computeEcart({
-                ...currentDetail,
-                [fieldName]: nextValue,
-              });
-              ecartField.value = Number.isFinite(nextEcart) ? String(nextEcart) : '0';
-              ecartField.classList.toggle('cell-input--ecart-alert', typeof nextEcart === 'number' && nextEcart !== 0);
-            }
+            syncRowEcart(row);
             applyDetailRowSemanticState(row);
           }
           applyCompactColumnWidths();
@@ -6193,22 +6208,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               const row = field.closest('tr');
               if (row) {
                 if (field.dataset.field !== 'statut') {
-                  const qteSortie = Number(row.querySelector('[data-field="qteSortie"]')?.value ?? 0);
-                  const qtePosee = Number(row.querySelector('[data-field="qtePosee"]')?.value ?? 0);
-                  const qteRebus = Number(row.querySelector('[data-field="qteRebus"]')?.value ?? 0);
-                  const qteRetour = Number(row.querySelector('[data-field="qteRetour"]')?.value ?? 0);
-                  const ecart = qteSortie - qtePosee - qteRebus - qteRetour;
-                  const ecartField = row.querySelector('[data-col-key="ecart"]');
-                  if (ecartField) {
-                    ecartField.value = String(ecart);
-                    ecartField.classList.toggle('cell-input--ecart-alert', ecart !== 0);
-                  }
+                  syncRowEcart(row);
                 }
                 applyDetailRowSemanticState(row);
               }
             }
             applyCompactColumnWidths();
           });
+
+          if (field.dataset.field === 'qtePosee' || field.dataset.field === 'qteSortie' || field.dataset.field === 'qteRebus' || field.dataset.field === 'qteRetour') {
+            field.addEventListener('blur', () => {
+              if (String(field.value).trim() === '') {
+                field.value = '0';
+                const row = field.closest('tr');
+                if (row) {
+                  syncRowEcart(row);
+                  applyDetailRowSemanticState(row);
+                }
+              }
+            });
+          }
         }
       });
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -1402,6 +1402,7 @@ async function createDetail(siteId, itemId, payload) {
     dateRetour: '',
     qtePosee: 0,
     qteRebus: 0,
+    ecart: payload.qteSortie === '' ? 0 : sanitizeNumber(payload.qteSortie),
     observation: '',
     statut: sanitizeDetailStatut(payload.statut),
     ownerId: state.userId,
@@ -1461,6 +1462,10 @@ async function updateDetail(siteId, itemId, detailId, changes) {
   if ('qteRebus' in changes) {
     nextValues.qteRebus = sanitizeNumber(changes.qteRebus);
     syncedChanges.qteRebus = nextValues.qteRebus;
+  }
+  if ('ecart' in changes) {
+    nextValues.ecart = sanitizeNumber(changes.ecart);
+    syncedChanges.ecart = nextValues.ecart;
   }
   if ('observation' in changes) {
     nextValues.observation = sanitizeText(changes.observation, false);
@@ -1631,6 +1636,7 @@ function normalizeImportPayload(payload) {
           dateRetour: sanitizeReturnDate(detail.dateRetour),
           qtePosee: sanitizeNumber(detail.qtePosee),
           qteRebus: sanitizeNumber(detail.qteRebus),
+          ecart: sanitizeNumber(detail.ecart),
           observation: sanitizeText(detail.observation, false),
           statut: sanitizeDetailStatut(detail.statut),
           ownerId: state.userId,


### PR DESCRIPTION
### Motivation
- Corriger le calcul et l'affichage immédiat de la colonne `Ecart` sur la page 3 pour que la valeur réagisse instantanément aux modifications de Qté (Sortie / Posée / Rebus / Retour) et soit envoyée correctement à Firestore.

### Description
- Ajout d'un helper `toNumber(value)` et remplacement de la logique existante par `computeEcart(detail)` qui calcule systématiquement `qteSortie - (qtePosee + qteRebus + qteRetour)` en traitant les valeurs vides/`-` comme `0` (fichiers modifiés : `js/app.js`).
- Implémentation de `syncRowEcart(row)` pour recalculer et afficher immédiatement l'Ecart et son style d'alerte pendant la saisie, et appel de cette fonction sur `input`/`change`/`blur` des champs concernés (fichiers modifiés : `js/app.js`).
- Préservation de l'expérience de saisie : laisser les champs numériques vides pendant la saisie, normaliser à `0` seulement au `blur`, et mettre à jour immédiatement l'état visuel de la ligne (couleurs/filtre/compteurs) après chaque recalcul. 
- Inclusion de la valeur recalculée `ecart` dans le payload envoyé à `StorageService.updateDetail` et ajout de la persistance `ecart` dans les chemins de création/mise à jour/import (`js/storage.js`).

### Testing
- Vérification de syntaxe statique : `node --check js/app.js` a réussi. 
- Vérification de syntaxe statique : `node --check js/storage.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0616434388832aa203e6f234e68fdf)