### PR TITLE
Corrige la mise en page : hauteur complète de la page Historiques

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -159,7 +159,15 @@ body {
 }
 
 body[data-page="history"] {
+  height: 100%;
   background: linear-gradient(180deg, #d8ecff 0%, #eef6ff 45%, #f6f9ff 100%);
+}
+
+body[data-page="history"] .app-shell {
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 
@@ -948,12 +956,15 @@ body[data-page="history"] .list-grid {
 }
 
 .page-content--history {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding-bottom: 16px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(216, 236, 255, 0.35));
   overflow: hidden;
 }
 
 .history-list {
-  flex: 1;
+  flex: 1 1 auto;
   min-height: 0;
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid rgba(182, 206, 232, 0.8);


### PR DESCRIPTION
### Motivation
- Éliminer la grande zone blanche sous la liste quand il y a peu d'éléments en faisant en sorte que le conteneur principal occupe toujours toute la hauteur disponible entre l'en-tête et le bas de l'écran.
- Restreindre le défilement vertical à la seule liste des historiques pour que l'interface reste prévisible sur mobile, tablette et desktop.
- Respecter les contraintes visuelles existantes sans modifier les couleurs, marges, cartes ou comportements actuels.

### Description
- Ajout de `height: 100%` sur `body[data-page="history"]` et d'une règle dédiée pour `.app-shell` qui force la hauteur à `100vh` / `100dvh` avec `min-height` en fallback afin de couvrir les cas de viewport mobile.
- Conversion de la zone de contenu historique en une zone flexible en ajoutant `flex: 1 1 auto` et `min-height: 0` à `.page-content--history` pour qu'elle prenne l'espace restant sous l'en-tête.
- Assouplissement de `.history-list` en lui donnant `flex: 1 1 auto` et en conservant `overflow-y: auto` pour que seule la liste devienne défilable lorsque nécessaire.
- Ajout d'un léger `padding-bottom` sur la zone de contenu pour éviter tout chevauchement visuel des éléments de bas d'écran sans changer le design.

### Testing
- Exécution de `git diff --check` pour vérifier l'absence d'erreurs de diff, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6caf8b4a78832aae8f7acabb55e7c3)