### PR TITLE
Compact sticky header sizing across all pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@
   --radius-lg: 24px;
   --radius-md: 16px;
   --radius-sm: 12px;
-  --header-height: 5.75rem;
+  --header-height: 4.85rem;
   --header-side-width: 3rem;
   --primary-color: #2e6ce5;
   --content-max-width: 820px;
@@ -3506,14 +3506,17 @@ body[data-page="item-detail"] .meta-value {
   --header-gradient-top: #66beff;
   --header-gradient-bottom: #2f89d8;
   --header-shadow: 0 8px 22px rgba(17, 58, 94, 0.18);
-  --header-title-size: clamp(1.08rem, 3.7vw, 1.5rem);
-  --header-subtitle-size: clamp(0.8rem, 2.6vw, 0.95rem);
+  --header-title-size: clamp(1rem, 3.5vw, 1.35rem);
+  --header-subtitle-size: clamp(0.76rem, 2.45vw, 0.9rem);
+  --header-padding-y: 0.58rem;
+  --header-padding-x: clamp(0.75rem, 2.6vw, 1.1rem);
+  --header-title-gap: 0.16rem;
 }
 
 .app-header {
   min-height: var(--header-height);
   height: var(--header-height);
-  padding: 0.75rem clamp(0.75rem, 2.6vw, 1.1rem);
+  padding: var(--header-padding-y) var(--header-padding-x);
   background: linear-gradient(180deg, var(--header-gradient-top) 0%, var(--header-gradient-bottom) 100%);
   box-shadow: var(--header-shadow);
   border-bottom: 1px solid rgba(255, 255, 255, 0.24);
@@ -3576,7 +3579,7 @@ body[data-page="item-detail"] .meta-value {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.22rem;
+  gap: var(--header-title-gap);
 }
 
 .header-title--stacked h1 {
@@ -5671,7 +5674,7 @@ body[data-page="site-detail"] .list-separator {
 .app-header {
   min-height: var(--header-height);
   height: var(--header-height);
-  padding: 0.75rem clamp(0.75rem, 2.6vw, 1.1rem);
+  padding: var(--header-padding-y) var(--header-padding-x);
   background: linear-gradient(180deg, #66beff 0%, #2f89d8 100%);
   box-shadow: 0 8px 22px rgba(17, 58, 94, 0.18);
   border-bottom: 1px solid rgba(255, 255, 255, 0.24);
@@ -5720,7 +5723,7 @@ body[data-page="site-detail"] .list-separator {
 .header-title h1 {
   margin: 0;
   width: 100%;
-  font-size: clamp(1.08rem, 3.7vw, 1.5rem);
+  font-size: var(--header-title-size);
   font-weight: 700;
   color: #ffffff;
   text-align: center;
@@ -5732,7 +5735,7 @@ body[data-page="site-detail"] .list-separator {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.22rem;
+  gap: var(--header-title-gap);
 }
 
 .header-title--stacked h1 {
@@ -5743,7 +5746,7 @@ body[data-page="site-detail"] .list-separator {
   margin: 0;
   width: 100%;
   text-align: center;
-  font-size: clamp(0.8rem, 2.6vw, 0.95rem);
+  font-size: var(--header-subtitle-size);
   font-weight: 500;
   line-height: 1.2;
   color: rgba(255, 255, 255, 0.9);


### PR DESCRIPTION
### Motivation
- Reduce the vertical footprint of the sticky header by ~15–20% across all pages while preserving the existing visual design, sticky behavior, shadow, blur, animations and button/avatar positions.

### Description
- Decreased the global header height by changing `--header-height` from `5.75rem` to `4.85rem` in `css/style.css`.
- Added shared CSS variables `--header-title-size`, `--header-subtitle-size`, `--header-padding-y`, `--header-padding-x`, and `--header-title-gap` to control title size, subtitle size, vertical padding and stacked gap consistently.
- Replaced hardcoded padding, title font-size and stacked gap in `.app-header`, `.header-title h1`, `.header-title--stacked` and `.site-detail-subtitle` with the new variables so all page headers keep identical, compact sizing while preserving backgrounds, shadows and layout.
- All changes are confined to `css/style.css` and do not modify page content, cards, tables or sticky calculations.

### Testing
- Inspected the stylesheet diff with `git diff -- css/style.css` to verify only spacing and typography tokens were changed and this check succeeded.
- Committed the change with `git commit` and the commit completed successfully.
- No automated visual/regression tests were run in this rollout; manual inspection of the diff was used to confirm only header sizing variables were updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0844052afc832a93eeb74bc93f8896)