### PR TITLE
Page 2 : pagination Firestore réelle (20 OUT / page)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6266,3 +6266,26 @@ body[data-page="item-detail"] .search-highlight {
   font-weight: 500;
   line-height: 1.45;
 }
+
+.outs-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 16px 4px 8px;
+}
+.outs-pagination__button {
+  border: 0;
+  border-radius: var(--radius-pill, 999px);
+  background: var(--primary, #2457f5);
+  color: #fff;
+  padding: 10px 14px;
+  font-weight: 700;
+}
+.outs-pagination__button:disabled { opacity: .45; }
+.outs-pagination__label { font-weight: 700; color: var(--text, #12131a); }
+@media (max-width: 540px) {
+  .outs-pagination { gap: 6px; }
+  .outs-pagination__button { padding: 9px 10px; font-size: 13px; }
+  .outs-pagination__label { font-size: 13px; }
+}

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
-import { addDoc, collection, deleteDoc, doc, getDocs, orderBy, query, serverTimestamp, updateDoc } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+import { addDoc, collection, deleteDoc, doc, getDocs, limit, orderBy, query, serverTimestamp, startAfter, updateDoc } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
 (function () {
@@ -2903,6 +2903,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const saveEditOutNameBtn = document.getElementById('saveEditOutNameBtn');
     const itemSearchInput = requireElement('itemSearchInput');
     const itemDateFilter = requireElement('itemDateFilter');
+    const outsPagination = requireElement('outsPagination');
+    const outsPrevPageBtn = requireElement('outsPrevPageBtn');
+    const outsNextPageBtn = requireElement('outsNextPageBtn');
+    const outsPaginationLabel = requireElement('outsPaginationLabel');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
     const itemNumberLabel = itemDialog?.querySelector('.input-group--item-create > span');
 
@@ -4044,7 +4048,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         clearCursorFilterReadIdsStorage();
       }
       syncItemStatusFilterUi();
-      renderItems();
+      outPageLastDocs = [];
+      loadOutPage(1).catch(() => {
+        UiService.showToast('Chargement impossible.');
+      });
     }
 
     const openCreateItem = document.querySelector('body[data-page="site-detail"] #openCreateItem');
@@ -4076,6 +4083,44 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let itemDialogMode = ITEM_DIALOG_MODE_CREATE;
     let editingItemId = null;
     let activeOutSearchQuery = (itemSearchInput.value || "").trim().toUpperCase();
+    const PAGE_SIZE = 20;
+    let currentOutPage = 1;
+    let hasMoreOutPages = false;
+    let outPageLastDocs = [];
+
+    function buildOutsFirestoreQuery(pageIndex) {
+      // Pagination Firestore réelle : ne pas remplacer par slice()
+      const constraints = [orderBy('dateCreation', 'desc')];
+      if (pageIndex > 0 && outPageLastDocs[pageIndex - 1]) {
+        constraints.push(startAfter(outPageLastDocs[pageIndex - 1]));
+      }
+      constraints.push(limit(PAGE_SIZE + 1));
+      return query(collection(firebaseDb, 'sites', siteId, 'items'), ...constraints);
+    }
+
+    async function loadOutPage(page = 1) {
+      const targetPage = Math.max(1, Number(page) || 1);
+      const pageIndex = targetPage - 1;
+      const snap = await getDocs(buildOutsFirestoreQuery(pageIndex));
+      const docs = snap.docs || [];
+      hasMoreOutPages = docs.length > PAGE_SIZE;
+      const visibleDocs = hasMoreOutPages ? docs.slice(0, PAGE_SIZE) : docs;
+      currentItems = visibleDocs.map((entry) => ({ id: entry.id, ...entry.data() }));
+      outPageLastDocs[pageIndex] = visibleDocs.length ? visibleDocs[visibleDocs.length - 1] : null;
+      currentOutPage = targetPage;
+      updateOutPaginationUi();
+      renderActiveTabContent();
+    }
+
+    function updateOutPaginationUi() {
+      if (!outsPagination) return;
+      const isOutsTab = activeSiteTab === 'outs';
+      outsPagination.classList.toggle('hidden', !isOutsTab);
+      if (!isOutsTab) return;
+      outsPrevPageBtn.disabled = currentOutPage <= 1;
+      outsNextPageBtn.disabled = !hasMoreOutPages;
+      outsPaginationLabel.textContent = hasMoreOutPages ? `Page ${currentOutPage} / ...` : `Page ${currentOutPage}`;
+    }
     function readSearchReadIdsFromStorage() {
       try {
         const rawValue = window.localStorage.getItem(searchReadIdsStorageKey);
@@ -4961,6 +5006,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       renderActiveTabContent({
         flashSearchMatches: isOutSearchInput,
       });
+      if (isOutSearchInput) {
+        outPageLastDocs = [];
+        loadOutPage(1).catch(() => {
+          UiService.showToast('Chargement impossible.');
+        });
+      }
+    });
+
+    outsPrevPageBtn?.addEventListener('click', async () => {
+      if (currentOutPage <= 1) return;
+      await loadOutPage(currentOutPage - 1);
+    });
+
+    outsNextPageBtn?.addEventListener('click', async () => {
+      if (!hasMoreOutPages) return;
+      await loadOutPage(currentOutPage + 1);
     });
 
     if (itemStatusFilterButton && itemStatusFilterMenu && itemStatusFilterOptions.length) {
@@ -5019,7 +5080,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         selectedDateFilter = itemDateFilter.value || 'all';
         window.localStorage.setItem(dateFilterStorageKey, selectedDateFilter);
         updateFilterChipsState();
-        renderActiveTabContent();
+        outPageLastDocs = [];
+        loadOutPage(1).catch(() => {
+          UiService.showToast('Chargement impossible.');
+        });
       });
     }
 
@@ -5126,19 +5190,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       siteTitle.textContent = currentSite.nom;
     });
 
