### PR TITLE
Page 3: make `Code` input reuse Remarque auto-sizing

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6044,7 +6044,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             return `
             <tr data-detail-id="${detail.id}" class="${rowClasses}"${enterAnimationStyle}>
               <td><span class="field-badge">${detail.champ}</span></td>
-              <td><input class="cell-input cell-input--autosize cell-input--left" data-field="code" value="${escapeHtml(detail.code)}" size="${Math.max(String(detail.code || '').length + 1, 10)}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic cell-input--left" data-col-key="code" data-field="code" type="text" maxlength="120" value="${escapeHtml(detail.code)}" /></td>
               <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
               <td>
                 <div class="qte-sortie-field">
@@ -6205,6 +6205,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         dateRetour: 140,
         ecart: 48,
         observation: 48,
+        code: 48,
         statut: 84,
       };
 


### PR DESCRIPTION
### Motivation
- Align the Page 3 `Code` field with the already-existing auto-sizing behavior used by the `Remarque` column so it grows and shrinks with content while keeping visual style and responsiveness. 
- Reuse the existing dynamic sizing implementation to avoid introducing new logic and to preserve Firebase compatibility and existing exports/filters. 

### Description
- Render the `Code` cell as a dynamic compact input by replacing the previous autosize markup with an input using `cell-input--compact-dynamic` and `data-col-key="code"` in `js/app.js`. 
- Register `code` in the `minWidthByColumn` map inside `applyCompactColumnWidths()` so the `Code` column participates in the existing width calculation and keeps a sensible minimum. 
- Change surface only affects the Page 3 detail table rendering and the width-calculation map, reusing existing CSS/JS sizing behavior and not touching `Remarque`, other pages, or other columns. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06204ed998832a88da6adba8b57aca)