### PR TITLE
Corrige chevauchement flèche du champ Date de retour (Page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3286,7 +3286,7 @@ body[data-page="item-detail"] .date-retour-field {
   width: 96px !important;
   max-width: 96px !important;
   min-height: 2.25rem;
-  padding: 0.3rem 0.38rem;
+  padding: 0.3rem 1.8rem 0.3rem 0.38rem;
   text-align: center;
   line-height: 1.2;
 }


### PR DESCRIPTION
### Motivation
- Empêcher l’icône native du sélecteur de date de chevaucher et masquer la valeur affichée du champ « Date de retour » sur la Page 3 tout en conservant l’apparence compacte et le comportement natif.

### Description
- Ajustement CSS ciblé dans `body[data-page="item-detail"]` pour le vrai input : la classe `date-retour-field` passe de `padding: 0.3rem 0.38rem;` à `padding: 0.3rem 1.8rem 0.3rem 0.38rem;` afin de réserver l’espace à droite pour la flèche sans modifier la largeur/hauteur ni le style général.

### Testing
- Aucun test automatisé n’a été exécuté pour ce correctif CSS; la modification a été appliquée et committée (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a7fca3a8832ab35e25e76069f932)