### PR TITLE
Fix Page 3 filter menu open/close and outside-click handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5864,6 +5864,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
       detailFilterMenu.hidden = true;
+      detailFilterMenu.style.display = 'none';
       detailFilterButton.setAttribute('aria-expanded', 'false');
     }
 
@@ -5872,6 +5873,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
       detailFilterMenu.hidden = false;
+      detailFilterMenu.style.display = '';
       detailFilterButton.setAttribute('aria-expanded', 'true');
     }
 
@@ -6549,8 +6551,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       toggleClearButton();
     }
 
-    if (detailFilterButton && detailFilterMenu && detailFilterOptions.length) {
+    function bindDetailFilterMenuEvents() {
+      if (!detailFilterButton || !detailFilterMenu || !detailFilterOptions.length) {
+        return;
+      }
+      if (detailFilterButton.dataset.menuBound === 'true') {
+        return;
+      }
+
       syncDetailFilterUi();
+      closeDetailFilterMenu();
+
       detailFilterButton.addEventListener('click', () => {
         if (detailFilterMenu.hidden) {
           openDetailFilterMenu();
@@ -6577,7 +6588,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           closeDetailFilterMenu();
         }
       });
+
+      detailFilterButton.dataset.menuBound = 'true';
     }
+
+    bindDetailFilterMenuEvents();
+    window.addEventListener('pageshow', () => {
+      bindDetailFilterMenuEvents();
+      closeDetailFilterMenu();
+    });
 
     if (exportButton) {
       exportButton.addEventListener('click', openDetailExportDialog);


### PR DESCRIPTION
### Motivation
- Corriger le comportement du bouton filtre sur Page 3 pour que le menu s'ouvre au premier clic, se ferme au second clic et se ferme au clic en dehors. 
- Éviter les réattachements / doublons d'event listeners lors de la restauration/réaffichage de la page. 
- Empêcher que le menu reste bloqué en `display:none` après des navigations/restores.

### Description
- Ajout d'une fonction `bindDetailFilterMenuEvents()` dans `js/app.js` qui attache de façon centralisée les écouteurs pour le bouton filtre, les options, le clic extérieur et la touche `Escape`.
- Protection contre les doublons d'écouteurs via un drapeau `detailFilterButton.dataset.menuBound = 'true'` pour empêcher les réattachements multiples.
- Réattachement sûr au `pageshow` avec appel à `bindDetailFilterMenuEvents()` et fermeture explicite du menu pour gérer les restaurations d'état.
- Synchronisation explicite de l'état visuel en fermant/ouvrant le menu avec `detailFilterMenu.hidden` ET `detailFilterMenu.style.display` pour éviter qu'il reste coincé en `display:none`.

### Testing
- Vérification syntaxique exécutée avec `node --check js/app.js` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09eed2829c832ab27250725221ceb5)