### PR TITLE
Fix full-width layout for tablet/desktop and Chrome Android desktop mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6399,3 +6399,56 @@ body[data-page="item-detail"] .search-highlight {
     max-width: 100% !important;
   }
 }
+
+@media (min-width: 768px) {
+  :root {
+    --content-max-width: 100%;
+    --content-max-width-wide: 100%;
+    --app-shell-max-width: 100%;
+  }
+
+  html,
+  body {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .app-shell,
+  .app-shell--wide {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  .page-content,
+  .page-content--wide,
+  .main-content {
+    width: 100% !important;
+    max-width: 100% !important;
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+
+  .app-header,
+  .page1-header,
+  .app-header--home,
+  .app-header--detail {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  .surface-card,
+  .table-card,
+  .search-panel,
+  .list-card,
+  body[data-page="home"] .list-card {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  .search-panel .input-group {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Chrome Android in “Desktop site” can report a CSS width around ~980px which prevented the existing `@media (min-width: 1024px)` desktop rules from applying, leaving the layout constrained and centered like mobile.
- The goal is to ensure tablet, desktop and Chrome Android desktop-mode get full-width layout without changing normal mobile behavior and without using global scaling or zoom hacks.

### Description
- Appended a new `@media (min-width: 768px)` override block at the very end of `css/style.css` to target tablet and desktop-mode mobile reliably.
- Forced root width variables and key containers (`html`, `body`, `.app-shell`, `.page-content`, headers, cards and search input groups) to `100%` and included `!important` where needed to override prior rules.
- Kept mobile-only styles intact and explicitly avoided touching table horizontal scrolling, `transform: scale`, or CSS `zoom`.
- The change is limited to `css/style.css` and is added as an override block so it only applies from `768px` and up.

### Testing
- Appended block presence verified with `tail -n 80 css/style.css` which printed the new `@media (min-width: 768px)` block successfully.
- File content and placement validated with `nl -ba css/style.css | tail -n 90` which confirmed the block is at the end of the file.
- Repository changes confirmed with `git status --short` and committed successfully using `git add css/style.css && git commit -m "Fix 100% width behavior from 768px for desktop-mode mobile"` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf7000c90832aba2bdc95349abe11)