### PR TITLE
Persist OUT status filter between Page 2 and Page 3 using localStorage

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2899,6 +2899,30 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const cursorFilterReadOutsStorageKey = 'page2_cursor_filter_read_outs';
     const cursorFilterActiveStorageKey = 'page2_cursor_filter_active';
     const activeOutStatusFilterStorageKey = 'activeOutStatusFilter';
+    const uiStatusFilterToStorageValue = {
+      all: 'all',
+      todo: 'pending',
+      fix: 'warning',
+      done: 'completed',
+      ko: 'ko',
+    };
+    const storageValueToUiStatusFilter = {
+      all: 'all',
+      pending: 'todo',
+      warning: 'fix',
+      completed: 'done',
+      ko: 'ko',
+      todo: 'todo',
+      fix: 'fix',
+      done: 'done',
+    };
+    function normalizeStoredOutStatusFilter(value) {
+      const normalized = String(value || '').trim().toLowerCase();
+      return storageValueToUiStatusFilter[normalized] || 'all';
+    }
+    function toStoredOutStatusFilterValue(filterKey) {
+      return uiStatusFilterToStorageValue[filterKey] || 'all';
+    }
     const outPageScrollStorageKey = 'outPageScrollY';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
     const itemStatusFilterButton = document.getElementById('itemStatusFilterButton');
@@ -2930,7 +2954,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       ko: 'K.O',
     };
     const storedCursorFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
-    const storedSharedStatusFilter = window.localStorage.getItem(activeOutStatusFilterStorageKey) || '';
+    const storedSharedStatusFilter = normalizeStoredOutStatusFilter(window.localStorage.getItem(activeOutStatusFilterStorageKey) || '');
     let activeStatusFilter = storedSharedStatusFilter || statusFilterKeyByLabel[storedCursorFilterLabel] || 'all';
     if (!['all', 'todo', 'fix', 'done', 'ko'].includes(activeStatusFilter)) {
       activeStatusFilter = 'all';
@@ -3970,7 +3994,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         activeStatusFilter = 'all';
         try {
           window.localStorage.setItem(cursorFilterActiveStorageKey, statusFilterLabelByKey[activeStatusFilter] || 'Tous');
-          window.localStorage.setItem(activeOutStatusFilterStorageKey, activeStatusFilter);
+          window.localStorage.setItem(activeOutStatusFilterStorageKey, toStoredOutStatusFilterValue(activeStatusFilter));
         } catch (_error) {
           // Ignore localStorage restrictions.
         }
@@ -4015,7 +4039,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       activeStatusFilter = nextFilter;
       try {
         window.localStorage.setItem(cursorFilterActiveStorageKey, statusFilterLabelByKey[activeStatusFilter] || 'Tous');
-        window.localStorage.setItem(activeOutStatusFilterStorageKey, activeStatusFilter);
+        window.localStorage.setItem(activeOutStatusFilterStorageKey, toStoredOutStatusFilterValue(activeStatusFilter));
       } catch (_error) {
         // Ignore localStorage restrictions.
       }
@@ -5224,6 +5248,30 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let designationInputErrorStateTimeoutId = null;
     const cursorFilterActiveStorageKey = 'page2_cursor_filter_active';
     const activeOutStatusFilterStorageKey = 'activeOutStatusFilter';
+    const uiStatusFilterToStorageValue = {
+      all: 'all',
+      todo: 'pending',
+      fix: 'warning',
+      done: 'completed',
+      ko: 'ko',
+    };
+    const storageValueToUiStatusFilter = {
+      all: 'all',
+      pending: 'todo',
+      warning: 'fix',
+      completed: 'done',
+      ko: 'ko',
+      todo: 'todo',
+      fix: 'fix',
+      done: 'done',
+    };
+    function normalizeStoredOutStatusFilter(value) {
+      const normalized = String(value || '').trim().toLowerCase();
+      return storageValueToUiStatusFilter[normalized] || 'all';
+    }
+    function toStoredOutStatusFilterValue(filterKey) {
+      return uiStatusFilterToStorageValue[filterKey] || 'all';
+    }
     const detailFilterKeyByPage2Label = {
       'Tous': 'all',
       'À faire': 'todo',
@@ -5239,9 +5287,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       page2SearchValue = String(window.localStorage.getItem(page2SearchStorageKey) || '').trim();
       page2CursorFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
       const sharedStatusFilter = String(window.localStorage.getItem(activeOutStatusFilterStorageKey) || '').trim();
-      if (['all', 'todo', 'fix', 'done', 'ko'].includes(sharedStatusFilter)) {
-        activeDetailFilter = sharedStatusFilter;
-      }
+      activeDetailFilter = normalizeStoredOutStatusFilter(sharedStatusFilter);
     } catch (_error) {
       page2SearchValue = '';
       page2CursorFilterLabel = 'Tous';
@@ -5810,6 +5856,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const activeCount = Number(activeOption?.querySelector('.page3-filter-option__count')?.textContent || '0');
       if (activeDetailFilter !== 'all' && activeCount <= 0) {
         activeDetailFilter = 'all';
+        try {
+          window.localStorage.setItem(activeOutStatusFilterStorageKey, toStoredOutStatusFilterValue(activeDetailFilter));
+        } catch (_error) {
+          // Ignore localStorage restrictions.
+        }
       }
       detailFilterOptions.forEach((option) => {
         const count = Number(option.querySelector('.page3-filter-option__count')?.textContent || '0');
@@ -5836,7 +5887,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       activeDetailFilter = filterKey;
       try {
-        window.localStorage.setItem(activeOutStatusFilterStorageKey, activeDetailFilter);
+        window.localStorage.setItem(activeOutStatusFilterStorageKey, toStoredOutStatusFilterValue(activeDetailFilter));
       } catch (_error) {
         // Ignore localStorage restrictions.
       }


### PR DESCRIPTION
### Motivation
- Persist the active OUT status filter across Page 2 (site listing) and Page 3 (item details) and across full browser reloads using the requested `localStorage` key `activeOutStatusFilter`.
- Keep the UI synchronization between Page 2 and Page 3 unchanged while ensuring the filter survives page changes and browser restarts.
- Store values in the recommended canonical format while remaining compatible with previously stored UI keys.
- Ensure the UI remains stable when a stored filter points to a disabled option (count 0) by falling back to `all`.

### Description
- Added mapping helpers `uiStatusFilterToStorageValue`, `storageValueToUiStatusFilter`, `normalizeStoredOutStatusFilter` and `toStoredOutStatusFilterValue` in `js/app.js` to translate between UI filter keys and stored values.
- On Page 2 and Page 3 the code now reads `activeOutStatusFilter` from `localStorage` on load and applies the normalized UI filter, and writes the canonical stored value when the user changes the filter via `setItemStatusFilter` and `setDetailFilter`.
- When a restored filter corresponds to a disabled option (count `0`) the code reverts to `all` and updates `localStorage` to the canonical `all` value to avoid broken UI state.
- Changes are limited to a single file (`js/app.js`) and preserve existing search behavior, read/unread handling, counters and the existing Page 2 / Page 3 synchronization logic.

### Testing
- Ran a syntax check with `node --check js/app.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076812a878832aba4859eb4ba41073)