### PR TITLE
Style blocked site countdown as error

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1484,6 +1484,10 @@ body[data-page="home"] #siteUnlockDialog .form-info--attempts {
   font-size: 0.82rem;
 }
 
+body[data-page="home"] #siteUnlockDialog .form-info--attempts.form-info--blocked {
+  color: var(--danger);
+}
+
 body[data-page="home"] #siteUnlockDialog #siteUnlockPasswordInput.is-error,
 body[data-page="home"] #siteUnlockDialog #siteUnlockPasswordInput.is-error:focus {
   border-color: #e57373;

--- a/js/app.js
+++ b/js/app.js
@@ -1458,6 +1458,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       siteUnlockAttemptsInfo.textContent = '';
       siteUnlockAttemptsInfo.hidden = true;
+      siteUnlockAttemptsInfo.classList.remove('form-info--blocked');
     }
 
     function formatSiteUnlockCountdown(blockedUntil) {
@@ -1494,6 +1495,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (siteUnlockAttemptsInfo) {
         siteUnlockAttemptsInfo.textContent = message;
         siteUnlockAttemptsInfo.hidden = false;
+        siteUnlockAttemptsInfo.classList.add('form-info--blocked');
       }
     }
 


### PR DESCRIPTION
### Motivation
- Make the site-unlock countdown message visually match other error states by showing it in the shared danger color while the site is blocked, without changing layout, font, size, spacing or other UI elements.

### Description
- Add a new CSS selector that applies `color: var(--danger)` to the blocked countdown message via the `form-info--blocked` class in `css/style.css`.
- Update `js/app.js` to add `form-info--blocked` when a blocked countdown message is shown and to remove it when the attempts/countdown info is cleared.
- Only the text color is changed; no other styles, dialog layout, or text content were modified (files changed: `css/style.css`, `js/app.js`).

### Testing
- Ran `node --check js/app.js` which completed successfully.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a680900684c832aaee5b2f1d4468d1a)