### PR TITLE
Améliore la visibilité des lignes K.O dans les exports Excel (Page 2 & 3)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -525,6 +525,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   function applyProfessionalExcelStyling(worksheet) {
     const centeredColumns = [4, 5, 6, 7, 8, 9, 10, 11, 12];
     const wrappedColumns = [3];
+    const statusColumnNumber = 12;
+    const koRowFill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FFFFF1F1' },
+    };
     const headerRow = worksheet.getRow(1);
 
     headerRow.font = { bold: true, color: { argb: 'FF1F2937' } };
@@ -553,6 +559,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
 
       if (rowNumber > 1) {
+        const statusValue = String(row.getCell(statusColumnNumber).value || '').trim().toUpperCase();
+        if (statusValue === 'K.O') {
+          row.eachCell({ includeEmpty: true }, (cell) => {
+            cell.fill = koRowFill;
+          });
+        }
         row.height = computeWrappedRowHeightFromValues([row.getCell(3).value, row.getCell(11).value]);
       }
     });


### PR DESCRIPTION
### Motivation
- Rendre les lignes dont le `Statut` est `K.O` immédiatement visibles dans les fichiers Excel exportés sans altérer le rendu professionnel existant.
- Appliquer la couleur de fond à toute la ligne exportée et non à la seule cellule `Statut` pour une lecture rapide et cohérente.
- Conserver les bordures, alignements, hauteur de ligne, wrapping, formats de date et autres styles actuels.

### Description
- Mise à jour de la fonction `applyProfessionalExcelStyling(worksheet)` dans `js/app.js` pour détecter le statut (colonne `12`) et appliquer un `fill` à toute la ligne quand la valeur normalisée vaut `K.O`.
- Ajout d’un `koRowFill` professionnel doux avec la couleur recommandée `FFFFF1F1` et application via `row.eachCell({ includeEmpty: true }, ...)` pour couvrir toutes les cellules de la ligne.
- Le code conserve les bordures, les alignements centrés/left, le `wrapText`, la hauteur des lignes et le style d’en-tête existants.

### Testing
- Patch appliqué avec succès par l’outil de modification (mise à jour de `js/app.js` confirmée).
- Recherches statiques réalisées avec `rg` ont confirmé que les exports Page 2 et Page 3 utilisent la fonction modifiée et ne sont pas dupliqués ailleurs.
- Inspection du fichier avec `nl`/`sed` a vérifié la présence du `statusColumnNumber` (`12`) et du `koRowFill` (`FFFFF1F1`) et la logique conditionnelle `if (statusValue === 'K.O')`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0912e5d488832aa1cea8a4f54eda49)