### PR TITLE
Mettre le bouton “Exporter IMG” en vert dans la modal Demande de matériel

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -294,6 +294,19 @@
       }
 
 
+
+
+      .materials-page .export-img-btn {
+        background: var(--green-color, var(--success, #22c55e));
+        color: #fff;
+        border: none;
+      }
+
+      .materials-page .export-img-btn:hover,
+      .materials-page .export-img-btn:active {
+        filter: brightness(0.95);
+      }
+
       .materials-page #confirmRequestPngBtn {
         display: inline-flex;
         align-items: center;
@@ -407,7 +420,7 @@
           <div id="materialCartList" class="material-cart-list"></div>
           <div class="modal-actions modal-actions__row modal-actions__row--pair">
             <button id="clearMaterialCartBtn" class="btn btn-secondary" type="button">Vider</button>
-            <button id="downloadRequestPngBtn" class="btn btn-primary" type="button">Exporter IMG</button>
+            <button id="downloadRequestPngBtn" class="btn btn-primary export-img-btn" type="button">Exporter IMG</button>
           </div>
         </div>
       </dialog>


### PR DESCRIPTION
### Motivation
- Harmoniser le bouton “Exporter IMG” avec la couleur verte déjà utilisée dans le projet sans créer de nouvelle couleur ni modifier l’apparence premium globale.

### Description
- Ajout de la classe `export-img-btn` sur le bouton `#downloadRequestPngBtn` dans `materiels.html` pour cibler uniquement ce bouton.
- Insertion de règles CSS embarquées `.materials-page .export-img-btn` réutilisant la couleur du projet via `var(--green-color, var(--success, #22c55e))`, couleur du texte blanche et suppression de la bordure.
- Ajout de l’état `:hover` / `:active` avec `filter: brightness(0.95)` tout en conservant les arrondis, la taille, l’alignement et les animations existantes.
- Aucun autre bouton (notamment `Vider`) ni fichier n’a été modifié et aucune nouvelle ressource n’a été créée.

### Testing
- Exécution de `rg` et `sed` pour localiser et valider les sélecteurs et l’emplacement des changements, qui a renvoyé les occurrences attendues et a confirmé la cible unique du bouton, succès.
- Vérification du diff avec `git diff -- materiels.html` pour s’assurer que seule la modification voulue a été appliquée, succès.
- Commit effectué via `git commit -m "Style Exporter IMG button with project green tone"` et vérification de l’ID de commit via `git rev-parse --short HEAD`, succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07425e0548832abf2afe4cbb05583d)