### PR TITLE
Uniformiser le champ de recherche de la Page 3 avec la Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2412,23 +2412,23 @@ body[data-page="item-detail"] .search-panel .input-group {
   position: relative;
 }
 
-body[data-page="item-detail"] .page3-search-filter-bar {
+body[data-page="item-detail"] .page2-search-filter-bar {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-body[data-page="item-detail"] .page3-search-filter-bar .input-group {
+body[data-page="item-detail"] .page2-search-filter-bar .input-group {
   flex: 1;
   min-width: 0;
 }
 
-body[data-page="item-detail"] .page3-filter-menu-wrap {
+body[data-page="item-detail"] .page2-filter-menu-wrap {
   position: relative;
   flex-shrink: 0;
 }
 
-body[data-page="item-detail"] .page3-filter-button {
+body[data-page="item-detail"] .page2-filter-button {
   width: 42px;
   height: 42px;
   border-radius: 999px;
@@ -2441,20 +2441,20 @@ body[data-page="item-detail"] .page3-filter-button {
   transition: transform 0.18s ease, box-shadow 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
 }
 
-body[data-page="item-detail"] .page3-filter-button:hover,
-body[data-page="item-detail"] .page3-filter-button:focus-visible {
+body[data-page="item-detail"] .page2-filter-button:hover,
+body[data-page="item-detail"] .page2-filter-button:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
 }
 
-body[data-page="item-detail"] .page3-filter-button.is-filtered {
+body[data-page="item-detail"] .page2-filter-button.is-filtered {
   background: #e8f1ff;
   border-color: #b6cbef;
 }
 
-body[data-page="item-detail"] .page3-filter-button__icon {
-  width: 17px;
-  height: 17px;
+body[data-page="item-detail"] .page2-filter-button__icon {
+  width: 18px;
+  height: 18px;
   object-fit: contain;
   opacity: 0.82;
 }
@@ -2515,30 +2515,42 @@ body[data-page="item-detail"] .page3-filter-option.is-disabled {
   cursor: not-allowed;
 }
 
-body[data-page="item-detail"] .search-input__icon-wrap {
+body[data-page="item-detail"] .site-search-icon-wrap {
   position: absolute;
-  left: 0.85rem;
+  left: 0.95rem;
   top: 50%;
   transform: translateY(-50%);
-  width: 19px;
-  height: 19px;
+  width: 18px;
+  height: 18px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  opacity: 0.72;
-  filter: grayscale(1) brightness(0.65);
+  opacity: 0.8;
   pointer-events: none;
 }
 
-body[data-page="item-detail"] .search-input__icon {
+body[data-page="item-detail"] .site-search-icon {
   width: 100%;
   height: 100%;
   object-fit: contain;
 }
 
 body[data-page="item-detail"] #detailSearchInput {
-  padding-left: 2.9rem;
+  width: 100%;
+  min-height: 3rem;
+  border-radius: 999px;
+  border: 1px solid #d8e2ef;
+  background: #fff;
+  padding-left: 2.6rem;
   padding-right: 52px;
+  box-shadow: 0 7px 18px rgba(15, 23, 42, 0.06);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+body[data-page="item-detail"] #detailSearchInput:focus {
+  outline: none;
+  border: 2px solid var(--detail-primary);
+  box-shadow: 0 0 0 4px rgba(39, 141, 218, 0.12);
 }
 
 body[data-page="all-materials"] #materialsSearchInput {

--- a/page3.html
+++ b/page3.html
@@ -42,17 +42,17 @@
 
             <div id="detailStore" class="store-info magasin-block page3-info-row">Magasin : Non défini</div>
           </div>
-          <div class="search-panel search-panel--inline page3-search-filter-bar">
+          <div class="search-panel search-panel--inline page2-search-filter-bar">
             <label class="input-group">
-              <span class="search-input__icon-wrap" aria-hidden="true">
-                <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
+              <span class="site-search-icon-wrap" aria-hidden="true">
+                <img src="Icon/Recherche.png" alt="" class="site-search-icon" />
               </span>
               <input id="detailSearchInput" class="search-input" type="text" placeholder="Recherche" autocomplete="off" />
               <button id="clearSearchBtn" class="clear-search-btn" type="button" aria-label="Effacer la recherche">×</button>
             </label>
-            <div class="page3-filter-menu-wrap">
-              <button type="button" id="detailFilterButton" class="page3-filter-button" aria-label="Filtrer le tableau" aria-haspopup="true" aria-expanded="false" aria-controls="detailFilterMenu">
-                <img src="Icon/filtre.png" alt="" aria-hidden="true" class="page3-filter-button__icon" />
+            <div class="page2-filter-menu-wrap">
+              <button type="button" id="detailFilterButton" class="page2-filter-button" aria-label="Filtrer le tableau" aria-haspopup="true" aria-expanded="false" aria-controls="detailFilterMenu">
+                <img src="Icon/filtre.png" alt="" aria-hidden="true" class="page2-filter-button__icon" />
               </button>
               <div id="detailFilterMenu" class="page3-filter-menu" role="menu" hidden>
                 <button type="button" class="page3-filter-option is-active" data-detail-filter="all" role="menuitemradio" aria-checked="true"><span class="page3-filter-option__label">Tous</span><span class="page3-filter-option__count">0</span></button>


### PR DESCRIPTION
### Motivation
- Rendre la ligne de recherche de la Page 3 visuellement identique à celle de la Page 2 en réutilisant le modèle visuel existant pour forme, bordure, icône, bouton `×`, espacements et positionnement du filtre.
- Corriger les incohérences visuelles observées (forme, bordure au focus, taille/icône, espacements) sans modifier le comportement JavaScript existant.

### Description
- Remplacement de classes HTML dans `page3.html` pour réutiliser le pattern visuel de la Page 2 : `page2-search-filter-bar`, `page2-filter-menu-wrap`, `page2-filter-button` et `page2-filter-button__icon` ; et remplacement de l’icône de recherche par `site-search-icon-wrap` / `site-search-icon` pour aligner la taille et la position.
- Ajout / ajustement de règles CSS dans `css/style.css` sous le scope `body[data-page="item-detail"]` pour appliquer la même bordure arrondie, hauteur, padding interne, ombre et anneau de focus bleu que Page 2 au champ `#detailSearchInput` et pour aligner l’icône et le bouton `clear` sur la même ligne.
- Conserver les IDs JavaScript existants (`detailSearchInput`, `clearSearchBtn`, `detailFilterButton`) afin de ne pas casser la logique de recherche, le reset via le bouton `×` ni le filtre.
- Les modifications sont limitées à la Page 3 et n’altèrent pas Page 1 ni Page 2 ni leurs styles.

### Testing
- Aucune suite de tests automatisés n’est configurée pour ces changements, donc aucun test automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098017b2d0832a841842f2ffc61716)