### PR TITLE
Corrige la persistance du filtre partagé (activeOutStatusFilter) sur Page 2 et Page 3

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2953,12 +2953,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       done: 'Complété',
       ko: 'K.O',
     };
+    const validOutStatusFilters = ['all', 'todo', 'fix', 'done', 'ko'];
     const storedCursorFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
     const rawStoredSharedStatusFilter = window.localStorage.getItem(activeOutStatusFilterStorageKey) || '';
     const storedSharedStatusFilter = normalizeStoredOutStatusFilter(rawStoredSharedStatusFilter);
-    let activeStatusFilter = storedSharedStatusFilter || statusFilterKeyByLabel[storedCursorFilterLabel] || 'all';
-    if (!['all', 'todo', 'fix', 'done', 'ko'].includes(activeStatusFilter)) {
+    const fallbackStatusFilter = statusFilterKeyByLabel[storedCursorFilterLabel] || 'all';
+    const hasValidStoredSharedStatusFilter = validOutStatusFilters.includes(storedSharedStatusFilter);
+    let activeStatusFilter = hasValidStoredSharedStatusFilter ? storedSharedStatusFilter : fallbackStatusFilter;
+    if (!validOutStatusFilters.includes(activeStatusFilter)) {
       activeStatusFilter = 'all';
+    }
+    if (!hasValidStoredSharedStatusFilter) {
+      try {
+        window.localStorage.setItem(activeOutStatusFilterStorageKey, toStoredOutStatusFilterValue(activeStatusFilter));
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
     }
     const readCursorFilterOuts = new Set();
     itemSearchInput.value = window.localStorage.getItem(searchStorageKey) || '';
@@ -5280,6 +5290,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       'Complété': 'done',
       'K.O': 'ko',
     };
+    const validOutStatusFilters = ['all', 'todo', 'fix', 'done', 'ko'];
     let activeDetailFilter = 'all';
     const page2SearchStorageKey = 'page2_search_value';
     let page2SearchValue = '';
@@ -5288,17 +5299,23 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       page2SearchValue = String(window.localStorage.getItem(page2SearchStorageKey) || '').trim();
       page2CursorFilterLabel = window.localStorage.getItem(cursorFilterActiveStorageKey) || 'Tous';
       const sharedStatusFilter = String(window.localStorage.getItem(activeOutStatusFilterStorageKey) || '').trim();
-      activeDetailFilter = normalizeStoredOutStatusFilter(sharedStatusFilter);
+      const normalizedSharedStatusFilter = normalizeStoredOutStatusFilter(sharedStatusFilter);
+      const hasValidSharedStatusFilter = validOutStatusFilters.includes(normalizedSharedStatusFilter);
+      const hasPage2CursorFilterContext = page2CursorFilterLabel !== 'Tous';
+      const page2CursorFilterKey = hasPage2CursorFilterContext
+        ? (detailFilterKeyByPage2Label[page2CursorFilterLabel] || 'all')
+        : 'all';
+      activeDetailFilter = hasValidSharedStatusFilter ? normalizedSharedStatusFilter : page2CursorFilterKey;
+      if (!validOutStatusFilters.includes(activeDetailFilter)) {
+        activeDetailFilter = 'all';
+      }
+      if (!hasValidSharedStatusFilter) {
+        window.localStorage.setItem(activeOutStatusFilterStorageKey, toStoredOutStatusFilterValue(activeDetailFilter));
+      }
     } catch (_error) {
       page2SearchValue = '';
       page2CursorFilterLabel = 'Tous';
-    }
-    const hasPage2CursorFilterContext = page2CursorFilterLabel !== 'Tous';
-    const page2CursorFilterKey = hasPage2CursorFilterContext
-      ? (detailFilterKeyByPage2Label[page2CursorFilterLabel] || 'all')
-      : 'all';
-    if (!activeDetailFilter) {
-      activeDetailFilter = page2CursorFilterKey || 'all';
+      activeDetailFilter = 'all';
     }
 
     function setDetailModalOpenState(isOpen) {


### PR DESCRIPTION
### Motivation
- La sélection du filtre (ex. « En attente », « À corriger », « Terminés », « K.O ») était perdue au rechargement parce que l’initialisation pouvait écraser la valeur stockée par une valeur dérivée ou invalide.
- Il faut faire de `activeOutStatusFilter` la source de vérité partagée entre Page 2 et Page 3 et ne jamais écraser une valeur valide déjà persistée.

### Description
- Ajout d’une validation explicite `validOutStatusFilters = ['all','todo','fix','done','ko']` pour vérifier les valeurs lues depuis `localStorage` avant usage.
- Page 2 : priorité à la valeur normalisée de `activeOutStatusFilter` si elle est valide, sinon recours au label curseur; on n’écrit dans `localStorage` que si la valeur partagée était absente/invalide (migration/initialisation contrôlée).
- Page 3 : même logique appliquée au bootstrap du filtre de détails pour conserver une unique source de vérité et faire une écriture de migration uniquement si nécessaire.
- Aucune modification des fonctions de synchronisation Page2/Page3, lu/non lu, recherche, compteurs ou chips temps n’a été effectuée.

### Testing
- `node --check js/app.js` a été exécuté et s’est terminé sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076e0405cc832a82765f3c721c7601)