### PR TITLE
Apply per-site/user unlock protection to secure access management dialog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1476,7 +1476,8 @@ body[data-page="home"] #siteUnlockDialog .form-error--field {
   font-size: 0.82rem;
 }
 
-body[data-page="home"] #siteUnlockDialog .form-info--attempts {
+body[data-page="home"] #siteUnlockDialog .form-info--attempts,
+body[data-page="home"] #siteLockManageDialog .form-info--attempts {
   margin: 0.1rem 0 0;
   min-height: 1rem;
   text-align: left;
@@ -1484,7 +1485,8 @@ body[data-page="home"] #siteUnlockDialog .form-info--attempts {
   font-size: 0.82rem;
 }
 
-body[data-page="home"] #siteUnlockDialog .form-info--attempts.form-info--blocked {
+body[data-page="home"] #siteUnlockDialog .form-info--attempts.form-info--blocked,
+body[data-page="home"] #siteLockManageDialog .form-info--attempts.form-info--blocked {
   color: var(--danger);
 }
 

--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
                 <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
               </button>
             </div>
+            <p id="siteLockManageAttemptsInfo" class="form-info form-info--attempts" aria-live="polite" hidden></p>
             <p id="siteLockCurrentPasswordError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
           <label class="input-group input-group--site-lock-manage">

--- a/js/app.js
+++ b/js/app.js
@@ -1097,6 +1097,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const siteLockCurrentPasswordInput = requireElement('siteLockCurrentPasswordInput');
     const siteLockNewPasswordInput = requireElement('siteLockNewPasswordInput');
     const siteLockCurrentPasswordError = requireElement('siteLockCurrentPasswordError');
+    const siteLockManageAttemptsInfo = requireElement('siteLockManageAttemptsInfo');
     const siteLockNewPasswordError = requireElement('siteLockNewPasswordError');
     const siteLockCurrentPasswordToggle = requireElement('siteLockCurrentPasswordToggle');
     const siteLockNewPasswordToggle = requireElement('siteLockNewPasswordToggle');
@@ -1130,6 +1131,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let isSiteUnlockPending = false;
     let siteUnlockBlockTimer = null;
     let siteUnlockCountdownTimer = null;
+    let siteLockManageBlockTimer = null;
+    let siteLockManageCountdownTimer = null;
+    let isSiteLockManageBlocked = false;
     let isSiteLockManageUpdatePending = false;
     let isSiteLockManageUnlockPending = false;
 
@@ -1167,7 +1171,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         if (!siteLockManageUnlockButton) {
           return;
         }
-        siteLockManageUnlockButton.disabled = isSiteLockManageUnlockPending;
+        siteLockManageUnlockButton.disabled = isSiteLockManageUnlockPending || isSiteLockManageBlocked;
         siteLockManageUnlockButton.classList.toggle('is-loading', isSiteLockManageUnlockPending);
         siteLockManageUnlockButton.setAttribute('aria-busy', String(isSiteLockManageUnlockPending));
         return;
@@ -1176,7 +1180,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!siteLockManageUpdateButton) {
         return;
       }
-      siteLockManageUpdateButton.disabled = isSiteLockManageUpdatePending;
+      siteLockManageUpdateButton.disabled = isSiteLockManageUpdatePending || isSiteLockManageBlocked;
       siteLockManageUpdateButton.classList.toggle('is-loading', isSiteLockManageUpdatePending);
       siteLockManageUpdateButton.setAttribute('aria-busy', String(isSiteLockManageUpdatePending));
     }
