### PR TITLE
Agrandir l’UI tablette/desktop via `@media (min-width:768px)` sans toucher au mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6452,3 +6452,87 @@ body[data-page="item-detail"] .search-highlight {
     max-width: 100% !important;
   }
 }
+
+@media (min-width: 768px) {
+  html {
+    font-size: 18px;
+  }
+
+  .app-header {
+    min-height: 4.6rem;
+    height: 4.6rem;
+  }
+
+  .header-title h1 {
+    font-size: 1.55rem;
+  }
+
+  .site-detail-subtitle,
+  .header-title__line--secondary {
+    font-size: 1rem;
+  }
+
+  .page-content,
+  .page-content--wide,
+  .main-content {
+    padding-left: 28px !important;
+    padding-right: 28px !important;
+    gap: 1.15rem;
+  }
+
+  .search-input,
+  #searchInput,
+  #detailSearchInput,
+  #materialsSearchInput {
+    min-height: 58px;
+    font-size: 1.05rem;
+  }
+
+  .search-panel,
+  .surface-card,
+  .table-card,
+  .list-card {
+    padding: 1.35rem 1.5rem;
+  }
+
+  .list-card {
+    min-height: 120px;
+    border-radius: 22px;
+  }
+
+  .list-card__title {
+    font-size: 1.22rem;
+  }
+
+  .list-card__meta {
+    font-size: 1.02rem;
+    gap: 0.38rem;
+  }
+
+  .section-title,
+  .section-heading h2 {
+    font-size: 1.25rem;
+  }
+
+  .btn,
+  .btn-danger {
+    min-height: 52px;
+    font-size: 1rem;
+  }
+
+  .fab,
+  .fab-add,
+  .fab-add--item-detail {
+    width: 68px;
+    height: 68px;
+    font-size: 2.25rem;
+  }
+
+  .bottom-nav,
+  .bottom-navigation,
+  .mobile-nav,
+  .tab-bar {
+    min-height: 72px;
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Sur Chrome Android en “Version ordinateur” (et sur tablettes/desktop) l’UI devenait trop petite malgré `width:100%`, il faut améliorer la lisibilité sans modifier le rendu mobile standard.
- Respecter les contraintes demandées : ne pas utiliser de `zoom` global ni `transform: scale` sur le `body`, ne pas casser le scroll, la navigation bottom, les modals ni les tableaux.

### Description
- Ajout d’un bloc `@media (min-width: 768px)` à la fin de `css/style.css` qui augmente la taille de base (`html { font-size: 18px; }`) et agrandit header, titres, cards, champs, boutons, FAB, paddings et gaps pour tablette/desktop et Chrome mobile en mode ordinateur.
- Les règles de largeur `100%` existantes n’ont pas été remplacées et restent actives ; ce bloc complète uniquement les règles pour améliorer la lisibilité sous la media-query ciblée.
- Le bloc a été placé après toutes les autres règles CSS pour assurer des overrides contrôlés et maintenir le comportement mobile inchangé.

### Testing
- Vérification du fichier et du contenu ajouté avec `nl -ba css/style.css | tail -n 120`, qui a affiché le bloc ajouté avec succès.
- Contrôles git effectués avec `git status --short` et `git add css/style.css && git commit -m "Adjust tablet/desktop UI scaling for readability"`, la commit a réussi et la modification est d’un fichier avec 84 insertions.
- Aucune suite de tests automatisés d’UI n’a été exécutée dans ce rollout, une validation visuelle sur appareils cibles est recommandée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfa8d3c80832a93e9741405dbde23)