### PR TITLE
Add global responsive UI scaling for tablet/desktop modes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6453,271 +6453,50 @@ body[data-page="item-detail"] .search-highlight {
   }
 }
 
+/* =========================================================
+   RESPONSIVE UI SCALING
+   Premium scaling for tablet / desktop / Chrome desktop mode
+========================================================= */
+
+/* Tablette + Chrome mobile mode ordinateur */
 @media (min-width: 768px) {
-  html {
-    font-size: 18px;
-  }
-
-  .app-header {
-    min-height: 4.6rem;
-    height: 4.6rem;
-  }
-
-  .header-title h1 {
-    font-size: 1.55rem;
-  }
-
-  .site-detail-subtitle,
-  .header-title__line--secondary {
-    font-size: 1rem;
-  }
-
-  .page-content,
-  .page-content--wide,
-  .main-content {
-    padding-left: 28px !important;
-    padding-right: 28px !important;
-    gap: 1.15rem;
-  }
-
-  .search-input,
-  #searchInput,
-  #detailSearchInput,
-  #materialsSearchInput {
-    min-height: 58px;
-    font-size: 1.05rem;
-  }
-
-  .search-panel,
-  .surface-card,
-  .table-card,
-  .list-card {
-    padding: 1.35rem 1.5rem;
-  }
-
-  .list-card {
-    min-height: 120px;
-    border-radius: 22px;
-  }
-
-  .list-card__title {
-    font-size: 1.22rem;
-  }
-
-  .list-card__meta {
-    font-size: 1.02rem;
-    gap: 0.38rem;
-  }
-
-  .section-title,
-  .section-heading h2 {
-    font-size: 1.25rem;
-  }
-
-  .btn,
-  .btn-danger {
-    min-height: 52px;
-    font-size: 1rem;
-  }
-
-  .fab,
-  .fab-add,
-  .fab-add--item-detail {
-    width: 68px;
-    height: 68px;
-    font-size: 2.25rem;
-  }
-
-  .bottom-nav,
-  .bottom-navigation,
-  .mobile-nav,
-  .tab-bar {
-    min-height: 72px;
-    font-size: 1rem;
-  }
-}
-
-/* Premium responsive differentiation: desktop pointer vs touch pointer in desktop mode */
-@media (min-width: 768px) and (pointer: fine) {
+  html { font-size: 17px; }
   :root {
     --content-max-width: 100%;
     --content-max-width-wide: 100%;
     --app-shell-max-width: 100%;
+    --header-height: 4.8rem;
+    --radius-lg: 28px;
+    --radius-md: 18px;
   }
-
-  html {
-    font-size: 16px;
+  html, body { width: 100%; max-width: 100%; }
+  .app-shell, .app-shell--wide, .page-content, .page-content--wide, .main-content { width: 100%; max-width: 100%; }
+  .page-content { padding-inline: 24px; gap: 1rem; }
+  .app-header, .page1-header, .app-header--home, .app-header--detail { width: 100%; max-width: 100%; }
+  .list-card, .surface-card, .table-card, .search-panel, .modal-content, body[data-page="home"] .list-card {
+    width: 100%; max-width: 100%; border-radius: 24px;
   }
-
-  .app-shell,
-  .app-shell--wide,
-  .page-content,
-  .page-content--wide,
-  .main-content,
-  .surface-card,
-  .table-card,
-  .search-panel,
-  .list-card,
-  .table-wrapper--shared,
-  .table-container--card,
-  .table-wrapper--users,
-  body[data-page="home"] .list-card {
-    width: 100% !important;
-    max-width: 100% !important;
+  .list-card { padding: 1.25rem; min-height: 120px; }
+  .table-wrapper--shared, .table-container--card, .table-wrapper--users { width: 100%; max-width: 100%; }
+  .search-panel .input-group, .input-group { width: 100%; max-width: 100%; }
+  .input-group input, .input-group select, .cell-input, .cell-textarea, #detailSearchInput, #searchInput, #materialsSearchInput {
+    min-height: 58px; font-size: 1rem;
   }
-
-  .page-content,
-  .page-content--wide,
-  .main-content,
-  .app-header {
-    padding-left: 24px !important;
-    padding-right: 24px !important;
-  }
-
-  .search-input,
-  #searchInput,
-  #detailSearchInput,
-  #materialsSearchInput {
-    min-height: 48px;
-    font-size: 1rem;
-  }
-
-  .search-panel,
-  .surface-card,
-  .table-card,
-  .list-card {
-    padding: 1rem 1.1rem;
-  }
-
-  .list-card {
-    min-height: 0;
-    border-radius: 16px;
-  }
-
-  .btn,
-  .btn-danger {
-    min-height: 44px;
-    font-size: 0.95rem;
-  }
-
-  .fab,
-  .fab-add,
-  .fab-add--item-detail {
-    width: 58px;
-    height: 58px;
-    font-size: 2rem;
-    transform: none;
-  }
-
-  .bottom-nav,
-  .bottom-navigation,
-  .mobile-nav,
-  .tab-bar {
-    min-height: 64px;
-    width: calc(100% - 24px);
-    max-width: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  body[data-page="users-management"] .table-wrapper--users .data-table {
-    min-width: 64rem;
-  }
-
-  body[data-page="item-detail"] .data-table {
-    min-width: 82rem;
+  .btn, .btn-danger { min-height: 56px; font-size: 1rem; }
+  .fab, .fab-add, .fab-add--item-detail { width: 72px; height: 72px; font-size: 2.4rem; }
+  .header-title h1, .page-title, .section-heading h2, .section-title { font-size: 1.7rem; }
+  .site-detail-subtitle, .header-title__line--secondary { font-size: 1rem; }
+  .list-card__title { font-size: 1.35rem; }
+  .list-card__meta { font-size: 1rem; }
+  .bottom-nav, .bottom-navigation, .mobile-nav, .tab-bar {
+    min-height: 72px; font-size: 1rem; width: calc(100% - 24px); max-width: 100%; left: 50%; transform: translateX(-50%);
   }
 }
 
-@media (min-width: 768px) and (pointer: coarse) {
-  :root {
-    --content-max-width: 100%;
-    --content-max-width-wide: 100%;
-    --app-shell-max-width: 100%;
-  }
-
-  html {
-    font-size: 18px;
-  }
-
-  .app-shell,
-  .app-shell--wide,
-  .page-content,
-  .page-content--wide,
-  .main-content,
-  .surface-card,
-  .table-card,
-  .search-panel,
-  .list-card,
-  .table-wrapper--shared,
-  .table-container--card,
-  .table-wrapper--users,
-  body[data-page="home"] .list-card {
-    width: 100% !important;
-    max-width: 100% !important;
-  }
-
-  .page-content,
-  .page-content--wide,
-  .main-content,
-  .app-header {
-    padding-left: 28px !important;
-    padding-right: 28px !important;
-    gap: 1.15rem;
-  }
-
-  .search-input,
-  #searchInput,
-  #detailSearchInput,
-  #materialsSearchInput {
-    min-height: 58px;
-    font-size: 1.05rem;
-  }
-
-  .search-panel,
-  .surface-card,
-  .table-card,
-  .list-card {
-    padding: 1.35rem 1.5rem;
-  }
-
-  .list-card {
-    min-height: 120px;
-    border-radius: 22px;
-  }
-
-  .btn,
-  .btn-danger {
-    min-height: 52px;
-    font-size: 1rem;
-  }
-
-  .fab,
-  .fab-add,
-  .fab-add--item-detail {
-    width: 68px;
-    height: 68px;
-    font-size: 2.25rem;
-    transform: none;
-  }
-
-  .bottom-nav,
-  .bottom-navigation,
-  .mobile-nav,
-  .tab-bar {
-    min-height: 72px;
-    font-size: 1rem;
-    width: calc(100% - 24px);
-    max-width: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  body[data-page="users-management"] .table-wrapper--users .data-table {
-    min-width: 64rem;
-  }
-
-  body[data-page="item-detail"] .data-table {
-    min-width: 82rem;
-  }
+/* Grand desktop */
+@media (min-width: 1200px) {
+  html { font-size: 18px; }
+  .page-content { padding-inline: 36px; }
+  .list-grid { gap: 1.2rem; }
+  .list-card { padding: 1.4rem; }
 }


### PR DESCRIPTION
### Motivation
- Appliquer un système global de scaling UI professionnel (via `html { font-size }`, `rem`, paddings et tailles réactives) pour tablette, desktop et Chrome Android en « Version ordinateur » afin d’améliorer lisibilité et confort sans utiliser `transform`, `zoom` ni `scale`.
- Supprimer les limitations de largeur artificielles (containers / `max-width` bridés) qui empêchaient l’utilisation propre de l’espace disponible sur tablettes et desktop.
- Unifier et simplifier les overrides finaux en évitant doubles règles et conflits issus des anciens media-queries basés sur `pointer`.

### Description
- Ajout d’un bloc `RESPONSIVE UI SCALING` placé tout en bas de `css/style.css` contenant les breakpoints demandés `@media (min-width: 768px)` et `@media (min-width: 1200px)` et progressions de `html { font-size }` pour améliorer l’échelle typographique.
- Forçage propre de la largeur utile (`width: 100%` / `max-width: 100%`) pour `:root` variables et composants principaux (`.app-shell`, `.page-content`, `.list-card`, `.surface-card`, `.table-card`, `.table-wrapper--shared`, `.table-container--card`, `.table-wrapper--users`, `.app-header`, etc.) pour supprimer les contraintes desktop/tablette.
- Ajustements de lisibilité et d’accessibilité : augmentation des `font-size` (titres, meta, sous-titres), `min-height` pour inputs et boutons, paddings de cards, tailles de `fab` et navigation basse, et variables CSS (`--header-height`, `--radius-*`) dans le scope des media-queries.
- Suppression/remplacement de l’ancien code différenciant par `pointer` en fin de fichier pour éviter overrides conflictuels et centraliser la stratégie de scaling; aucune création de fichier, seul `css/style.css` a été modifié.

### Testing
- Inspecté le fichier et le positionnement du bloc via `nl -ba css/style.css | tail -n 80` et `wc -l css/style.css` (résultats valides and block placé en fin de fichier); check réussi.
- Validation de l’état git avec `git status --short` et commit des changements avec `git commit` pour s’assurer que seul `css/style.css` a été modifié; opération réussie.
- Aucune suite de tests automatisés front-end (visual/regression) n’était présente dans le repo, les vérifications réalisées sont des inspections de fichier et commit, toutes réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c3aa651e4832aaf8b93318b89d3c6)