### PR TITLE
Add per-site lockout for invalid site passwords

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1476,6 +1476,14 @@ body[data-page="home"] #siteUnlockDialog .form-error--field {
   font-size: 0.82rem;
 }
 
+body[data-page="home"] #siteUnlockDialog .form-info--attempts {
+  margin: 0.1rem 0 0;
+  min-height: 1rem;
+  text-align: left;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
 body[data-page="home"] #siteUnlockDialog #siteUnlockPasswordInput.is-error,
 body[data-page="home"] #siteUnlockDialog #siteUnlockPasswordInput.is-error:focus {
   border-color: #e57373;

--- a/index.html
+++ b/index.html
@@ -250,7 +250,8 @@
                 <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
               </button>
             </div>
-            <p id="siteUnlockError" class="form-error form-error--field" aria-live="polite"></p>
+            <p id="siteUnlockAttemptsInfo" class="form-info form-info--attempts" aria-live="polite"></p>
+            <p id="siteUnlockError" class="form-error form-error--field" aria-live="assertive"></p>
           </label>
           <div class="modal-actions modal-actions--split modal-actions--password">
             <button type="button" class="btn" data-close-dialog>Annuler</button>

--- a/js/app.js
+++ b/js/app.js
@@ -1090,6 +1090,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const siteUnlockPasswordInput = requireElement('siteUnlockPasswordInput');
     const siteUnlockPasswordToggle = requireElement('siteUnlockPasswordToggle');
     const siteUnlockSubmitButton = requireElement('siteUnlockSubmitButton');
+    const siteUnlockAttemptsInfo = requireElement('siteUnlockAttemptsInfo');
     const siteUnlockError = requireElement('siteUnlockError');
     const siteLockManageDialog = requireElement('siteLockManageDialog');
     const siteLockManageForm = requireElement('siteLockManageForm');
@@ -1127,6 +1128,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let isSiteCreateInputValid = false;
     const siteLockFieldStateTimers = new WeakMap();
     let isSiteUnlockPending = false;
+    let siteUnlockBlockTimer = null;
     let isSiteLockManageUpdatePending = false;
     let isSiteLockManageUnlockPending = false;
 
@@ -1153,7 +1155,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!siteUnlockSubmitButton) {
         return;
       }
-      siteUnlockSubmitButton.disabled = isSiteUnlockPending;
+      siteUnlockSubmitButton.disabled = isSiteUnlockPending || Boolean(siteUnlockSubmitButton.dataset.blocked === 'true');
       siteUnlockSubmitButton.classList.toggle('is-loading', isSiteUnlockPending);
       siteUnlockSubmitButton.setAttribute('aria-busy', String(isSiteUnlockPending));
     }
@@ -1429,6 +1431,68 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         siteLockFieldStateTimers.delete(siteUnlockPasswordInput);
       }, durationMs);
       siteLockFieldStateTimers.set(siteUnlockPasswordInput, timer);
+    }
+
+    function formatAttemptsRemainingMessage(attemptsRemaining) {
+      const count = Math.max(0, Number(attemptsRemaining) || 0);
+      return `Il vous reste ${count} ${count === 1 ? 'tentative' : 'tentatives'}.`;
+    }
+
+    function setSiteUnlockBlockedState(isBlocked) {
+      if (siteUnlockPasswordInput) {
+        siteUnlockPasswordInput.disabled = Boolean(isBlocked);
+      }
+      if (siteUnlockPasswordToggle) {
+        siteUnlockPasswordToggle.disabled = Boolean(isBlocked);
+      }
+      if (siteUnlockSubmitButton) {
+        siteUnlockSubmitButton.dataset.blocked = String(Boolean(isBlocked));
+        siteUnlockSubmitButton.disabled = Boolean(isBlocked) || isSiteUnlockPending;
+      }
+    }
+
+    function updateSiteUnlockAttemptsInfo(attemptsRemaining) {
+      if (!siteUnlockAttemptsInfo) {
+        return;
+      }
+      siteUnlockAttemptsInfo.textContent = formatAttemptsRemainingMessage(attemptsRemaining);
+    }
+
+    function clearSiteUnlockBlockTimer() {
+      if (siteUnlockBlockTimer) {
+        window.clearTimeout(siteUnlockBlockTimer);
+        siteUnlockBlockTimer = null;
+      }
+    }
+
+    function scheduleSiteUnlockUnblock(siteId, blockedUntil) {
+      clearSiteUnlockBlockTimer();
+      const unblockAt = new Date(blockedUntil || '').getTime();
+      const delayMs = unblockAt - Date.now();
+      if (!Number.isFinite(delayMs) || delayMs <= 0) {
+        return;
+      }
+      siteUnlockBlockTimer = window.setTimeout(() => {
+        if (siteIdPendingUnlock === siteId && siteUnlockDialog?.open) {
+          refreshSiteUnlockProtectionState(siteId);
+        }
+      }, Math.min(delayMs, 24 * 60 * 60 * 1000));
+    }
+
+    async function refreshSiteUnlockProtectionState(siteId) {
+      const protection = await StorageService.getSiteUnlockProtectionState(siteId);
+      if (!protection?.ok) {
+        return null;
+      }
+      updateSiteUnlockAttemptsInfo(protection.attemptsRemaining);
+      setSiteUnlockBlockedState(protection.isBlocked);
+      if (protection.isBlocked) {
+        showSiteUnlockFieldError('Réessayez dans 24 heures.', 24 * 60 * 60 * 1000);
+        scheduleSiteUnlockUnblock(siteId, protection.blockedUntil);
+      } else {
+        clearSiteUnlockBlockTimer();
+      }
+      return protection;
     }
 
     function setPasswordVisibility(inputElement, toggleButton, isVisible) {
@@ -2139,8 +2203,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           clearSiteUnlockFieldErrorState();
           setPasswordVisibility(siteUnlockPasswordInput, siteUnlockPasswordToggle, false);
           setSiteUnlockLoadingState(false);
+          setSiteUnlockBlockedState(false);
           siteUnlockDialog.showModal();
-          siteUnlockPasswordInput.focus();
+          refreshSiteUnlockProtectionState(siteId).then((protection) => {
+            if (!protection?.isBlocked) {
+              siteUnlockPasswordInput.focus();
+            }
+          });
         });
       });
 
