### PR TITLE
Aligner la taille du FAB de Page 3 sur Page 2 (56×56)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2916,8 +2916,8 @@ body[data-page="item-detail"] .item-detail-fab-row .fab-add--item-detail {
   position: fixed;
   right: 24px;
   bottom: 24px;
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
   z-index: 1000;
   box-shadow: 0 10px 22px var(--detail-primary-shadow);
@@ -4982,8 +4982,8 @@ body[data-page="item-detail"] .item-detail-fab-row .fab-add--item-detail {
   position: fixed;
   right: 24px;
   bottom: 24px;
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
   z-index: 1000;
   box-shadow: 0 10px 22px var(--detail-primary-shadow);


### PR DESCRIPTION
### Motivation
- Corriger l’incohérence visuelle : le FAB de la Page 3 héritait de règles qui le forçaient à 64×64 au lieu du diamètre standard 56×56 utilisé en Page 2.

### Description
- Remplacement des `width`/`height` 64px → 56px dans `css/style.css` pour les sélecteurs `body[data-page="item-detail"] .item-detail-fab-row .fab-add--item-detail` et pour le bloc combiné `body[data-page="site-detail"] .site-detail-fab-row .fab-add, body[data-page="site-detail"] .site-detail-fab-row .fab-add--item-detail, body[data-page="item-detail"] .item-detail-fab-row .fab-add--item-detail`, sans modifier la position, le gradient, l’ombre, l’animation ni le `z-index`.

### Testing
- Vérifications automatiques effectuées : recherche des règles ciblées avec `rg` et inspection des lignes modifiées avec `nl`/`sed`, et les contrôles ont confirmé la mise à jour `width: 56px` / `height: 56px` avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a00651f08832a9866f38e683df299)