### PR TITLE
Corrige la persistance du filtre actif (Page 2 / Page 3) au rechargement

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2918,7 +2918,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     };
     function normalizeStoredOutStatusFilter(value) {
       const normalized = String(value || '').trim().toLowerCase();
-      return storageValueToUiStatusFilter[normalized] || 'all';
+      return storageValueToUiStatusFilter[normalized] || '';
     }
     function toStoredOutStatusFilterValue(filterKey) {
       return uiStatusFilterToStorageValue[filterKey] || 'all';
@@ -2954,7 +2954,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       ko: 'K.O',
     };
     const storedCursorFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
-    const storedSharedStatusFilter = normalizeStoredOutStatusFilter(window.localStorage.getItem(activeOutStatusFilterStorageKey) || '');
+    const rawStoredSharedStatusFilter = window.localStorage.getItem(activeOutStatusFilterStorageKey) || '';
+    const storedSharedStatusFilter = normalizeStoredOutStatusFilter(rawStoredSharedStatusFilter);
     let activeStatusFilter = storedSharedStatusFilter || statusFilterKeyByLabel[storedCursorFilterLabel] || 'all';
     if (!['all', 'todo', 'fix', 'done', 'ko'].includes(activeStatusFilter)) {
       activeStatusFilter = 'all';
@@ -5267,7 +5268,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     };
     function normalizeStoredOutStatusFilter(value) {
       const normalized = String(value || '').trim().toLowerCase();
-      return storageValueToUiStatusFilter[normalized] || 'all';
+      return storageValueToUiStatusFilter[normalized] || '';
     }
     function toStoredOutStatusFilterValue(filterKey) {
       return uiStatusFilterToStorageValue[filterKey] || 'all';
@@ -5297,7 +5298,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       ? (detailFilterKeyByPage2Label[page2CursorFilterLabel] || 'all')
       : 'all';
     if (!activeDetailFilter) {
-      activeDetailFilter = page2CursorFilterKey;
+      activeDetailFilter = page2CursorFilterKey || 'all';
     }
 
     function setDetailModalOpenState(isOpen) {


### PR DESCRIPTION
### Motivation
- Corriger un bug où le filtre sélectionné (ex. « En attente ») était écrasé au chargement parce que l'initialisation normalisait toujours la valeur sauvée vers `all`.
- Préserver le comportement de synchronisation existant entre Page 2 et Page 3 sans toucher la recherche, les compteurs, le mode lu/non lu ou les chips de date.

### Description
- `normalizeStoredOutStatusFilter` renvoie désormais une chaîne vide `''` pour les valeurs manquantes/invalide au lieu de `all`, afin de différencier "aucune valeur" de "all" (modifications dans les deux blocs Page 2 et Page 3 de `js/app.js`).
- Page 2 lit d'abord la valeur brute `rawStoredSharedStatusFilter` depuis `localStorage` puis applique la valeur normalisée en priorité avant d'utiliser le fallback du curseur (`cursorFilterActiveStorageKey`).
- Page 3 est alignée sur la même logique et le fallback final garantit `page2CursorFilterKey || 'all'` pour éviter une initialisation indéfinie.
- Aucune modification apportée aux compteurs, à la recherche, au mode lu/non lu, aux chips Aujourd'hui/Hier/Plus ancien ou à la synchronisation Page 2/Page 3 existante.

### Testing
- Exécution de `git add js/app.js && git commit -m "Fix persisted out status filter restoration on reload"` qui a réussi (commit créé).
- Vérification de l'état du dépôt avec `git status --short` avant et après commit qui a confirmé les modifications et un working tree propre.
- Aucun test unitaire automatisé présent dans ce patch ; comportement observable à valider en navigation (sélection de filtre + rechargement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076ae78c14832aa0f54d5be2858d03)