@@ -2683,6 +2752,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
       clearSiteUnlockFieldErrorState();
+      const protection = await refreshSiteUnlockProtectionState(siteIdPendingUnlock);
+      if (protection?.isBlocked) {
+        return;
+      }
       const passwordValue = siteUnlockPasswordInput?.value || '';
       if (!passwordValue.trim()) {
         showSiteUnlockFieldError('Veuillez entrer le mot de passe.');
@@ -2703,10 +2776,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         setSiteUnlockLoadingState(true);
         const passwordHash = await hashPassword(passwordValue);
         if (passwordHash !== targetSite.passwordHash) {
-          showSiteUnlockFieldError('Mot de passe incorrect.');
+          const failure = await StorageService.registerSiteUnlockFailure(siteIdPendingUnlock);
+          updateSiteUnlockAttemptsInfo(failure?.attemptsRemaining ?? 0);
+          if (failure?.isBlocked) {
+            setSiteUnlockBlockedState(true);
+            showSiteUnlockFieldError('Vous avez atteint le nombre maximal de tentatives. Réessayez dans 24 heures.', 24 * 60 * 60 * 1000);
+          } else {
+            showSiteUnlockFieldError(`Mot de passe incorrect. ${formatAttemptsRemainingMessage(failure?.attemptsRemaining)}`);
+          }
           setSiteUnlockLoadingState(false);
           return;
         }
+        await StorageService.resetSiteUnlockProtection(siteIdPendingUnlock);
         const openSiteId = siteIdPendingUnlock;
         siteUnlockDialog?.close();
         siteIdPendingUnlock = null;
@@ -2829,7 +2910,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     siteUnlockDialog?.addEventListener('close', () => {
       siteIdPendingUnlock = null;
+      clearSiteUnlockBlockTimer();
       clearSiteUnlockFieldErrorState();
+      if (siteUnlockAttemptsInfo) {
+        siteUnlockAttemptsInfo.textContent = '';
+      }
+      setSiteUnlockBlockedState(false);
       setPasswordVisibility(siteUnlockPasswordInput, siteUnlockPasswordToggle, false);
       setSiteUnlockLoadingState(false);
     });

--- a/js/storage.js
+++ b/js/storage.js
@@ -1085,6 +1085,8 @@ async function setSiteLock(siteId, lockPayload) {
     lockedBy: lockerEmail,
     lockedByName: lockerName,
     unlockedBy: deleteField(),
+    unlockAttemptsRemaining: 3,
+    unlockBlockedUntil: deleteField(),
     dateModification: timestamp,
   };
 
@@ -1123,6 +1125,8 @@ async function clearSiteLock(siteId) {
     lockedByName: deleteField(),
     lockedBy: deleteField(),
     unlockedBy: unlockerEmail,
+    unlockAttemptsRemaining: deleteField(),
+    unlockBlockedUntil: deleteField(),
     dateModification: timestamp,
   };
 
@@ -1140,12 +1144,91 @@ async function clearSiteLock(siteId) {
     lockedBy: '',
     lockedByName: '',
     unlockedBy: unlockerEmail,
+    unlockAttemptsRemaining: null,
+    unlockBlockedUntil: null,
     dateModification: timestamp,
   };
   sortState();
   persistOfflineState();
   emitAll();
   return { ok: true };
+}
+
+function normalizeUnlockProtection(site) {
+  const blockedUntilRaw = site?.unlockBlockedUntil || null;
+  const blockedUntilDate = blockedUntilRaw ? new Date(blockedUntilRaw) : null;
+  const blockedUntilMs = blockedUntilDate && !Number.isNaN(blockedUntilDate.getTime()) ? blockedUntilDate.getTime() : 0;
+  if (blockedUntilMs > Date.now()) {
+    return {
+      attemptsRemaining: 0,
+      blockedUntil: new Date(blockedUntilMs).toISOString(),
+      isBlocked: true,
+    };
+  }
+  const attempts = Number(site?.unlockAttemptsRemaining);
+  return {
+    attemptsRemaining: Number.isInteger(attempts) && attempts >= 0 && attempts <= 3 ? attempts : 3,
+    blockedUntil: null,
+    isBlocked: false,
+  };
+}
+
+async function resetSiteUnlockProtection(siteId) {
+  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
+  if (siteIndex === -1) {
+    return { ok: false, reason: 'site_not_found' };
+  }
+  const payload = {
+    unlockAttemptsRemaining: 3,
+    unlockBlockedUntil: deleteField(),
+  };
+  await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true });
+  state.sites[siteIndex] = {
+    ...state.sites[siteIndex],
+    unlockAttemptsRemaining: 3,
+    unlockBlockedUntil: null,
+  };
+  persistOfflineState();
+  emitAll();
+  return { ok: true, ...normalizeUnlockProtection(state.sites[siteIndex]) };
+}
+
+async function getSiteUnlockProtectionState(siteId) {
+  const site = state.sites.find((item) => item.id === siteId);
+  if (!site) {
+    return { ok: false, reason: 'site_not_found' };
+  }
+  const protection = normalizeUnlockProtection(site);
+  if (!protection.isBlocked && site.unlockBlockedUntil) {
+    return resetSiteUnlockProtection(siteId);
+  }
+  return { ok: true, ...protection };
+}
+
+async function registerSiteUnlockFailure(siteId) {
+  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
+  if (siteIndex === -1) {
+    return { ok: false, reason: 'site_not_found' };
+  }
+  const current = normalizeUnlockProtection(state.sites[siteIndex]);
+  if (current.isBlocked) {
+    return { ok: true, ...current };
+  }
+  const attemptsRemaining = Math.max(0, current.attemptsRemaining - 1);
+  const blockedUntil = attemptsRemaining === 0 ? new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() : null;
+  const payload = {
+    unlockAttemptsRemaining: attemptsRemaining,
+    unlockBlockedUntil: blockedUntil || deleteField(),
+  };
+  await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true });
+  state.sites[siteIndex] = {
+    ...state.sites[siteIndex],
+    unlockAttemptsRemaining: attemptsRemaining,
+    unlockBlockedUntil: blockedUntil,
+  };
+  persistOfflineState();
+  emitAll();
+  return { ok: true, attemptsRemaining, blockedUntil, isBlocked: Boolean(blockedUntil) };
 }
 
 async function removeSite(siteId) {
@@ -1737,6 +1820,9 @@ window.StorageService = {
   updateSiteName,
   setSiteLock,
   clearSiteLock,
+  getSiteUnlockProtectionState,
+  registerSiteUnlockFailure,
+  resetSiteUnlockProtection,
   removeSite,
   restoreSite,
   createItem,


### PR DESCRIPTION
### Motivation
- Empêcher les tentatives de mot de passe incorrectes d’affecter d’autres sites en suivant un compteur de tentatives par `siteId` et en appliquant un blocage localisé de 24 heures. 
- Conserver le comportement existant quand le mot de passe est correct tout en rendant la protection persistante et non réinitialisable par simple reload.

### Description
- Ajout de deux champs persistants sur les documents site : `unlockAttemptsRemaining` et `unlockBlockedUntil` pour stocker le compteur et la date de fin de blocage. (`js/storage.js`).
- Implémentation de helpers de protection dans `js/storage.js` : `normalizeUnlockProtection`, `registerSiteUnlockFailure`, `getSiteUnlockProtectionState` et `resetSiteUnlockProtection` pour gérer lecture, incrément / blocage 24h et réinitialisation par `siteId`.
- Mise à jour de l’interface de déverrouillage dans `js/app.js` : affichage des tentatives restantes (`siteUnlockAttemptsInfo`), désactivation du champ mot de passe et du bouton `Valider` lorsque le site est bloqué, enregistrement des échecs via `StorageService.registerSiteUnlockFailure`, et réinitialisation automatique sur succès via `StorageService.resetSiteUnlockProtection`.
- Ajout de l’élément d’info dans le template (`index.html`) et du style `.form-info--attempts` dans `css/style.css` pour l’affichage sous le champ mot de passe.

### Testing
- Exécution de `node --check js/app.js` (succès). 
- Exécution de `node --check js/storage.js` (succès). 
- Exécution de `git diff --check` (aucune erreur).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6718012ff8832aa82985ffc12209a1)