### PR TITLE
Preserve required asterisk for “Numéro OUT” by only updating the text node

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2906,6 +2906,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const itemDateFilter = requireElement('itemDateFilter');
     const itemDialogTitle = itemDialog?.querySelector('.modal-header h2');
     const itemNumberLabel = itemDialog?.querySelector('.input-group--item-create > span');
+    const itemNumberLabelText = itemDialog?.querySelector('.item-number-label-text');
 
     let currentSite = StorageService.getSite(siteId);
     let currentItems = [];
@@ -4573,9 +4574,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             ? 'Modifier l’achat matériel'
             : 'Nouveau numéro OUT';
       }
-      if (itemNumberLabel) {
+      if (itemNumberLabelText) {
+        itemNumberLabelText.textContent = itemDialogMode === ITEM_DIALOG_MODE_CREATE ? 'Numéro OUT' : 'Nom';
+      } else if (itemNumberLabel) {
         itemNumberLabel.textContent = itemDialogMode === ITEM_DIALOG_MODE_CREATE ? 'Numéro OUT' : 'Nom';
       }
+      console.log('item-number-label innerHTML:', document.querySelector('#itemDialog .item-number-label')?.innerHTML);
       const defaultLabel = itemCreateSubmitButton?.querySelector('.btn-label-default');
       const loadingLabel = itemCreateSubmitButton?.querySelector('.btn-label-loading');
       const isEditMode = itemDialogMode === ITEM_DIALOG_MODE_EDIT || itemDialogMode === ITEM_DIALOG_MODE_EDIT_PURCHASE;


### PR DESCRIPTION
### Motivation
- Runtime code was removing the red asterisk next to the “Numéro OUT” label because the dialog mode switch used `textContent` on the entire label container, which wiped out the `<span class="required-star">*</span>` already present in `page2.html`. 
- The goal is to fix the real runtime source of the issue without changing markup, design, or the “Magasin” field.

### Description
- Stop replacing the whole label: add `itemNumberLabelText = itemDialog?.querySelector('.item-number-label-text')` and update that span's `textContent` instead of using `textContent` on the container. 
- Keep a fallback to the original container selector when the `.item-number-label-text` span is not present. 
- Add a temporary `console.log(document.querySelector('#itemDialog .item-number-label')?.innerHTML)` to help verify the actual DOM rendered in the browser. 
- No CSS or design changes were introduced and the asterisk markup in `page2.html` is preserved.

### Testing
- Confirmed presence of the asterisk markup and single `#itemDialog` modal by searching `page2.html` with `rg -n` which succeeded. 
- Verified the JS location that mutated the label and the new selectors using `rg -n` and `nl -ba` which succeeded. 
- Applied and verified the code patch by running the local text-replace script and inspecting the file diff which succeeded. 
- Added runtime debug log to be validated in the browser console during a hard-refresh of the deployed page to confirm the DOM now includes the `<span class="required-star">*</span>` (to be checked on production URL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a883f8c38832a83ac0b7fd765fbd4)