### PR TITLE
Compacte le tableau de la Page 3 pour mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2716,7 +2716,7 @@ body[data-page="item-detail"] .table-container textarea {
 
 body[data-page="item-detail"] .data-table th,
 body[data-page="item-detail"] .data-table td {
-  padding: 0.4rem 0.45rem;
+  padding: 0.3rem 0.35rem;
 }
 
 body[data-page="item-detail"] .data-table tbody tr:nth-child(even) {
@@ -2755,7 +2755,7 @@ body[data-page="item-detail"] .data-table td {
 }
 
 body[data-page="item-detail"] .data-table {
-  font-size: 0.86rem;
+  font-size: 0.6875rem;
 }
 
 body[data-page="item-detail"] .data-table th {
@@ -2771,6 +2771,12 @@ body[data-page="item-detail"] .data-table th:nth-child(3) {
 body[data-page="item-detail"] .data-table td:nth-child(2),
 body[data-page="item-detail"] .data-table td:nth-child(3) {
   text-align: left;
+}
+
+body[data-page="item-detail"] .data-table th:first-child,
+body[data-page="item-detail"] .data-table td:first-child {
+  min-width: 2rem;
+  width: 2rem;
 }
 
 body[data-page="item-detail"] .detail-skeleton-row td {
@@ -3234,9 +3240,9 @@ body[data-page="item-detail"] .field-badge {
 body[data-page="item-detail"] .cell-input,
 body[data-page="item-detail"] .cell-textarea {
   min-width: 5.5rem;
-  min-height: 2.45rem;
-  padding: 0.55rem 0.65rem;
-  font-size: 0.86rem;
+  min-height: 2.25rem;
+  padding: 0.38rem 0.5rem;
+  font-size: 0.6875rem;
   text-align: center;
   box-sizing: border-box;
 }
@@ -3251,7 +3257,7 @@ body[data-page="item-detail"] .cell-textarea {
 }
 
 body[data-page="item-detail"] .cell-textarea {
-  min-height: 2.45rem;
+  min-height: 2.25rem;
   resize: vertical;
 }
 
@@ -3262,10 +3268,10 @@ body[data-page="item-detail"] .cell-textarea {
 
 body[data-page="item-detail"] .cell-input--compact-dynamic {
   width: auto;
-  min-width: 46px;
+  min-width: 42px;
   max-width: none;
-  min-height: 2.45rem;
-  padding: 0.5rem 0.62rem;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.45rem;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: clip;
@@ -3286,12 +3292,12 @@ body[data-page="item-detail"] .detail-status-field--ko {
 }
 
 body[data-page="item-detail"] .detail-status-select {
-  min-width: 76px;
-  padding-left: 1.45rem;
+  min-width: 72px;
+  padding-left: 1.35rem;
   background-image: radial-gradient(circle at center, var(--detail-status-color) 0 60%, transparent 61%);
   background-repeat: no-repeat;
   background-size: 0.55rem 0.55rem;
-  background-position: 0.65rem 50%;
+  background-position: 0.55rem 50%;
 }
 
 body[data-page="item-detail"] .cell-input.cell-input--soft-disabled,
@@ -3311,9 +3317,9 @@ body[data-page="item-detail"] .cell-textarea.cell-input--soft-disabled {
 }
 
 body[data-page="item-detail"] .cell-input--designation {
-  min-width: 28ch;
-  max-width: 62ch;
-  min-height: 2.45rem;
+  min-width: 22ch;
+  max-width: 44ch;
+  min-height: 2.25rem;
   line-height: 1.3;
   white-space: normal;
   word-break: break-word;


### PR DESCRIPTION
### Motivation
- Le tableau de la Page 3 prend trop d’espace sur mobile et oblige à beaucoup de scroll horizontal, rendant difficile la lecture des autres colonnes.
- Objectif : rendre le tableau plus compact et lisible sur mobile sans casser l’édition, les calculs, les filtres, les exports ni Firestore.
- Restriction : modifications ciblées uniquement sur Page 3 via le sélecteur `body[data-page="item-detail"]`.

### Description
- Réduction du `font-size` du tableau Page 3 à `0.6875rem` (~11px) pour augmenter la visibilité de plusieurs colonnes sans toucher la structure générale.
- Diminution du `padding` des cellules `th/td` à `0.3rem 0.35rem` et ajustement de la hauteur de ligne pour compacter verticalement les lignes.
- Réduction de la taille visuelle des inputs du tableau (`.cell-input`, `.cell-textarea`, `.cell-input--compact-dynamic`) : hauteur mini à `2.25rem`, padding réduit et police ajustée pour rester cliquable.
- Ajustements de la colonne `#` (`th:first-child`/`td:first-child` = `2rem`) et du champ désignation (`min-width: 22ch`, `max-width: 44ch`) pour limiter l’emprise horizontale, plus légère optimisation du sélecteur de statut (`min-width: 72px`, `padding-left: 1.35rem`).
- Fichier modifié : `css/style.css` (changements uniquement sous `body[data-page="item-detail"]`).

### Testing
- Le patch CSS a été appliqué avec succès (modification de `css/style.css`) via l’outil de patch automatisé et a retourné `Success`.
- Le commit local a été créé avec succès (`git commit` a répondu OK et HEAD = `9545ad2`).
- La PR a été créée automatiquement via `make_pr` et le résumé a été enregistré sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06916b72d0832a8a0419e545a1a9ac)