### PR TITLE
Fix: render Demande d'indemnités page body and init flow

### DIFF
--- a/indemnites.html
+++ b/indemnites.html
@@ -7,10 +7,14 @@
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWix+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkR4j8A6NfA5RkXU4Q9z+7A8R2f2Y6xQfHXA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
-      body[data-page="indemnites"] .page-content {
+      body[data-page="indemnites"] .page-content,
+      #demandeIndemnitesRoot {
         display: flex;
         flex-direction: column;
         gap: 16px;
+      }
+
+      body[data-page="indemnites"] .page-content {
         padding-bottom: 28px;
       }
 
@@ -217,54 +221,7 @@
       </header>
 
       <main class="page-content main-content">
-        <section class="indemnity-card" aria-labelledby="indemnityFormTitle">
-          <h2 id="indemnityFormTitle" class="indemnity-section-title">Ajouter une personne</h2>
-          <form id="indemnityForm" class="indemnity-form">
-            <label class="input-group">
-              <span>Nom de la personne</span>
-              <input id="indemnityNameInput" type="text" autocomplete="off" maxlength="80" required />
-            </label>
-            <label class="input-group">
-              <span>Date de travail</span>
-              <input id="indemnityDateInput" type="date" required />
-            </label>
-            <label class="input-group">
-              <span>Nombre de jours</span>
-              <input id="indemnityDaysInput" type="number" min="1" max="999" step="1" inputmode="numeric" value="1" required />
-            </label>
-            <button id="indemnitySubmitButton" class="btn btn-success" type="submit">Ajouter</button>
-          </form>
-          <p id="indemnityFormError" class="form-error" aria-live="polite"></p>
-        </section>
-
-        <section class="indemnity-card" aria-labelledby="indemnitySummaryTitle">
-          <h2 id="indemnitySummaryTitle" class="indemnity-section-title">Résumé</h2>
-          <div class="indemnity-summary-grid">
-            <div class="indemnity-summary-item">
-              <p class="indemnity-summary-label">Personnes enregistrées</p>
-              <p id="indemnityPeopleTotal" class="indemnity-summary-value">0</p>
-            </div>
-            <div class="indemnity-summary-item">
-              <p class="indemnity-summary-label">Total des jours travaillés</p>
-              <p id="indemnityDaysTotal" class="indemnity-summary-value">0</p>
-            </div>
-          </div>
-        </section>
-
-        <section class="indemnity-card" aria-labelledby="indemnityListTitle">
-          <div class="indemnity-list-header">
-            <h2 id="indemnityListTitle" class="indemnity-section-title">Liste des personnes</h2>
-            <span id="indemnityListCount" class="indemnity-list-count">0 personne</span>
-          </div>
-          <div id="indemnityList" class="indemnity-list" aria-live="polite"></div>
-        </section>
-
-        <section class="indemnity-card" aria-labelledby="indemnityExportTitle">
-          <h2 id="indemnityExportTitle" class="indemnity-section-title">Export</h2>
-          <div class="indemnity-export-row">
-            <button id="exportIndemnityImageBtn" class="btn btn-primary export-img-btn" type="button">Exporter en image</button>
-          </div>
-        </section>
+        <div id="demandeIndemnitesRoot"></div>
       </main>
 
       <dialog id="indemnityPreviewModal" class="modal-card">

