### PR TITLE
Align filter button height with search field on Pages 2 and 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2429,8 +2429,9 @@ body[data-page="item-detail"] .page2-filter-menu-wrap {
 }
 
 body[data-page="item-detail"] .page2-filter-button {
-  width: 42px;
-  height: 42px;
+  width: 3rem;
+  height: 3rem;
+  min-height: 3rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.45);
   background: #ffffff;
@@ -3907,8 +3908,9 @@ body[data-page="site-detail"] .page2-filter-menu-wrap {
 }
 
 body[data-page="site-detail"] .page2-filter-button {
-  width: 42px;
-  height: 42px;
+  width: 3rem;
+  height: 3rem;
+  min-height: 3rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.45);
   background: #ffffff;


### PR DESCRIPTION
### Motivation
- Corriger un désalignement visuel où le bouton filtre avait une hauteur différente du champ de recherche sur Page 2 tout en conservant la forme arrondie, l’icône et l’espacement existants.
- Appliquer la même correction à Page 3 si le même composant est présent pour assurer une UI cohérente.

### Description
- Modifié les sélecteurs CSS `body[data-page="site-detail"] .page2-filter-button` et `body[data-page="item-detail"] .page2-filter-button` pour définir `width`, `height` et `min-height` à `3rem` afin d’aligner exactement la hauteur avec le champ de recherche.
- Les propriétés de `border-radius`, l’icône `page2-filter-button__icon` et le `gap` de la barre restent inchangés pour préserver l’apparence et l’espacement.
- Le changement est limité au fichier `css/style.css` et n’affecte aucune logique JavaScript ni Page 1.

### Testing
- Vérification des modifications dans le fichier avec `rg`/`sed` a confirmé la présence des nouvelles règles CSS et a réussi.
- Inspection du diff et commit via `git commit` a été effectué avec succès.
- Aucun test automatisé spécifique au CSS n’existe dans le projet et aucune logique JS n’a été modifiée, donc aucune suite de tests JS n’a été exécutée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099da92f60832a92c0244d4b418d7e)