### PR TITLE
Fix Excel data-cell centering for Page 2 and Page 3 exports

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -537,7 +537,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     headerRow.height = 24;
 
     worksheet.eachRow((row, rowNumber) => {
-      row.eachCell((cell, colNumber) => {
+      row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
         const isCentered = centeredColumns.includes(colNumber);
         cell.alignment = {
           vertical: 'middle',
@@ -555,6 +555,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (rowNumber > 1) {
         row.height = computeWrappedRowHeightFromValues([row.getCell(3).value, row.getCell(11).value]);
       }
+    });
+
+    centeredColumns.forEach((columnNumber) => {
+      worksheet.getColumn(columnNumber).eachCell({ includeEmpty: true }, (cell, rowNumber) => {
+        if (rowNumber === 1) {
+          return;
+        }
+        cell.alignment = {
+          ...(cell.alignment || {}),
+          horizontal: 'center',
+          vertical: 'middle',
+        };
+      });
     });
   }
 
@@ -577,7 +590,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         { header: 'Remarque', key: 'observation', width: 14 },
         { header: 'Statut', key: 'statut', width: 14 },
       ];
-      applyProfessionalExcelStyling(worksheet);
       details.forEach((detail) => {
         worksheet.addRow({
           champ: formatExcelCellValue(detail.champ),
@@ -594,6 +606,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           statut: formatExcelCellValue(normalizeDetailStatut(detail.statut)),
         });
       });
+      applyProfessionalExcelStyling(worksheet);
       return workbook;
     };
   }
@@ -617,7 +630,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         { header: 'Remarque', key: 'observation', width: 14 },
         { header: 'Statut', key: 'statut', width: 14 },
       ];
-      applyProfessionalExcelStyling(worksheet);
       rows.forEach((row) => {
         worksheet.addRow({
           out: formatExcelCellValue(row.out),
@@ -634,6 +646,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           statut: formatExcelCellValue(normalizeDetailStatut(row.statut)),
         });
       });
+      applyProfessionalExcelStyling(worksheet);
       return workbook;
     };
   }


### PR DESCRIPTION
### Motivation
- L’export Excel appliquait le style avant l’insertion des lignes, ce qui laissait les cellules de données avec l’alignement par défaut d’Excel (généralement à gauche). 
- Il faut garantir que les colonnes de données listées soient réellement centrées sur CHAQUE cellule et sur TOUTES les lignes exportées, pas seulement le header.

### Description
- La fonction `applyProfessionalExcelStyling(worksheet)` utilise désormais `row.eachCell({ includeEmpty: true }, ...)` pour appliquer alignement et bordures systématiquement à toutes les cellules des lignes exportées. 
- Une passe explicite par colonne a été ajoutée via `worksheet.getColumn(...).eachCell({ includeEmpty: true }, ...)` pour forcer `horizontal: 'center'` et `vertical: 'middle'` sur toutes les cellules de données (hors header) des colonnes ciblées. 
- L’appel à `applyProfessionalExcelStyling(worksheet)` a été déplacé pour s’exécuter **après** l’insertion de toutes les lignes dans `buildDetailExcelContent` et `buildSiteExcelContent`, garantissant que le style n’est pas écrasé par des ajouts ultérieurs. 
- Les colonnes ciblées correspondent aux champs demandés : `Qté Sortie`, `Unité`, `Qté posée`, `Qté Rebus`, `Qté Retour`, `Date de retour`, `Ecart` et `Statut`, et aucune donnée, largeur, couleur ou tri n’a été modifié.

### Testing
- `node --check js/app.js` a été exécuté et la vérification de syntaxe a réussi. 
- Le fichier modifié a été passé par une validation locale de cohérence et ne provoque pas d’erreur de parsing lors du chargement du bundle JavaScript.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09092ecf2c832a8aaf8e401f83c223)