### PR TITLE
Corriger centrage icône FAB panier sur la page Demande matériels

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -51,6 +51,10 @@
         right: 24px !important;
         left: auto !important;
         bottom: 24px !important;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
       }
 
       .materials-page .cart-fab-icon {
@@ -58,6 +62,10 @@
         height: 34px;
         object-fit: contain;
         display: block;
+        margin: 0;
+        padding: 0;
+        transform: none;
+        flex-shrink: 0;
       }
 
       .materials-page .cart-badge {


### PR DESCRIPTION
### Motivation
- Rectifier l’alignement visuel de l’icône du FAB panier sur la page « Demande matériels » pour un rendu centré et premium sans modifier la taille ni le comportement du bouton. 
- Préserver le badge rouge existant et l’utilisation de l’icône unique `Icon/Chariot.png` et conserver `object-fit: contain`.

### Description
- Ajout de centrage flexbox sur le sélecteur `#materialCartFab, .cart-fab` avec `display: flex`, `align-items: center`, `justify-content: center` et `padding: 0` dans `materiels.html` pour centrer l’icône. 
- Nettoyage des offsets de l’image via `margin: 0`, `padding: 0`, `transform: none` et `flex-shrink: 0` sur `.cart-fab-icon` tout en conservant `width: 34px`, `height: 34px` et `object-fit: contain`. 
- Aucune modification de comportement JavaScript, de taille du FAB, ni de création de nouveaux fichiers, et la positionnement absolu du badge (`.cart-badge`) est laissé intact.

### Testing
- Local code inspection et recherche des sélecteurs concernés avec `rg -n "cart-fab|materials-page|Chariot|Demande matériels|cart" .` succeeded. 
- Fichier mis à jour et commit effectué via `git add materiels.html && git commit -m "Fix cart FAB icon centering on materials page"` and the commit succeeded. 
- Contenu modifié vérifié avec `nl -ba materiels.html | sed -n '46,80p'` and changes match the intended CSS adjustments. 
- La PR a été générée via `make_pr` and the generated PR metadata reflects the applied CSS-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073b4763c0832aaab18f7c3c93bc5c)