### PR TITLE
Ajuste la bottom navigation pour un layout plus compact

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4492,8 +4492,8 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   display: flex;
   align-items: center;
   justify-content: space-around;
-  height: calc(72px + env(safe-area-inset-bottom));
-  padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
+  height: calc(64px + env(safe-area-inset-bottom));
+  padding: 6px 12px calc(6px + env(safe-area-inset-bottom));
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(12px);
   border-top: 1px solid rgba(15, 23, 42, 0.08);
@@ -4502,16 +4502,16 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
 
 .bottom-nav-item {
   flex: 1;
-  height: 56px;
+  height: 50px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 3px;
   border: none;
   background: transparent;
   color: #64748b;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 700;
   border-radius: 18px;
   transition: all 0.25s ease;
@@ -4523,19 +4523,19 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
 }
 
 .bottom-nav-icon {
-  font-size: 20px;
+  font-size: 18px;
   line-height: 1;
 }
 
 .bottom-nav-icon img {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   object-fit: contain;
   display: block;
 }
 
 .bottom-nav-label {
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1;
 }
 
@@ -4543,7 +4543,7 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
 .page2 #createOutFab,
 body.page2 .fab,
 body.page2 #createOutFab {
-  bottom: calc(92px + env(safe-area-inset-bottom)) !important;
+  bottom: calc(84px + env(safe-area-inset-bottom)) !important;
   z-index: 1001 !important;
 }
 
@@ -4551,7 +4551,7 @@ body.page2 #createOutFab {
 .page2 .page-content,
 .page2 .outs-list,
 body.page2 main {
-  padding-bottom: calc(110px + env(safe-area-inset-bottom)) !important;
+  padding-bottom: calc(102px + env(safe-area-inset-bottom)) !important;
 }
 
 body[data-page="site-detail"] .bottom-nav-item.hidden,


### PR DESCRIPTION
### Motivation
- Rendre la bottom navigation plus compacte et harmonisée avec le nouveau header compact tout en gardant l’expérience tactile et l’aspect premium.
- Ne modifier que l’apparence verticale (hauteur, paddings, tailles visuelles) sans toucher à la logique de navigation ni au FAB.

### Description
- Réduit la hauteur de la barre principale `bottom-navigation` de `72px` à `64px` et diminue le padding vertical de `8px` à `6px` dans `css/style.css`.
- Compacte les items : `bottom-nav-item` passe de `56px` à `50px`, `gap` de `4px` à `3px`, et `font-size` de `13px` à `12px`.
- Diminue les icônes `bottom-nav-icon` et leurs images de `20px` à `18px`, et ajuste `bottom-nav-label` à `12px`.
- Ajuste l’offset du FAB sur la page concernée de `bottom: calc(92px...)` à `bottom: calc(84px...)` et réduit le `padding-bottom` du contenu page2 de `110px` à `102px` pour préserver le positionnement visuel.

### Testing
- Exécuté `git diff` sur `css/style.css` pour vérifier les modifications et la conservation des propriétés non modifiées, sortie OK.
- Exécuté `git add` + `git commit` pour enregistrer le changement, commit créé avec succès.
- Inspecté le fichier final avec `nl -ba css/style.css | sed -n '4486,4560p'` pour valider les valeurs appliquées et la cohérence du fichier; vérification OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084ad8ee58832aad2e300ce875652e)