### PR TITLE
Fix invisible required asterisk on "Numéro OUT" label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4321,6 +4321,12 @@ body[data-page="site-detail"] #itemDialog .required-star {
   vertical-align: baseline;
 }
 
+body[data-page="site-detail"] #itemDialog .item-number-label .required-star {
+  display: inline;
+  opacity: 1;
+  visibility: visible;
+}
+
 body[data-page="home"] #siteDialog .required-star {
   color: #ef4444;
   font-weight: 700;

--- a/page2.html
+++ b/page2.html
@@ -140,7 +140,7 @@
             <h2>Nouveau numéro OUT <span class="required-star" aria-hidden="true">*</span></h2>
           </div>
           <label class="input-group input-group--site-create input-group--item-create">
-            <span>Numéro OUT <span class="required-star" aria-hidden="true">*</span></span>
+            <span class="item-number-label">Numéro OUT <span class="required-star" aria-hidden="true">*</span></span>
             <input
               id="itemNumberInput"
               name="itemNumber"


### PR DESCRIPTION
### Motivation
- The red required asterisk next to the "Numéro OUT" label in the "Nouveau numéro OUT" modal was not visible despite the same markup pattern working for "Magasin", so the label needed a stable selector to ensure visibility without changing visual design or layout.

### Description
- Added a dedicated class `item-number-label` to the `<span>` wrapping the "Numéro OUT" label in `page2.html` to create a reliable selector. 
- Added a narrowly scoped CSS rule `body[data-page="site-detail"] #itemDialog .item-number-label .required-star` in `css/style.css` to explicitly set `display: inline; opacity: 1; visibility: visible;` so the asterisk renders identically to other required labels while leaving color/size/margin untouched.
- No JS, modal structure, spacing, or broader style rules were changed.

### Testing
- Verified presence of both labels and `required-star` occurrences with `rg -n "Numéro OUT|Magasin|required-star"` which confirmed the updated markup location and selectors; the check succeeded. 
- Inspected the updated lines in `page2.html` and `css/style.css` with `nl`/`sed` to confirm the `item-number-label` class and the scoped CSS rule were added as intended; the inspection succeeded. 
- Performed a diff-style review to ensure only the intended markup and the scoped CSS rule were added and that existing `.required-star` styling was preserved; the review succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a08ff00b4832a854303c5fb51e834)