### PR TITLE
Désactiver le pinch-zoom tactile dans le tableau (Page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2380,7 +2380,9 @@ body[data-page="item-detail"] .table-wrapper--shared {
 body[data-page="item-detail"] .table-container--card {
   max-width: 100%;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: auto;
+  touch-action: pan-x pan-y;
+  overscroll-behavior: contain;
 }
 
 body[data-page="item-detail"] .search-panel .input-group {

--- a/js/app.js
+++ b/js/app.js
@@ -277,7 +277,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let translateX = 0;
     let translateY = 0;
     let dragState = null;
-    let pinchState = null;
 
     function clampScale(value) {
       return Math.min(maxScale, Math.max(minScale, value));
@@ -347,47 +346,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       tableContainer.classList.remove('is-grabbing');
     });
 
-    tableContainer.addEventListener('touchstart', (event) => {
-      if (event.touches.length === 2) {
-        const [touchA, touchB] = event.touches;
-        const dx = touchB.clientX - touchA.clientX;
-        const dy = touchB.clientY - touchA.clientY;
-        pinchState = {
-          distance: Math.hypot(dx, dy),
-          scale,
-        };
-      }
-    }, { passive: true });
-
-    tableContainer.addEventListener('touchmove', (event) => {
-      if (event.touches.length !== 2 || !pinchState) {
-        return;
-      }
-
-      const [touchA, touchB] = event.touches;
-      const dx = touchB.clientX - touchA.clientX;
-      const dy = touchB.clientY - touchA.clientY;
-      const currentDistance = Math.hypot(dx, dy);
-      if (!currentDistance || !pinchState.distance) {
-        return;
-      }
-
-      const midpointX = (touchA.clientX + touchB.clientX) / 2;
-      const midpointY = (touchA.clientY + touchB.clientY) / 2;
-      const scaleFactor = currentDistance / pinchState.distance;
-      zoomAtPoint(pinchState.scale * scaleFactor, midpointX, midpointY);
+    tableContainer.addEventListener('gesturestart', (event) => {
       event.preventDefault();
     }, { passive: false });
 
-    tableContainer.addEventListener('touchend', (event) => {
-      if (event.touches.length < 2) {
-        pinchState = null;
+    tableContainer.addEventListener('touchmove', (event) => {
+      if (typeof event.scale === 'number' && event.scale !== 1) {
+        event.preventDefault();
       }
-    });
-
-    tableContainer.addEventListener('touchcancel', () => {
-      pinchState = null;
-    });
+    }, { passive: false });
 
     applyTransform();
   }


### PR DESCRIPTION
### Motivation
- Empêcher le zoom tactile (pinch / double-tap) à l’intérieur du tableau de la Page 3 qui casse l’affichage et l’alignement des colonnes tout en conservant le scroll et les interactions normales.
- Appliquer la correction uniquement au conteneur scrollable du tableau de Page 3 sans toucher au zoom global ni bloquer le scroll.

### Description
- Ajout de `touch-action: pan-x pan-y;` et `overscroll-behavior: contain;` et passage de `overflow-y: hidden` à `overflow-y: auto` sur le sélecteur `body[data-page="item-detail"] .table-container--card` dans `css/style.css` pour désactiver le zoom natif dans la zone du tableau.
- Suppression de la logique de pinch-to-zoom basée sur `pinchState` dans `js/app.js` et remplacement par un blocage ciblé des gestes de zoom via un écouteur `gesturestart` (`preventDefault()`) et un `touchmove` qui empêche l’événement quand `event.scale` existe et diffère de `1`.
- Les modifications sont limitées au conteneur `detailTableContainer` et au scope `item-detail` afin d’éviter toute régression sur Page 1 et Page 2.

### Testing
- Exécution de recherches et vérifications de présence des changements avec `rg -n "table-wrapper|detailTableContainer|touch-action|overscroll|gesturestart" css/style.css js/*.js page3.html`, qui a confirmé les insertions attendues (succès).
- Affichage des sections modifiées avec `nl`/`sed` et contrôle d’état git via `git status --short`, puis `git add` et `git commit`, tous exécutés avec succès.
- Aucun test unitaire automatique n’a été trouvé dans le dépôt; les vérifications ci‑dessus servent d’assurance ciblée que les modifications sont appliquées et limitées au scope prévu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07260a6588832ab66c2b0783a43f05)