### PR TITLE
Aligner la colonne « Qté Sortie » (Page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3352,10 +3352,17 @@ body[data-page="item-detail"] .meta-value {
 }
 
 .qte-sortie-field {
-  display: inline-flex;
+  display: inline-grid;
+  grid-template-columns: auto auto auto;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  column-gap: 0.5rem;
+}
+
+.qte-sortie-unit-spacer {
+  visibility: hidden;
+  user-select: none;
+  pointer-events: none;
 }
 
 .toast {

--- a/js/app.js
+++ b/js/app.js
@@ -6048,6 +6048,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><textarea class="cell-input cell-textarea cell-input--autosize cell-input--designation designation-field cell-input--left" data-field="designation" maxlength="120" rows="1">${escapeHtml(detail.designation)}</textarea></td>
               <td>
                 <div class="qte-sortie-field">
+                  <span class="qte-sortie-unit-spacer" aria-hidden="true">${escapeHtml(detail.unite)}</span>
                   <input class="cell-input cell-input--compact-dynamic" data-col-key="qteSortie" data-field="qteSortie" type="number" min="0" step="1" maxlength="120" value="${escapeHtml(detail.qteSortie)}" />
                   <span class="meta-value meta-value--inline">${escapeHtml(detail.unite)}</span>
                 </div>


### PR DESCRIPTION
### Motivation
- Corriger précisément l’alignement visuel de la colonne « Qté Sortie » sur la Page 3 pour que le titre soit parfaitement centré au-dessus du champ numérique. 
- Empêcher que l’unité (`Pcs` ou `m`) décale le champ numérique vers la gauche ou la droite tout en conservant le style existant du tableau.

### Description
- Ajout d’un élément spacer invisible à gauche du champ dans le rendu de la ligne de détail pour créer une structure symétrique (fichier modifié : `js/app.js`).
- Remplacement du layout du conteneur `qte-sortie-field` par une grille à 3 colonnes et ajout de la classe `.qte-sortie-unit-spacer` en CSS pour conserver la symétrie sans affecter l’interaction (fichier modifié : `css/style.css`).
- Le champ numérique reste centré dans la colonne, l’unité est affichée immédiatement à droite du champ, et aucun calcul, filtre, export ou interaction Firestore n’a été modifié.

### Testing
- Vérifications statiques du dépôt et contrôles locaux de diff/style effectués et sans erreur détectée par les checks automatisés.
- Inspection rapide du rendu HTML/CSS de Page 3 (automated build not required) confirmant l’apparence attendue pour `Qté Sortie` avec les unités `Pcs` ou `m`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0696e248dc832a9154cad19cfb33ef)