### PR TITLE
Update protected site dialog title

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
       <dialog id="siteUnlockDialog" class="modal-card">
         <form class="modal-content" id="siteUnlockForm">
           <div class="modal-header">
-            <h2>Site verrouillé</h2>
+            <h2>Site protégé par un mot de passe</h2>
           </div>
           <label class="input-group input-group--site-unlock">
             <span>Mot de passe</span>

--- a/js/app.js
+++ b/js/app.js
@@ -2635,7 +2635,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         }
         siteLockDialog?.close();
         siteIdPendingLock = null;
-        UiService.showToast('Site verrouillé.');
+        UiService.showToast('Site protégé par un mot de passe.');
       } catch (_error) {
         showSiteLockFieldError(siteLockConfirmPasswordInput, siteLockConfirmPasswordError, 'Erreur pendant le verrouillage.');
       }


### PR DESCRIPTION
### Motivation
- Remplacer le libellé affiché « Site verrouillé » par le nouveau titre exact « Site protégé par un mot de passe » partout dans l’interface sans toucher au design, aux champs, aux boutons ni à la logique de validation.

### Description
- Remplacé le contenu de `<h2>` dans `index.html` par `Site protégé par un mot de passe` et mis à jour le toast affiché dans `js/app.js` pour utiliser la même formulation, sans autre modification fonctionnelle.

### Testing
- Vérification qu’aucune occurrence restante de `Site verrouillé` n’existe avec `rg -n "Site verrouillé" . -g '!node_modules' -g '!vendor'`, qui a réussi sans résultats; and `git diff --check` a été exécuté et a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6714d96878832aa4a205ef1756376b)