--- a/js/indemnites.js
+++ b/js/indemnites.js
@@ -1,6 +1,3 @@
-import { addDoc, collection, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
-import { firebaseDb } from './firebase-core.js';
-
 (function () {
   const isIndemnitiesPage = location.pathname.includes('indemnites.html');
   const STORAGE_KEY = 'indemnityRequestEntries';
@@ -74,7 +71,74 @@ import { firebaseDb } from './firebase-core.js';
     return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}`;
   }
 
+  function buildDemandeIndemnitesHtml() {
+    return `
+      <section class="indemnity-card" aria-labelledby="indemnityFormTitle">
+        <h2 id="indemnityFormTitle" class="indemnity-section-title">Ajouter une personne</h2>
+        <form id="indemnityForm" class="indemnity-form">
+          <label class="input-group">
+            <span>Nom de la personne</span>
+            <input id="indemnityNameInput" type="text" autocomplete="off" maxlength="80" required />
+          </label>
+          <label class="input-group">
+            <span>Date de travail</span>
+            <input id="indemnityDateInput" type="date" required />
+          </label>
+          <label class="input-group">
+            <span>Nombre de jours</span>
+            <input id="indemnityDaysInput" type="number" min="1" max="999" step="1" inputmode="numeric" value="1" required />
+          </label>
+          <button id="indemnitySubmitButton" class="btn btn-success" type="submit">Ajouter</button>
+        </form>
+        <p id="indemnityFormError" class="form-error" aria-live="polite"></p>
+      </section>
+
+      <section class="indemnity-card" aria-labelledby="indemnitySummaryTitle">
+        <h2 id="indemnitySummaryTitle" class="indemnity-section-title">Résumé</h2>
+        <div class="indemnity-summary-grid">
+          <div class="indemnity-summary-item">
+            <p class="indemnity-summary-label">Personnes enregistrées</p>
+            <p id="indemnityPeopleTotal" class="indemnity-summary-value">0</p>
+          </div>
+          <div class="indemnity-summary-item">
+            <p class="indemnity-summary-label">Total des jours travaillés</p>
+            <p id="indemnityDaysTotal" class="indemnity-summary-value">0</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="indemnity-card" aria-labelledby="indemnityListTitle">
+        <div class="indemnity-list-header">
+          <h2 id="indemnityListTitle" class="indemnity-section-title">Liste des personnes</h2>
+          <span id="indemnityListCount" class="indemnity-list-count">0 personne</span>
+        </div>
+        <div id="indemnityList" class="indemnity-list" aria-live="polite"></div>
+      </section>
+
+      <section class="indemnity-card" aria-labelledby="indemnityExportTitle">
+        <h2 id="indemnityExportTitle" class="indemnity-section-title">Export</h2>
+        <div class="indemnity-export-row">
+          <button id="exportIndemnityImageBtn" class="btn btn-primary export-img-btn" type="button">Exporter en image</button>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderDemandeIndemnites() {
+    console.log('[Demande indemnités] rendu du formulaire');
+    const container = requireElement('demandeIndemnitesRoot') || document.querySelector('main.page-content');
+    if (!container) {
+      console.error('[Demande indemnités] conteneur principal introuvable');
+      return false;
+    }
+
+    container.innerHTML = buildDemandeIndemnitesHtml();
+    console.log('[Demande indemnités] HTML injecté dans le conteneur principal', container);
+    return true;
+  }
+
   function loadEntries() {
+    console.log('[Demande indemnités] chargement des données');
     try {
       const savedEntries = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
       indemnityEntries = Array.isArray(savedEntries)
@@ -85,7 +149,9 @@ import { firebaseDb } from './firebase-core.js';
           days: sanitizeDays(entry.days),
         })).filter((entry) => entry.name && entry.workDate)
         : [];
-    } catch (_error) {
+      console.log('[Demande indemnités] données chargées', indemnityEntries.length);
+    } catch (error) {
+      console.error('[Demande indemnités] erreur de chargement des données', error);
       indemnityEntries = [];
     }
   }
