### PR TITLE
Remplacer les icônes par les PNG existants pour Page 2 et Demande matériels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4424,6 +4424,13 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   line-height: 1;
 }
 
+.bottom-nav-icon img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  display: block;
+}
+
 .bottom-nav-label {
   font-size: 13px;
   line-height: 1;
@@ -6111,4 +6118,3 @@ body[data-page="item-detail"] .search-highlight {
   padding: 0 2px;
   font-weight: 700;
 }
-

--- a/materiels.html
+++ b/materiels.html
@@ -53,6 +53,13 @@
         bottom: 24px !important;
       }
 
+      .materials-page .cart-fab-icon {
+        width: 22px;
+        height: 22px;
+        object-fit: contain;
+        display: block;
+      }
+
       .materials-page .cart-badge {
         position: absolute;
         top: -6px;
@@ -379,7 +386,7 @@
       </main>
 
       <button id="materialCartFab" class="fab fab-add cart-fab" type="button" aria-label="Voir la demande matériel">
-        🛒
+        <img src="Icon/Chariot.png" alt="" aria-hidden="true" class="cart-fab-icon" />
         <span id="materialCartBadge" class="cart-badge">0</span>
       </button>
 

--- a/page2.html
+++ b/page2.html
@@ -87,12 +87,12 @@
 
       <nav class="bottom-navigation" aria-label="Navigation des onglets">
         <button class="bottom-nav-item active" data-tab="outs" type="button">
-          <span class="bottom-nav-icon">📦</span>
+          <span class="bottom-nav-icon"><img src="Icon/OUT.png" alt="" aria-hidden="true" /></span>
           <span class="bottom-nav-label">OUT</span>
         </button>
 
         <button class="bottom-nav-item admin-only hidden" data-tab="purchases" type="button">
-          <span class="bottom-nav-icon">🛒</span>
+          <span class="bottom-nav-icon"><img src="Icon/Chariot.png" alt="" aria-hidden="true" /></span>
           <span class="bottom-nav-label">Achat matériel</span>
         </button>
       </nav>


### PR DESCRIPTION
### Motivation
- Remplacer les emoji/icônes système utilisés dans la navigation et le FAB par les fichiers PNG déjà présents pour uniformiser le style visuel et respecter les assets du dépôt.
- Conserver toutes les fonctionnalités existantes, badges et animations sans créer de nouveaux fichiers ni générer d’images.

### Description
- Page 2 : remplacement des icônes emoji de la bottom navigation par des images référencées `Icon/OUT.png` et `Icon/Chariot.png` dans `page2.html`.
- Page “Demande matériels” : remplacement de l’emoji du FAB par `Icon/Chariot.png` dans `materiels.html` tout en conservant le badge existant.
- Ajout de règles CSS pour garantir des tailles et alignements stables et `object-fit: contain` via `css/style.css` (`.bottom-nav-icon img` et `.materials-page .cart-fab-icon`).
- Aucune création de fichiers ni génération d’images, et aucun changement de comportement fonctionnel ou d’accessibilité n’a été effectué.

### Testing
- Vérification de l’état du dépôt et présence des modifications détectée avec l’outil d’inspection du repo — réussite.
- Comparaison des diffs ciblés pour `page2.html`, `materiels.html` et `css/style.css` pour valider les remplacements — réussite.
- Opération de mise à jour des modifications dans le contrôle de version et enregistrement des changements automatisés — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07360c5ee8832a8b5f7006e6b0239d)