### PR TITLE
Isoler le blocage mot de passe par site+utilisateur et ajouter compte à rebours dynamique

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1129,6 +1129,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const siteLockFieldStateTimers = new WeakMap();
     let isSiteUnlockPending = false;
     let siteUnlockBlockTimer = null;
+    let siteUnlockCountdownTimer = null;
     let isSiteLockManageUpdatePending = false;
     let isSiteLockManageUnlockPending = false;
 
@@ -1456,12 +1457,54 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
       siteUnlockAttemptsInfo.textContent = '';
+      siteUnlockAttemptsInfo.hidden = true;
+    }
+
+    function formatSiteUnlockCountdown(blockedUntil) {
+      const unblockAt = new Date(blockedUntil || '').getTime();
+      const remainingMs = unblockAt - Date.now();
+      if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+        return '';
+      }
+      const totalMinutes = Math.ceil(remainingMs / (60 * 1000));
+      if (totalMinutes <= 1) {
+        return "Réessayez dans moins d'une minute";
+      }
+      const hours = Math.floor(totalMinutes / 60);
+      const minutes = totalMinutes % 60;
+      if (hours <= 0) {
+        return `Réessayez dans ${minutes} min`;
+      }
+      if (minutes <= 0) {
+        return `Réessayez dans ${hours} h`;
+      }
+      return `Réessayez dans ${hours} h ${minutes} min`;
+    }
+
+    function updateSiteUnlockCountdownMessage(siteId, blockedUntil) {
+      const message = formatSiteUnlockCountdown(blockedUntil);
+      if (!message) {
+        clearSiteUnlockAttemptsInfo();
+        setSiteUnlockBlockedState(false);
+        if (siteIdPendingUnlock === siteId && siteUnlockDialog?.open) {
+          refreshSiteUnlockProtectionState(siteId);
+        }
+        return;
+      }
+      if (siteUnlockAttemptsInfo) {
+        siteUnlockAttemptsInfo.textContent = message;
+        siteUnlockAttemptsInfo.hidden = false;
+      }
     }
 
     function clearSiteUnlockBlockTimer() {
       if (siteUnlockBlockTimer) {
         window.clearTimeout(siteUnlockBlockTimer);
         siteUnlockBlockTimer = null;
+      }
+      if (siteUnlockCountdownTimer) {
+        window.clearInterval(siteUnlockCountdownTimer);
+        siteUnlockCountdownTimer = null;
       }
     }
 
@@ -1472,6 +1515,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!Number.isFinite(delayMs) || delayMs <= 0) {
         return;
       }
