### PR TITLE
Corriger l’état d’erreur du champ « Magasin » dans la modal Nouveau numéro OUT

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4139,7 +4139,11 @@ body[data-page="site-detail"] #itemDialog #itemNumberInput {
 }
 
 body[data-page="site-detail"] #itemDialog #itemNumberInput.is-error,
-body[data-page="site-detail"] #itemDialog #itemNumberInput.is-error:focus,
+body[data-page="site-detail"] #itemDialog #itemNumberInput.is-error:focus {
+  border-color: #e53935;
+  box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.14);
+}
+
 body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-error,
 body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-error:focus {
   border-color: #e53935;
@@ -4147,8 +4151,7 @@ body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-error:focus {
 }
 
 body[data-page="site-detail"] #itemDialog #itemNumberInput.is-shaking,
-body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-shaking,
-body[data-page="site-detail"] #itemDialog .magasin-group.is-shaking {
+body[data-page="site-detail"] #itemDialog #itemStoreSelect.is-shaking {
   animation: item-number-input-shake 300ms ease-in-out 1;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -4505,23 +4505,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function clearItemStoreErrorState() {
-      itemStoreSelect?.classList.remove('is-error', 'is-shaking');
-      itemStoreSelect?.closest('.magasin-group')?.classList.remove('is-shaking');
-      if (itemStoreError) {
-        itemStoreError.textContent = '';
-      }
+      itemStoreError.textContent = '';
+      itemStoreSelect.classList.remove('is-error', 'is-shaking');
     }
 
-    function showItemStoreErrorState() {
-      itemStoreSelect?.classList.remove('is-shaking');
-      itemStoreSelect?.closest('.magasin-group')?.classList.remove('is-shaking');
-      // Force un reflow pour rejouer l'animation à chaque nouvelle erreur.
-      void itemStoreSelect?.offsetWidth;
-      itemStoreSelect?.classList.add('is-error', 'is-shaking');
-      itemStoreSelect?.closest('.magasin-group')?.classList.add('is-shaking');
-      if (itemStoreError) {
-        itemStoreError.textContent = 'Veuillez sélectionner un magasin.';
-      }
+    function showItemStoreError(message = 'Veuillez sélectionner un magasin.') {
+      itemStoreError.textContent = message;
+      itemStoreSelect.classList.remove('is-shaking');
+      void itemStoreSelect.offsetWidth;
+      itemStoreSelect.classList.add('is-error', 'is-shaking');
+
+      window.setTimeout(() => {
+        clearItemStoreErrorState();
+      }, 2300);
     }
 
     function showItemFormError(message, durationMs = 2300) {
@@ -5105,12 +5101,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           showItemFormError('Veuillez saisir au moins 4 chiffres.');
           return;
         }
-        const hasStoreValue = Boolean(resolveItemStoreValue() !== 'None');
-        if (!hasStoreValue) {
-          showItemStoreErrorState();
-          if (!hasBlockingItemNumberError) {
-            itemStoreSelect?.focus();
-          }
+        const storeValue = resolveItemStoreValue();
+        if (!storeValue || storeValue === 'None') {
+          showItemStoreError();
+          itemStoreSelect.focus();
           return;
         }
       }


### PR DESCRIPTION
### Motivation
- Harmoniser le comportement UX d’erreur du champ `itemStoreSelect` avec celui existant de `itemNumberInput` (bordure rouge + shake + message) dans la modal de création d’un OUT sur la page 2.

### Description
- Modifié `js/app.js` pour remplacer l’ancien couple `showItemStoreErrorState()` / variant par `clearItemStoreErrorState()` qui vide `#itemStoreError` et retire `is-error`/`is-shaking`, et `showItemStoreError(message)` qui affiche le message, relance l’animation et la réinitialise après `2300ms`.
- Mis à jour la validation de `#itemForm` en mode création pour utiliser `resolveItemStoreValue()` et appeler `showItemStoreError()` + `itemStoreSelect.focus()` quand la valeur de magasin est vide ou égale à `'None'`, tout en conservant la priorité des erreurs sur `Numéro OUT` car ce bloc est après les validations du numéro.
- Ajusté `css/style.css` pour que `#itemStoreSelect.is-error` et `#itemStoreSelect.is-shaking` réutilisent exactement la bordure rouge et l’animation `item-number-input-shake` existantes sans créer de nouvelle animation ni modifier le rendu normal du `select`.
- Aucune modification HTML n’a été nécessaire car `#itemStoreError` est déjà présent dans `page2.html` sous `#itemStoreSelect`.

### Testing
- Exécuté la recherche de références avec `rg -n "itemStoreSelect|itemStoreError|clearItemStoreErrorState|showItemStoreError|resolveItemStoreValue"` sur les fichiers concernés et confirmé la présence/usage des symboles (succès). 
- Inspecté le diff produit par `git diff -- page2.html js/app.js css/style.css` pour vérifier les modifications attendues (succès). 
- Validé le commit avec `git commit -m "Fix store field error state animation in new OUT modal"` et la création du PR via la commande de packaging utilisée (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa26d5530832a8647897832c6d262)