### PR TITLE
Fix indemnities page content visibility (mark page ready)

### DIFF
--- a/js/indemnites.js
+++ b/js/indemnites.js
@@ -393,6 +393,10 @@ import { firebaseDb } from './firebase-core.js';
     }
   }
 
+  function markIndemnitiesPageReady() {
+    window.UiService?.markAppReady?.();
+  }
+
   function initIndemnitiesPage() {
     requireElement('indemnitiesBackButton')?.addEventListener('click', () => {
       window.location.assign('index.html');
@@ -410,6 +414,8 @@ import { firebaseDb } from './firebase-core.js';
         closePreviewModal();
       }
     });
+
+    markIndemnitiesPageReady();
   }
 
   if (isIndemnitiesPage) {


### PR DESCRIPTION
### Motivation
- La page « Demande d'indemnités » restait en état de chargement global et masquait son contenu parce qu'elle n'indiquait pas à l'UI que son initialisation était terminée.

### Description
- Ajout de la fonction `markIndemnitiesPageReady()` et appel à `window.UiService?.markAppReady?.()` depuis `initIndemnitiesPage()` dans `js/indemnites.js` pour signaler la fin de l'initialisation après le rendu du formulaire, de la liste et des contrôles d'export.

### Testing
- Vérification syntaxique avec `node --check js/indemnites.js` (OK).
- Vérification statique par script Python confirmant la présence du conteneur principal et des éléments clés (`main`, `#indemnityForm`, `#indemnityList`, `#exportIndemnityImageBtn`) et la présence d'un appel à `markAppReady` (OK).
- Tentative d'exécution de tests navigateur avec `npx playwright` interrompue par un `403 Forbidden` côté registre npm (non franchi dans cet environnement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2073613a40832aaedce3ab97ecbae2)