@@ -120,8 +186,10 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   function renderEntries() {
+    console.log('[Demande indemnités] rendu de la liste', indemnityEntries.length);
     const list = requireElement('indemnityList');
     if (!list) {
+      console.error('[Demande indemnités] #indemnityList introuvable');
       return;
     }
 
@@ -243,15 +311,19 @@ import { firebaseDb } from './firebase-core.js';
 
   function startEditEntry(id) {
     const entry = indemnityEntries.find((item) => item.id === id);
-    if (!entry) {
+    const nameInput = requireElement('indemnityNameInput');
+    const dateInput = requireElement('indemnityDateInput');
+    const daysInput = requireElement('indemnityDaysInput');
+    const submitButton = requireElement('indemnitySubmitButton');
+    if (!entry || !nameInput || !dateInput || !daysInput || !submitButton) {
       return;
     }
     editingId = id;
-    requireElement('indemnityNameInput').value = entry.name;
-    requireElement('indemnityDateInput').value = entry.workDate;
-    requireElement('indemnityDaysInput').value = String(sanitizeDays(entry.days));
-    requireElement('indemnitySubmitButton').textContent = 'Modifier';
-    requireElement('indemnityNameInput')?.focus();
+    nameInput.value = entry.name;
+    dateInput.value = entry.workDate;
+    daysInput.value = String(sanitizeDays(entry.days));
+    submitButton.textContent = 'Modifier';
+    nameInput.focus();
     showFormError('');
   }
 
@@ -266,6 +338,12 @@ import { firebaseDb } from './firebase-core.js';
   }
 
   async function createIndemnityRequestRecord(exportDateLabel) {
+    const [firestoreModule, firebaseCoreModule] = await Promise.all([
+      import('https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js'),
+      import('./firebase-core.js'),
+    ]);
+    const { addDoc, collection, serverTimestamp } = firestoreModule;
+    const { firebaseDb } = firebaseCoreModule;
     const people = indemnityEntries.map((entry) => ({
       name: String(entry.name || ''),
       workDate: String(entry.workDate || ''),
@@ -393,19 +471,7 @@ import { firebaseDb } from './firebase-core.js';
     }
   }
 
-  function markIndemnitiesPageReady() {
-    window.UiService?.markAppReady?.();
-  }
-
-  function initIndemnitiesPage() {
-    requireElement('indemnitiesBackButton')?.addEventListener('click', () => {
-      window.location.assign('index.html');
-    });
-
-    loadEntries();
-    resetForm();
-    renderEntries();
-
+  function bindDemandeIndemnitesEvents() {
     requireElement('indemnityForm')?.addEventListener('submit', saveFormEntry);
     requireElement('exportIndemnityImageBtn')?.addEventListener('click', exportAsImage);
     requireElement('indemnityPreviewOkBtn')?.addEventListener('click', closePreviewModal);
@@ -414,15 +480,43 @@ import { firebaseDb } from './firebase-core.js';
         closePreviewModal();
       }
     });
-
-    markIndemnitiesPageReady();
   }
+
+  function markIndemnitiesPageReady() {
+    window.UiService?.markAppReady?.();
+    document.body.classList.remove('loading', 'is-loading', 'app-content-loading', 'app-content-pending');
+    document.body.classList.add('app-content-ready');
+  }
+
+  function openDemandeIndemnites() {
+    console.log('[Demande indemnités] ouverture de la page');
+    try {
+      requireElement('indemnitiesBackButton')?.addEventListener('click', () => {
+        window.location.assign('index.html');
+      });
+
+      if (!renderDemandeIndemnites()) {
+        return;
+      }
+      loadEntries();
+      resetForm();
+      renderEntries();
+      bindDemandeIndemnitesEvents();
+    } catch (error) {
+      console.error('[Demande indemnités] erreur JavaScript pendant l’ouverture', error);
+    } finally {
+      markIndemnitiesPageReady();
+    }
+  }
+
+  window.openDemandeIndemnites = openDemandeIndemnites;
+  window.renderDemandeIndemnites = renderDemandeIndemnites;
 
   if (isIndemnitiesPage) {
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initIndemnitiesPage);
+      document.addEventListener('DOMContentLoaded', openDemandeIndemnites);
     } else {
-      initIndemnitiesPage();
+      openDemandeIndemnites();
     }
   }
 }());


### PR DESCRIPTION
### Motivation
- La page « Demande d'indemnités » restait vide car le contenu statique de la page a été supprimé ou non injecté dans le DOM principal, empêchant l’affichage du formulaire, de la liste et du bouton d’export.
- Il fallait s’assurer que le rendu soit effectué dynamiquement, que les fonctions d’ouverture/rendu soient appelées, et que toute erreur ou l’état global de chargement n’empêche pas l’affichage.

### Description
- Ajout d’un conteneur `#demandeIndemnitesRoot` dans `indemnites.html` et adaptation du CSS pour préserver l’espacement visuel après injection dynamique.
- Remplacement du rendu HTML statique par `buildDemandeIndemnitesHtml()` et `renderDemandeIndemnites()` dans `js/indemnites.js` afin d’injecter le formulaire, le résumé, la liste et le bouton Exporter dynamiquement dans le conteneur principal.
- Ajout de `openDemandeIndemnites()` qui orchestre l’ouverture de la page : rendu, chargement des données, initialisation du formulaire/liste et branchement des événements, puis sortie garantie de l’état de chargement global.
- Ajout de logs diagnostics (`console.log` / `console.error`) pour vérifier l’ouverture, le rendu du formulaire, le rendu de la liste et le chargement des données, et migration des imports Firebase vers un import dynamique lors de l’export pour éviter de bloquer l’affichage.

### Testing
- `curl -fsS http://127.0.0.1:4173/indemnites.html >/tmp/indemnites.html && test -s /tmp/indemnites.html && echo ok` — succès.
- `node --check js/indemnites.js` — syntaxe valide (succès).
- `node --check js/ui.js` — syntaxe valide (succès).
- `git diff --check` — aucun problème détecté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20fb09d9c8832a80181616991c3da0)