### PR TITLE
Fix Page 1 site-create modal validation error behavior

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1262,7 +1262,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
       isSiteCreateInputValid = Boolean(isEnabled);
-      siteCreateSubmitButton.disabled = isSiteCreationPending || !isSiteCreateInputValid;
+      siteCreateSubmitButton.disabled = isSiteCreationPending;
     }
 
     function clearSiteNameAvailabilityMessage() {
@@ -2438,6 +2438,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     });
 
     siteNameInput.addEventListener('input', () => {
+      clearTransientError(siteFormError);
+      siteFormError.style.color = '';
+      clearSiteNameErrorState();
       updateSiteNameCounter();
       if (siteNameAvailabilityDebounceTimer) {
         window.clearTimeout(siteNameAvailabilityDebounceTimer);
@@ -2445,6 +2448,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       siteNameAvailabilityDebounceTimer = window.setTimeout(() => {
         validateSiteNameDuringInput();
       }, 200);
+    });
+
+    siteCreateSubmitButton?.addEventListener('click', () => {
+      if (isSiteCreationPending) {
+        return;
+      }
+      siteForm.requestSubmit();
     });
     siteEditNameInput?.addEventListener('input', () => {
       clearTransientError(siteEditNameError);
@@ -2470,6 +2480,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     });
 
     siteForm.addEventListener('submit', async (event) => {
+      console.log('site validation triggered');
       event.preventDefault();
       if (isSiteCreationPending) {
         return;


### PR DESCRIPTION
### Motivation

- Corriger le flux de validation du modal "Entrer nom du site" (Page 1) pour que le `submit` déclenche correctement le système d'erreur existant (bordure rouge, animation `shake`, message d'erreur) sans ajouter de nouveau style ou modal.

### Description

- Modifié `js/app.js` pour que `setSiteCreateSubmitEnabled` ne désactive le bouton `#siteCreateSubmitButton` que pendant l'état pending (retiré la dépendance à la validité du champ). 
- Ajouté un listener `click` sur `#siteCreateSubmitButton` qui appelle `siteForm.requestSubmit()` pour garantir que le `submit` de `#siteForm` s'exécute même si d'autres interactions interfèrent. 
- Nettoyage immédiat de l'état d'erreur dans le listener `input` de `#siteNameInput` en réutilisant les classes CSS existantes (`.is-error`, `.is-shaking`, `.form-error`) et la logique de validation déjà utilisée sur Page 2. 
- Ajout du log temporaire `console.log("site validation triggered");` au début du handler `submit` pour vérifier que la validation est bien déclenchée, et conservé l'utilisation de `showSiteNameError()` et `clearSiteNameErrorState()`.

### Testing

- Exécuté `git diff -- js/app.js` pour inspecter les modifications appliquées et la diff a été produite avec succès. (succès)
- Exécuté `git add` + `git commit -m "Fix site create modal validation flow on Page 1"` pour enregistrer la modification et le commit a réussi. (succès)
- Exécuté `git status --short` pour vérifier l'état du dépôt après commit et il est propre. (succès)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8f64e934832ab4825eafe89d6ffc)