### PR TITLE
Corrige la visibilité des séparateurs du bottom sheet d'action de site

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1694,12 +1694,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               <img src="Icon/cle.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
               <span id="siteActionLockToggleLabel">Verrouiller</span>
             </button>
-            <div class="item-action-sheet__divider" aria-hidden="true"></div>
+            <div class="item-action-sheet__divider" id="siteActionDividerAfterLock" aria-hidden="true"></div>
             <button type="button" class="item-action-sheet__row" id="siteActionEditNameButton">
               <img src="Icon/crayon-de-blog.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
               <span>Modifier le nom</span>
             </button>
-            <div class="item-action-sheet__divider" aria-hidden="true"></div>
+            <div class="item-action-sheet__divider" id="siteActionDividerBeforeDelete" aria-hidden="true"></div>
             <button type="button" class="item-action-sheet__row item-action-sheet__row--danger" id="siteActionDeleteButton">
               <img src="Icon/poubelle.png" alt="" aria-hidden="true" class="item-action-sheet__icon" />
               <span>Supprimer</span>
@@ -1882,7 +1882,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const lockToggleLabel = overlay.querySelector('#siteActionLockToggleLabel');
       const editNameButton = overlay.querySelector('#siteActionEditNameButton');
       const deleteButton = overlay.querySelector('#siteActionDeleteButton');
-      if (!sheet || !title || !lockToggleButton || !lockToggleLabel || !editNameButton || !deleteButton) {
+      const dividerAfterLock = overlay.querySelector('#siteActionDividerAfterLock');
+      const dividerBeforeDelete = overlay.querySelector('#siteActionDividerBeforeDelete');
+      if (!sheet || !title || !lockToggleButton || !lockToggleLabel || !editNameButton || !deleteButton || !dividerAfterLock || !dividerBeforeDelete) {
         return;
       }
       const closeTransitionDurationMs = 280;
@@ -1904,6 +1906,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         deleteButton.hidden = !canDeleteSite;
         deleteButton.style.display = canDeleteSite ? 'inline-flex' : 'none';
         deleteButton.disabled = !canDeleteSite;
+
+        const showDividerAfterLock = canEditSiteName || canDeleteSite;
+        const showDividerBeforeDelete = canEditSiteName && canDeleteSite;
+
+        dividerAfterLock.hidden = !showDividerAfterLock;
+        dividerAfterLock.style.display = showDividerAfterLock ? '' : 'none';
+
+        dividerBeforeDelete.hidden = !showDividerBeforeDelete;
+        dividerBeforeDelete.style.display = showDividerBeforeDelete ? '' : 'none';
         return latestSite;
       };
 


### PR DESCRIPTION
### Motivation
- Quand un site est verrouillé et que seul le bouton `Déverrouiller` est affiché, les deux lignes séparatrices restaient visibles sous le bouton à cause de séparateurs toujours présents dans le DOM.

### Description
- Ajout des `id` aux deux séparateurs dans `ensureSiteActionBottomSheet()` : `siteActionDividerAfterLock` et `siteActionDividerBeforeDelete`.
- Récupération des deux séparateurs dans `openSiteActionSheet()` via `querySelector` et ajout des vérifications null-safe correspondantes.
- Mise à jour de `refreshSiteActionSheetContent()` pour calculer `showDividerAfterLock = canEditSiteName || canDeleteSite` et `showDividerBeforeDelete = canEditSiteName && canDeleteSite`, puis bascule de `hidden` et `style.display` sur chaque séparateur selon ces valeurs.
- Aucun changement de design/CSS, Page 2/3 inchangées, et les boutons `Modifier`, `Supprimer` et `Déverrouiller` sont conservés.

### Testing
- Examen du diff avec `git diff -- js/app.js` (succès).
- Vérification de l'état du dépôt avec `git status --short` (succès).
- Ajout et commit du fichier modifié avec `git add js/app.js && git commit -m "Fix site action sheet dividers visibility for locked sites"` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad223c994832abf7201d3231aae69)