-    StorageService.subscribeItems(
-      siteId,
-      (items) => {
-        currentItems = items;
-        renderActiveTabContent();
-        if (itemDialog.open && itemDialogMode === ITEM_DIALOG_MODE_CREATE) {
-          validateItemNumberAvailability();
-        }
-      },
-      () => {
-        UiService.showToast('Synchronisation  indisponible.');
-      },
-    );
+    loadOutPage(1).catch(() => {
+      UiService.showToast('Synchronisation  indisponible.');
+    });
 
     StorageService.subscribeDetailCounts(
       siteId,

--- a/page2.html
+++ b/page2.html
@@ -106,6 +106,11 @@
 
         <section id="outsTabContent" class="tab-content active">
           <section id="itemList" class="list-grid" aria-live="polite"></section>
+          <nav id="outsPagination" class="outs-pagination" aria-label="Pagination des OUT">
+            <button type="button" id="outsPrevPageBtn" class="outs-pagination__button">← Précédent</button>
+            <span id="outsPaginationLabel" class="outs-pagination__label">Page 1</span>
+            <button type="button" id="outsNextPageBtn" class="outs-pagination__button">Suivant →</button>
+          </nav>
         </section>
 
         <section id="purchasesTabContent" class="tab-content hidden">


### PR DESCRIPTION
### Motivation
- Limiter réellement les lectures Firestore sur la Page 2 en ne récupérant que 20 OUT par page et éviter toute pagination côté client avec `slice()`.
- Conserver le design des cards et ajouter un contrôle de pagination professionnel en bas de la liste OUT.

### Description
- Ajout d’un composant de pagination sous la liste des OUT dans `page2.html` (`outsPrevPageBtn`, `outsNextPageBtn`, `outsPaginationLabel`).
- Remplacement du chargement global des OUT sur Page 2 par une requête paginée Firestore dans `js/app.js` en utilisant `orderBy('dateCreation','desc')`, `limit(...)` et `startAfter(...)`, avec le commentaire de garde `// Pagination Firestore réelle : ne pas remplacer par slice()`.
- Lecture limitée à 20 OUT visibles par page avec une lecture « lookahead » (`limit(PAGE_SIZE + 1)`) pour détecter s’il y a une page suivante et activer/désactiver le bouton « Suivant ». 
- Mémorisation du curseur (`outPageLastDocs[pageIndex]`) pour chaque page afin de permettre de revenir en arrière sans relire toute la collection.
- Remplacement de l’appel `StorageService.subscribeItems(...)` pour Page 2 par `loadOutPage(1)` afin d’éviter la récupération complète de la collection en parallèle.
- Réinitialisation de la pagination (retour à la page 1) quand la recherche, le filtre statut ou le filtre date change.
- Ajout de styles responsive pour le contrôle de pagination dans `css/style.css` pour s’adapter au mobile et conserver le style de l’application.

### Testing
- Exécuté `git status --short` pour vérifier les fichiers modifiés (succès).
- Fait un commit via `git commit -m "Add real Firestore pagination for Page 2 OUT list"` (succès).
- Test d’exécution rapide `node -e "new Function(require('fs').readFileSync('js/app.js','utf8')); console.log('ok')"` échoué de façon attendue car `js/app.js` utilise des imports ESM HTTP destinés au navigateur et n’est pas exécutable directement dans ce contexte (échec attendu, pas une régression du code de pagination).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b9b79964832a9673ade28a5f72e2)