### PR TITLE
Affiner le rendu du champ Date de retour sur la page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3281,6 +3281,26 @@ body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="observa
   min-width: 88px;
 }
 
+body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="dateRetour"] {
+  min-width: 122px;
+  width: 122px;
+  max-width: 122px;
+  min-height: 2.25rem;
+  padding: 0.3rem 0.38rem;
+  text-align: center;
+  line-height: 1.2;
+}
+
+body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="dateRetour"]::-webkit-datetime-edit {
+  text-align: center;
+  padding: 0;
+}
+
+body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="dateRetour"]::-webkit-calendar-picker-indicator {
+  margin: 0;
+  padding: 0.02rem;
+}
+
 body[data-page="item-detail"] .detail-status-field {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Rendre le champ « Date de retour » dans le tableau de la Page 3 plus compact, mieux aligné et visuellement homogène sans toucher au comportement ou à la logique existante.

### Description
- Ajout de règles CSS ciblées dans `css/style.css` pour `.cell-input--compact-dynamic[data-col-key="dateRetour"]` et ses pseudo-éléments `::-webkit-datetime-edit` et `::-webkit-calendar-picker-indicator`.
- Fixe la largeur visuelle à `122px`, réduit le `padding`, centre le texte et ajuste le `line-height` pour correspondre à la hauteur des autres champs numériques.
- Resserre le rendu de l’indicateur calendrier pour centrer la flèche verticalement et conserver un aspect arrondi tout en gardant le `type="date"` natif.
- Scope limité à `body[data-page="item-detail"]` (Page 3) et aucun changement JavaScript, calculs, Firestore, exports ou filtres n’a été modifié.

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069bb59638832ab95bbd5b6954e734)