### PR TITLE
Reduce sticky header height globally (~16%) via CSS variables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@
   --radius-lg: 24px;
   --radius-md: 16px;
   --radius-sm: 12px;
-  --header-height: 4.85rem;
+  --header-height: 4.05rem;
   --header-side-width: 3rem;
   --primary-color: #2e6ce5;
   --content-max-width: 820px;
@@ -3506,11 +3506,11 @@ body[data-page="item-detail"] .meta-value {
   --header-gradient-top: #66beff;
   --header-gradient-bottom: #2f89d8;
   --header-shadow: 0 8px 22px rgba(17, 58, 94, 0.18);
-  --header-title-size: clamp(1rem, 3.5vw, 1.35rem);
-  --header-subtitle-size: clamp(0.76rem, 2.45vw, 0.9rem);
-  --header-padding-y: 0.58rem;
+  --header-title-size: clamp(0.9rem, 3.1vw, 1.15rem);
+  --header-subtitle-size: clamp(0.7rem, 2.2vw, 0.82rem);
+  --header-padding-y: 0.48rem;
   --header-padding-x: clamp(0.75rem, 2.6vw, 1.1rem);
-  --header-title-gap: 0.16rem;
+  --header-title-gap: 0.12rem;
 }
 
 .app-header {
@@ -5478,12 +5478,12 @@ body[data-page="site-detail"] .app-header--detail {
   --detail-side-size: clamp(2.5rem, 7.8vw, 2.75rem);
   min-height: var(--header-height);
   height: var(--header-height);
-  padding: 0.75rem clamp(0.75rem, 2.3vw, 1.2rem);
+  padding: 0.62rem clamp(0.75rem, 2.3vw, 1.2rem);
   background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   display: grid;
   grid-template-columns: var(--detail-side-size) minmax(0, 1fr) var(--detail-side-size);
   align-items: center;
-  gap: clamp(0.4rem, 1.4vw, 0.8rem);
+  gap: clamp(0.32rem, 1.1vw, 0.62rem);
   position: sticky;
   top: 0;
 }


### PR DESCRIPTION
### Motivation
- Rendre l’interface des headers plus compacte et plus premium en gagnant ~15–20% d’espace vertical sans toucher au design visuel ni aux comportements existants.
- Appliquer une réduction uniforme sur tous les headers sticky pour garantir une cohérence professionnelle entre les pages.
- Conserver exactement le fond bleu, les ombres, le blur, l’effet sticky, les alignements, les boutons, l’avatar et les animations existantes.

### Description
- Modifié `css/style.css` pour réduire la variable globale `--header-height` de `4.85rem` à `4.05rem` afin d’obtenir l’effet de compactage global.
- Ajusté les variables de mise en forme du header : `--header-title-size`, `--header-subtitle-size`, `--header-padding-y` et `--header-title-gap` pour réduire légèrement la taille du titre, le padding vertical et l’espacement titre/sous-titre.
- Affiné les règles spécifiques à la page de détail (`body[data-page="site-detail"] .app-header--detail`) en diminuant le `padding` vertical et le `gap` interne pour préserver l’apparence des pages de type Page 2.
- Aucun contenu métier, card, tableau ou markup HTML n’a été modifié ; seuls des variables et règles CSS dans `css/style.css` ont été mis à jour.

### Testing
- Il n’y a pas de tests automatisés pour le style dans ce dépôt, donc aucun test automatisé n’a été exécuté pour ces changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084811ca2c832aa8bc68a73d15bb38)