### PR TITLE
Page 2 : vraie pagination Firestore pour la liste OUT (20 / page)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4049,6 +4049,34 @@ body[data-page="site-detail"] .progress-fill.pending { background: #facc15; }
 body[data-page="site-detail"] .progress-fill.warning { background: #fb923c; }
 body[data-page="site-detail"] .progress-fill.ko { background: #ef4444; }
 
+body[data-page="site-detail"] .outs-pagination {
+  margin: 14px 0 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+body[data-page="site-detail"] .outs-pagination__btn {
+  border: 1px solid #d8e2ef;
+  background: #fff;
+  color: var(--primary, #1d4ed8);
+  border-radius: 12px;
+  padding: 9px 12px;
+  font-weight: 600;
+}
+
+body[data-page="site-detail"] .outs-pagination__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+body[data-page="site-detail"] .outs-pagination__indicator {
+  color: #475569;
+  font-weight: 600;
+  font-size: 14px;
+}
+
 body[data-page="site-detail"] .site-search-icon-wrap {
   position: absolute;
   left: 0.95rem;

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
-import { addDoc, collection, deleteDoc, doc, getDocs, orderBy, query, serverTimestamp, updateDoc } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+import { addDoc, collection, deleteDoc, doc, getDocs, limit, orderBy, query, serverTimestamp, startAfter, updateDoc, where } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
 (function () {
@@ -2905,9 +2905,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const itemDateFilter = requireElement('itemDateFilter');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
     const itemNumberLabel = itemDialog?.querySelector('.input-group--item-create > span');
+    const outsPagination = requireElement('outsPagination');
+    const outsPrevPageBtn = requireElement('outsPrevPageBtn');
+    const outsNextPageBtn = requireElement('outsNextPageBtn');
+    const outsPageIndicator = requireElement('outsPageIndicator');
 
     let currentSite = StorageService.getSite(siteId);
     let currentItems = [];
+    const PAGE_SIZE = 20;
+    let currentOutPage = 1;
+    let hasNextOutPage = false;
+    const outPageCursors = new Map();
+    const outPageCache = new Map();
     let currentPurchases = [];
     let detailCountsByItem = {};
     let detailDesignationsByItem = {};
@@ -3006,6 +3015,69 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     siteTitle.textContent = currentSite ? currentSite.nom : 'Chargement...';
+
+    async function loadOutPage(pageToLoad = 1) {
+      // Pagination Firestore réelle : ne pas remplacer par slice()
+      const targetPage = Math.max(1, Number(pageToLoad) || 1);
+      const cachedPage = outPageCache.get(targetPage);
+      if (cachedPage) {
+        currentOutPage = targetPage;
+        currentItems = cachedPage.items;
+        hasNextOutPage = cachedPage.hasNext;
+        renderItems();
+        return;
+      }
+      let outQuery = query(
+        collection(firebaseDb, 'pages', 'page2', 'items'),
+        where('siteId', '==', siteId),
+        orderBy('dateModification', 'desc'),
+        limit(PAGE_SIZE),
+      );
+      if (targetPage > 1) {
+        const previousLastDoc = outPageCursors.get(targetPage - 1);
+        if (!previousLastDoc) {
+          return;
+        }
+        outQuery = query(
+          collection(firebaseDb, 'pages', 'page2', 'items'),
+          where('siteId', '==', siteId),
+          orderBy('dateModification', 'desc'),
+          startAfter(previousLastDoc),
+          limit(PAGE_SIZE),
+        );
+      }
+      const pageSnapshot = await getDocs(outQuery);
+      const docs = pageSnapshot.docs;
+      const items = docs.map((snapshot) => ({ id: snapshot.id, ...snapshot.data() }));
+      const lastVisibleDoc = docs.length ? docs[docs.length - 1] : null;
+      if (lastVisibleDoc) {
+        outPageCursors.set(targetPage, lastVisibleDoc);
+      }
+      let hasNext = false;
+      if (lastVisibleDoc && docs.length === PAGE_SIZE) {
+        const nextProbe = await getDocs(query(
+          collection(firebaseDb, 'pages', 'page2', 'items'),
+          where('siteId', '==', siteId),
+          orderBy('dateModification', 'desc'),
+          startAfter(lastVisibleDoc),
+          limit(1),
+        ));
+        hasNext = !nextProbe.empty;
+      }
+      outPageCache.set(targetPage, { items, hasNext });
+      currentOutPage = targetPage;
+      currentItems = items;
+      hasNextOutPage = hasNext;
+      renderItems();
+    }
+
+    function resetOutPaginationAndReload() {
+      currentOutPage = 1;
+      hasNextOutPage = false;
+      outPageCursors.clear();
+      outPageCache.clear();
+      loadOutPage(1);
+    }
 
     function resetPurchaseForm() {
       purchaseForm?.reset();
@@ -3814,6 +3886,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
 
       restoreOutPageScrollPosition();
+      if (outsPagination && outsPageIndicator && outsPrevPageBtn && outsNextPageBtn) {
+        outsPagination.hidden = activeSiteTab !== 'outs';
+        outsPageIndicator.textContent = hasNextOutPage ? `Page ${currentOutPage} / ...` : `Page ${currentOutPage}`;
+        outsPrevPageBtn.disabled = currentOutPage <= 1;
+        outsNextPageBtn.disabled = !hasNextOutPage;
+      }
     }
 
     function outMatchesSearch(item, query) {
@@ -4379,8 +4457,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       saveActiveSiteTab(safeTabName);
       if (safeTabName === 'outs') {
+        outsPagination.hidden = false;
         itemCount.innerHTML = `<span class="outs-number">0</span><span class="outs-label">OUTS</span>`;
       } else {
+        outsPagination.hidden = true;
         itemCount.innerHTML = `<span class="outs-number">0</span><span class="outs-label">Achat</span>`;
       }
       updateFabByActiveTab(safeTabName);
@@ -4961,6 +5041,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       renderActiveTabContent({
         flashSearchMatches: isOutSearchInput,
       });
+      if (isOutSearchInput) {
+        resetOutPaginationAndReload();
+      }
     });
 
     if (itemStatusFilterButton && itemStatusFilterMenu && itemStatusFilterOptions.length) {
@@ -5013,6 +5096,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           window.localStorage.setItem(dateFilterStorageKey, selectedDateFilter);
           updateFilterChipsState();
           renderActiveTabContent();
+          resetOutPaginationAndReload();
         });
       });
       itemDateFilter.addEventListener('change', () => {
@@ -5020,8 +5104,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         window.localStorage.setItem(dateFilterStorageKey, selectedDateFilter);
         updateFilterChipsState();
         renderActiveTabContent();
+        resetOutPaginationAndReload();
       });
     }
+
+    outsPrevPageBtn?.addEventListener('click', () => {
+      if (currentOutPage <= 1) return;
+      loadOutPage(currentOutPage - 1);
+    });
+
+    outsNextPageBtn?.addEventListener('click', () => {
+      if (!hasNextOutPage) return;
+      loadOutPage(currentOutPage + 1);
+    });
 
     itemForm.addEventListener('submit', async (event) => {
       event.preventDefault();
@@ -5126,19 +5221,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       siteTitle.textContent = currentSite.nom;
     });
 
-    StorageService.subscribeItems(
-      siteId,
-      (items) => {
-        currentItems = items;
-        renderActiveTabContent();
-        if (itemDialog.open && itemDialogMode === ITEM_DIALOG_MODE_CREATE) {
-          validateItemNumberAvailability();
-        }
-      },
-      () => {
-        UiService.showToast('Synchronisation  indisponible.');
-      },
-    );
+    resetOutPaginationAndReload();
 
     StorageService.subscribeDetailCounts(
       siteId,

--- a/page2.html
+++ b/page2.html
@@ -106,6 +106,11 @@
 
         <section id="outsTabContent" class="tab-content active">
           <section id="itemList" class="list-grid" aria-live="polite"></section>
+          <nav id="outsPagination" class="outs-pagination" aria-label="Pagination OUT">
+            <button id="outsPrevPageBtn" type="button" class="outs-pagination__btn">← Précédent</button>
+            <span id="outsPageIndicator" class="outs-pagination__indicator">Page 1</span>
+            <button id="outsNextPageBtn" type="button" class="outs-pagination__btn">Suivant →</button>
+          </nav>
         </section>
 
         <section id="purchasesTabContent" class="tab-content hidden">


### PR DESCRIPTION
### Motivation
- Ne plus charger toute la collection OUT en mémoire et appliquer une pagination réelle côté Firestore pour limiter les lectures à 20 OUT par page.
- Permettre navigation précédente/suivante professionnelle tout en conservant les recherches, filtres et l’état LU/NON LU sans recharger toute la collection.

### Description
- Remplacé le chargement global de la liste OUT par des requêtes paginées sur `pages/page2/items` utilisant `where('siteId','==', siteId)`, `orderBy('dateModification','desc')`, `limit(20)` et `startAfter(...)` pour la page suivante, et ajouté le commentaire `// Pagination Firestore réelle : ne pas remplacer par slice()` dans `js/app.js`.
- Ajouté gestion des curseurs et cache par page (`outPageCursors`, `outPageCache`) pour mémoriser le `lastVisibleDoc` de chaque page et revenir en arrière sans relire toute la collection.
- Ajouté une sonde `limit(1)` pour détecter s’il existe une page suivante et désactiver le bouton `Suivant` si nécessaire.
- Ajouté UI de pagination professionnelle sous les cards OUT (`page2.html`) et styles correspondants (`css/style.css`) avec états désactivés (`← Précédent`, `Page N / ...`, `Suivant →`), et réinitialisation de la pagination à la page 1 quand la recherche ou les filtres changent.
- Supprimé l’ancien chemin qui souscrivait/chargeait l’intégralité des OUT pour éviter des lectures parallèles inutiles et remplacé par `resetOutPaginationAndReload()` pour le chargement initial.

### Testing
- Exécution d’une vérification de syntaxe JS : `node --check js/app.js` a réussi.
- Aucune suite de tests automatisés supplémentaire n’a été exécutée dans ce patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09dd034644832ab48ea44bf46a8be5)