### PR TITLE
Fix Excel export column overlap on pages 2 and 3

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -542,7 +542,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     <meta charset="UTF-8" />
     <title>${escapeHtml(title)}</title>
     <style>
-      table { border-collapse: collapse; width: 100%; table-layout: fixed; }
+      table { border-collapse: collapse; width: 100%; table-layout: auto; }
       th, td {
         border: 1px solid #cfd8e3;
         padding: 8px 10px;
@@ -575,18 +575,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   <body>
     <table>
       <colgroup>
-        <col style="width: 18ch;" />
-        <col style="width: 18ch;" />
-        <col style="width: 40ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 10ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 22ch;" />
-        <col style="width: 12ch;" />
-        <col style="width: 30ch;" />
-        <col style="width: 12ch;" />
+        <col style="width: 18ch; min-width: 18ch;" />
+        <col style="width: 22ch; min-width: 22ch;" />
+        <col style="width: 45ch; min-width: 45ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 10ch; min-width: 10ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 20ch; min-width: 20ch;" />
+        <col style="width: 12ch; min-width: 12ch;" />
+        <col style="width: 30ch; min-width: 30ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
       </colgroup>
       <thead>
         <tr>
@@ -638,7 +638,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     <meta charset="UTF-8" />
     <title>${escapeHtml(title)}</title>
     <style>
-      table { border-collapse: collapse; width: 100%; table-layout: fixed; }
+      table { border-collapse: collapse; width: 100%; table-layout: auto; }
       th, td {
         border: 1px solid #cfd8e3;
         padding: 8px 10px;
@@ -671,18 +671,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   <body>
     <table>
       <colgroup>
-        <col style="width: 18ch;" />
-        <col style="width: 18ch;" />
-        <col style="width: 40ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 10ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 14ch;" />
-        <col style="width: 22ch;" />
-        <col style="width: 12ch;" />
-        <col style="width: 30ch;" />
-        <col style="width: 12ch;" />
+        <col style="width: 18ch; min-width: 18ch;" />
+        <col style="width: 22ch; min-width: 22ch;" />
+        <col style="width: 45ch; min-width: 45ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 10ch; min-width: 10ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
+        <col style="width: 20ch; min-width: 20ch;" />
+        <col style="width: 12ch; min-width: 12ch;" />
+        <col style="width: 30ch; min-width: 30ch;" />
+        <col style="width: 14ch; min-width: 14ch;" />
       </colgroup>
       <thead>
         <tr>


### PR DESCRIPTION
### Motivation
- Corriger le chevauchement des textes dans les fichiers Excel exportés pour les templates de Page 2 et Page 3 en ajustant le format d'export uniquement (sans toucher aux données ni à l'affichage web). 

### Description
- Changement de `table-layout: fixed` vers `table-layout: auto` pour laisser Excel/WPS répartir les colonnes selon le contenu. 
- Ajout des largeurs recommandées et de largeurs minimales (`min-width`) dans les `<colgroup>` pour toutes les colonnes (OUT, Code, Désignation, Qté Sortie, Unité, Qté posée, Qté Rebus, Qté Retour, Date de retour, Ecart, Remarque, Statut) dans `js/app.js` pour les deux templates d'export. 
- Conservez les bordures, le wrapping (`white-space: normal`, `word-break: break-word`) et l'alignement vertical centré (`vertical-align: middle`) afin de n'affecter que le format du fichier exporté. 
- Modifications limitées à `js/app.js` et appliquées aux fonctions `buildDetailExcelContent` et `buildSiteExcelContent` ; Page 1, l'affichage web, les filtres et les données Firestore n'ont pas été modifiés. 

### Testing
- Examen du diff avec `git diff -- js/app.js` pour vérifier les modifications appliquées avec succès (sortie OK). 
- Validation de commit via `git commit -m "Fix Excel export column overlap on pages 2 and 3"` (commit créé avec succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061c91f4d0832a81a71779ada3d1a1)