### PR TITLE
Conserver et synchroniser le filtre curseur entre Page 2 et Page 3

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3959,11 +3959,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function enforceItemStatusFilterAvailability() {
-      const activeOption = itemStatusFilterOptions.find((option) => option.dataset.itemStatusFilter === activeStatusFilter);
-      const activeCount = Number(activeOption?.querySelector('.page2-filter-option__count')?.textContent || '0');
-      if (activeStatusFilter !== 'all' && activeCount <= 0) {
-        activeStatusFilter = 'all';
-      }
       itemStatusFilterOptions.forEach((option) => {
         const count = Number(option.querySelector('.page2-filter-option__count')?.textContent || '0');
         const isDisabled = count <= 0;
@@ -3976,7 +3971,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function syncItemStatusFilterUi() {
       itemStatusFilterButton?.classList.toggle('is-filtered', activeStatusFilter !== 'all');
       itemStatusFilterOptions.forEach((option) => {
-        const isActive = option.dataset.itemStatusFilter === activeStatusFilter && !option.classList.contains('is-disabled');
+        const isActive = option.dataset.itemStatusFilter === activeStatusFilter;
         option.classList.toggle('is-active', isActive);
         option.setAttribute('aria-checked', isActive ? 'true' : 'false');
       });
@@ -5217,6 +5212,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       'Complété': 'done',
       'K.O': 'ko',
     };
+    const detailFilterLabelByKey = {
+      all: 'Tous',
+      todo: 'À faire',
+      fix: 'À corriger',
+      done: 'Complété',
+      ko: 'K.O',
+    };
     let activeDetailFilter = 'all';
     const page2SearchStorageKey = 'page2_search_value';
     let page2SearchValue = '';
@@ -5786,11 +5788,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function enforceDetailFilterAvailability() {
-      const activeOption = detailFilterOptions.find((option) => option.dataset.detailFilter === activeDetailFilter);
-      const activeCount = Number(activeOption?.querySelector('.page3-filter-option__count')?.textContent || '0');
-      if (activeDetailFilter !== 'all' && activeCount <= 0) {
-        activeDetailFilter = 'all';
-      }
       detailFilterOptions.forEach((option) => {
         const count = Number(option.querySelector('.page3-filter-option__count')?.textContent || '0');
         const isDisabled = count <= 0;
@@ -5803,7 +5800,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function syncDetailFilterUi() {
       detailFilterButton?.classList.toggle('is-filtered', activeDetailFilter !== 'all');
       detailFilterOptions.forEach((option) => {
-        const isActive = option.dataset.detailFilter === activeDetailFilter && !option.classList.contains('is-disabled');
+        const isActive = option.dataset.detailFilter === activeDetailFilter;
         option.classList.toggle('is-active', isActive);
         option.setAttribute('aria-checked', isActive ? 'true' : 'false');
       });
@@ -5815,6 +5812,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
       activeDetailFilter = filterKey;
+      try {
+        window.localStorage.setItem(cursorFilterActiveStorageKey, detailFilterLabelByKey[activeDetailFilter] || 'Tous');
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
       syncDetailFilterUi();
       renderTable();
     }


### PR DESCRIPTION
### Motivation
- Empêcher la perte d’état du filtre curseur sur Page 2 et Page 3 lorsque l’utilisateur change d’onglet date, fait un refresh, scrolle ou revient sur la page. 
- Utiliser le même stockage local (`page2_cursor_filter_active`) pour que la sélection soit partagée et synchronisée entre Page 2 et Page 3. 

### Description
- Ajout de la table inverse `detailFilterLabelByKey` pour mapper les clés de filtre vers leurs libellés affichés (`js/app.js`).
- Persistance de la sélection utilisateur depuis Page 3 en écrivant dans la même clé localStorage `page2_cursor_filter_active` dans la fonction `setDetailFilter(...)`.
- Suppression du reset automatique du filtre vers `Tous` quand le compteur d’un filtre tombe à 0 dans les vérifications d’accessibilité des filtres pour Page 2 et Page 3, afin de préserver le choix utilisateur lors des rerenders.
- Ajustement de la synchronisation UI (`is-active` / `aria-checked`) pour conserver visuellement l’option active même si son compteur devient 0, sans modifier d’autres pages/comportements.

### Testing
- Exécutions de recherche et inspections de fichiers avec `rg --files | head -n 200` ont réussi et listent les fichiers du projet. (succès)
- Vérifications ciblées avec `rg -n "À faire|A faire|corriger|Complété|K.O|filtre|cursor|curseur|Tous" js page2.html page3.html` ont réussi et montrent les occurrences modifiées. (succès)
- Vérification des nouvelles références avec `rg -n "detailFilterLabelByKey|setItem\(cursorFilterActiveStorageKey|isActive = option.dataset.(itemStatusFilter|detailFilter) ===|enforce(ItemStatus|Detail)FilterAvailability" js/app.js` a réussi. (succès)
- Le patch a été appliqué et commité (`git commit`) sur `js/app.js` avec message descriptif. (succès)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077377b15c832aaba83e423cd4d3c6)