### PR TITLE
Aligner la taille du FAB de la Page 3 sur celle de la Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2898,7 +2898,7 @@ body[data-page="item-detail"] .fab-add--item-detail {
   justify-content: center;
   background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   color: #fff;
-  font-size: 32px;
+  font-size: 28px;
   line-height: 1;
   box-shadow: 0 10px 22px var(--detail-primary-shadow);
   z-index: 45;


### PR DESCRIPTION
### Motivation
- Corriger l'incohérence visuelle où le FAB de la Page 3 (`item-detail`) apparaissait plus grand que celui des Pages 1 et 2.

### Description
- Ajustement unique de `font-size` pour le sélecteur `body[data-page="item-detail"] .fab-add--item-detail` de `32px` à `28px` dans `css/style.css` pour obtenir exactement la même apparence visuelle que le FAB de la Page 2 sans modifier les autres propriétés (width, height, border-radius, couleur, dégradé, ombre, animation, position, z-index, icône).

### Testing
- Exécutés: recherche des sélecteurs avec `rg`, inspection du CSS avec `sed`, modification via script Python, puis validation avec `git diff -- css/style.css`, `git status --short` et `git commit`, et toutes les vérifications de commande ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fc95039c832a952f6fa5d3f7361b)