### PR TITLE
Réduire la largeur max du champ « Date de retour » sur la page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3282,9 +3282,9 @@ body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="observa
 }
 
 body[data-page="item-detail"] .date-retour-field {
-  min-width: 122px !important;
-  width: 122px !important;
-  max-width: 122px !important;
+  min-width: 96px !important;
+  width: 96px !important;
+  max-width: 96px !important;
   min-height: 2.25rem;
   padding: 0.3rem 0.38rem;
   text-align: center;


### PR DESCRIPTION
### Motivation
- Le champ `Date de retour` sur la page 3 est visuellement trop large et réduit la lisibilité des autres colonnes sur mobile, il faut le rendre plus compact tout en conservant la lisibilité et la flèche du sélecteur de date.

### Description
- Mise à jour de `css/style.css` pour modifier le sélecteur `body[data-page="item-detail"] .date-retour-field` en passant `min-width`, `width` et `max-width` à `96px !important`, en conservant `text-align: center`, la hauteur et le comportement du calendrier, sans toucher aux calculs, Firestore, exports ou filtres.

### Testing
- Exécution de `git diff -- css/style.css` pour vérifier le diff (réussi). 
- Commit réalisé avec `git commit -m "Réduire la largeur du champ Date de retour sur page 3"` (réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a2fc10d4832a810168c295b30e08)