### PR TITLE
Compacter le tableau Page 3 pour meilleure lisibilité mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2714,6 +2714,11 @@ body[data-page="item-detail"] .table-container textarea {
   vertical-align: top;
 }
 
+body[data-page="item-detail"] .data-table th,
+body[data-page="item-detail"] .data-table td {
+  padding: 0.4rem 0.45rem;
+}
+
 body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
   background: #f7faff;
 }
@@ -2749,8 +2754,13 @@ body[data-page="item-detail"] .data-table td {
   z-index: 1;
 }
 
+body[data-page="item-detail"] .data-table {
+  font-size: 0.86rem;
+}
+
 body[data-page="item-detail"] .data-table th {
   text-align: center;
+  line-height: 1.2;
 }
 
 body[data-page="item-detail"] .data-table th:nth-child(2),
@@ -3208,22 +3218,25 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   }
 }
 
-.field-badge {
+body[data-page="item-detail"] .field-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 2.2rem;
-  height: 2.2rem;
+  min-width: 1.9rem;
+  height: 1.9rem;
   border-radius: 999px;
   background: rgba(89, 184, 255, 0.18);
   color: var(--primary-dark);
   font-weight: 700;
+  font-size: 0.83rem;
 }
 
-.cell-input,
-.cell-textarea {
-  min-width: 6rem;
-  padding: 0.7rem 0.8rem;
+body[data-page="item-detail"] .cell-input,
+body[data-page="item-detail"] .cell-textarea {
+  min-width: 5.5rem;
+  min-height: 2.45rem;
+  padding: 0.55rem 0.65rem;
+  font-size: 0.86rem;
   text-align: center;
   box-sizing: border-box;
 }
@@ -3237,8 +3250,8 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   border-color: #f08e8e;
 }
 
-.cell-textarea {
-  min-height: 5rem;
+body[data-page="item-detail"] .cell-textarea {
+  min-height: 2.45rem;
   resize: vertical;
 }
 
@@ -3247,18 +3260,19 @@ body[data-page="item-detail"] #designationInput.is-shaking {
   min-width: fit-content;
 }
 
-.cell-input--compact-dynamic {
+body[data-page="item-detail"] .cell-input--compact-dynamic {
   width: auto;
-  min-width: 48px;
+  min-width: 46px;
   max-width: none;
-  padding: 0.7rem 0.75rem;
+  min-height: 2.45rem;
+  padding: 0.5rem 0.62rem;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: clip;
 }
 
-.cell-input--compact-dynamic[data-col-key="observation"] {
-  min-width: 100px;
+body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="observation"] {
+  min-width: 88px;
 }
 
 body[data-page="item-detail"] .detail-status-field {
@@ -3296,11 +3310,11 @@ body[data-page="item-detail"] .cell-textarea.cell-input--soft-disabled {
   pointer-events: none;
 }
 
-.cell-input--designation {
-  min-width: 38ch;
-  max-width: 86ch;
-  min-height: 2.75rem;
-  line-height: 1.4;
+body[data-page="item-detail"] .cell-input--designation {
+  min-width: 28ch;
+  max-width: 62ch;
+  min-height: 2.45rem;
+  line-height: 1.3;
   white-space: normal;
   word-break: break-word;
   overflow-wrap: anywhere;
@@ -3319,10 +3333,11 @@ body[data-page="item-detail"] .designation-field::-webkit-scrollbar {
   display: none;
 }
 
-.meta-value {
+body[data-page="item-detail"] .meta-value {
   display: inline-block;
-  min-width: 6rem;
-  padding: 0.75rem 0.2rem;
+  min-width: 5.25rem;
+  padding: 0.55rem 0.15rem;
+  font-size: 0.83rem;
 }
 
 .meta-value--inline {


### PR DESCRIPTION
### Motivation
- Le tableau de la Page 3 (détails d'article) était trop volumineux sur mobile et masquait les colonnes adjacentes, rendant la lecture et l'édition pénibles.
- L'objectif est de réduire la surface visuelle du tableau tout en conservant le style arrondi existant, le scroll horizontal, et sans toucher aux calculs, filtres, exports ni à Firestore.

### Description
- Ajusté uniquement `css/style.css` et scoped les règles à `body[data-page="item-detail"]` pour que les changements n'affectent pas Pages 1 et 2.
- Réduit la taille de police du tableau à `0.86rem` (~13–14px) et ajusté le `line-height` des en-têtes pour compacité.
- Diminué le padding des cellules à `0.4rem 0.45rem` et réduit visuellement la hauteur des lignes via `min-height` des inputs/textarea autour de `2.45rem` (≈39px) pour rester dans l'objectif tactile (38–42px).
- Resserrement des champs éditables (`.cell-input`, `.cell-textarea`, `.cell-input--compact-dynamic`, `.cell-input--designation`) : padding plus compact, `min-width`/`max-width` révisés pour `Code`/`Désignation` afin de conserver l'auto-resize mais limiter l'étalement horizontal.
- Réduit légèrement la taille du badge `#` (`.field-badge`) et des blocs métadonnées (`.meta-value`) pour homogénéiser la densité visuelle.

### Testing
- Vérification ciblée de l'étendue des changements via recherche dans le repo (`rg`) pour confirmer que les sélecteurs sont bien limités à Page 3 et qu'aucun JS métier n'a été modifié, résultat : OK.
- Inspection locale du fichier modifié `css/style.css` et du diff pour valider que seules les règles de style sont changées et que les valeurs respectent les contraintes demandées, résultat : OK.
- Aucune suite de tests automatisés spécifique au CSS n'était configurée dans le dépôt; les vérifications automatiques réalisées (recherche et inspection de diff) ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a063018cd30832a900ed31e3ac47f45)