### PR TITLE
Supprimer l’option "-- Sélectionner --" du filtre d’export Page 2 et définir `Tous` par défaut

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3366,7 +3366,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const defaultName = currentSite?.nom ? `SUIVI MATERIEL . ${currentSite.nom}` : 'export-materiel';
       siteExportFileNameInput.value = sanitizeExportFileName(defaultName);
       if (siteExportLineFilterSelect) {
-        siteExportLineFilterSelect.value = '';
+        siteExportLineFilterSelect.value = 'all';
       }
       if (siteExportFileNameError) {
         siteExportFileNameError.textContent = '';

--- a/page2.html
+++ b/page2.html
@@ -196,8 +196,7 @@
           <label class="input-group input-group--site-create">
             <span>Filtrer les lignes</span>
             <select id="siteExportLineFilterSelect" name="siteExportLineFilter">
-              <option value="">-- Sélectionner --</option>
-              <option value="all">Tous</option>
+              <option value="all" selected>Tous</option>
               <option value="todo">En attente</option>
               <option value="fix">À corriger</option>
               <option value="done">Terminés</option>


### PR DESCRIPTION
### Motivation
- Le menu de filtrage d’export sur Page 2 affichait une option placeholder inutile `-- Sélectionner --`, alors que l’état par défaut attendu est déjà `Tous`, ce qui alourdissait visuellement le menu et dégradait l’UX.

### Description
- Dans `page2.html` le `<select id="siteExportLineFilterSelect">` a été modifié pour retirer `<option value="">-- Sélectionner --</option>` et rendre `<option value="all">Tous</option>` sélectionnée par défaut.
- Dans `js/app.js` la fonction `openSiteExportDialog()` réinitialise désormais le filtre par `siteExportLineFilterSelect.value = 'all';` au lieu de `''` pour garder la logique de filtrage cohérente.
- Aucune autre logique, style, animation, responsive ni persistance `localStorage` n’a été modifiée.

### Testing
- Recherche dans le repo avec `rg` a été utilisée pour localiser les éléments affectés et vérifier qu’il n’y a pas d’autres occurrences (succès).
- Inspection des fichiers modifiés via affichage de lignes (`nl`/`sed`) et revue du diff avec `git diff -- page2.html js/app.js` a confirmé les changements attendus (succès).
- Changements ont été ajoutés et commités (`git status --short` + commit) pour finaliser la modification (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09724d7ca4832aac8e31d689edc916)