### PR TITLE
Compact, left-aligned Excel header for Page 2 & Page 3 exports

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -528,15 +528,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   }
 
   function applyExcelProfessionalHeader(worksheet, siteName) {
-    const totalColumns = worksheet.columns.length || 12;
-    const mergeEndColumnLetter = worksheet.getColumn(totalColumns).letter;
-    const mergedRange = `A1:${mergeEndColumnLetter}1`;
-    worksheet.mergeCells(mergedRange);
-
     const titleCell = worksheet.getCell('A1');
     titleCell.value = 'SUIVI MATERIEL';
-    titleCell.font = { bold: true, size: 20, color: { argb: 'FF1F2937' } };
-    titleCell.alignment = { horizontal: 'center', vertical: 'middle' };
+    titleCell.font = { bold: true, size: 12, color: { argb: 'FF374151' } };
+    titleCell.alignment = { horizontal: 'left', vertical: 'middle' };
 
     const siteCell = worksheet.getCell('A2');
     siteCell.value = `Site concerné : ${siteName || '-'}`;
@@ -548,8 +543,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     updateCell.font = { size: 11, color: { argb: 'FF4B5563' } };
     updateCell.alignment = { horizontal: 'left', vertical: 'middle' };
 
-    worksheet.getRow(1).height = 32;
-    worksheet.getRow(2).height = 22;
+    worksheet.getRow(1).height = 20;
+    worksheet.getRow(2).height = 20;
     worksheet.getRow(3).height = 20;
     worksheet.getRow(4).height = 12;
   }


### PR DESCRIPTION
### Motivation
- Le titre actuel `SUIVI MATERIEL` était rendu comme un grand texte centré et fusionné en première ligne, occupant trop d’espace visuel, il doit devenir un libellé discret et aligné à gauche pour un rendu professionnel et compact.

### Description
- Modification de `applyExcelProfessionalHeader()` dans `js/app.js` pour supprimer la fusion de la cellule A1 et le grand titre centré, et rendre `SUIVI MATERIEL` en `A1` avec style normal et alignement à gauche.
- Conservation de la structure sur trois lignes : ligne 1 `SUIVI MATERIEL`, ligne 2 `Site concerné : {nom du site}`, ligne 3 `Date de dernière mise à jour : {date et heure}` avec styles de couleur existants pour site/date.
- Normalisation des hauteurs des lignes (valeurs compactes) pour un rendu cohérent et professionnel tout en conservant les couleurs, les lignes K.O rouges, les alignements, l’auto width, le wrap text, le tri A→Z, les bordures et l’export Excel responsive.
- Changement appliqué aux exports Page 2 et Page 3 puisque les deux utilisent la même fonction d’en-tête.

### Testing
- Exécuté `rg -n "applyExcelProfessionalHeader\(" js/app.js` pour confirmer que les deux chemins d’export appellent la fonction d’en-tête, et la recherche a réussi.
- Inspecté la plage modifiée de `js/app.js` avec `nl -ba js/app.js | sed -n '528,560p'` pour vérifier les nouvelles tailles de police, alignements et hauteurs de lignes.
- Revérifié le diff du fichier modifié pour s’assurer que seules les logiques de mise en page de l’en-tête ont été changées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0978dbb1b8832a95bd1f46de752655)