### PR TITLE
Masquer la scrollbar du champ Désignation sur Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3308,6 +3308,17 @@ body[data-page="item-detail"] .cell-textarea.cell-input--soft-disabled {
   resize: none;
 }
 
+body[data-page="item-detail"] .designation-field {
+  overflow-y: hidden;
+  overflow-x: hidden;
+  resize: none;
+  scrollbar-width: none;
+}
+
+body[data-page="item-detail"] .designation-field::-webkit-scrollbar {
+  display: none;
+}
+
 .meta-value {
   display: inline-block;
   min-width: 6rem;

--- a/js/app.js
+++ b/js/app.js
@@ -6045,7 +6045,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <tr data-detail-id="${detail.id}" class="${rowClasses}"${enterAnimationStyle}>
               <td><span class="field-badge">${detail.champ}</span></td>
               <td><input class="cell-input cell-input--compact-dynamic cell-input--left" data-col-key="code" data-field="code" type="text" maxlength="120" value="${escapeHtml(detail.code)}" /></td>
-              <td><textarea class="cell-input cell-textarea cell-input--autosize cell-input--designation cell-input--left" data-field="designation" maxlength="120" rows="1">${escapeHtml(detail.designation)}</textarea></td>
+              <td><textarea class="cell-input cell-textarea cell-input--autosize cell-input--designation designation-field cell-input--left" data-field="designation" maxlength="120" rows="1">${escapeHtml(detail.designation)}</textarea></td>
               <td>
                 <div class="qte-sortie-field">
                   <input class="cell-input cell-input--compact-dynamic" data-col-key="qteSortie" data-field="qteSortie" type="number" min="0" step="1" maxlength="120" value="${escapeHtml(detail.qteSortie)}" />


### PR DESCRIPTION
### Motivation
- Masquer la barre de scroll visible dans le champ « Désignation » uniquement sur la Page 3 tout en conservant le comportement multi‑ligne, l’auto‑resize et la possibilité d’éditer/sélectionner le texte.

### Description
- Ajout de la classe `designation-field` sur le `<textarea>` de la colonne Désignation dans le rendu du tableau de la Page 3 (`js/app.js`).
- Ajout de règles CSS ciblées sous le sélecteur `body[data-page="item-detail"] .designation-field` dans `css/style.css` pour appliquer `overflow-y: hidden;`, `overflow-x: hidden;`, `resize: none;`, `scrollbar-width: none;` et la compatibilité Chrome/WebView via `::-webkit-scrollbar { display: none; }`.
- Les modifications sont limitées à ces deux fichiers et n’altèrent pas les calculs métier, Firestore, ni les autres champs ou le scroll horizontal global.

### Testing
- Recherche scoped sur le dépôt a confirmé que la classe a été ajoutée uniquement au textarea de la colonne Désignation pour la Page 3 et que le CSS a été inséré dans `css/style.css`, et cette vérification a réussi.
- Inspection du diff a montré que seules `js/app.js` et `css/style.css` ont été modifiées et que les changements implémentent la suppression visuelle des scrollbars sans toucher à la logique existante, et cette vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062a8df428832aa31864528bf4c2f8)