### PR TITLE
Fix desktop bottom navigation alignment with app shell width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6264,6 +6264,15 @@ body[data-page="item-detail"] .search-highlight {
     margin-inline: auto;
   }
 
+  .bottom-navigation {
+    left: 50%;
+    right: auto;
+    width: 96%;
+    max-width: var(--app-shell-max-width);
+    margin-inline: auto;
+    transform: translateX(-50%);
+  }
+
   .page-content,
   .page-content--wide,
   body[data-page="users-management"] .page-content--wide,


### PR DESCRIPTION
### Motivation
- Aligner la navigation basse sur desktop/tablette avec la largeur et le centrage de `.app-shell` pour corriger le décalage visuel causé par la position fixe pleine largeur.

### Description
- Ajout d’une règle CSS dans `@media (min-width: 1024px)` pour `.bottom-navigation` appliquant `left: 50%`, `right: auto`, `width: 96%`, `max-width: var(--app-shell-max-width)`, `margin-inline: auto` et `transform: translateX(-50%)`, en maintenant intact le comportement mobile, les animations, la safe-area et les icônes.

### Testing
- Aucun test automatique n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be9fb8088832abd49834e31cd5cb8)