### PR TITLE
Fix Page 3 return-date field CSS targeting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3281,22 +3281,22 @@ body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="observa
   min-width: 88px;
 }
 
-body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="dateRetour"] {
-  min-width: 122px;
-  width: 122px;
-  max-width: 122px;
+body[data-page="item-detail"] .date-retour-field {
+  min-width: 122px !important;
+  width: 122px !important;
+  max-width: 122px !important;
   min-height: 2.25rem;
   padding: 0.3rem 0.38rem;
   text-align: center;
   line-height: 1.2;
 }
 
-body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="dateRetour"]::-webkit-datetime-edit {
+body[data-page="item-detail"] .date-retour-field::-webkit-datetime-edit {
   text-align: center;
   padding: 0;
 }
 
-body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="dateRetour"]::-webkit-calendar-picker-indicator {
+body[data-page="item-detail"] .date-retour-field::-webkit-calendar-picker-indicator {
   margin: 0;
   padding: 0.02rem;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -6051,7 +6051,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qtePosee" data-field="qtePosee" type="number" min="0" step="1" maxlength="120" value="${detail.qtePosee}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRebus" data-field="qteRebus" type="number" min="0" step="1" maxlength="120" value="${detail.qteRebus ?? 0}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRetour" data-field="qteRetour" type="number" min="0" step="1" maxlength="120" value="${detail.qteRetour}" /></td>
-              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="dateRetour" data-field="dateRetour" type="date" value="${escapeHtml(detail.dateRetour || '')}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic date-retour-field" data-col-key="dateRetour" data-field="dateRetour" type="date" value="${escapeHtml(detail.dateRetour || '')}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic${ecartClassName}" data-col-key="ecart" type="number" maxlength="120" value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><input class="cell-input cell-input--compact-dynamic" data-col-key="observation" data-field="observation" type="text" maxlength="120" value="${escapeHtml(detail.observation)}" /></td>
               <td>
@@ -6216,6 +6216,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       };
 
       columns.forEach((inputs, key) => {
+        if (key === 'dateRetour') {
+          inputs.forEach((input) => {
+            input.style.width = '';
+          });
+          return;
+        }
+
         let maxWidth = minWidthByColumn[key] || 48;
 
         inputs.forEach((input) => {


### PR DESCRIPTION
### Motivation
- Le style ajouté pour le champ « Date de retour » dans `css/style.css` ne s’appliquait pas parce qu’une règle inline écrite par le JS auto-redimensionnait l’input et prenait le dessus.
- Il fallait cibler l’`input` réel de la colonne et non le parent pour garantir l’application visuelle uniquement en Page 3.

### Description
- Ajout de la classe `date-retour-field` directement sur l’`input[type="date"]` de la colonne `dateRetour` dans `js/app.js` (Page 3 uniquement via `body[data-page="item-detail"]`).
- Remplacement du sélecteur CSS ciblant `[data-col-key="dateRetour"]` par `.date-retour-field` dans `css/style.css` et ajout de `!important` aux largeurs fixes pour éviter les conflits hérités.
- Mise à jour de la logique d’auto-sizing (`applyCompactColumnWidths`) pour exclure la colonne `dateRetour` afin d’empêcher l’écriture d’un `style.width` inline qui écrasait la feuille de style.

### Testing
- Recherches par motif avec `rg` ont confirmé la présence de `date-retour-field` dans `js/app.js` et `css/style.css` après modification et ont localisé les anciens sélecteurs.
- Inspection des fichiers modifiés a vérifié l’injection de la classe sur l’`input` et la substitution des sélecteurs dans `css/style.css`.
- Vérification manuelle du code (`diff`/lecture des fichiers) a confirmé que l’exclusion de `dateRetour` du redimensionnement automatique est en place et que la CSS ciblée s’appliquera sans modifier le comportement du champ.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069faa94d0832ab167ae781684a3cf)