### PR TITLE
Ajoute l’icône au bouton « Déconnexion » du bottom sheet profil

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3776,7 +3776,19 @@ body[data-page="home"] .app-header--home > h1 {
   border-radius: 12px;
   padding: 0.625rem 1.25rem;
   margin-top: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
   transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.bottom-sheet__action-icon {
+  width: 19px;
+  height: 19px;
+  object-fit: contain;
+  opacity: 0.86;
+  display: block;
 }
 
 .bottom-sheet__action:hover,

--- a/js/app.js
+++ b/js/app.js
@@ -829,7 +829,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <div class="bottom-sheet__avatar" id="avatarSheetPreview">U</div>
           </div>
           <p class="bottom-sheet__name" id="avatarSheetName">Utilisateur</p>
-          <button type="button" class="bottom-sheet__action" id="avatarSheetLogout">Déconnexion</button>
+          <button type="button" class="bottom-sheet__action" id="avatarSheetLogout">
+            <img src="Icon/se-deconnecter.png" alt="" class="bottom-sheet__action-icon" aria-hidden="true">
+            <span>Déconnexion</span>
+          </button>
           <p id="avatarSheetMessage" class="form-error" aria-live="polite"></p>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Améliorer l’apparence du bouton `Déconnexion` dans le bottom sheet profil en ajoutant l’icône existante pour un rendu moderne et aligné sans changer la logique de déconnexion.

### Description
- `js/app.js` : le bouton `#avatarSheetLogout` conserve son `id` et sa fonction et son contenu HTML devient `<img src="Icon/se-deconnecter.png" ...>` suivi d’un `<span>Déconnexion</span>` pour réaliser la structure `[icon] Déconnexion`.
- `css/style.css` : la classe `.bottom-sheet__action` passe en `display: inline-flex` avec `align-items: center`, `justify-content: center` et `gap: 10px` pour un alignement et un espacement propre entre icône et texte.
- `css/style.css` : ajout de la règle `.bottom-sheet__action-icon` avec `width: 19px`, `height: 19px`, `object-fit: contain` et `opacity: 0.86` pour un rendu premium sans créer de nouveau fichier image.
- Toutes les modifications sont purement visuelles et n’altèrent pas la logique de déconnexion, le layout global ni les autres boutons du projet.

### Testing
- Vérification que l’icône existe via `rg --files` et présence de `Icon/se-deconnecter.png`, résultat OK.
- Recherche ciblée `rg -n "Déconnexion|avatarSheetLogout|se-deconnecter|bottom-sheet__action-icon" -S js/app.js css/style.css` pour valider l’insertion et les styles, résultat OK.
- Contrôle de l’état des fichiers modifiés avec `git status --short` pour confirmer les changements appliqués, résultat OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083d988154832ab59f89315cd6e777)