### PR TITLE
Améliorer l’état vide de recherche sur Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6172,3 +6172,29 @@ body[data-page="item-detail"] .search-highlight {
   padding: 0 2px;
   font-weight: 700;
 }
+
+.empty-search-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 20px 16px;
+}
+
+.empty-search-state img {
+  width: 110px;
+  height: auto;
+  object-fit: contain;
+  margin-bottom: 14px;
+  opacity: 0.92;
+  pointer-events: none;
+  user-select: none;
+}
+
+.empty-search-state .empty-text {
+  color: #6b7280;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.45;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -3701,10 +3701,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       itemCount.innerHTML = `<span class="outs-number">${filteredItems.length}</span><span class="outs-label">OUT${filteredItems.length > 1 ? 'S' : ''}</span>`;
 
       if (!filteredItems.length) {
-        UiService.renderEmptyState(
-          itemList,
-          query ? 'Aucun N° OUT Ou Article correspond à votre recherche.' : 'Aucune Article Disponible.',
-        );
+        if (query) {
+          itemList.innerHTML = `
+            <div class="empty-state empty-search-state">
+              <img src="Icon/Stikers.png" alt="" aria-hidden="true" loading="lazy" decoding="async" />
+              <div class="empty-text">Aucun N° OUT Ou Article correspond à votre recherche.</div>
+            </div>
+          `;
+        } else {
+          UiService.renderEmptyState(itemList, 'Aucune Article Disponible.');
+        }
         return;
       }
 


### PR DESCRIPTION
### Motivation
- Améliorer l’expérience visuelle lorsque la recherche sur la Page 2 (onglet OUT) ne retourne aucun résultat en ajoutant une illustration discrète au-dessus du message vide existant.
- Utiliser uniquement une image déjà présente dans le dépôt pour rester conforme aux contraintes de projet.
- Conserver intacte la logique de recherche, les filtres, le mode lu/non lu, le FAB et le style global de la page.

### Description
- Dans `js/app.js` la branche où `filteredItems.length === 0` a été ajustée pour, quand `query` est non vide, injecter directement dans `itemList` un bloc HTML `.empty-state.empty-search-state` contenant l’image `Icon/Stikers.png` puis le texte `Aucun N° OUT Ou Article correspond à votre recherche.`.
- Dans `css/style.css` ajout des règles `.empty-search-state`, `.empty-search-state img` et `.empty-search-state .empty-text` pour centrer l’illustration, définir une taille modérée et appliquer un style discret, minimaliste et premium conforme à la recommandation fournie.
- Aucun fichier ajouté, aucune image générée et aucun autre comportement ou page (notamment Page 3) modifié.

### Testing
- Recherche par motifs avec `rg -n "empty-search-state|Stikers|Aucun N° OUT Ou Article" js/app.js css/style.css` a confirmé la présence des nouvelles classes et du chemin d’image et a réussi.
- Inspection des lignes modifiées avec `nl -ba js/app.js` et `nl -ba css/style.css` a vérifié l’insertion attendue du HTML et des règles CSS et a réussi.
- Vérification de l’état du dépôt avec `git status --short` a montré les fichiers modifiés (`js/app.js` et `css/style.css`) et a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f3c386a8832a899cde8dc6a041fc)