### PR TITLE
Densifie le tableau « Demande matériels » pour un rendu mobile plus compact

### DIFF
--- a/materiels.html
+++ b/materiels.html
@@ -46,6 +46,29 @@
         background: rgba(59, 130, 246, 0.08);
       }
 
+      .materials-page .table-wrapper--shared {
+        max-height: clamp(20rem, 56vh, 36rem);
+      }
+
+      .materials-page .data-table {
+        font-size: 0.9rem;
+      }
+
+      .materials-page .data-table th,
+      .materials-page .data-table td {
+        padding: 0.56rem 0.58rem;
+        line-height: 1.28;
+      }
+
+      .materials-page .data-table th {
+        font-size: 0.82rem;
+      }
+
+      .materials-page .data-table td {
+        font-size: 0.88rem;
+        vertical-align: middle;
+      }
+
       .materials-page #materialCartFab,
       .materials-page .cart-fab {
         right: 24px !important;


### PR DESCRIPTION
### Motivation
- Rendre le tableau de la page « Demande matériels » visuellement plus compact et professionnel sur mobile en affichant davantage de lignes visibles tout en conservant l’excellente lisibilité et le style premium.

### Description
- Ajout de règles CSS scoped dans `materiels.html` pour `.materials-page .table-wrapper--shared` afin d’augmenter la zone verticale visible du tableau.
- Ajout de règles CSS scoped pour `.materials-page .data-table`, `.data-table th` et `.data-table td` réduisant la taille de police, les paddings et le `line-height` pour diminuer la hauteur des lignes.
- Les modifications sont uniquement de style et ciblées à la page concernée; la structure du tableau, le scroll horizontal, les données, le champ de recherche, le bouton FAB et les autres pages n’ont pas été modifiés.

### Testing
- Vérifications automatiques: comparaison des différences du fichier modifié et contrôle d’état du dépôt; ces contrôles ont réussi.
- Création de la PR automatique pour revue: opération réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fe5af6d8832ab49280c1481db2b5)