### PR TITLE
Ne plus désactiver « Créer » quand Magasin est vide pour Nouveau numéro OUT

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4551,8 +4551,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function setItemCreateButtonState() {
       const value = normalizeItemNumberInput(itemNumberInput.value.trim());
       const isValidLength = value.length >= 4;
-      const hasStoreValue = itemDialogMode === ITEM_DIALOG_MODE_EDIT || Boolean(resolveItemStoreValue() !== 'None');
-      itemCreateSubmitButton.disabled = hasBlockingItemNumberError || !isValidLength || !hasStoreValue;
+      itemCreateSubmitButton.disabled = hasBlockingItemNumberError || !isValidLength;
     }
 
     function validateItemNumberAvailability() {


### PR DESCRIPTION
### Motivation
- Éviter que la sélection du `Magasin` bloque l’envoi du formulaire afin que la validation du magasin s’exécute au `submit` et affiche l’erreur UI au clic sur `Créer`.

### Description
- Modifié `setItemCreateButtonState()` dans `js/app.js` pour supprimer la condition `hasStoreValue` et utiliser `itemCreateSubmitButton.disabled = hasBlockingItemNumberError || !isValidLength;`, en laissant la validation du magasin dans le gestionnaire `itemForm.addEventListener('submit')` qui appelle `showItemStoreError()` et effectue le focus.

### Testing
- Inspecté le fichier avec `rg -n "function setItemCreateButtonState|selectedStoreValue|showItemStoreError\('Veuillez sélectionner un magasin'\'" js/app.js`, vérifié les lignes modifiées avec `nl -ba js/app.js | sed -n '4546,4560p;5098,5120p'`, et committé les changements avec `git commit`; toutes les commandes automatisées ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acbf02f10832ab332a87b579bb3ef)