### PR TITLE
Validation visuelle du champ Magasin dans la modal Nouveau numéro OUT (Page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4139,12 +4139,16 @@ body[data-page="site-detail"] #itemDialog #itemNumberInput {
 }
 
 body[data-page="site-detail"] #itemDialog #itemNumberInput.is-error,
-body[data-page="site-detail"] #itemDialog #itemNumberInput.is-error:focus {
+body[data-page="site-detail"] #itemDialog #itemNumberInput.is-error:focus,
+body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-error,
+body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-error:focus {
   border-color: #e53935;
   box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.14);
 }
 
-body[data-page="site-detail"] #itemDialog #itemNumberInput.is-shaking {
+body[data-page="site-detail"] #itemDialog #itemNumberInput.is-shaking,
+body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-shaking,
+body[data-page="site-detail"] #itemDialog .magasin-group.is-shaking {
   animation: item-number-input-shake 300ms ease-in-out 1;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -2870,6 +2870,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const itemForm = requireElement('itemForm');
     const itemNumberInput = requireElement('itemNumberInput');
     const itemStoreSelect = requireElement('itemStoreSelect');
+    const itemStoreError = requireElement('itemStoreError');
     const itemStoreOtherGroup = requireElement('itemStoreOtherGroup');
     const itemStoreOtherInput = requireElement('itemStoreOtherInput');
     const itemNumberCounter = requireElement('itemNumberCounter');
@@ -4503,6 +4504,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       itemNumberInput.classList.remove('is-error', 'is-shaking');
     }
 
+    function clearItemStoreErrorState() {
+      itemStoreSelect?.classList.remove('is-error', 'is-shaking');
+      itemStoreSelect?.closest('.magasin-group')?.classList.remove('is-shaking');
+      if (itemStoreError) {
+        itemStoreError.textContent = '';
+      }
+    }
+
+    function showItemStoreErrorState() {
+      itemStoreSelect?.classList.remove('is-shaking');
+      itemStoreSelect?.closest('.magasin-group')?.classList.remove('is-shaking');
+      // Force un reflow pour rejouer l'animation à chaque nouvelle erreur.
+      void itemStoreSelect?.offsetWidth;
+      itemStoreSelect?.classList.add('is-error', 'is-shaking');
+      itemStoreSelect?.closest('.magasin-group')?.classList.add('is-shaking');
+      if (itemStoreError) {
+        itemStoreError.textContent = 'Veuillez sélectionner un magasin.';
+      }
+    }
+
     function showItemFormError(message, durationMs = 2300) {
       clearItemNumberErrorState();
       hasBlockingItemNumberError = true;
@@ -4811,6 +4832,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     updatePurchaseDesignationCounter();
 
     itemStoreSelect?.addEventListener('change', () => {
+      clearItemStoreErrorState();
       updateItemStoreOtherVisibility();
       setItemCreateButtonState();
     });
@@ -4884,6 +4906,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     itemDialog.addEventListener('close', () => {
       clearItemFormError();
       clearItemNumberErrorState();
+      clearItemStoreErrorState();
       hasBlockingItemNumberError = false;
       if (itemAvailabilityDebounceTimer) {
         window.clearTimeout(itemAvailabilityDebounceTimer);
@@ -5080,6 +5103,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         }
         if (value.length < 4) {
           showItemFormError('Veuillez saisir au moins 4 chiffres.');
+          return;
+        }
+        const hasStoreValue = Boolean(resolveItemStoreValue() !== 'None');
+        if (!hasStoreValue) {
+          showItemStoreErrorState();
+          if (!hasBlockingItemNumberError) {
+            itemStoreSelect?.focus();
+          }
           return;
         }
       }

--- a/page2.html
+++ b/page2.html
@@ -168,6 +168,7 @@
               <option value="BY Pass">BYPASS</option>
               <option value="Autre à préciser">Autre à préciser</option>
             </select>
+            <p id="itemStoreError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
           <label id="itemStoreOtherGroup" class="input-group input-group--site-create input-group--item-create" hidden>
             <span>Préciser le magasin</span>


### PR DESCRIPTION
### Motivation
- Faire apparaître sur Page 2 la même validation visuelle que pour le champ « Numéro OUT » lorsque le select « Magasin » n’est pas sélectionné, en réutilisant les classes CSS et l’animation existantes.

### Description
- Ajout d’un conteneur d’erreur field-level sous le select `#itemStoreSelect` : `<p id="itemStoreError" class="form-error form-error--field" aria-live="polite"></p>` (fichier `page2.html`).
- Extension du CSS pour réutiliser le style d’erreur et l’animation de shake existants sur `#itemStoreSelect` et sur la `.magasin-group` (fichier `css/style.css`).
- Ajout de la gestion côté client dans `js/app.js` avec l’accès à `itemStoreError`, les fonctions `clearItemStoreErrorState()` et `showItemStoreErrorState()` pour appliquer/retirer `is-error`/`is-shaking` et afficher le message `Veuillez sélectionner un magasin.`.
- Intégration de la validation lors de la soumission de `#itemForm` en mode création pour empêcher la création si aucun magasin n’est choisi, mettre le focus sur `#itemStoreSelect` si le Numéro OUT est déjà valide, et nettoyage de l’état d’erreur au changement de sélection et à la fermeture du dialog.

### Testing
- Aucun test automatisé ajouté ni exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a926de978832a9219cb95aeaccda8)