### PR TITLE
Align designation field text to left on item-detail page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3335,6 +3335,17 @@ body[data-page="item-detail"] .cell-textarea.cell-input--soft-disabled {
   pointer-events: none;
 }
 
+
+body[data-page="item-detail"] [data-col-key="designation"] .cell-input,
+body[data-page="item-detail"] .cell-input--designation,
+body[data-page="item-detail"] textarea.cell-input--designation,
+body[data-page="item-detail"] input[data-field="designation"] {
+  text-align: left !important;
+  justify-content: flex-start !important;
+  align-items: center;
+  padding-left: 0.75rem !important;
+}
+
 body[data-page="item-detail"] .cell-input--designation {
   min-width: 22ch;
   max-width: 44ch;


### PR DESCRIPTION
### Motivation
- Aligner le texte du champ “Désignation” à gauche exclusivement sur la Page 3 (`body[data-page="item-detail"]`) afin que le texte commence à gauche du champ tout en gardant le style visuel actuel et l’alignement vertical centré.
- Appliquer la modification uniquement sur la colonne/champ `designation` sans toucher aux autres colonnes ni aux comportements existants (auto resize, saut de ligne automatique, hauteur dynamique).

### Description
- Ajout d’un bloc CSS dans `css/style.css` positionné près des règles existantes pour `.cell-input--designation` afin de limiter la portée au contexte `item-detail`.
- Nouveaux sélecteurs ajoutés : `body[data-page="item-detail"] [data-col-key="designation"] .cell-input`, `body[data-page="item-detail"] .cell-input--designation`, `body[data-page="item-detail"] textarea.cell-input--designation`, et `body[data-page="item-detail"] input[data-field="designation"]`.
- Propriétés appliquées : `text-align: left !important;`, `justify-content: flex-start !important;`, `align-items: center;`, et `padding-left: 0.75rem !important;` pour garantir le comportement demandé tout en préservant le wrapping/resize existant.
- Aucun fichier JavaScript ni aucune autre règle de colonne n’a été modifié.

### Testing
- Exécution de `git diff -- css/style.css && git status --short` pour valider les changements de fichier — réussite.
- Commit réalisé avec `git commit -m "Adjust designation cell text alignment on item-detail page"` — réussite.
- Vérification de l’insertion dans `css/style.css` via `nl -ba css/style.css | sed -n '3334,3362p'` pour confirmer l’emplacement et le contenu — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ba865034832aa66bc40e7421a592)