### PR TITLE
Ajouter total dynamique dans la card de progression (Page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3935,6 +3935,14 @@ body[data-page="site-detail"] .progress-stats-card {
   box-shadow: 0 8px 22px rgba(15, 23, 42, 0.06);
 }
 
+body[data-page="site-detail"] .progress-total {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6b7280;
+  margin-bottom: 12px;
+  opacity: 0.9;
+}
+
 body[data-page="site-detail"] .progress-item {
   margin-bottom: 10px;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -2904,6 +2904,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const itemStatusFilterMenu = document.getElementById('itemStatusFilterMenu');
     const itemStatusFilterOptions = Array.from(document.querySelectorAll('[data-item-status-filter]'));
     const itemProgressStatsCard = document.getElementById('itemProgressStatsCard');
+    const itemProgressTotal = document.getElementById('itemProgressTotal');
     const itemProgressDoneMeta = document.getElementById('itemProgressDoneMeta');
     const itemProgressTodoMeta = document.getElementById('itemProgressTodoMeta');
     const itemProgressFixMeta = document.getElementById('itemProgressFixMeta');
@@ -3937,6 +3938,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const total = doneCount + todoCount + fixCount + koCount;
 
       itemProgressStatsCard.hidden = total <= 0;
+      if (itemProgressTotal) {
+        itemProgressTotal.textContent = `Total • ${total} OUT${total > 1 ? 'S' : ''}`;
+      }
       if (total <= 0) {
         return;
       }

--- a/page2.html
+++ b/page2.html
@@ -65,6 +65,7 @@
             <button class="filter-chip" type="button" data-filter-chip="lastMonth">Plus ancien</button>
           </div>
           <section id="itemProgressStatsCard" class="progress-stats-card" aria-live="polite" hidden>
+            <div id="itemProgressTotal" class="progress-total">Total • 0 OUTS</div>
             <div class="progress-item">
               <div class="progress-header">
                 <span>Terminés</span>


### PR DESCRIPTION
### Motivation
- Afficher un total discret en haut de la card de progression de la Page 2, juste au‑dessus de « Terminés », en réutilisant le total déjà calculé par les filtres.

### Description
- Ajout d’un élément HTML `#itemProgressTotal` dans `page2.html` placé comme première ligne de la card de progression.
- Liaison du nouvel élément via `const itemProgressTotal = document.getElementById('itemProgressTotal')` dans `js/app.js` et mise à jour dynamique dans `updateItemProgressStatsCard` en utilisant `done + todo + fix + ko` sans modifier la logique des filtres.
- Ajout du style discret demandé dans `css/style.css` via la classe `.progress-total` (taille, poids, couleur et marge) pour rester compact et professionnel.
- Aucun changement apporté aux barres de progression, à la recherche, aux cartes OUT ou à la logique des filtres existante.

### Testing
- Inspecté les modifications avec `git diff -- page2.html js/app.js css/style.css` et la sortie correspond aux changements attendus (réussi).
- Validé l’ajout et créé un commit avec `git add ... && git commit -m "Add dynamic total label in page 2 progress card"` (réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075d860c54832a91782dab4caf3183)