### PR TITLE
Autoriser le layout en pleine largeur sur Desktop en supprimant les max-width restrictifs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -44,6 +44,31 @@
   gap: 0.55rem;
 }
 
+@media (min-width: 1024px) {
+  :root {
+    --content-max-width: none;
+    --content-max-width-wide: none;
+    --app-shell-max-width: none;
+  }
+
+  .app-shell,
+  .app-shell--wide {
+    width: 100%;
+    max-width: none;
+    margin-inline: auto;
+  }
+
+  .page-content--wide {
+    width: 100%;
+    max-width: none;
+  }
+
+  body[data-page="users-management"] .app-shell.app-shell--wide {
+    width: 100%;
+    max-width: none;
+  }
+}
+
 .app-header__side {
   min-width: 0;
   min-height: 100%;


### PR DESCRIPTION
### Motivation

- Le contenu sur PC était contraint par des variables CSS (`--content-max-width`, `--content-max-width-wide`, `--app-shell-max-width`) et des classes (`.app-shell`, `.app-shell--wide`, `.page-content--wide`) qui forcent une largeur fixe.
- Cela empêchait les tables et les cards d’utiliser l’espace horizontal disponible sur les écrans larges tout en conservant l’affichage correct sur mobile.
- L’objectif est d’autoriser l’occupation maximale de la largeur sur Desktop/Grand écran sans casser le responsive mobile ni les comportements existants (modals, boutons, scroll horizontal des tableaux).

### Description

- Ajout d’un bloc `@media (min-width: 1024px)` dans `css/style.css` pour n’appliquer les changements que sur Desktop/tablette large.
- Dans ce media query, les variables de largeur sont désactivées en mettant `--content-max-width`, `--content-max-width-wide` et `--app-shell-max-width` à `none` pour lever les plafonds globaux.
- Les sélecteurs `.app-shell`, `.app-shell--wide` et `.page-content--wide` reçoivent `width: 100%` et `max-width: none` pour permettre l’utilisation complète de l’espace horizontal.
- Un override spécifique `body[data-page="users-management"] .app-shell.app-shell--wide` est ajouté pour lever toute limitation résiduelle sur la page de gestion des utilisateurs.

### Testing

- Aucun test automatisé n’est configuré dans le dépôt, donc aucun test automatisé n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be3d851cc832a809874cc308a373a)