### PR TITLE
Disable zero-count filter options on Page 2 and Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2486,6 +2486,12 @@ body[data-page="item-detail"] .page3-filter-option.is-active {
   font-weight: 600;
 }
 
+body[data-page="item-detail"] .page3-filter-option.is-disabled {
+  opacity: 0.38;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
 body[data-page="item-detail"] .search-input__icon-wrap {
   position: absolute;
   left: 0.85rem;
@@ -3913,6 +3919,12 @@ body[data-page="site-detail"] .page2-filter-option.is-active {
   background: #e7f0ff;
   color: #1d4ed8;
   font-weight: 600;
+}
+
+body[data-page="site-detail"] .page2-filter-option.is-disabled {
+  opacity: 0.38;
+  pointer-events: none;
+  cursor: not-allowed;
 }
 
 body[data-page="site-detail"] .site-search-icon-wrap {

--- a/js/app.js
+++ b/js/app.js
@@ -3911,12 +3911,28 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           countNode.textContent = String(count);
         }
       });
+      enforceItemStatusFilterAvailability();
+    }
+
+    function enforceItemStatusFilterAvailability() {
+      const activeOption = itemStatusFilterOptions.find((option) => option.dataset.itemStatusFilter === activeStatusFilter);
+      const activeCount = Number(activeOption?.querySelector('.page2-filter-option__count')?.textContent || '0');
+      if (activeStatusFilter !== 'all' && activeCount <= 0) {
+        activeStatusFilter = 'all';
+      }
+      itemStatusFilterOptions.forEach((option) => {
+        const count = Number(option.querySelector('.page2-filter-option__count')?.textContent || '0');
+        const isDisabled = count <= 0;
+        option.classList.toggle('is-disabled', isDisabled);
+        option.disabled = isDisabled;
+        option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+      });
     }
 
     function syncItemStatusFilterUi() {
       itemStatusFilterButton?.classList.toggle('is-filtered', activeStatusFilter !== 'all');
       itemStatusFilterOptions.forEach((option) => {
-        const isActive = option.dataset.itemStatusFilter === activeStatusFilter;
+        const isActive = option.dataset.itemStatusFilter === activeStatusFilter && !option.classList.contains('is-disabled');
         option.classList.toggle('is-active', isActive);
         option.setAttribute('aria-checked', isActive ? 'true' : 'false');
       });
@@ -3936,6 +3952,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function setItemStatusFilter(filterKey) {
       const nextFilter = filterKey || 'all';
+      const targetOption = itemStatusFilterOptions.find((option) => (option.dataset.itemStatusFilter || 'all') === nextFilter);
+      if (targetOption?.classList.contains('is-disabled')) {
+        return;
+      }
       activeStatusFilter = nextFilter;
       try {
         window.localStorage.setItem(cursorFilterActiveStorageKey, statusFilterLabelByKey[activeStatusFilter] || 'Tous');
@@ -5707,18 +5727,38 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           countNode.textContent = String(count);
         }
       });
+      enforceDetailFilterAvailability();
+    }
+
+    function enforceDetailFilterAvailability() {
+      const activeOption = detailFilterOptions.find((option) => option.dataset.detailFilter === activeDetailFilter);
+      const activeCount = Number(activeOption?.querySelector('.page3-filter-option__count')?.textContent || '0');
+      if (activeDetailFilter !== 'all' && activeCount <= 0) {
+        activeDetailFilter = 'all';
+      }
+      detailFilterOptions.forEach((option) => {
+        const count = Number(option.querySelector('.page3-filter-option__count')?.textContent || '0');
+        const isDisabled = count <= 0;
+        option.classList.toggle('is-disabled', isDisabled);
+        option.disabled = isDisabled;
+        option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+      });
     }
 
     function syncDetailFilterUi() {
       detailFilterButton?.classList.toggle('is-filtered', activeDetailFilter !== 'all');
       detailFilterOptions.forEach((option) => {
-        const isActive = option.dataset.detailFilter === activeDetailFilter;
+        const isActive = option.dataset.detailFilter === activeDetailFilter && !option.classList.contains('is-disabled');
         option.classList.toggle('is-active', isActive);
         option.setAttribute('aria-checked', isActive ? 'true' : 'false');
       });
     }
 
     function setDetailFilter(filterKey) {
+      const targetOption = detailFilterOptions.find((option) => (option.dataset.detailFilter || 'all') === filterKey);
+      if (targetOption?.classList.contains('is-disabled')) {
+        return;
+      }
       activeDetailFilter = filterKey;
       syncDetailFilterUi();
       renderTable();


### PR DESCRIPTION
### Motivation
- Rendre les entrées du menu filtre de Page 2 (site-detail) et Page 3 (item-detail) visuellement et fonctionnellement désactivées quand leur compteur est `0`, sans modifier la logique existante des filtres ni les compteurs.
- Assurer que l’état soit dynamique après recherche, changement de données ou retour sur la page et préserver le comportement de la recherche et du mode lu/non lu.

### Description
- Ajout d’une classe CSS scoped `.is-disabled` appliquée à `.page2-filter-option` et `.page3-filter-option` pour implémenter `opacity: 0.38`, `pointer-events: none` et `cursor: not-allowed` dans `css/style.css`.
- Implémentation de `enforceItemStatusFilterAvailability()` et `enforceDetailFilterAvailability()` dans `js/app.js` pour basculer automatiquement la classe `.is-disabled`, l’attribut `disabled` et `aria-disabled` selon la valeur des compteurs, et appel de ces fonctions depuis `updateCursorFilterCounters()` et `updateDetailFilterCounters()`.
- Ajout de gardes dans `setItemStatusFilter()` et `setDetailFilter()` pour empêcher l’activation d’un filtre désactivé, et ajustement de `syncItemStatusFilterUi()` / `syncDetailFilterUi()` pour n’appliquer le style actif qu’aux options non désactivées.
- Aucune modification de Page 1, des compteurs, de la logique de filtrage, ou création de nouveaux fichiers; changements limités à `js/app.js` et `css/style.css`.

### Testing
- Exécution de la vérification de syntaxe : `node --check js/app.js` — succès.
- Inspection automatisée du diff et vérification statique des fichiers modifiés — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0728ba7830832aa05260135578d3e6)