### PR TITLE
Uniformiser l'erreur « nom du site » vide sur Page 1 avec Page 2

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2476,7 +2476,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const name = siteNameInput.value.trim();
       if (!name) {
-        showSiteNameError('Veuillez remplir ce champ');
+        showSiteNameError('Veuillez renseigner le nom du site.');
+        siteNameInput.focus();
         return;
       }
 


### PR DESCRIPTION
### Motivation
- Assurer que la soumission du formulaire de création de site sur Page 1 réutilise exactement la même logique d'erreur que Page 2 (bordure rouge, animation shake, message transitoire et focus conservé) lorsque le champ `siteNameInput` est vide.

### Description
- Dans `js/app.js` le handler `siteForm` submit vérifie `siteNameInput.value.trim()` et, si vide, appelle `showSiteNameError('Veuillez renseigner le nom du site.')`, exécute `siteNameInput.focus()` puis `return`, en réutilisant la logique existante d'affichage transitoire et des classes `is-error`/`is-shaking` sans modifier Page 2, le modal, le compteur ou Firebase.

### Testing
- Exécutions automatiques d'inspection et validation du changement : `rg`/`nl` pour localiser les lignes modifiées, puis `git status --short`, `git diff -- js/app.js` et un `git commit` ont été lancés et se sont terminés avec succès, et le bloc de code modifié a été vérifié dans `js/app.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0bb5f5e0832aba797b9033e7b545)