### PR TITLE
feat(profile): afficher l'e-mail dans le bottom sheet utilisateur

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3750,6 +3750,17 @@ body[data-page="home"] .app-header--home > h1 {
   text-align: center;
 }
 
+
+.bottom-sheet__email {
+  margin: 6px 0 20px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #7d8592;
+  text-align: center;
+  line-height: 1.35;
+  max-width: min(88vw, 320px);
+  word-break: break-word;
+}
 .bottom-sheet__avatar-edit {
   position: absolute;
   right: -0.15rem;

--- a/js/app.js
+++ b/js/app.js
@@ -829,6 +829,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             <div class="bottom-sheet__avatar" id="avatarSheetPreview">U</div>
           </div>
           <p class="bottom-sheet__name" id="avatarSheetName">Utilisateur</p>
+          <p class="bottom-sheet__email" id="avatarSheetEmail"></p>
           <button type="button" class="bottom-sheet__action" id="avatarSheetLogout">
             <img src="Icon/se-deconnecter.png" alt="" class="bottom-sheet__action-icon" aria-hidden="true">
             <span>Déconnexion</span>
@@ -927,15 +928,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const sheet = overlay.querySelector('#avatarBottomSheet');
     const avatarPreview = overlay.querySelector('#avatarSheetPreview');
     const nameLabel = overlay.querySelector('#avatarSheetName');
+    const emailLabel = overlay.querySelector('#avatarSheetEmail');
     const logoutButton = overlay.querySelector('#avatarSheetLogout');
     const message = overlay.querySelector('#avatarSheetMessage');
 
-    if (!sheet || !avatarPreview || !nameLabel || !logoutButton || !message) {
+    if (!sheet || !avatarPreview || !nameLabel || !emailLabel || !logoutButton || !message) {
       return;
     }
 
     renderUserAvatar(authUserData);
     nameLabel.textContent = String(authUserData?.name || authUserData?.email || 'Utilisateur');
+    emailLabel.textContent = String(authUserData?.email || '');
     avatarPreview.title = authUserData?.name || authUserData?.email || '';
     message.textContent = '';
 


### PR DESCRIPTION
### Motivation
- Afficher l’adresse e-mail de l’utilisateur directement dans le bottom sheet profil sous le nom pour améliorer l’identification de l’utilisateur.
- Conserver le bouton `Déconnexion` et la logique existante sans toucher à Firebase Auth.

### Description
- Ajout d’un élément HTML `#avatarSheetEmail` dans le bottom sheet et insertion entre le nom et le bouton Déconnexion dans `js/app.js`.
- Récupération et affectation automatique de l’e-mail via `authUserData?.email` dans la fonction `openAvatarBottomSheet` sans modifier la logique de logout.
- Ajout de la classe CSS `.bottom-sheet__email` dans `css/style.css` avec les styles recommandés (`font-size: 14px`, `font-weight: 500`, `color: #7d8592`, `margin-top: 6px`, `margin-bottom: 20px`, centrage et responsive).

### Testing
- Aucun test automatisé n’a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083fad37c0832aa253a531261b28a7)