### PR TITLE
Forcer les FilterChips de la page 2 sur une seule ligne

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5608,9 +5608,23 @@ body[data-page="site-detail"] .filter-chip-group {
   width: 100%;
 }
 
-body[data-page="site-detail"] .filter-chip {
+body.page2 .filter-chips-container {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
   white-space: nowrap;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+body.page2 .filter-chips-container::-webkit-scrollbar {
+  display: none;
+}
+
+body.page2 .filter-chips-container .filter-chip {
   flex: 0 0 auto;
+  width: fit-content;
+  white-space: nowrap;
 }
 
 body[data-page="site-detail"] .list-grid {

--- a/page2.html
+++ b/page2.html
@@ -58,7 +58,7 @@
               <span aria-hidden="true">›</span>
             </button>
           </section>
-          <div class="filter-chip-group filters" role="group" aria-label="Filtrer les résultats par date">
+          <div class="filter-chip-group filter-chips-container filters" role="group" aria-label="Filtrer les résultats par date">
             <button class="filter-chip" type="button" data-filter-chip="all">Tous</button>
             <button class="filter-chip" type="button" data-filter-chip="today">Aujourd’hui</button>
             <button class="filter-chip" type="button" data-filter-chip="yesterday">Hier</button>


### PR DESCRIPTION
### Motivation
- Empêcher que les FilterChip de la page 2 (Tous / Aujourd’hui / Hier / Plus ancien) passent à la ligne lorsqu'il n'y a pas assez d'espace. 
- Permettre un défilement horizontal si l'espace est insuffisant tout en conservant l'espacement et le comportement visuel actuels. 

### Description
- Ajout de la classe `filter-chips-container` sur le conteneur de chips dans `page2.html` pour cibler uniquement la page 2. 
- Ajout de règles CSS scoped à `body.page2` dans `css/style.css` qui appliquent `display: flex`, `flex-wrap: nowrap`, `overflow-x: auto`, `scrollbar-width: none`, `-ms-overflow-style: none` et masquent le scrollbar WebKit via `::-webkit-scrollbar`. 
- Les chips conservent `flex: 0 0 auto` et reçoivent `width: fit-content` et `white-space: nowrap` pour garder leur largeur naturelle et empêcher leur compression. 
- Aucun autre fichier, logique, filtre, requête ou design n'a été modifié et le comportement fonctionnel de l'application est inchangé. 

### Testing
- Exécution de `git diff --check` pour vérifier les erreurs de diff (réussi). 
- Exécution d'un script de vérification Python qui confirme la présence de la classe conteneur et des règles CSS (`nowrap`, `overflow-x: auto`, masquage des scrollbars, `flex: 0 0 auto`, `width: fit-content`) (réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fe2b50a54832aa04e4d83495bf656)