### PR TITLE
Improve desktop and tablet responsive layout width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6248,3 +6248,53 @@ body[data-page="item-detail"] .search-highlight {
   font-weight: 500;
   line-height: 1.45;
 }
+
+@media (min-width: 1024px) {
+  :root {
+    --content-max-width: 1800px;
+    --content-max-width-wide: 1800px;
+    --app-shell-max-width: 1800px;
+  }
+
+  .app-shell,
+  .app-shell--wide,
+  body[data-page="users-management"] .app-shell.app-shell--wide {
+    width: min(96%, var(--app-shell-max-width));
+    max-width: var(--app-shell-max-width);
+    margin-inline: auto;
+  }
+
+  .page-content,
+  .page-content--wide,
+  body[data-page="users-management"] .page-content--wide,
+  body[data-page="item-detail"] .page-content,
+  body[data-page="site-detail"] .page-content {
+    width: 100%;
+    max-width: 100%;
+    margin-inline: auto;
+  }
+
+  .surface-card,
+  .table-card,
+  .details-card,
+  .list-card,
+  .card {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  body[data-page="item-detail"] .table-container--card,
+  body[data-page="item-detail"] .table-wrapper--shared,
+  body[data-page="users-management"] .table-wrapper--users {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  body[data-page="users-management"] .table-wrapper--users .data-table {
+    min-width: 64rem;
+  }
+
+  body[data-page="item-detail"] .data-table {
+    min-width: 82rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Desktop and tablet layouts were visually constrained, causing tables (Page 3, users) and cards to appear too narrow on large screens.
- The goal is to provide a premium, wider layout on PC while keeping mobile rendering identical and avoiding overly stretched content.
- Preserve existing horizontal scrolling behavior for wide tables and keep margins/padding for a premium look.

### Description
- Added a scoped responsive rule `@media (min-width: 1024px)` in `css/style.css` that raises the content cap to a premium `--app-shell-max-width: 1800px` and uses `width: min(96%, var(--app-shell-max-width))` with `margin-inline: auto` to center the app shell.
- Made `.page-content`, `.page-content--wide` and page-specific content containers (`item-detail`, `site-detail`, users) expand to full available width while maintaining max-width constraints.
- Set main UI blocks (`.surface-card`, `.table-card`, `.details-card`, `.list-card`, `.card`) to use `width: 100%` so cards take available horizontal space on larger screens.
- Increased minimum table widths for desktop to provide more horizontal room without breaking horizontal scroll by setting users table `min-width: 64rem` and item-detail/Page 3 table `min-width: 82rem`, while leaving `width: max-content`, `min-width: 100%`, and `overflow-x` behavior intact.

### Testing
- Ran repository scans and file inspections with `rg` and `sed` to validate selectors and insertion points, which completed successfully.
- Verified the CSS diff with `git diff -- css/style.css` to confirm changes, which showed the new media query and rules.
- Committed the change with `git add css/style.css && git commit -m "Improve desktop/tablet responsive width behavior"`, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be5b0375c832abf205c03a8aba5a6)