### PR TITLE
Centre l'alignement des colonnes d'export Excel (Page 2 & 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -523,7 +523,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   }
 
   function applyProfessionalExcelStyling(worksheet) {
-    const centeredColumns = [4, 6, 7, 8, 9, 10, 11];
+    const centeredColumns = [4, 5, 6, 7, 8, 9, 10, 12];
     const wrappedColumns = [3, 11];
     const headerRow = worksheet.getRow(1);
 


### PR DESCRIPTION
### Motivation
- Aligner horizontalement et verticalement les colonnes Qté Sortie, Unité, Qté posée, Qté Rebus, Qté Retour, Date de retour, Ecart et Statut dans les exports Excel Page 2 et Page 3 sans modifier les données, largueurs ou structure du fichier.

### Description
- Mise à jour de la configuration d'alignement dans `applyProfessionalExcelStyling` (`js/app.js`) en modifiant la liste `centeredColumns` de `[4, 6, 7, 8, 9, 10, 11]` à `[4, 5, 6, 7, 8, 9, 10, 12]` pour appliquer `horizontal: 'center'` et `vertical: 'middle'` à ces colonnes.

### Testing
- Commandes de validation automatisées exécutées : `git diff -- js/app.js` (vérification du diff restreint) et `git commit` (commit réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09054e0f6c832aac616bd6787f5494)