### PR TITLE
Reorder 'Terminés' filter to follow 'Tous' on Page 2 and Page 3

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -43,9 +43,9 @@
               </button>
               <div id="itemStatusFilterMenu" class="page2-filter-menu" role="menu" hidden>
                 <button type="button" class="page2-filter-option is-active" data-item-status-filter="all" role="menuitemradio" aria-checked="true"><span class="page2-filter-option__label">Tous</span><span class="page2-filter-option__count">0</span></button>
+                <button type="button" class="page2-filter-option" data-item-status-filter="done" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">Terminés</span><span class="page2-filter-option__count">0</span></button>
                 <button type="button" class="page2-filter-option" data-item-status-filter="todo" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">En attente</span><span class="page2-filter-option__count">0</span></button>
                 <button type="button" class="page2-filter-option" data-item-status-filter="fix" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">À corriger</span><span class="page2-filter-option__count">0</span></button>
-                <button type="button" class="page2-filter-option" data-item-status-filter="done" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">Terminés</span><span class="page2-filter-option__count">0</span></button>
                 <button type="button" class="page2-filter-option" data-item-status-filter="ko" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">K.O</span><span class="page2-filter-option__count">0</span></button>
               </div>
             </div>

--- a/page3.html
+++ b/page3.html
@@ -56,9 +56,9 @@
               </button>
               <div id="detailFilterMenu" class="page3-filter-menu" role="menu" hidden>
                 <button type="button" class="page3-filter-option is-active" data-detail-filter="all" role="menuitemradio" aria-checked="true"><span class="page3-filter-option__label">Tous</span><span class="page3-filter-option__count">0</span></button>
+                <button type="button" class="page3-filter-option" data-detail-filter="done" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">Terminés</span><span class="page3-filter-option__count">0</span></button>
                 <button type="button" class="page3-filter-option" data-detail-filter="todo" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">En attente</span><span class="page3-filter-option__count">0</span></button>
                 <button type="button" class="page3-filter-option" data-detail-filter="fix" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">À corriger</span><span class="page3-filter-option__count">0</span></button>
-                <button type="button" class="page3-filter-option" data-detail-filter="done" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">Terminés</span><span class="page3-filter-option__count">0</span></button>
                 <button type="button" class="page3-filter-option" data-detail-filter="ko" role="menuitemradio" aria-checked="false"><span class="page3-filter-option__label">K.O</span><span class="page3-filter-option__count">0</span></button>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Move the “Terminés” filter to appear directly below “Tous” in the status filter menus on Page 2 and Page 3 while keeping all existing behavior, counters, colors and storage mappings unchanged.

### Description
- Updated only the HTML markup in `page2.html` and `page3.html` to place the `done` (`Terminés`) filter button immediately after the `all` (`Tous`) button, preserving the same `data-*` attributes, labels, counters and JS hooks.

### Testing
- Verified the change by inspecting the modified HTML blocks and file diffs; only the display order of existing buttons changed and no business logic, localStorage keys or runtime behavior were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ebfa5c4c832aaae781eccabea02d)