### PR TITLE
Distinct responsive behavior for mouse vs touch in desktop mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6536,3 +6536,188 @@ body[data-page="item-detail"] .search-highlight {
     font-size: 1rem;
   }
 }
+
+/* Premium responsive differentiation: desktop pointer vs touch pointer in desktop mode */
+@media (min-width: 768px) and (pointer: fine) {
+  :root {
+    --content-max-width: 100%;
+    --content-max-width-wide: 100%;
+    --app-shell-max-width: 100%;
+  }
+
+  html {
+    font-size: 16px;
+  }
+
+  .app-shell,
+  .app-shell--wide,
+  .page-content,
+  .page-content--wide,
+  .main-content,
+  .surface-card,
+  .table-card,
+  .search-panel,
+  .list-card,
+  .table-wrapper--shared,
+  .table-container--card,
+  .table-wrapper--users,
+  body[data-page="home"] .list-card {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  .page-content,
+  .page-content--wide,
+  .main-content,
+  .app-header {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+
+  .search-input,
+  #searchInput,
+  #detailSearchInput,
+  #materialsSearchInput {
+    min-height: 48px;
+    font-size: 1rem;
+  }
+
+  .search-panel,
+  .surface-card,
+  .table-card,
+  .list-card {
+    padding: 1rem 1.1rem;
+  }
+
+  .list-card {
+    min-height: 0;
+    border-radius: 16px;
+  }
+
+  .btn,
+  .btn-danger {
+    min-height: 44px;
+    font-size: 0.95rem;
+  }
+
+  .fab,
+  .fab-add,
+  .fab-add--item-detail {
+    width: 58px;
+    height: 58px;
+    font-size: 2rem;
+    transform: none;
+  }
+
+  .bottom-nav,
+  .bottom-navigation,
+  .mobile-nav,
+  .tab-bar {
+    min-height: 64px;
+    width: calc(100% - 24px);
+    max-width: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  body[data-page="users-management"] .table-wrapper--users .data-table {
+    min-width: 64rem;
+  }
+
+  body[data-page="item-detail"] .data-table {
+    min-width: 82rem;
+  }
+}
+
+@media (min-width: 768px) and (pointer: coarse) {
+  :root {
+    --content-max-width: 100%;
+    --content-max-width-wide: 100%;
+    --app-shell-max-width: 100%;
+  }
+
+  html {
+    font-size: 18px;
+  }
+
+  .app-shell,
+  .app-shell--wide,
+  .page-content,
+  .page-content--wide,
+  .main-content,
+  .surface-card,
+  .table-card,
+  .search-panel,
+  .list-card,
+  .table-wrapper--shared,
+  .table-container--card,
+  .table-wrapper--users,
+  body[data-page="home"] .list-card {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  .page-content,
+  .page-content--wide,
+  .main-content,
+  .app-header {
+    padding-left: 28px !important;
+    padding-right: 28px !important;
+    gap: 1.15rem;
+  }
+
+  .search-input,
+  #searchInput,
+  #detailSearchInput,
+  #materialsSearchInput {
+    min-height: 58px;
+    font-size: 1.05rem;
+  }
+
+  .search-panel,
+  .surface-card,
+  .table-card,
+  .list-card {
+    padding: 1.35rem 1.5rem;
+  }
+
+  .list-card {
+    min-height: 120px;
+    border-radius: 22px;
+  }
+
+  .btn,
+  .btn-danger {
+    min-height: 52px;
+    font-size: 1rem;
+  }
+
+  .fab,
+  .fab-add,
+  .fab-add--item-detail {
+    width: 68px;
+    height: 68px;
+    font-size: 2.25rem;
+    transform: none;
+  }
+
+  .bottom-nav,
+  .bottom-navigation,
+  .mobile-nav,
+  .tab-bar {
+    min-height: 72px;
+    font-size: 1rem;
+    width: calc(100% - 24px);
+    max-width: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  body[data-page="users-management"] .table-wrapper--users .data-table {
+    min-width: 64rem;
+  }
+
+  body[data-page="item-detail"] .data-table {
+    min-width: 82rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent Android/iPad browsers in “Version ordinateur” from using compact desktop rules that make the UI tiny on touch devices by distinguishing pointer types at desktop breakpoints.
- Preserve a premium, full-width desktop layout for true desktops while providing a larger, touch-friendly desktop-mode UI for coarse-pointer devices.

### Description
- Added pointer-aware media queries to `css/style.css`: `@media (min-width: 768px) and (pointer: fine)` and `@media (min-width: 768px) and (pointer: coarse)` to split behaviors.
- For `pointer: fine` the stylesheet enforces desktop density with `html { font-size: 16px; }`, tighter paddings, more compact cards/inputs/buttons and standard FAB/bottom-nav sizes while keeping `width:100%`/`max-width:100%` for wide layout.
- For `pointer: coarse` the stylesheet increases base sizing with `html { font-size: 18px; }`, larger paddings, bigger inputs/buttons/cards/FAB and taller bottom navigation to provide comfortable touch targets while still keeping full-width layout.
- Kept existing large table `min-width` values for `users-management` and `item-detail`, avoided any global `transform: scale` or CSS zoom, and did not alter mobile rules below `768px`.

### Testing
- File-level CSS syntax and diff inspection of `css/style.css` confirmed the new media-query blocks and rule changes and passed automated checks.
- Repository update and PR preparation completed successfully; no unit tests were modified or added and visual verification on real devices is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c33e9ffb4832a8e7a88d88bef5533)