### PR TITLE
Fix premium responsive scaling to preserve side background gutters

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6500,3 +6500,37 @@ body[data-page="item-detail"] .search-highlight {
   .list-grid { gap: 1.2rem; }
   .list-card { padding: 1.4rem; }
 }
+
+/* Premium fluid width guardrails (tablet/desktop zoom safe) */
+@media (min-width: 768px) {
+  .app-shell,
+  .app-shell--wide {
+    width: min(calc(100% - 24px), 1600px) !important;
+    max-width: 1600px !important;
+    margin-inline: auto !important;
+  }
+
+  .page-content,
+  .page-content--wide,
+  .main-content {
+    width: 100% !important;
+    max-width: 100% !important;
+    padding-left: 18px !important;
+    padding-right: 18px !important;
+    box-sizing: border-box;
+  }
+
+  .app-header {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  .list-card,
+  .surface-card,
+  .table-card,
+  .search-panel {
+    width: 100% !important;
+    max-width: 100% !important;
+    box-sizing: border-box;
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent content from stretching to the viewport edges and disappearing gutters at tablet/desktop sizes while keeping responsive scaling and avoiding CSS hacks like `100vw`, `transform:scale()` or `zoom`.
- Ensure header, cards, search and statistics are never clipped when the user zooms the browser and keep the main content centered with visible left/right background.

### Description
- Added a final `@media (min-width: 768px)` block that sets `.app-shell` and `.app-shell--wide` to `width: min(calc(100% - 24px), 1600px)`, `max-width: 1600px`, and `margin-inline: auto` to create a fluid, centered premium container.
- Updated `.page-content`, `.page-content--wide`, and `.main-content` to `width: 100%`, `padding-left/right: 18px`, and `box-sizing: border-box` so inner content stays centered and never touches the shell edges.
- Bounded `.app-header`, `.list-card`, `.surface-card`, `.table-card`, and `.search-panel` to the shell width and applied `box-sizing` to avoid horizontal overflow and clipping under zoom.

### Testing
- Ran pattern searches (`rg`) across the stylesheet to confirm the targeted selectors and width rules were present and not duplicated.
- Inspected the updated CSS region (`sed`/file preview) to verify the new media block was appended with the intended declarations.
- Performed a local smoke validation on the stylesheet with no syntax errors observed in the changed snippets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c3e7e7ea8832aa77ab30c5b5bb787)