### PR TITLE
Fix OUT number required star rendering in create modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4321,10 +4321,24 @@ body[data-page="site-detail"] #itemDialog .required-star {
   vertical-align: baseline;
 }
 
+body[data-page="site-detail"] #itemDialog .item-number-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+body[data-page="site-detail"] #itemDialog .item-number-label-text {
+  display: inline-block;
+}
+
 body[data-page="site-detail"] #itemDialog .item-number-label .required-star {
-  display: inline;
-  opacity: 1;
-  visibility: visible;
+  color: #ef4444 !important;
+  font-weight: 700;
+  display: inline-block !important;
+  line-height: 1;
+  opacity: 1 !important;
+  visibility: visible !important;
+  flex-shrink: 0;
 }
 
 body[data-page="home"] #siteDialog .required-star {

--- a/page2.html
+++ b/page2.html
@@ -140,7 +140,10 @@
             <h2>Nouveau numéro OUT <span class="required-star" aria-hidden="true">*</span></h2>
           </div>
           <label class="input-group input-group--site-create input-group--item-create">
-            <span class="item-number-label">Numéro OUT <span class="required-star" aria-hidden="true">*</span></span>
+            <span class="item-number-label">
+              <span class="item-number-label-text">Numéro OUT</span>
+              <span class="required-star" aria-hidden="true">*</span>
+            </span>
             <input
               id="itemNumberInput"
               name="itemNumber"


### PR DESCRIPTION
### Motivation
- The red required asterisk next to the “Numéro OUT” label in the create modal was intermittently invisible on some devices/zoom levels due to inherited label styles and rendering issues. 
- The intent is to isolate the star visually from the label so it is always visible and stable on Android Chrome and other browsers without changing JS or other label behavior.

### Description
- Replaced the inline label markup in `page2.html` so the label text and star are separated into `<span class="item-number-label-text">Numéro OUT</span>` and `<span class="required-star" aria-hidden="true">*</span>` inside the existing `.item-number-label` container. 
- Added scoped CSS under `body[data-page="site-detail"] #itemDialog` in `css/style.css` to make `.item-number-label` `display:inline-flex` with `align-items:center` and `gap:4px`, make `.item-number-label-text` `display:inline-block`, and force the `.required-star` visuals with `color:#ef4444 !important`, `display:inline-block !important`, `line-height:1`, `opacity:1 !important`, `visibility:visible !important`, and `flex-shrink:0`. 
- Kept the real `*` character (no `::after`), did not change the spacing of the modal globally, did not touch the “Magasin *” label, and left all JS logic untouched.

### Testing
- No automated unit/integration tests were added or run for this visual change. 
- Verified the change and presence of the new DOM/CSS with repository checks using `rg -n "item-number-label|required-star|Numéro OUT|Magasin"`, inspected the diff with `git diff`, and committed the updates successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0dfd5008832a892647e4af79c840)