### PR TITLE
Add “Unité” column to Page 3 detail table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3346,25 +3346,6 @@ body[data-page="item-detail"] .meta-value {
   font-size: 0.83rem;
 }
 
-.meta-value--inline {
-  min-width: auto;
-  padding: 0;
-}
-
-.qte-sortie-field {
-  display: inline-grid;
-  grid-template-columns: auto auto auto;
-  align-items: center;
-  justify-content: center;
-  column-gap: 0.5rem;
-}
-
-.qte-sortie-unit-spacer {
-  visibility: hidden;
-  user-select: none;
-  pointer-events: none;
-}
-
 .toast {
   --toast-bg: #3b82f6;
   --toast-text: #ffffff;

--- a/js/app.js
+++ b/js/app.js
@@ -6012,7 +6012,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function renderTable() {
       if (!hasResolvedInitialDetails) {
         updateCount(null, null);
-        detailTableBody.innerHTML = `<tr><td colspan="14"><div class="empty-state">Chargement...</div></td></tr>`;
+        detailTableBody.innerHTML = `<tr><td colspan="15"><div class="empty-state">Chargement...</div></td></tr>`;
         return;
       }
 
@@ -6026,7 +6026,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       updateDetailFilterCounters(currentDetails);
 
       if (!filteredDetails.length) {
-        detailTableBody.innerHTML = `<tr><td colspan="14"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
+        detailTableBody.innerHTML = `<tr><td colspan="15"><div class="empty-state">${currentDetails.length ? 'Aucune  désignation ne correspond à votre recherche.' : 'Aucune article enregistrée.'}</div></td></tr>`;
         return;
       }
 
@@ -6046,13 +6046,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><span class="field-badge">${detail.champ}</span></td>
               <td><input class="cell-input cell-input--compact-dynamic cell-input--left" data-col-key="code" data-field="code" type="text" maxlength="120" value="${escapeHtml(detail.code)}" /></td>
               <td><textarea class="cell-input cell-textarea cell-input--autosize cell-input--designation designation-field cell-input--left" data-field="designation" maxlength="120" rows="1">${escapeHtml(detail.designation)}</textarea></td>
-              <td>
-                <div class="qte-sortie-field">
-                  <span class="qte-sortie-unit-spacer" aria-hidden="true">${escapeHtml(detail.unite)}</span>
-                  <input class="cell-input cell-input--compact-dynamic" data-col-key="qteSortie" data-field="qteSortie" type="number" min="0" step="1" maxlength="120" value="${escapeHtml(detail.qteSortie)}" />
-                  <span class="meta-value meta-value--inline">${escapeHtml(detail.unite)}</span>
-                </div>
-              </td>
+              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteSortie" data-field="qteSortie" type="number" min="0" step="1" maxlength="120" value="${escapeHtml(detail.qteSortie)}" /></td>
+              <td><span class="meta-value">${escapeHtml(detail.unite)}</span></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qtePosee" data-field="qtePosee" type="number" min="0" step="1" maxlength="120" value="${detail.qtePosee}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRebus" data-field="qteRebus" type="number" min="0" step="1" maxlength="120" value="${detail.qteRebus ?? 0}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRetour" data-field="qteRetour" type="number" min="0" step="1" maxlength="120" value="${detail.qteRetour}" /></td>

--- a/page3.html
+++ b/page3.html
@@ -80,6 +80,7 @@
                   <th>Code</th>
                   <th>Désignation</th>
                   <th>Qté Sortie</th>
+                  <th>Unité</th>
                   <th>Qté posée</th>
                   <th>Qté Rebus</th>
                   <th>Qté Retour</th>


### PR DESCRIPTION
### Motivation
- Rendre l'affichage des unités (`Pcs` / `m`) sur la Page 3 plus propre et professionnel en leur donnant une colonne dédiée afin qu'elles soient alignées avec les autres en-têtes de colonne.

### Description
- Ajout de l'en-tête `<th>Unité</th>` dans le tableau de la Page 3 entre `Qté Sortie` et `Qté posée` (`page3.html`).
- Modification du rendu des lignes dans `renderTable()` pour afficher l'unité dans sa propre cellule `<td><span class="meta-value">...</span></td>` et suppression de l'affichage inline précédent (`js/app.js`).
- Ajustement des `colspan` des lignes vides/chargement de `14` à `15` pour refléter la nouvelle colonne (`js/app.js`).
- Suppression des règles CSS obsolètes liées à l'affichage inline de l'unité (`.meta-value--inline`, `.qte-sortie-field`, `.qte-sortie-unit-spacer`) dans `css/style.css` tout en conservant le style global du tableau (espacements, hauteurs, scroll horizontal).
- Changements limités à la Page 3 (pas de modification des calculs, Firestore, filtres, exports, Page 1 ou Page 2).

### Testing
- Exécution de `node --check js/app.js` qui a réussi sans erreurs de syntaxe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0699876b3c832a8fa4606f123ac37f)