@@ -1403,6 +1407,89 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function clearSiteLockManageLoadingStates() {
       setSiteLockManageActionLoadingState('update', false);
       setSiteLockManageActionLoadingState('unlock', false);
+    }
+
+    function setSiteLockManageBlockedState(isBlocked) {
+      isSiteLockManageBlocked = Boolean(isBlocked);
+      if (siteLockCurrentPasswordInput) {
+        siteLockCurrentPasswordInput.disabled = isSiteLockManageBlocked;
+      }
+      if (siteLockCurrentPasswordToggle) {
+        siteLockCurrentPasswordToggle.disabled = isSiteLockManageBlocked;
+      }
+      setSiteLockManageActionLoadingState('update', isSiteLockManageUpdatePending);
+      setSiteLockManageActionLoadingState('unlock', isSiteLockManageUnlockPending);
+    }
+
+    function clearSiteLockManageAttemptsInfo() {
+      if (!siteLockManageAttemptsInfo) {
+        return;
+      }
+      siteLockManageAttemptsInfo.textContent = '';
+      siteLockManageAttemptsInfo.hidden = true;
+      siteLockManageAttemptsInfo.classList.remove('form-info--blocked');
+    }
+
+    function updateSiteLockManageCountdownMessage(siteId, blockedUntil) {
+      const message = formatSiteUnlockCountdown(blockedUntil);
+      if (!message) {
+        clearSiteLockManageAttemptsInfo();
+        setSiteLockManageBlockedState(false);
+        if (siteIdPendingLockManage === siteId && siteLockManageDialog?.open) {
+          refreshSiteLockManageProtectionState(siteId);
+        }
+        return;
+      }
+      if (siteLockManageAttemptsInfo) {
+        siteLockManageAttemptsInfo.textContent = message;
+        siteLockManageAttemptsInfo.hidden = false;
+        siteLockManageAttemptsInfo.classList.add('form-info--blocked');
+      }
+    }
+
+    function clearSiteLockManageBlockTimer() {
+      if (siteLockManageBlockTimer) {
+        window.clearTimeout(siteLockManageBlockTimer);
+        siteLockManageBlockTimer = null;
+      }
+      if (siteLockManageCountdownTimer) {
+        window.clearInterval(siteLockManageCountdownTimer);
+        siteLockManageCountdownTimer = null;
+      }
+    }
+
+    function scheduleSiteLockManageUnblock(siteId, blockedUntil) {
+      clearSiteLockManageBlockTimer();
+      const unblockAt = new Date(blockedUntil || '').getTime();
+      const delayMs = unblockAt - Date.now();
+      if (!Number.isFinite(delayMs) || delayMs <= 0) {
+        return;
+      }
+      updateSiteLockManageCountdownMessage(siteId, blockedUntil);
+      siteLockManageCountdownTimer = window.setInterval(() => {
+        updateSiteLockManageCountdownMessage(siteId, blockedUntil);
+      }, 60 * 1000);
+      siteLockManageBlockTimer = window.setTimeout(() => {
+        if (siteIdPendingLockManage === siteId && siteLockManageDialog?.open) {
+          refreshSiteLockManageProtectionState(siteId);
+        }
+      }, Math.min(delayMs, 24 * 60 * 60 * 1000));
+    }
+
+    async function refreshSiteLockManageProtectionState(siteId) {
+      const protection = await StorageService.getSiteUnlockProtectionState(siteId);
+      if (!protection?.ok) {
+        return null;
+      }
+      clearSiteLockManageAttemptsInfo();
+      setSiteLockManageBlockedState(protection.isBlocked);
+      if (protection.isBlocked) {
+        clearSiteLockManageFieldErrorState(siteLockCurrentPasswordInput, siteLockCurrentPasswordError);
+        scheduleSiteLockManageUnblock(siteId, protection.blockedUntil);
+      } else {
+        clearSiteLockManageBlockTimer();
+      }
+      return protection;
     }
 
     function clearSiteUnlockFieldErrorState() {
@@ -1956,8 +2043,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         clearSiteLockManageLoadingStates();
         setPasswordVisibility(siteLockCurrentPasswordInput, siteLockCurrentPasswordToggle, false);
         setPasswordVisibility(siteLockNewPasswordInput, siteLockNewPasswordToggle, false);
+        setSiteLockManageBlockedState(false);
+        clearSiteLockManageAttemptsInfo();
         siteLockManageDialog.showModal();
-        siteLockCurrentPasswordInput.focus();
+        refreshSiteLockManageProtectionState(siteId).then((protection) => {
+          if (!protection?.isBlocked) {
+            siteLockCurrentPasswordInput.focus();
+          }
+        });
         return;
       }
 
@@ -2863,6 +2956,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
 
       clearSiteLockManageErrors();
