### PR TITLE
Améliorer lisibilité Page 2 (desktop/tablette) sur site-detail

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6306,4 +6306,75 @@ body[data-page="item-detail"] .search-highlight {
   body[data-page="item-detail"] .data-table {
     min-width: 82rem;
   }
+
+  body[data-page="site-detail"] .app-shell,
+  body[data-page="site-detail"] .app-shell--wide {
+    width: 96%;
+    max-width: 1500px;
+    margin-inline: auto;
+  }
+
+  body[data-page="site-detail"] .page-content,
+  body[data-page="site-detail"] .page-content--wide {
+    width: 100%;
+    max-width: 100%;
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+
+  body[data-page="site-detail"] .search-panel,
+  body[data-page="site-detail"] .search-panel--site,
+  body[data-page="site-detail"] .page2-search-filter-bar {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  body[data-page="site-detail"] .search-panel .input-group,
+  body[data-page="site-detail"] .search-panel--site .input-group,
+  body[data-page="site-detail"] .page2-search-filter-bar .input-group {
+    max-width: none;
+    width: 100%;
+  }
+
+  body[data-page="site-detail"] .search-input,
+  body[data-page="site-detail"] #itemSearchInput {
+    min-height: 52px;
+    font-size: 1rem;
+  }
+
+  body[data-page="site-detail"] .progress-stats-card {
+    padding: 1.2rem 1.3rem;
+  }
+
+  body[data-page="site-detail"] .progress-total,
+  body[data-page="site-detail"] .progress-header {
+    font-size: 1rem;
+  }
+
+  body[data-page="site-detail"] .list-card {
+    width: 100%;
+    max-width: 100%;
+    padding: 1.25rem 1.4rem;
+    font-size: 1rem;
+  }
+
+  body[data-page="site-detail"] .list-card__title {
+    font-size: 1.12rem;
+  }
+
+  body[data-page="site-detail"] .list-card__meta {
+    font-size: 0.98rem;
+  }
+
+  body[data-page="site-detail"] .bottom-navigation {
+    width: 96%;
+    max-width: 1500px;
+  }
+
+  body[data-page="site-detail"] .site-detail-fab-stack,
+  body[data-page="site-detail"] .site-detail-fab-row,
+  body[data-page="site-detail"] .fab-add,
+  body[data-page="site-detail"] #openCreateItem {
+    right: max(24px, calc((100vw - min(96vw, 1500px)) / 2 + 24px));
+  }
 }


### PR DESCRIPTION
### Motivation
- Sur grands écrans la Page 2 (`body[data-page="site-detail"]`) reste trop compacte : les cards OUT, le champ recherche et les textes n’exploitent pas l’espace disponible alors que le mobile est correct.

### Description
- Ajout d’un bloc `@media (min-width: 1024px)` strictement scoped à `body[data-page="site-detail"]` pour ne pas toucher au rendu mobile.
- Mise à jour de `app-shell` / `app-shell--wide` en `width: 96%` et `max-width: 1500px` et centrage pour mieux utiliser les grands écrans.
- Extension de `page-content` / `page-content--wide` avec padding horizontal (`32px`) et largeur pleine, et passage des blocs de recherche (`search-panel`, `search-panel--site`, `page2-search-filter-bar`) et des `.input-group` à `width: 100%`.
- Agrandissement du champ recherche (`.search-input`, `#itemSearchInput`) avec `min-height: 52px` et `font-size: 1rem`, augmentation du padding et tailles de police des `.list-card`, `.list-card__title` et `.list-card__meta`, ajustement de la carte statistiques (`.progress-stats-card`) et de la `bottom-navigation`, et recalage horizontal du FAB (`.site-detail-fab-stack` / `.fab-add`) pour rester aligné au nouveau conteneur.

### Testing
- Inspection du fichier et des sélecteurs avec `rg` et `sed` pour valider l’emplacement et l’ordre des règles, opération réussie.
- Validation de l’application du patch via `git add` + `git commit` et création des métadonnées de PR (`make_pr`), toutes les commandes automatisées ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0becaac1bc832a89b4d9637905b7f3)