### PR TITLE
Forcer largeur 100% pour desktop et tablette

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6348,3 +6348,54 @@ body[data-page="item-detail"] .search-highlight {
     min-width: 82rem;
   }
 }
+
+@media (min-width: 1024px) {
+  :root {
+    --content-max-width: 100%;
+    --content-max-width-wide: 100%;
+    --app-shell-max-width: 100%;
+  }
+
+  .app-shell,
+  .app-shell--wide {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin-inline: 0 !important;
+  }
+
+  .page-content,
+  .page-content--wide,
+  .main-content {
+    width: 100% !important;
+    max-width: 100% !important;
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+
+  .app-header,
+  .page1-header,
+  .app-header--detail,
+  .app-header--home {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  .surface-card,
+  .table-card,
+  .search-panel,
+  .list-card,
+  body[data-page="home"] .list-card {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  .search-panel .input-group {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  body[data-page="users-management"] .app-shell.app-shell--wide {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Corriger le rendu desktop/tablette où la page et ses composants restaient centrés avec une largeur limitée par des variables et des classes globales. 
- S’assurer que l’en-tête, les cards, le champ de recherche et le contenu principal utilisent 100% de la largeur disponible sans modifier le comportement mobile. 

### Description
- Ajout d’une règle finale `@media (min-width: 1024px)` à la fin de `css/style.css` qui force `--content-max-width`, `--content-max-width-wide` et `--app-shell-max-width` à `100%`. 
- Ajout d’overrides `!important` pour ` .app-shell`, `.app-shell--wide`, `.page-content`, `.page-content--wide`, `.main-content`, les headers, les cards et `.search-panel .input-group` pour garantir `width/max-width: 100%` tout en conservant `padding-left/right: 24px`. 
- Ajout d’overrides spécifiques pour `body[data-page="home"] .list-card` et `body[data-page="users-management"] .app-shell.app-shell--wide` afin de traiter les cas demandés sans toucher au mobile. 

### Testing
- Vérification du fichier avec `tail -n 120 css/style.css` pour confirmer l’insertion de la media query, opération réussie. 
- Ajout et commit du fichier avec `git add css/style.css && git commit -m "Fix desktop/tablet layout to use full available width"`, commande réussie. 
- Création de la PR via l’outil automatique, PR générée avec succès; aucune suite de tests automatisés supplémentaires n’a été lancée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf3e80cb0832a8eb88f7f6761a74a)