### PR TITLE
Add required asterisk to 'Nouveau numéro OUT' modal title

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -137,7 +137,7 @@
       <dialog id="itemDialog" class="modal-card">
         <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="itemForm">
           <div class="modal-header">
-            <h2>Nouveau numéro OUT</h2>
+            <h2>Nouveau numéro OUT <span class="required-star" aria-hidden="true">*</span></h2>
           </div>
           <label class="input-group input-group--site-create input-group--item-create">
             <span>Numéro OUT <span class="required-star" aria-hidden="true">*</span></span>


### PR DESCRIPTION
### Motivation
- Indiquer visuellement que le titre de la modal "Nouveau numéro OUT" représente un champ obligatoire en affichant un astérisque rouge cohérent avec les autres champs obligatoires.

### Description
- Ajout d'un `<span class="required-star" aria-hidden="true">*</span>` au `h2` de la modal dans `page2.html`, réutilisant la classe CSS existante `required-star` sans modifier les inputs, placeholders, boutons, espacements ni le comportement responsive.

### Testing
- Exécution des vérifications automatisées `git status --short` et `nl -ba page2.html | sed -n '136,146p'`, toutes deux réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099b3b4094832a9b42a10f74140cb0)