### PR TITLE
Ajouter une carte de progression des statuts sur la Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3927,6 +3927,52 @@ body[data-page="site-detail"] .page2-filter-option.is-disabled {
   cursor: not-allowed;
 }
 
+body[data-page="site-detail"] .progress-stats-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 14px 16px;
+  margin-top: 2px;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.06);
+}
+
+body[data-page="site-detail"] .progress-item {
+  margin-bottom: 10px;
+}
+
+body[data-page="site-detail"] .progress-item:last-child {
+  margin-bottom: 0;
+}
+
+body[data-page="site-detail"] .progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #334155;
+}
+
+body[data-page="site-detail"] .progress-track {
+  width: 100%;
+  height: 7px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+body[data-page="site-detail"] .progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  transition: width 0.35s ease;
+}
+
+body[data-page="site-detail"] .progress-fill.completed { background: #22c55e; }
+body[data-page="site-detail"] .progress-fill.pending { background: #facc15; }
+body[data-page="site-detail"] .progress-fill.warning { background: #fb923c; }
+body[data-page="site-detail"] .progress-fill.ko { background: #ef4444; }
+
 body[data-page="site-detail"] .site-search-icon-wrap {
   position: absolute;
   left: 0.95rem;

--- a/js/app.js
+++ b/js/app.js
@@ -2903,6 +2903,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const itemStatusFilterButton = document.getElementById('itemStatusFilterButton');
     const itemStatusFilterMenu = document.getElementById('itemStatusFilterMenu');
     const itemStatusFilterOptions = Array.from(document.querySelectorAll('[data-item-status-filter]'));
+    const itemProgressStatsCard = document.getElementById('itemProgressStatsCard');
+    const itemProgressDoneMeta = document.getElementById('itemProgressDoneMeta');
+    const itemProgressTodoMeta = document.getElementById('itemProgressTodoMeta');
+    const itemProgressFixMeta = document.getElementById('itemProgressFixMeta');
+    const itemProgressKoMeta = document.getElementById('itemProgressKoMeta');
+    const itemProgressDoneFill = document.getElementById('itemProgressDoneFill');
+    const itemProgressTodoFill = document.getElementById('itemProgressTodoFill');
+    const itemProgressFixFill = document.getElementById('itemProgressFixFill');
+    const itemProgressKoFill = document.getElementById('itemProgressKoFill');
     let selectedDateFilter = window.localStorage.getItem(dateFilterStorageKey) || 'all';
     const statusFilterKeyByLabel = {
       'Tous': 'all',
@@ -3903,15 +3912,46 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!itemStatusFilterOptions.length) {
         return;
       }
+      const countsByFilterKey = {};
       itemStatusFilterOptions.forEach((option) => {
         const filterKey = option.dataset.itemStatusFilter || 'all';
         const count = getTotalMatchingDetailCount(query, filterKey);
+        countsByFilterKey[filterKey] = count;
         const countNode = option.querySelector('.page2-filter-option__count');
         if (countNode) {
           countNode.textContent = String(count);
         }
       });
+      updateItemProgressStatsCard(countsByFilterKey);
       enforceItemStatusFilterAvailability();
+    }
+
+    function updateItemProgressStatsCard(countsByFilterKey = {}) {
+      if (!itemProgressStatsCard) {
+        return;
+      }
+      const doneCount = Number(countsByFilterKey.done || 0);
+      const todoCount = Number(countsByFilterKey.todo || 0);
+      const fixCount = Number(countsByFilterKey.fix || 0);
+      const koCount = Number(countsByFilterKey.ko || 0);
+      const total = doneCount + todoCount + fixCount + koCount;
+
+      itemProgressStatsCard.hidden = total <= 0;
+      if (total <= 0) {
+        return;
+      }
+
+      const setProgress = (metaNode, fillNode, count) => {
+        if (!metaNode || !fillNode) return;
+        const percentage = Math.round((count / total) * 100);
+        metaNode.textContent = `${count} • ${percentage}%`;
+        fillNode.style.width = `${percentage}%`;
+      };
+
+      setProgress(itemProgressDoneMeta, itemProgressDoneFill, doneCount);
+      setProgress(itemProgressTodoMeta, itemProgressTodoFill, todoCount);
+      setProgress(itemProgressFixMeta, itemProgressFixFill, fixCount);
+      setProgress(itemProgressKoMeta, itemProgressKoFill, koCount);
     }
 
     function enforceItemStatusFilterAvailability() {

--- a/page2.html
+++ b/page2.html
@@ -64,6 +64,36 @@
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>
             <button class="filter-chip" type="button" data-filter-chip="lastMonth">Plus ancien</button>
           </div>
+          <section id="itemProgressStatsCard" class="progress-stats-card" aria-live="polite" hidden>
+            <div class="progress-item">
+              <div class="progress-header">
+                <span>Terminés</span>
+                <span id="itemProgressDoneMeta">0 • 0%</span>
+              </div>
+              <div class="progress-track"><div id="itemProgressDoneFill" class="progress-fill completed" style="width: 0%;"></div></div>
+            </div>
+            <div class="progress-item">
+              <div class="progress-header">
+                <span>En attente</span>
+                <span id="itemProgressTodoMeta">0 • 0%</span>
+              </div>
+              <div class="progress-track"><div id="itemProgressTodoFill" class="progress-fill pending" style="width: 0%;"></div></div>
+            </div>
+            <div class="progress-item">
+              <div class="progress-header">
+                <span>À corriger</span>
+                <span id="itemProgressFixMeta">0 • 0%</span>
+              </div>
+              <div class="progress-track"><div id="itemProgressFixFill" class="progress-fill warning" style="width: 0%;"></div></div>
+            </div>
+            <div class="progress-item">
+              <div class="progress-header">
+                <span>K.O</span>
+                <span id="itemProgressKoMeta">0 • 0%</span>
+              </div>
+              <div class="progress-track"><div id="itemProgressKoFill" class="progress-fill ko" style="width: 0%;"></div></div>
+            </div>
+          </section>
           <label class="sr-only" for="itemDateFilter">Filtrer les résultats par date</label>
           <select id="itemDateFilter" class="visually-hidden-control" aria-label="Filtrer les résultats par date">
             <option value="all">Tous</option>


### PR DESCRIPTION
### Motivation
- Afficher, sous les chips filtre de la Page 2, des statistiques visuelles compactes des statuts (Terminés, En attente, À corriger, K.O) sans altérer la logique existante des filtres, la recherche, les cards OUT ni le popup filtre.
- Offrir une lecture rapide des proportions et comptes par statut en réutilisant les compteurs déjà calculés pour garantir cohérence et mises à jour dynamiques.

### Description
- Ajout d’un bloc HTML `#itemProgressStatsCard` directement sous les chips filtre dans `page2.html` contenant les 4 lignes de statut avec métadonnées et barres (`#itemProgress*Meta`, `#itemProgress*Fill`).
- Introduction de la fonction `updateItemProgressStatsCard(countsByFilterKey)` dans `js/app.js` et branchement depuis `updateCursorFilterCounters()` pour réutiliser les compteurs existants, calculer les pourcentages, mettre à jour le texte et animer la largeur des barres; la section est automatiquement masquée si le total est zéro.
- Ajout de styles dans `css/style.css` pour une carte blanche légère, coins arrondis, padding compact, barres fines (7px) et transition smooth (`transition: width 0.35s ease`) avec les couleurs projet demandées pour chaque statut.
- Aucune modification de la logique de filtrage/recherche/cards/popups, aucun fichier nouveau créé et compatibilité mobile prise en compte.

### Testing
- Vérification des diffs et de l’état du repository via outils de dépôt (`git status`, `git diff`) et inspection des extraits de fichier avec `nl`/`sed`, sans anomaly détectée.
- Inspection ciblée des fichiers modifiés `page2.html`, `js/app.js` et `css/style.css` pour confirmer l’insertion des éléments et la liaison JS/CSS, et validation que la section est masquée lorsque le total = 0.
- Aucun test unitaire automatisé disponible dans le projet pour ce changement; les vérifications manuelles automatisées ci‑dessus ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0757f23380832ab9e8d575c4815dba)