### PR TITLE
Corriger validation du champ Magasin dans le modal « Nouveau numéro OUT »

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4507,6 +4507,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function clearItemStoreErrorState() {
       itemStoreError.textContent = '';
       itemStoreSelect.classList.remove('is-error', 'is-shaking');
+      itemStoreOtherInput?.classList.remove('is-error', 'is-shaking');
     }
 
     function showItemStoreError(message = 'Veuillez sélectionner un magasin.') {
@@ -4834,6 +4835,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     });
 
     itemStoreOtherInput?.addEventListener('input', () => {
+      clearItemStoreErrorState();
       setItemCreateButtonState();
     });
 
@@ -5062,7 +5064,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     itemForm.addEventListener('submit', async (event) => {
       event.preventDefault();
-      if (itemCreateSubmitButton.disabled) {
+      if (itemCreateSubmitButton.classList.contains('is-loading')) {
         return;
       }
       const value = itemDialogMode === ITEM_DIALOG_MODE_EDIT_PURCHASE
@@ -5101,11 +5103,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           showItemFormError('Veuillez saisir au moins 4 chiffres.');
           return;
         }
-        const storeValue = resolveItemStoreValue();
-        if (!storeValue || storeValue === 'None') {
-          showItemStoreError();
+        const selectedStoreValue = String(itemStoreSelect?.value || '').trim();
+        if (!selectedStoreValue) {
+          showItemStoreError('Veuillez sélectionner un magasin.');
           itemStoreSelect.focus();
           return;
+        }
+        if (selectedStoreValue === 'Autre à préciser') {
+          const customStoreValue = String(itemStoreOtherInput?.value || '').trim();
+          if (!customStoreValue) {
+            showItemStoreError('Veuillez préciser le magasin.');
+            itemStoreOtherInput?.classList.remove('is-shaking');
+            void itemStoreOtherInput?.offsetWidth;
+            itemStoreOtherInput?.classList.add('is-error', 'is-shaking');
+            itemStoreOtherInput?.focus();
+            return;
+          }
         }
       }
       if (itemDialogMode === ITEM_DIALOG_MODE_CREATE) {


### PR DESCRIPTION
### Motivation
- Le flux de `submit` du formulaire de création d’OUT court-circuitait la validation du champ `Magasin` quand le bouton était `disabled`, empêchant l’affichage visuel d’erreur et le focus attendu.
- Il faut valider dans l’ordre : `Numéro OUT` → `Magasin` → `Autre à préciser` (si nécessaire) → création Firestore, sans modifier Page 1/3 ni le design du modal.

### Description
- Dans `js/app.js` la garde précoce `if (itemCreateSubmitButton.disabled)` a été remplacée par une vérification d’état de chargement `if (itemCreateSubmitButton.classList.contains('is-loading'))` pour ne plus empêcher la validation du magasin avant création.
- Ajout dans `clearItemStoreErrorState()` de la suppression des classes d’erreur pour le champ libre `itemStoreOtherInput` (`is-error` et `is-shaking`).
- Lors du `change` sur `itemStoreSelect` et de l’`input` sur `itemStoreOtherInput`, l’état d’erreur du magasin est maintenant nettoyé immédiatement (`clearItemStoreErrorState()`).
- Dans le `submit` de `itemForm` (mode création) la validation du magasin a été explicitement ajoutée : si `itemStoreSelect.value` est vide on appelle `showItemStoreError('Veuillez sélectionner un magasin.')`, on `focus()` le `itemStoreSelect` et on `return`; si la valeur est `Autre à préciser` et que `itemStoreOtherInput` est vide on affiche une erreur, on applique `is-error` + `is-shaking` sur `itemStoreOtherInput`, on la focalise et on arrête le submit.

### Testing
- Exécution de recherches et inspections de fichier pour vérifier les emplacements et modifications de code avec `rg -n 'itemForm|itemStoreSelect|showItemStoreError|itemCreateSubmitButton|Autre à préciser' js/app.js` et `nl -ba js/app.js | sed -n '4498,5145p'`, toutes concluant que les changements sont présents et cohérents.
- Vérification du diff appliqué via `git diff -- js/app.js` pour s’assurer que seules les modifications ciblées ont été introduites, et revue manuelle des blocs concernés, toutes réussies.
- Aucun test automatisé spécifique (suite unit/CI) n’a été exécuté car il n’y a pas de tests unitaires pour ce flux; les contrôles listés ci‑dessus ont été utilisés pour valider les modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac75f55d8832a9842edffa163cb02)