### PR TITLE
Auto-resize du champ « Désignation » (Page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3298,6 +3298,14 @@ body[data-page="item-detail"] .cell-textarea.cell-input--soft-disabled {
 
 .cell-input--designation {
   min-width: 20ch;
+  max-width: 44ch;
+  min-height: 2.75rem;
+  line-height: 1.4;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  overflow-x: hidden;
+  resize: none;
 }
 
 .meta-value {

--- a/js/app.js
+++ b/js/app.js
@@ -6045,7 +6045,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <tr data-detail-id="${detail.id}" class="${rowClasses}"${enterAnimationStyle}>
               <td><span class="field-badge">${detail.champ}</span></td>
               <td><input class="cell-input cell-input--compact-dynamic cell-input--left" data-col-key="code" data-field="code" type="text" maxlength="120" value="${escapeHtml(detail.code)}" /></td>
-              <td><input class="cell-input cell-input--autosize cell-input--designation cell-input--left" data-field="designation" value="${escapeHtml(detail.designation)}" size="${Math.max(String(detail.designation || '').length + 1, 20)}" /></td>
+              <td><textarea class="cell-input cell-textarea cell-input--autosize cell-input--designation cell-input--left" data-field="designation" maxlength="120" rows="1">${escapeHtml(detail.designation)}</textarea></td>
               <td>
                 <div class="qte-sortie-field">
                   <input class="cell-input cell-input--compact-dynamic" data-col-key="qteSortie" data-field="qteSortie" type="number" min="0" step="1" maxlength="120" value="${escapeHtml(detail.qteSortie)}" />
@@ -6167,6 +6167,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             applyCompactColumnWidths();
           });
         }
+
+        if (field.classList.contains('cell-input--designation')) {
+          field.addEventListener('input', () => {
+            if (field.value.length > 120) {
+              field.value = field.value.slice(0, 120);
+            }
+            adjustDesignationFieldHeight(field);
+          });
+          adjustDesignationFieldHeight(field);
+        }
       });
 
       detailTableBody.querySelectorAll('[data-detail-delete]').forEach((button) => {
@@ -6231,6 +6241,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
 
       measurer.remove();
+    }
+
+    function adjustDesignationFieldHeight(field) {
+      if (!field || !field.classList?.contains('cell-input--designation')) {
+        return;
+      }
+
+      field.style.height = 'auto';
+      const minHeight = parseFloat(window.getComputedStyle(field).minHeight) || 0;
+      const nextHeight = Math.max(minHeight, field.scrollHeight);
+      field.style.height = `${Math.ceil(nextHeight)}px`;
     }
 
     detailForm.addEventListener('submit', async (event) => {


### PR DESCRIPTION
### Motivation
- Rendre le champ « Désignation » sur la Page 3 auto-ajustable verticalement pour améliorer la lisibilité des longues désignations sans élargir excessivement la colonne ni impacter les autres pages/colonnes/exports.

### Description
- Remplacement du `<input>` par un `<textarea>` (même classes visuelles conservées) pour la cellule Désignation dans la grille de la Page 3 afin d'autoriser le retour à la ligne réel.
- Ajout d'une fonction JS `adjustDesignationFieldHeight` qui tronque au `maxlength` (120), mesure `scrollHeight` et réapplique la hauteur à chaque `input` et à l'initialisation pour un auto-resize vertical.
- Aucune modification des comportements auto-ajustables existants des autres colonnes ni des filtres, couleurs, calculs ou de la synchronisation Firestore.
- Ajout de règles CSS ciblées pour `.cell-input--designation` (`white-space: normal`, `word-break: break-word`, `overflow-wrap: anywhere`, `overflow-x: hidden`, `resize: none`, `line-height` confortable, `min-height` et `max-width`) pour forcer le wrapping, éviter le scroll horizontal interne et limiter l'élargissement.

### Testing
- Vérification statique par recherche dans le code confirmant la substitution `input` → `textarea` et l'ajout du JS/CSS dans `js/app.js` et `css/style.css` (ok).
- Aucun test d'interface automatisé n'a été exécuté dans cet environnement; une validation visuelle dans le navigateur sur Page 3 est recommandée pour confirmer le rendu (désignations courtes compactes, longues sur plusieurs lignes, pas de scroll horizontal interne).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0623de54a0832ab17ba718967e4001)