### PR TITLE
Aligner le bouton X de Page 3 sur le style de Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2567,9 +2567,7 @@ body[data-page="all-materials"] .clear-search-btn {
   transform: translateY(-50%);
   width: 30px;
   height: 30px;
-  border-radius: 50%;
   border: none;
-  background: #eef5fb;
   color: #6b7280;
   font-size: 20px;
   font-weight: 600;
@@ -2578,9 +2576,22 @@ body[data-page="all-materials"] .clear-search-btn {
   padding: 0;
 }
 
+body[data-page="item-detail"] .clear-search-btn {
+  background: transparent;
+  border-radius: 0;
+}
+
+body[data-page="all-materials"] .clear-search-btn {
+  border-radius: 50%;
+  background: #eef5fb;
+}
+
 body[data-page="item-detail"] .clear-search-btn:active,
 body[data-page="all-materials"] .clear-search-btn:active {
   transform: translateY(-50%) scale(0.94);
+}
+
+body[data-page="all-materials"] .clear-search-btn:active {
   background: #e0eefc;
 }
 


### PR DESCRIPTION
### Motivation
- Corriger l’apparence du bouton d’effacement (X) sur Page 3 (`data-page="item-detail"`) pour qu’il reprenne le rendu visuel de Page 2 en supprimant le fond circulaire gris visible sur Page 3 tout en conservant le comportement existant.

### Description
- Scindé le style partagé de `.clear-search-btn` et ajouté une règle spécifique `body[data-page="item-detail"] .clear-search-btn` qui applique `background: transparent` et `border-radius: 0` pour neutraliser le cercle gris sur Page 3.
- Rétabli la règle circulaire et le fond gris uniquement pour `body[data-page="all-materials"] .clear-search-btn` afin de ne pas impacter Page 2 ni le bouton filtre.
- Aucun changement JavaScript, aucune modification de Page 2, et les dimensions/positionnement (`width`, `height`, `top: 50%`, `transform: translateY(-50%)`) restent inchangés pour préserver l’alignement et la clicabilité.

### Testing
- Recherché les sélecteurs concernés avec `rg` pour vérifier l’emplacement des règles CSS et la portée ciblée, et la vérification a réussi.
- Appliqué la mise à jour par script sur `css/style.css` puis inspecté le fichier avec `sed`/`nl` pour confirmer la présence des nouvelles règles, et la vérification a réussi.
- Inspecté le diff du fichier modifié pour s’assurer que seules les règles CSS de `.clear-search-btn` ont été touchées et que les fichiers JS et Page 2 n’ont pas été modifiés, et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f77d601c832a81278d7d192b4968)