+      updateSiteUnlockCountdownMessage(siteId, blockedUntil);
+      siteUnlockCountdownTimer = window.setInterval(() => {
+        updateSiteUnlockCountdownMessage(siteId, blockedUntil);
+      }, 60 * 1000);
       siteUnlockBlockTimer = window.setTimeout(() => {
         if (siteIdPendingUnlock === siteId && siteUnlockDialog?.open) {
           refreshSiteUnlockProtectionState(siteId);
@@ -1487,7 +1534,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       clearSiteUnlockAttemptsInfo();
       setSiteUnlockBlockedState(protection.isBlocked);
       if (protection.isBlocked) {
-        showSiteUnlockFieldError('Réessayez dans 24 heures.', 24 * 60 * 60 * 1000);
+        clearSiteUnlockFieldErrorState();
         scheduleSiteUnlockUnblock(siteId, protection.blockedUntil);
       } else {
         clearSiteUnlockBlockTimer();
@@ -2780,7 +2827,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           clearSiteUnlockAttemptsInfo();
           if (failure?.isBlocked) {
             setSiteUnlockBlockedState(true);
-            showSiteUnlockFieldError('Vous avez atteint le nombre maximal de tentatives. Réessayez dans 24 heures.', 24 * 60 * 60 * 1000);
+            clearSiteUnlockFieldErrorState();
+            scheduleSiteUnlockUnblock(siteIdPendingUnlock, failure.blockedUntil);
           } else {
             showSiteUnlockFieldError(`Mot de passe incorrect. ${formatAttemptsRemainingMessage(failure?.attemptsRemaining)}`);
           }

--- a/js/storage.js
+++ b/js/storage.js
@@ -1154,8 +1154,22 @@ async function clearSiteLock(siteId) {
   return { ok: true };
 }
 
-function normalizeUnlockProtection(site) {
-  const blockedUntilRaw = site?.unlockBlockedUntil || null;
+function buildSiteUnlockProtectionKey(siteId) {
+  const uid = String(state.authUser?.uid || state.userId || firebaseAuth.currentUser?.uid || '').trim();
+  const normalizedSiteId = String(siteId || '').trim();
+  return uid && normalizedSiteId ? `${normalizedSiteId}_${uid}` : '';
+}
+
+function readSiteUnlockProtection(site, siteId) {
+  const protectionKey = buildSiteUnlockProtectionKey(siteId || site?.id);
+  const protections = site?.unlockProtections && typeof site.unlockProtections === 'object' ? site.unlockProtections : {};
+  const scopedProtection = protectionKey ? protections[protectionKey] : null;
+  return scopedProtection && typeof scopedProtection === 'object' ? scopedProtection : {};
+}
+
+function normalizeUnlockProtection(site, siteId) {
+  const scopedProtection = readSiteUnlockProtection(site, siteId);
+  const blockedUntilRaw = scopedProtection?.blockedUntil || null;
   const blockedUntilDate = blockedUntilRaw ? new Date(blockedUntilRaw) : null;
   const blockedUntilMs = blockedUntilDate && !Number.isNaN(blockedUntilDate.getTime()) ? blockedUntilDate.getTime() : 0;
   if (blockedUntilMs > Date.now()) {
@@ -1165,7 +1179,7 @@ function normalizeUnlockProtection(site) {
       isBlocked: true,
     };
   }
-  const attempts = Number(site?.unlockAttemptsRemaining);
+  const attempts = Number(scopedProtection?.attemptsRemaining);
   return {
     attemptsRemaining: Number.isInteger(attempts) && attempts >= 0 && attempts <= 3 ? attempts : 3,
     blockedUntil: null,
@@ -1178,19 +1192,28 @@ async function resetSiteUnlockProtection(siteId) {
   if (siteIndex === -1) {
     return { ok: false, reason: 'site_not_found' };
   }
-  const payload = {
-    unlockAttemptsRemaining: 3,
-    unlockBlockedUntil: deleteField(),
+  const protectionKey = buildSiteUnlockProtectionKey(siteId);
+  if (!protectionKey) {
+    return { ok: false, reason: 'auth_required' };
+  }
+  const unlockProtections = {
+    ...(state.sites[siteIndex].unlockProtections && typeof state.sites[siteIndex].unlockProtections === 'object'
+      ? state.sites[siteIndex].unlockProtections
+      : {}),
+    [protectionKey]: {
+      attemptsRemaining: 3,
+      blockedUntil: null,
+    },
   };
+  const payload = { unlockProtections };
   await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true });
   state.sites[siteIndex] = {
     ...state.sites[siteIndex],
-    unlockAttemptsRemaining: 3,
-    unlockBlockedUntil: null,
+    unlockProtections,
   };
   persistOfflineState();
   emitAll();
-  return { ok: true, ...normalizeUnlockProtection(state.sites[siteIndex]) };
+  return { ok: true, ...normalizeUnlockProtection(state.sites[siteIndex], siteId) };
 }
 
 async function getSiteUnlockProtectionState(siteId) {
@@ -1198,8 +1221,9 @@ async function getSiteUnlockProtectionState(siteId) {
   if (!site) {
     return { ok: false, reason: 'site_not_found' };
   }
-  const protection = normalizeUnlockProtection(site);
-  if (!protection.isBlocked && site.unlockBlockedUntil) {
+  const protection = normalizeUnlockProtection(site, siteId);
+  const scopedProtection = readSiteUnlockProtection(site, siteId);
+  if (!protection.isBlocked && scopedProtection.blockedUntil) {
     return resetSiteUnlockProtection(siteId);
   }
   return { ok: true, ...protection };
@@ -1210,21 +1234,30 @@ async function registerSiteUnlockFailure(siteId) {
   if (siteIndex === -1) {
     return { ok: false, reason: 'site_not_found' };
   }
-  const current = normalizeUnlockProtection(state.sites[siteIndex]);
+  const current = normalizeUnlockProtection(state.sites[siteIndex], siteId);
   if (current.isBlocked) {
     return { ok: true, ...current };
   }
   const attemptsRemaining = Math.max(0, current.attemptsRemaining - 1);
   const blockedUntil = attemptsRemaining === 0 ? new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() : null;
-  const payload = {
-    unlockAttemptsRemaining: attemptsRemaining,
-    unlockBlockedUntil: blockedUntil || deleteField(),
+  const protectionKey = buildSiteUnlockProtectionKey(siteId);
+  if (!protectionKey) {
+    return { ok: false, reason: 'auth_required' };
+  }
+  const unlockProtections = {
+    ...(state.sites[siteIndex].unlockProtections && typeof state.sites[siteIndex].unlockProtections === 'object'
+      ? state.sites[siteIndex].unlockProtections
+      : {}),
+    [protectionKey]: {
+      attemptsRemaining,
+      blockedUntil,
+    },
   };
+  const payload = { unlockProtections };
   await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true });
   state.sites[siteIndex] = {
     ...state.sites[siteIndex],
-    unlockAttemptsRemaining: attemptsRemaining,
-    unlockBlockedUntil: blockedUntil,
+    unlockProtections,
   };
   persistOfflineState();
   emitAll();


### PR DESCRIPTION
### Motivation
- Empêcher un blocage global en associant les tentatives et la date de déblocage à la paire `siteId + uid` afin que chaque utilisateur conserve son propre compteur par site.
- Afficher un message permanent et dynamique pendant la période de blocage, mis à jour automatiquement pour indiquer le temps restant avant réessai.
- Réactiver automatiquement le champ `Mot de passe` et le bouton `Valider` et remettre le compteur à 3 tentatives à la fin du délai de blocage.

### Description
- Stockage : ajout d’un objet `unlockProtections` dans les documents site et ajout des fonctions `buildSiteUnlockProtectionKey` et `readSiteUnlockProtection` pour isoler les protections par `siteId_uid` dans `js/storage.js`.
- Logique serveur/stockage : `normalizeUnlockProtection`, `resetSiteUnlockProtection`, `getSiteUnlockProtectionState` et `registerSiteUnlockFailure` ont été modifiés pour lire/mettre à jour uniquement l’entrée scoped (par utilisateur) et retourner `auth_required` si l’UID n’est pas disponible.
- UI : dans `js/app.js` ajout d’un timer `siteUnlockCountdownTimer` et des fonctions `formatSiteUnlockCountdown` et `updateSiteUnlockCountdownMessage` pour afficher un message permanent dans `#siteUnlockAttemptsInfo` (formats demandés comme `Réessayez dans 2 h 15 min` ou `Réessayez dans moins d'une minute`) et mise à jour toutes les minutes.
- Comportement : l’interface utilise `setSiteUnlockBlockedState` pour désactiver le champ et le bouton durant le blocage, planifie un rafraîchissement à la fin du délai et réinitialise l’état sans modifier le reste du design ou des fonctionnalités existantes.

### Testing
- Exécution de `node --check js/app.js` qui a réussi.
- Exécution de `node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a680679e1b8832a82b94fbddd74f61f)