### PR TITLE
Improve Page 2 empty state with centered existing icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1994,6 +1994,29 @@ body[data-page="home"] .modal-actions--password:not(.modal-actions--password-man
   background: rgba(255, 255, 255, 0.72);
 }
 
+body[data-page="site-detail"] .empty-state--page2 {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: clamp(14rem, 42vh, 22rem);
+  padding: clamp(2.4rem, 7vh, 4.25rem) 1.25rem;
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+body[data-page="site-detail"] .empty-state--page2 .empty-state__icon {
+  width: clamp(5.5rem, 22vw, 6rem);
+  height: auto;
+  opacity: 0.74;
+}
+
+body[data-page="site-detail"] .empty-state--page2 .empty-text {
+  text-align: center;
+  font-weight: 500;
+}
+
 .responsive-form {
   display: grid;
   grid-template-columns: 1fr;

--- a/js/app.js
+++ b/js/app.js
@@ -3709,7 +3709,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             </div>
           `;
         } else {
-          UiService.renderEmptyState(itemList, 'Aucune Article Disponible.');
+          itemList.innerHTML = `
+            <div class="empty-state empty-state--page2" role="status" aria-live="polite">
+              <img src="Icon/boite.png" alt="" aria-hidden="true" loading="lazy" decoding="async" class="empty-state__icon" />
+              <div class="empty-text">Aucune Article Disponible.</div>
+            </div>
+          `;
         }
         return;
       }


### PR DESCRIPTION
### Motivation
- Améliorer l’état vide de la Page 2 pour afficher l’icône existante `Icon/boite.png` centrée au‑dessus du libellé sans modifier la logique métier, les filtres, la recherche, le FAB ou le layout global.

### Description
- Remplacé l’appel générique `UiService.renderEmptyState(...)` dans `js/app.js` pour Page 2 par un markup dédié qui inclut l’image `Icon/boite.png` au‑dessus du texte `Aucune Article Disponible.`.
- Ajouté du style scopié dans `css/style.css` sous `body[data-page="site-detail"] .empty-state--page2` appliquant `display:flex`, `flex-direction:column`, `align-items:center`, `justify-content:center`, espacement vertical, taille contrainte et opacité légère pour un rendu moderne/minimaliste.

### Testing
- Exécuté les contrôles automatiques `git status --short`, `git diff -- js/app.js css/style.css` et `git commit -m "Improve Page 2 empty state with existing box icon"`, toutes les commandes ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f7be81cc832a8644812f69383e3c)