### PR TITLE
Adjust profile bottom-sheet name/email spacing on Page 1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3793,6 +3793,15 @@ body[data-page="home"] .app-header--home > h1 {
   max-width: min(88vw, 320px);
   word-break: break-word;
 }
+
+body[data-page="home"] .bottom-sheet__name {
+  margin-bottom: 4px;
+}
+
+body[data-page="home"] .bottom-sheet__email {
+  margin-top: 2px;
+}
+
 .bottom-sheet__avatar-edit {
   position: absolute;
   right: -0.15rem;


### PR DESCRIPTION
### Motivation
- Rapprocher légèrement l'adresse mail du nom dans le bottom sheet profil sur la Page 1 pour un rendu plus compact et professionnel tout en conservant une respiration visuelle premium.

### Description
- Ajout d’overrides ciblés dans `css/style.css` pour `body[data-page="home"]` qui réduisent `margin-bottom` de `.bottom-sheet__name` à `4px` et `margin-top` de `.bottom-sheet__email` à `2px`, sans introduire de nouvelles classes ni modifier d’autres styles ou éléments.

### Testing
- Aucun test automatisé n’est configuré/exécuté; la modification a été validée par revue du `git diff` et un commit réussi (`Adjust home profile sheet name/email spacing`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a02e8feb8832aacf2b025123a914f)