### PR TITLE
Ajouter la page « Demande d'indemnités » et entrée Sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6183,11 +6183,19 @@ body.sidebar-open {
   padding: 0 14px;
   display: flex;
   align-items: center;
+  gap: 10px;
   font-size: 15px;
   font-weight: 600;
   color: #1f2937;
   background: transparent;
   transition: all 0.2s ease;
+}
+
+.sidebar-item__icon {
+  width: 20px;
+  color: #2563eb;
+  font-size: 18px;
+  text-align: center;
 }
 
 .sidebar-item:hover {

--- a/indemnites.html
+++ b/indemnites.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Demande d'indemnités - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+      body[data-page="indemnites"] .page-content {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding-bottom: 28px;
+      }
+
+      .indemnity-card {
+        background: var(--surface, #fff);
+        border-radius: 22px;
+        box-shadow: var(--shadow-card, 0 14px 35px rgba(15, 23, 42, 0.08));
+        padding: clamp(16px, 4vw, 24px);
+      }
+
+      .indemnity-section-title {
+        margin: 0 0 14px;
+        color: #0f172a;
+        font-size: clamp(1.05rem, 3.6vw, 1.25rem);
+        font-weight: 800;
+      }
+
+      .indemnity-form {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+        gap: 12px;
+        align-items: end;
+      }
+
+      .indemnity-form .input-group input {
+        width: 100%;
+      }
+
+      .indemnity-form .btn {
+        min-height: 48px;
+        white-space: nowrap;
+      }
+
+      .indemnity-summary-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .indemnity-summary-item {
+        border-radius: 18px;
+        background: #eef5fb;
+        padding: 16px;
+      }
+
+      .indemnity-summary-label {
+        margin: 0 0 6px;
+        color: #64748b;
+        font-size: 0.9rem;
+        font-weight: 700;
+      }
+
+      .indemnity-summary-value {
+        margin: 0;
+        color: #0f172a;
+        font-size: clamp(1.7rem, 8vw, 2.35rem);
+        font-weight: 900;
+        line-height: 1;
+      }
+
+      .indemnity-list-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 14px;
+      }
+
+      .indemnity-list-count {
+        border-radius: 999px;
+        background: #eef5fb;
+        color: #2563eb;
+        font-size: 0.85rem;
+        font-weight: 800;
+        padding: 6px 10px;
+      }
+
+      .indemnity-list {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .indemnity-person-card {
+        display: grid;
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) auto auto;
+        gap: 12px;
+        align-items: center;
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        border-radius: 18px;
+        background: #f8fbff;
+        padding: 12px;
+      }
+
+      .indemnity-person-main strong,
+      .indemnity-person-meta strong {
+        display: block;
+        color: #0f172a;
+        font-size: 0.98rem;
+      }
+
+      .indemnity-person-main span,
+      .indemnity-person-meta span {
+        display: block;
+        margin-top: 3px;
+        color: #64748b;
+        font-size: 0.82rem;
+        font-weight: 700;
+      }
+
+      .indemnity-card-actions {
+        display: inline-flex;
+        gap: 8px;
+      }
+
+      .indemnity-icon-btn {
+        border: 0;
+        width: 38px;
+        height: 38px;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: #e2e8f0;
+        color: #0f172a;
+      }
+
+      .indemnity-icon-btn--delete {
+        background: #fee2e2;
+        color: #b91c1c;
+      }
+
+      .indemnity-empty {
+        margin: 0;
+        border: 1px dashed #cbd5e1;
+        border-radius: 18px;
+        color: #64748b;
+        padding: 22px 14px;
+        text-align: center;
+        font-weight: 700;
+      }
+
+      .indemnity-export-row {
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .indemnity-export-row .btn {
+        min-height: 48px;
+      }
+
+      .indemnity-export-row .btn:disabled {
+        cursor: not-allowed;
+        opacity: 0.55;
+      }
+
+      .indemnity-preview-wrap {
+        max-height: min(62vh, 560px);
+        overflow: auto;
+        border-radius: 18px;
+        background: #eef5fb;
+        padding: 10px;
+      }
+
+      .indemnity-preview-image {
+        display: block;
+        width: 100%;
+        height: auto;
+        border-radius: 14px;
+      }
+
+      @media (max-width: 820px) {
+        .indemnity-form,
+        .indemnity-person-card {
+          grid-template-columns: 1fr;
+        }
+
+        .indemnity-form .btn,
+        .indemnity-export-row .btn {
+          width: 100%;
+        }
+
+        .indemnity-list-header,
+        .indemnity-export-row {
+          align-items: stretch;
+          flex-direction: column;
+        }
+
+        .indemnity-card-actions {
+          justify-content: flex-end;
+        }
+      }
+    </style>
+  </head>
+  <body data-page="indemnites" class="indemnites-page">
+    <div class="app-shell">
+      <header class="app-header app-header--detail">
+        <button id="indemnitiesBackButton" class="back-button" type="button" aria-label="Retour">
+          <img src="Icon/btn-retour.png" alt="" aria-hidden="true" class="back-button__icon" />
+        </button>
+        <div class="header-title">
+          <h1>Demande d'indemnités</h1>
+        </div>
+      </header>
+
+      <main class="page-content main-content">
+        <section class="indemnity-card" aria-labelledby="indemnityFormTitle">
+          <h2 id="indemnityFormTitle" class="indemnity-section-title">Ajouter une personne</h2>
+          <form id="indemnityForm" class="indemnity-form">
+            <label class="input-group">
+              <span>Nom de la personne</span>
+              <input id="indemnityNameInput" type="text" autocomplete="off" maxlength="80" required />
+            </label>
+            <label class="input-group">
+              <span>Date de travail</span>
+              <input id="indemnityDateInput" type="date" required />
+            </label>
+            <label class="input-group">
+              <span>Nombre de jours</span>
+              <input id="indemnityDaysInput" type="number" min="1" max="999" step="1" inputmode="numeric" value="1" required />
+            </label>
+            <button id="indemnitySubmitButton" class="btn btn-success" type="submit">Ajouter</button>
+          </form>
+          <p id="indemnityFormError" class="form-error" aria-live="polite"></p>
+        </section>
+
+        <section class="indemnity-card" aria-labelledby="indemnitySummaryTitle">
+          <h2 id="indemnitySummaryTitle" class="indemnity-section-title">Résumé</h2>
+          <div class="indemnity-summary-grid">
+            <div class="indemnity-summary-item">
+              <p class="indemnity-summary-label">Personnes enregistrées</p>
+              <p id="indemnityPeopleTotal" class="indemnity-summary-value">0</p>
+            </div>
+            <div class="indemnity-summary-item">
+              <p class="indemnity-summary-label">Total des jours travaillés</p>
+              <p id="indemnityDaysTotal" class="indemnity-summary-value">0</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="indemnity-card" aria-labelledby="indemnityListTitle">
+          <div class="indemnity-list-header">
+            <h2 id="indemnityListTitle" class="indemnity-section-title">Liste des personnes</h2>
+            <span id="indemnityListCount" class="indemnity-list-count">0 personne</span>
+          </div>
+          <div id="indemnityList" class="indemnity-list" aria-live="polite"></div>
+        </section>
+
+        <section class="indemnity-card" aria-labelledby="indemnityExportTitle">
+          <h2 id="indemnityExportTitle" class="indemnity-section-title">Export</h2>
+          <div class="indemnity-export-row">
+            <button id="exportIndemnityImageBtn" class="btn btn-primary export-img-btn" type="button">Exporter en image</button>
+          </div>
+        </section>
+      </main>
+
+      <dialog id="indemnityPreviewModal" class="modal-card">
+        <div class="modal-content modal-content--site-create">
+          <div class="modal-header">
+            <h2 class="modal-title">Image générée</h2>
+            <p class="modal-subtitle">Votre demande d'indemnités a été téléchargée avec succès.</p>
+          </div>
+          <div class="indemnity-preview-wrap">
+            <img id="indemnityPreviewImage" class="indemnity-preview-image" alt="Aperçu demande d'indemnités" />
+          </div>
+          <div class="modal-actions modal-actions--split modal-actions--site-create">
+            <button id="indemnityPreviewOkBtn" class="btn btn-success" type="button">OK</button>
+          </div>
+        </div>
+      </dialog>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script type="module" src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+    <script type="module" src="js/indemnites.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,10 @@
           <button id="sidebarAllMaterialsBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="materiels.html">
             Demande matériels
           </button>
+          <button id="sidebarIndemnitiesBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="indemnites.html">
+            <i class="fa-solid fa-user-clock sidebar-item__icon" aria-hidden="true"></i>
+            <span>Demande d'indemnités</span>
+          </button>
           <button id="sidebarImportBtn" class="header-menu__option sidebar-item" type="button" role="menuitem">
             Importer les données
           </button>

--- a/js/app.js
+++ b/js/app.js
@@ -1075,6 +1075,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const usersSidebarBtn = homeMenuPanel?.querySelector('#sidebarUsersBtn') || null;
     const historySidebarBtn = homeMenuPanel?.querySelector('#sidebarHistoryBtn') || null;
     const allMaterialsSidebarBtn = homeMenuPanel?.querySelector('#sidebarAllMaterialsBtn') || null;
+    const indemnitiesSidebarBtn = homeMenuPanel?.querySelector('#sidebarIndemnitiesBtn') || null;
     const sidebarItems = homeMenuPanel ? Array.from(homeMenuPanel.querySelectorAll('.sidebar-item')) : [];
     const siteLockDialog = requireElement('siteLockDialog');
     const siteLockForm = requireElement('siteLockForm');
@@ -2304,6 +2305,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    if (indemnitiesSidebarBtn) {
+      indemnitiesSidebarBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        window.location.assign('indemnites.html');
+      });
+    }
+
     if (historySidebarBtn) {
       historySidebarBtn.addEventListener('click', (event) => {
         event.preventDefault();
@@ -2352,6 +2361,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       setSidebarItemVisible('#sidebarHistoryBtn', true);
       setSidebarItemVisible('#sidebarAllMaterialsBtn', isConnected);
+      setSidebarItemVisible('#sidebarIndemnitiesBtn', isConnected);
 
       if (!isConnected || isLimited) {
         setSidebarItemVisible('#sidebarImportBtn', false);

--- a/js/indemnites.js
+++ b/js/indemnites.js
@@ -1,0 +1,422 @@
+import { addDoc, collection, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+import { firebaseDb } from './firebase-core.js';
+
+(function () {
+  const isIndemnitiesPage = location.pathname.includes('indemnites.html');
+  const STORAGE_KEY = 'indemnityRequestEntries';
+  const MAX_DAYS = 999;
+  let indemnityEntries = [];
+  let editingId = null;
+  let isExporting = false;
+
+  function requireElement(id) {
+    return document.getElementById(id);
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function sanitizeText(value) {
+    return String(value || '').normalize('NFC').trim();
+  }
+
+  function sanitizeDays(value) {
+    let days = parseInt(value, 10);
+    if (!Number.isFinite(days) || days < 1) {
+      days = 1;
+    }
+    if (days > MAX_DAYS) {
+      days = MAX_DAYS;
+    }
+    return days;
+  }
+
+  function getTodayInputValue(date = new Date()) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  function formatRequestDateTime(date = new Date()) {
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = String(date.getFullYear());
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${day}/${month}/${year} • ${hours}:${minutes}`;
+  }
+
+  function formatWorkDate(dateValue) {
+    if (!dateValue) {
+      return '-';
+    }
+    const [year, month, day] = String(dateValue).split('-');
+    if (!year || !month || !day) {
+      return String(dateValue);
+    }
+    return `${day}/${month}/${year}`;
+  }
+
+  function buildExportTimestamp(date = new Date()) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const seconds = String(date.getSeconds()).padStart(2, '0');
+    return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}`;
+  }
+
+  function loadEntries() {
+    try {
+      const savedEntries = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      indemnityEntries = Array.isArray(savedEntries)
+        ? savedEntries.map((entry) => ({
+          id: String(entry.id || `indemnity-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`),
+          name: sanitizeText(entry.name),
+          workDate: String(entry.workDate || ''),
+          days: sanitizeDays(entry.days),
+        })).filter((entry) => entry.name && entry.workDate)
+        : [];
+    } catch (_error) {
+      indemnityEntries = [];
+    }
+  }
+
+  function saveEntries() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(indemnityEntries));
+  }
+
+  function getTotalDays() {
+    return indemnityEntries.reduce((total, entry) => total + sanitizeDays(entry.days), 0);
+  }
+
+  function updateSummary() {
+    const peopleTotal = requireElement('indemnityPeopleTotal');
+    const daysTotal = requireElement('indemnityDaysTotal');
+    const listCount = requireElement('indemnityListCount');
+    const exportBtn = requireElement('exportIndemnityImageBtn');
+    const count = indemnityEntries.length;
+
+    if (peopleTotal) {
+      peopleTotal.textContent = String(count);
+    }
+    if (daysTotal) {
+      daysTotal.textContent = String(getTotalDays());
+    }
+    if (listCount) {
+      listCount.textContent = `${count} personne${count > 1 ? 's' : ''}`;
+    }
+    if (exportBtn) {
+      exportBtn.disabled = count === 0 || isExporting;
+    }
+  }
+
+  function renderEntries() {
+    const list = requireElement('indemnityList');
+    if (!list) {
+      return;
+    }
+
+    if (!indemnityEntries.length) {
+      list.innerHTML = '<p class="indemnity-empty">Aucune personne enregistrée pour le moment.</p>';
+      updateSummary();
+      return;
+    }
+
+    list.innerHTML = indemnityEntries.map((entry) => `
+      <article class="indemnity-person-card">
+        <div class="indemnity-person-main">
+          <strong>${escapeHtml(entry.name)}</strong>
+          <span>Nom de la personne</span>
+        </div>
+        <div class="indemnity-person-meta">
+          <strong>${escapeHtml(formatWorkDate(entry.workDate))}</strong>
+          <span>Date de travail</span>
+        </div>
+        <div class="indemnity-person-meta">
+          <strong>${sanitizeDays(entry.days)}</strong>
+          <span>Nombre de jours</span>
+        </div>
+        <div class="indemnity-card-actions">
+          <button class="indemnity-icon-btn" type="button" data-edit-id="${escapeHtml(entry.id)}" aria-label="Modifier ${escapeHtml(entry.name)}">
+            <i class="fa-solid fa-pen" aria-hidden="true"></i>
+          </button>
+          <button class="indemnity-icon-btn indemnity-icon-btn--delete" type="button" data-delete-id="${escapeHtml(entry.id)}" aria-label="Supprimer ${escapeHtml(entry.name)}">
+            <i class="fa-solid fa-trash" aria-hidden="true"></i>
+          </button>
+        </div>
+      </article>
+    `).join('');
+
+    list.querySelectorAll('[data-edit-id]').forEach((button) => {
+      button.addEventListener('click', () => startEditEntry(button.dataset.editId || ''));
+    });
+
+    list.querySelectorAll('[data-delete-id]').forEach((button) => {
+      button.addEventListener('click', () => deleteEntry(button.dataset.deleteId || ''));
+    });
+
+    updateSummary();
+  }
+
+  function showFormError(message = '') {
+    const errorEl = requireElement('indemnityFormError');
+    if (!errorEl) {
+      return;
+    }
+    errorEl.textContent = message;
+    errorEl.classList.toggle('visible', Boolean(message));
+  }
+
+  function resetForm() {
+    editingId = null;
+    requireElement('indemnityForm')?.reset();
+    const dateInput = requireElement('indemnityDateInput');
+    const daysInput = requireElement('indemnityDaysInput');
+    const submitButton = requireElement('indemnitySubmitButton');
+    if (dateInput) {
+      dateInput.value = getTodayInputValue();
+    }
+    if (daysInput) {
+      daysInput.value = '1';
+    }
+    if (submitButton) {
+      submitButton.textContent = 'Ajouter';
+    }
+    showFormError('');
+  }
+
+  function readFormEntry() {
+    const nameInput = requireElement('indemnityNameInput');
+    const dateInput = requireElement('indemnityDateInput');
+    const daysInput = requireElement('indemnityDaysInput');
+    const name = sanitizeText(nameInput?.value);
+    const workDate = String(dateInput?.value || '').trim();
+    const days = sanitizeDays(daysInput?.value);
+
+    if (!name) {
+      showFormError('Le nom de la personne est obligatoire.');
+      nameInput?.focus();
+      return null;
+    }
+    if (!workDate) {
+      showFormError('La date de travail est obligatoire.');
+      dateInput?.focus();
+      return null;
+    }
+
+    return { name, workDate, days };
+  }
+
+  function saveFormEntry(event) {
+    event.preventDefault();
+    const formEntry = readFormEntry();
+    if (!formEntry) {
+      return;
+    }
+
+    if (editingId) {
+      indemnityEntries = indemnityEntries.map((entry) => (
+        entry.id === editingId ? { ...entry, ...formEntry } : entry
+      ));
+      window.UiService?.showToast?.('Personne modifiée.');
+    } else {
+      indemnityEntries.push({
+        id: `indemnity-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        ...formEntry,
+      });
+      window.UiService?.showToast?.('Personne ajoutée.');
+    }
+
+    saveEntries();
+    renderEntries();
+    resetForm();
+  }
+
+  function startEditEntry(id) {
+    const entry = indemnityEntries.find((item) => item.id === id);
+    if (!entry) {
+      return;
+    }
+    editingId = id;
+    requireElement('indemnityNameInput').value = entry.name;
+    requireElement('indemnityDateInput').value = entry.workDate;
+    requireElement('indemnityDaysInput').value = String(sanitizeDays(entry.days));
+    requireElement('indemnitySubmitButton').textContent = 'Modifier';
+    requireElement('indemnityNameInput')?.focus();
+    showFormError('');
+  }
+
+  function deleteEntry(id) {
+    indemnityEntries = indemnityEntries.filter((entry) => entry.id !== id);
+    if (editingId === id) {
+      resetForm();
+    }
+    saveEntries();
+    renderEntries();
+    window.UiService?.showToast?.('Personne supprimée.');
+  }
+
+  async function createIndemnityRequestRecord(exportDateLabel) {
+    const people = indemnityEntries.map((entry) => ({
+      name: String(entry.name || ''),
+      workDate: String(entry.workDate || ''),
+      days: sanitizeDays(entry.days),
+    }));
+
+    await addDoc(collection(firebaseDb, 'indemnityRequests'), {
+      title: 'Demande d\'indemnités',
+      createdAt: serverTimestamp(),
+      exportDateLabel,
+      totalPeople: people.length,
+      totalDays: getTotalDays(),
+      people,
+    });
+  }
+
+  function buildExportArea(exportDateLabel) {
+    const exportArea = document.createElement('div');
+    exportArea.id = 'indemnityExportArea';
+    exportArea.style.position = 'fixed';
+    exportArea.style.left = '-9999px';
+    exportArea.style.top = '0';
+    exportArea.style.width = '900px';
+    exportArea.style.background = '#ffffff';
+    exportArea.style.padding = '32px';
+    exportArea.style.fontFamily = "'Segoe UI', Roboto, Arial, sans-serif";
+    exportArea.style.color = '#111827';
+
+    exportArea.innerHTML = `
+      <h1 style="margin:0;font-size:28px;font-weight:800;">Demande d'indemnités</h1>
+      <p style="margin:6px 0 20px;font-size:18px;color:#334155;">Date d'export : ${escapeHtml(exportDateLabel)}</p>
+      <table style="width:100%;border-collapse:collapse;font-size:20px;">
+        <thead>
+          <tr style="background:#eef5fb;">
+            <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;width:52px;">#</th>
+            <th style="text-align:left;padding:16px;border:1px solid #cbd5e1;">Nom de la personne</th>
+            <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;">Date de travail</th>
+            <th style="text-align:center;padding:16px;border:1px solid #cbd5e1;">Nombre de jours</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${indemnityEntries.map((entry, index) => `
+            <tr>
+              <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;width:52px;">${index + 1}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;">${escapeHtml(entry.name)}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;">${escapeHtml(formatWorkDate(entry.workDate))}</td>
+              <td style="padding:14px;border:1px solid #cbd5e1;text-align:center;">${sanitizeDays(entry.days)}</td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+      <div style="margin-top:22px;padding:18px 20px;border-radius:18px;background:#eef5fb;display:flex;justify-content:space-between;gap:16px;font-size:22px;font-weight:800;">
+        <span>Total général des jours travaillés</span>
+        <span>${getTotalDays()}</span>
+      </div>
+    `;
+
+    document.body.appendChild(exportArea);
+    return exportArea;
+  }
+
+  function openPreviewModal(dataUrl) {
+    const image = requireElement('indemnityPreviewImage');
+    if (image) {
+      image.src = String(dataUrl || '');
+    }
+    const modal = requireElement('indemnityPreviewModal');
+    if (modal && typeof modal.showModal === 'function' && !modal.open) {
+      modal.showModal();
+    }
+  }
+
+  function closePreviewModal() {
+    const modal = requireElement('indemnityPreviewModal');
+    if (modal && typeof modal.close === 'function' && modal.open) {
+      modal.close();
+    }
+  }
+
+  async function exportAsImage() {
+    const showToast = window.UiService?.showToast;
+    if (!indemnityEntries.length) {
+      showToast?.('Aucune personne à exporter');
+      return;
+    }
+    if (typeof window.html2canvas !== 'function') {
+      showToast?.('Export PNG indisponible');
+      return;
+    }
+    if (isExporting) {
+      return;
+    }
+
+    isExporting = true;
+    updateSummary();
+    let exportArea = null;
+
+    try {
+      const exportDateLabel = formatRequestDateTime(new Date());
+      await createIndemnityRequestRecord(exportDateLabel);
+      exportArea = buildExportArea(exportDateLabel);
+      const canvas = await window.html2canvas(exportArea, {
+        backgroundColor: '#ffffff',
+        scale: 2,
+        useCORS: true,
+        logging: false,
+        width: exportArea.scrollWidth,
+        height: exportArea.scrollHeight,
+        windowWidth: exportArea.scrollWidth,
+        windowHeight: exportArea.scrollHeight,
+      });
+      const dataUrl = canvas.toDataURL('image/png');
+      const link = document.createElement('a');
+      link.download = `demande-indemnites-${buildExportTimestamp()}.png`;
+      link.href = dataUrl;
+      link.click();
+      openPreviewModal(dataUrl);
+    } catch (error) {
+      console.error('Erreur export indemnités PNG :', error);
+      showToast?.('Erreur téléchargement PNG');
+    } finally {
+      exportArea?.remove();
+      isExporting = false;
+      updateSummary();
+    }
+  }
+
+  function initIndemnitiesPage() {
+    requireElement('indemnitiesBackButton')?.addEventListener('click', () => {
+      window.location.assign('index.html');
+    });
+
+    loadEntries();
+    resetForm();
+    renderEntries();
+
+    requireElement('indemnityForm')?.addEventListener('submit', saveFormEntry);
+    requireElement('exportIndemnityImageBtn')?.addEventListener('click', exportAsImage);
+    requireElement('indemnityPreviewOkBtn')?.addEventListener('click', closePreviewModal);
+    requireElement('indemnityPreviewModal')?.addEventListener('click', (event) => {
+      if (event.target === event.currentTarget) {
+        closePreviewModal();
+      }
+    });
+  }
+
+  if (isIndemnitiesPage) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initIndemnitiesPage);
+    } else {
+      initIndemnitiesPage();
+    }
+  }
+}());


### PR DESCRIPTION
### Motivation
- Fournir une page dédiée pour enregistrer les personnes ayant travaillé et le nombre de jours, avec export image et stockage compatible au système existant sans toucher aux pages OUT / Achat matériel / Demande matériels.

### Description
- Ajout de la page `indemnites.html` implémentant le formulaire (nom, date, jours), la liste éditable/supprimable et le résumé (total personnes / total jours) en respectant le style et la responsivité existants.
- Nouveau module `js/indemnites.js` gérant la persistance en `localStorage`, l’édition/suppression des entrées, la génération d’un enregistrement Firebase dans `indemnityRequests` et l’export PNG via la même approche `html2canvas` que la page "Demande matériels" (titre, date d’export, liste complète, total jours).
- Ajout d’une entrée Sidebar sous « Demande matériels » dans `index.html` avec une icône cohérente (`fa-user-clock`) et navigation vers `indemnites.html`, plus adaptation minimale du `js/app.js` pour gérer la visibilité et l’action du nouveau bouton.
- Ajustement CSS mineur (`css/style.css`) pour supporter l’icône dans les items de la barre latérale sans modifier le comportement existant des autres éléments.

### Testing
- `git diff --check` exécuté et OK.
- `node --check js/indemnites.js` et `node --check js/app.js` exécutés et OK (syntaxe validée).
- Recherche automatique pour termes financiers (`rg`) sur les nouveaux fichiers pour vérifier qu’aucun calcul monétaire n’a été introduit et aucun résultat trouvé.
- Tentative d’exécuter `npx playwright --version` pour tests UI/headless bloquée par accès au registre npm (`403 Forbidden`), donc aucun test de rendu navigateur automatisé n’a été exécuté dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff8afd82c832abd69a2bf3ebccabf)