### PR TITLE
Centrer la colonne « Remarque » sur la Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3310,6 +3310,11 @@ body[data-page="item-detail"] .cell-input--compact-dynamic {
 
 body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="observation"] {
   min-width: 88px;
+  text-align: center;
+}
+
+body[data-page="item-detail"] .data-table th:nth-child(11) {
+  text-align: center;
 }
 
 body[data-page="item-detail"] .date-retour-field {


### PR DESCRIPTION
### Motivation
- La colonne « Remarque » du tableau de données en Page 3 n’était pas centrée comme les autres colonnes numériques, il faut réutiliser le système CSS existant pour uniformiser l’alignement sans altérer le comportement existant des champs.

### Description
- Ajout de `text-align: center;` à la règle existante `body[data-page="item-detail"] .cell-input--compact-dynamic[data-col-key="observation"]` pour centrer le contenu des cellules Remarque tout en conservant l’auto-resize et le comportement input actuel.
- Ajout de `body[data-page="item-detail"] .data-table th:nth-child(11) { text-align: center; }` pour centrer l’en-tête « Remarque ». 
- Seul le fichier `css/style.css` a été modifié et aucune logique JavaScript ni autre style de colonne n’a été touchée.

### Testing
- Local search/inspection via `rg` and `sed` a été utilisé pour localiser et vérifier les sélecteurs ciblés et la zone modifiée, et ces commandes se sont exécutées avec succès. 
- Le fichier a été mis à jour avec un script Python et la modification a été validée par `git status` et `git commit`, et le commit s’est terminé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090be75d14832aaec2af43a94fb5ef)