### PR TITLE
Fix Page 3 filter menu click propagation and container selector

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5813,7 +5813,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!detailFilterOptions.length) {
         return;
       }
-
       detailFilterOptions.forEach((option) => {
         const filterKey = option.dataset.detailFilter || 'all';
         const count = details.filter((detail) => matchesDetailFilter(detail, filterKey)).length;
@@ -6551,12 +6550,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (detailFilterButton && detailFilterMenu && detailFilterOptions.length) {
       syncDetailFilterUi();
-      detailFilterButton.addEventListener('click', () => {
+      detailFilterButton.addEventListener('click', (event) => {
+        event.stopPropagation();
         if (detailFilterMenu.hidden) {
           openDetailFilterMenu();
           return;
         }
         closeDetailFilterMenu();
+      });
+
+      detailFilterMenu.addEventListener('click', (event) => {
+        event.stopPropagation();
       });
 
       detailFilterOptions.forEach((option) => {

--- a/page3.html
+++ b/page3.html
@@ -50,7 +50,7 @@
               <input id="detailSearchInput" class="search-input" type="text" placeholder="Recherche" autocomplete="off" />
               <button id="clearSearchBtn" class="clear-search-btn" type="button" aria-label="Effacer la recherche">×</button>
             </label>
-            <div class="page2-filter-menu-wrap">
+            <div class="page2-filter-menu-wrap page3-filter-menu-wrap">
               <button type="button" id="detailFilterButton" class="page2-filter-button" aria-label="Filtrer le tableau" aria-haspopup="true" aria-expanded="false" aria-controls="detailFilterMenu">
                 <img src="Icon/filtre.png" alt="" aria-hidden="true" class="page2-filter-button__icon" />
               </button>


### PR DESCRIPTION
### Motivation
- The Page 3 filter menu was immediately closed on open because the global `document.click` outside-click handler did not recognize the Page 3 wrapper, and clicks bubbled through causing the handler to close the menu.
- The change prevents the open action from being cancelled by the global listener and ensures clicks inside the menu don't prematurely close it.

### Description
- Add the `page3-filter-menu-wrap` class to the filter wrapper in `page3.html` so outside-click detection targets the correct container for Page 3 only.
- Add `event.stopPropagation()` to the `#detailFilterButton` click handler in `js/app.js` to prevent the `document.click` listener from immediately closing the menu after it is opened.
- Add a click listener on `#detailFilterMenu` that calls `event.stopPropagation()` so interactions inside the menu do not close it before selection.
- Changes are confined to `page3.html` and `js/app.js` and do not modify Page 1/Page 2 or the Page 2→Page 3 filter transfer logic.

### Testing
- No automated tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f5143ddc832aaf0f05ef6a860067)