+      const protection = await refreshSiteLockManageProtectionState(siteIdPendingLockManage);
+      if (protection?.isBlocked) {
+        return;
+      }
 
       const currentPasswordValue = siteLockCurrentPasswordInput?.value || '';
       const newPasswordValue = siteLockNewPasswordInput?.value || '';
@@ -2892,14 +2989,24 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         setSiteLockManageActionLoadingState(submittedAction, true);
         const currentPasswordHash = await hashPassword(currentPasswordValue);
         if (currentPasswordHash !== targetSite.passwordHash) {
-          showSiteLockManageFieldError(
-            siteLockCurrentPasswordInput,
-            siteLockCurrentPasswordError,
-            'Mot de passe actuel incorrect.',
-          );
+          const failure = await StorageService.registerSiteUnlockFailure(siteIdPendingLockManage);
+          clearSiteLockManageAttemptsInfo();
+          if (failure?.isBlocked) {
+            setSiteLockManageBlockedState(true);
+            clearSiteLockManageFieldErrorState(siteLockCurrentPasswordInput, siteLockCurrentPasswordError);
+            scheduleSiteLockManageUnblock(siteIdPendingLockManage, failure.blockedUntil);
+          } else {
+            showSiteLockManageFieldError(
+              siteLockCurrentPasswordInput,
+              siteLockCurrentPasswordError,
+              `Mot de passe actuel incorrect. ${formatAttemptsRemainingMessage(failure?.attemptsRemaining)}`,
+            );
+          }
           setSiteLockManageActionLoadingState(submittedAction, false);
           return;
         }
+
+        await StorageService.resetSiteUnlockProtection(siteIdPendingLockManage);
 
         if (submittedAction === 'unlock') {
           const result = await StorageService.clearSiteLock(siteIdPendingLockManage);
@@ -2970,8 +3077,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     siteLockManageDialog?.addEventListener('close', () => {
       siteIdPendingLockManage = null;
+      clearSiteLockManageBlockTimer();
       clearSiteLockManageErrors();
+      clearSiteLockManageAttemptsInfo();
       clearSiteLockManageLoadingStates();
+      setSiteLockManageBlockedState(false);
       setPasswordVisibility(siteLockCurrentPasswordInput, siteLockCurrentPasswordToggle, false);
       setPasswordVisibility(siteLockNewPasswordInput, siteLockNewPasswordToggle, false);
     });


### PR DESCRIPTION
### Motivation
- The existing unlock attempt protection only applied to the site-opening dialog and not to the management dialog, leaving the management flow less protected. 
- The same per-`siteId` + per-user (Firebase `uid`) scoped protection must be enforced for the "Gestion de l’accès sécurisé" dialog so blocks are isolated by site and user. 
- The change must not alter any other app behavior or visual design beyond adding the blocked-state UI and countdown to the management dialog. 

### Description
- Added a hidden attempts/countdown info element `#siteLockManageAttemptsInfo` to the management dialog in `index.html` and reused the existing `.form-info--attempts` styling in `css/style.css`. 
- Extended `js/app.js` with management-scoped state and timers (`siteLockManageBlockTimer`, `siteLockManageCountdownTimer`, `isSiteLockManageBlocked`) and added `setSiteLockManageBlockedState`, countdown update, schedule/unblock and clear timer helpers mirroring the unlock dialog logic. 
- Integrated protection checks when opening the management dialog and before submit, and wired incorrect current-password handling to `StorageService.registerSiteUnlockFailure` and successful verification to `StorageService.resetSiteUnlockProtection`. 
- Disabled the current-password input, the visibility toggle and both `Mettre à jour`/`Déverrouiller` buttons while the scoped block is active and ensured block state and timers are cleared on dialog close. 

### Testing
- Static syntax checks were run with `node --check js/app.js` and `node --check js/storage.js` and both succeeded. 
- UI/CSS integration verified by reusing existing `.form-info--attempts` styles and ensuring the management info element is hidden by default and becomes visible during blocked state. 
- General repository checks performed with `git diff --check` completed without reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c1db97500832a98322e7e0c611e06)