### PR TITLE
Page 2: rendre 'Tous' actif visuellement par défaut dans le popup filtre

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3965,8 +3965,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         activeStatusFilter = 'all';
       }
       itemStatusFilterOptions.forEach((option) => {
+        const filterKey = option.dataset.itemStatusFilter || 'all';
         const count = Number(option.querySelector('.page2-filter-option__count')?.textContent || '0');
-        const isDisabled = count <= 0;
+        const isDisabled = filterKey === 'all' ? false : count <= 0;
         option.classList.toggle('is-disabled', isDisabled);
         option.disabled = isDisabled;
         option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
@@ -3976,7 +3977,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function syncItemStatusFilterUi() {
       itemStatusFilterButton?.classList.toggle('is-filtered', activeStatusFilter !== 'all');
       itemStatusFilterOptions.forEach((option) => {
-        const isActive = option.dataset.itemStatusFilter === activeStatusFilter && !option.classList.contains('is-disabled');
+        const isActive = option.dataset.itemStatusFilter === activeStatusFilter;
         option.classList.toggle('is-active', isActive);
         option.setAttribute('aria-checked', isActive ? 'true' : 'false');
       });


### PR DESCRIPTION
### Motivation
- Corriger l’état visuel par défaut du menu filtre de la Page 2 pour que l’option « Tous » apparaisse active par défaut sans toucher à la logique métier, aux compteurs, à la recherche, aux chips ou à Page 3.

### Description
- Modifications uniquement dans `js/app.js` pour empêcher que l’option `all` (« Tous ») soit marquée comme désactivée lorsque son compteur est à `0` en forçant `isDisabled = false` pour `all`.
- Ajustement de la synchronisation UI pour que la classe `is-active` soit appliquée en fonction de la valeur de filtre active sans exclure les éléments marqués `is-disabled`, ce qui permet à « Tous » d’afficher le style actif existant par défaut.
- Aucun changement de la logique de filtrage, des compteurs, de la recherche, des chips ou création de fichiers.

### Testing
- Aucun test automatisé spécifique n’a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0761a08d58832a9d2a4b5408396202)