### PR TITLE
feat(css): mise en page immersive desktop/tablette (>=1024px)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6251,47 +6251,41 @@ body[data-page="item-detail"] .search-highlight {
 
 @media (min-width: 1024px) {
   :root {
-    --content-max-width: 1500px;
-    --content-max-width-wide: 1500px;
-    --app-shell-max-width: 1500px;
+    --content-max-width: 100%;
+    --content-max-width-wide: 100%;
+    --app-shell-max-width: 100%;
+  }
+
+  html {
+    font-size: 18px;
   }
 
   .app-shell,
   .app-shell--wide {
-    width: 96%;
-    max-width: 1500px;
-    margin-inline: auto;
-  }
-
-  .bottom-navigation {
-    left: 50%;
-    right: auto;
-    width: 96%;
-    max-width: 1500px;
-    margin-inline: auto;
-    transform: translateX(-50%);
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
   }
 
   .page-content,
   .page-content--wide {
     width: 100%;
     max-width: 100%;
-    margin-inline: auto;
-    padding-left: 32px;
-    padding-right: 32px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 
   .surface-card,
   .table-card,
-  .search-panel,
-  .list-card {
+  .list-card,
+  .search-panel {
     width: 100%;
     max-width: 100%;
   }
 
   .list-card {
-    padding: 1.25rem 1.4rem;
-    font-size: 1rem;
+    padding: 1.35rem 1.5rem;
+    border-radius: 20px;
   }
 
   .search-panel .input-group {
@@ -6299,33 +6293,51 @@ body[data-page="item-detail"] .search-highlight {
     width: 100%;
   }
 
-  .search-input {
-    min-height: 52px;
+  .search-input,
+  #detailSearchInput,
+  #searchInput {
+    min-height: 56px;
     font-size: 1rem;
   }
 
   .list-card__title {
-    font-size: 1.12rem;
+    font-size: 1.18rem;
+  }
+
+  .section-heading h2,
+  .section-title {
+    font-size: 1.2rem;
   }
 
   .list-card__meta {
-    font-size: 0.98rem;
-  }
-
-  .section-title,
-  .section-heading h2 {
-    font-size: 1.15rem;
+    font-size: 1rem;
   }
 
   .table-wrapper--shared,
-  .table-container--card {
+  .table-container--card,
+  .table-wrapper--users {
     width: 100%;
     max-width: 100%;
   }
 
-  body[data-page="users-management"] .table-wrapper--users {
-    width: 100%;
+  .app-header {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  .fab,
+  .fab-add {
+    transform: scale(1.08);
+  }
+
+  .bottom-nav,
+  .bottom-navigation,
+  .mobile-nav,
+  .tab-bar {
+    width: calc(100% - 24px);
     max-width: 100%;
+    left: 50%;
+    transform: translateX(-50%);
   }
 
   body[data-page="users-management"] .table-wrapper--users .data-table {
@@ -6334,12 +6346,5 @@ body[data-page="item-detail"] .search-highlight {
 
   body[data-page="item-detail"] .data-table {
     min-width: 82rem;
-  }
-
-  body[data-page="site-detail"] .site-detail-fab-stack,
-  body[data-page="site-detail"] .site-detail-fab-row,
-  body[data-page="site-detail"] .fab-add,
-  body[data-page="site-detail"] #openCreateItem {
-    right: max(24px, calc((100vw - min(96vw, 1500px)) / 2 + 24px));
   }
 }


### PR DESCRIPTION
### Motivation
- Offrir une version desktop/tablette immersive qui utilise presque toute la largeur d’écran et améliore la lisibilité sans toucher au rendu mobile existant.
- Agrandir l’interface desktop de manière propre et premium via `font-size`, largeur et espacements, en évitant `zoom` ou `transform: scale()` sur `body`/`.app-shell`.

### Description
- Mise à jour du bloc `@media (min-width: 1024px)` dans `css/style.css` pour redéfinir les variables `:root` et forcer des conteneurs en largeurs pleines afin d’autoriser un rendu quasi plein écran.
- Application d’un « zoom » lisibilité desktop via `html { font-size: 18px; }` et élargissement des conteneurs principaux avec `.app-shell, .app-shell--wide { width: 100%; max-width: 100%; margin: 0; }` et `page-content` avec `padding-left/right: 24px`.
- Ajustements des composants pour desktop : cartes (`.list-card`, `.surface-card`, `.table-card`, `.search-panel`) en `width: 100%`, padding/radius augmentés, champs de recherche (`.search-input`, `#detailSearchInput`, `#searchInput`) plus hauts, titres et méta-texte agrandis, et wrappers de tableaux élargis tout en conservant les min-width table existants.
- Améliorations visuelles ciblées : padding horizontal de l’`app-header`, légère mise à l’échelle des FAB (`.fab`, `.fab-add`), et recentrage/ajustement de la navigation basse (`.bottom-nav`, `.bottom-navigation`, `.mobile-nav`, `.tab-bar`) sans modifier les animations ni le comportement de scroll.

### Testing
- Inspection du fichier CSS et des sections ciblées via `rg` et `sed` pour localiser et relire le bloc `@media (min-width: 1024px)`, et vérification finale du fichier avec `nl -ba`, toutes ces commandes ayant réussi.
- Application automatisée du patch via un script Python qui a injecté le nouveau contenu dans le bloc média, et exécution des commandes d’inspection post-patch pour confirmer les modifications, toutes réussies.
- Vérification du diff résultant par inspection des différences du fichier modifié, confirmant que les changements sont uniquement contenus dans le bloc de breakpoint desktop/tablette et que le responsive mobile reste inchangé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf08d3acc832a9d12c428e555397b)