### PR TITLE
Preserve mobile-first centered layout by removing desktop >=992px overrides

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5845,72 +5845,7 @@ body[data-page="home"] .app-header--home > h1 {
   padding-inline: 0;
 }
 
-/* Desktop fluid layout adjustments (pages 1, 2, 3) */
-@media (min-width: 992px) {
-  body[data-page="home"] .app-shell,
-  body[data-page="site-detail"] .app-shell,
-  body[data-page="item-detail"] .app-shell,
-  body[data-page="item-detail"] .app-shell.app-shell--wide {
-    width: 100%;
-    max-width: none;
-    margin: 0;
-    box-sizing: border-box;
-  }
-
-  body[data-page="home"] .app-header,
-  body[data-page="site-detail"] .app-header,
-  body[data-page="item-detail"] .app-header {
-    width: 100%;
-    max-width: none;
-    padding-left: clamp(16px, 4vw, 48px);
-    padding-right: clamp(16px, 4vw, 48px);
-    box-sizing: border-box;
-  }
-
-  body[data-page="home"] .page-content,
-  body[data-page="site-detail"] .page-content,
-  body[data-page="item-detail"] .page-content,
-  body[data-page="item-detail"] .page-content--wide {
-    width: 100%;
-    max-width: none;
-    margin: 0;
-    padding-left: clamp(16px, 4vw, 48px);
-    padding-right: clamp(16px, 4vw, 48px);
-    box-sizing: border-box;
-  }
-
-  body[data-page="home"] .search-panel,
-  body[data-page="home"] .section-heading--sticky,
-  body[data-page="home"] .list-grid,
-  body[data-page="site-detail"] .search-panel--site,
-  body[data-page="site-detail"] .list-grid,
-  body[data-page="site-detail"] .list-separator,
-  body[data-page="item-detail"] .surface-card,
-  body[data-page="item-detail"] .table-card,
-  body[data-page="item-detail"] .section,
-  body[data-page="item-detail"] .search-panel {
-    width: 100%;
-    max-width: none;
-    margin-left: 0;
-    margin-right: 0;
-    box-sizing: border-box;
-  }
-
-  body[data-page="item-detail"] .table-container,
-  body[data-page="item-detail"] .table-container--card,
-  body[data-page="item-detail"] .table-wrapper,
-  body[data-page="item-detail"] .table-wrapper--shared {
-    width: 100%;
-    max-width: none;
-    min-width: 0;
-    box-sizing: border-box;
-  }
-
-  body[data-page="item-detail"] .data-table {
-    width: 100%;
-    min-width: 70rem;
-  }
-}
+/* Desktop >= 992px keeps the same centered mobile-first layout intentionally. */
 
 /* Global skeleton shimmer layouts */
 body.is-loading .page-content > :not(.global-skeleton),


### PR DESCRIPTION
### Motivation
- Le bloc `@media (min-width: 992px)` élargissait l’interface desktop (`width: 100%`, `max-width: none`, paddings latéraux) et cassait le rendu centré et mobile-first attendu.
- L’objectif est d’unifier l’affichage pour que mobile, tablette et PC gardent le même rendu visuel centré et la même taille de cartes/éléments.

### Description
- Supprimé le bloc responsif `@media (min-width: 992px)` dans `css/style.css` qui forçait le layout « étiré » sur grands écrans.
- Ajouté un commentaire explicite `/* Desktop >= 992px keeps the same centered mobile-first layout intentionally. */` pour documenter l’intention.
- Conservées les variables de largeur existantes `--content-max-width`, `--content-max-width-wide` et la structure centrée de `.app-shell`/`.app-shell--wide` sans autre changement de style.
- Aucune couleur, animation ou logique JavaScript/Firebase modifiée (changement CSS ciblé uniquement).

### Testing
- Exécuté la recherche des breakpoints avec `rg -n "@media \((max|min)-width" css/style.css` pour vérifier la présence et suppression du bloc, résultat OK.
- Inspecté les portions de fichier avec `sed -n` et `nl -ba css/style.css` pour valider la suppression et l’insertion du commentaire, résultat OK.
- Script de remplacement (Python) appliqué pour neutraliser le bloc et la sortie a confirmé la mise à jour du fichier, résultat OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab7a9eac4832ab1e61728a8a69671)