### PR TITLE
Ne pas afficher les tentatives restantes avant une erreur de déverrouillage

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1451,11 +1451,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
     }
 
-    function updateSiteUnlockAttemptsInfo(attemptsRemaining) {
+    function clearSiteUnlockAttemptsInfo() {
       if (!siteUnlockAttemptsInfo) {
         return;
       }
-      siteUnlockAttemptsInfo.textContent = formatAttemptsRemainingMessage(attemptsRemaining);
+      siteUnlockAttemptsInfo.textContent = '';
     }
 
     function clearSiteUnlockBlockTimer() {
@@ -1484,7 +1484,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!protection?.ok) {
         return null;
       }
-      updateSiteUnlockAttemptsInfo(protection.attemptsRemaining);
+      clearSiteUnlockAttemptsInfo();
       setSiteUnlockBlockedState(protection.isBlocked);
       if (protection.isBlocked) {
         showSiteUnlockFieldError('Réessayez dans 24 heures.', 24 * 60 * 60 * 1000);
@@ -2777,7 +2777,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const passwordHash = await hashPassword(passwordValue);
         if (passwordHash !== targetSite.passwordHash) {
           const failure = await StorageService.registerSiteUnlockFailure(siteIdPendingUnlock);
-          updateSiteUnlockAttemptsInfo(failure?.attemptsRemaining ?? 0);
+          clearSiteUnlockAttemptsInfo();
           if (failure?.isBlocked) {
             setSiteUnlockBlockedState(true);
             showSiteUnlockFieldError('Vous avez atteint le nombre maximal de tentatives. Réessayez dans 24 heures.', 24 * 60 * 60 * 1000);
@@ -2912,9 +2912,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       siteIdPendingUnlock = null;
       clearSiteUnlockBlockTimer();
       clearSiteUnlockFieldErrorState();
-      if (siteUnlockAttemptsInfo) {
-        siteUnlockAttemptsInfo.textContent = '';
-      }
+      clearSiteUnlockAttemptsInfo();
       setSiteUnlockBlockedState(false);
       setPasswordVisibility(siteUnlockPasswordInput, siteUnlockPasswordToggle, false);
       setSiteUnlockLoadingState(false);


### PR DESCRIPTION
### Motivation
- Éviter d’afficher la ligne « Il vous reste X tentative(s). » dès l’ouverture de la boîte de dialogue de déverrouillage et ne la montrer qu’après une saisie incorrecte. 
- Conserver le compteur de tentatives fonctionnel en arrière-plan et n’altérer aucune autre logique de protection (blocage après 3 tentatives, délai de 24h, désactivation des champs). 

### Description
- Remplacement de la fonction `updateSiteUnlockAttemptsInfo` par `clearSiteUnlockAttemptsInfo` dans `js/app.js` pour vider la zone d’information des tentatives au lieu d’y écrire automatiquement un message. 
- Lors du rafraîchissement de l’état de protection (`refreshSiteUnlockProtectionState`) la zone d’affichage des tentatives est désormais vidée (`clearSiteUnlockAttemptsInfo()`) au lieu d’être remplie. 
- Après un échec de mot de passe, l’UI efface la zone dédiée (`clearSiteUnlockAttemptsInfo()`) et affiche le message approprié via l’erreur transitoire : soit l’erreur bloquante (`Vous avez atteint le nombre maximal de tentatives…`) soit `Mot de passe incorrect. Il vous reste X tentatives.` construit avec `formatAttemptsRemainingMessage`. 
- À la fermeture du dialogue `siteUnlockDialog` la zone d’information des tentatives est également vidée pour éviter tout affichage résiduel. 

### Testing
- Vérification syntaxique du fichier modifié avec `node --check js/app.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a671bea67ec832a97096ffea9c0335d)