### PR TITLE
Centrage vertical du champ « Désignation » sur Page 3

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3407,10 +3407,16 @@ body[data-page="item-detail"] input[data-field="designation"] {
 }
 
 body[data-page="item-detail"] .cell-input--designation {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
   min-width: 22ch;
   max-width: 44ch;
   min-height: 2.25rem;
-  line-height: 1.3;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  line-height: 1.2;
+  box-sizing: border-box;
   white-space: normal;
   word-break: break-word;
   overflow-wrap: anywhere;


### PR DESCRIPTION
### Motivation
- Corriger l’alignement vertical du texte dans la colonne « Désignation » de la Page 3 (`data-page="item-detail"`) car les caractères apparaissent légèrement collés vers le haut sur Android, sans impacter l’apparence ni le comportement des autres colonnes/pages.

### Description
- Modification ciblée du sélecteur `body[data-page="item-detail"] .cell-input--designation` dans `css/style.css` pour forcer un centrage vertical via `display: flex` et `align-items: center` tout en conservant l’alignement horizontal gauche avec `justify-content: flex-start`.
- Suppression des paddings verticaux excessifs (`padding-top: 0 !important; padding-bottom: 0 !important`), ajustement de `line-height` à `1.2` et ajout de `box-sizing: border-box` pour un rendu stable sur mobile.
- Les contraintes existantes (`min-height`, largeur, responsive, scroll horizontal et le style général du tableau) ont été conservées et seul le fichier `css/style.css` a été modifié.

### Testing
- Recherches ciblées avec `rg` ont été exécutées pour s’assurer que les sélecteurs concernés sont bien ceux de la Page 3 et que la modification reste limitée; la recherche a réussi.
- Inspection du fichier modifié avec `nl -ba css/style.css | sed -n '3396,3438p'` a confirmé l’insertion des nouvelles règles au bon emplacement; la vérification a réussi.
- Vérification du diff a confirmé que seule la règle CSS attendue a été changée dans `css/style.css`; la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0adf183410832a91c31d96690e88aa)