### PR TITLE
Corrige positionnement du FAB sur la page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4634,7 +4634,7 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
 .page2 #createOutFab,
 body.page2 .fab,
 body.page2 #createOutFab {
-  bottom: calc(84px + env(safe-area-inset-bottom)) !important;
+  bottom: calc(var(--page2-visible-bottom-nav-height, 0px) + var(--page2-fab-bottom-gap, 20px)) !important;
   z-index: 1001 !important;
 }
 
@@ -4642,7 +4642,7 @@ body.page2 #createOutFab {
 .page2 .page-content,
 .page2 .outs-list,
 body.page2 main {
-  padding-bottom: calc(102px + env(safe-area-inset-bottom)) !important;
+  padding-bottom: calc(var(--page2-visible-bottom-nav-height, 0px) + var(--page2-content-bottom-gap, 38px)) !important;
 }
 
 body[data-page="site-detail"] .bottom-nav-item.hidden,

--- a/js/app.js
+++ b/js/app.js
@@ -4437,6 +4437,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
     }
 
+    function updateSiteDetailFloatingOffsets() {
+      if (!bottomNavigation) {
+        document.body.style.setProperty('--page2-visible-bottom-nav-height', '0px');
+        return;
+      }
+      const bottomNavigationStyle = window.getComputedStyle(bottomNavigation);
+      const isBottomNavigationVisible = !bottomNavigation.hidden
+        && !bottomNavigation.classList.contains('hidden')
+        && bottomNavigationStyle.display !== 'none'
+        && bottomNavigationStyle.visibility !== 'hidden';
+      const bottomNavigationHeight = isBottomNavigationVisible
+        ? bottomNavigation.getBoundingClientRect().height
+        : 0;
+      document.body.style.setProperty('--page2-visible-bottom-nav-height', `${bottomNavigationHeight}px`);
+    }
+
     function updateTabsByRole() {
       isAdminTabAllowed = Boolean(permissions?.isAdmin);
       siteTabButtons.forEach((tabButton) => {
@@ -4448,6 +4464,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (purchasesTabButton) {
         purchasesTabButton.classList.toggle('hidden', !isAdminTabAllowed);
       }
+      updateSiteDetailFloatingOffsets();
       if (!isAdminTabAllowed && activeSiteTab === 'purchases') {
         setActiveSiteTab('outs');
       }
@@ -4903,6 +4920,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     updateCreateItemButtonVisibility(firebaseAuth.currentUser);
     updateTabsByRole();
+    window.addEventListener('resize', updateSiteDetailFloatingOffsets, { passive: true });
+    if (bottomNavigation && 'ResizeObserver' in window) {
+      const bottomNavigationResizeObserver = new ResizeObserver(updateSiteDetailFloatingOffsets);
+      bottomNavigationResizeObserver.observe(bottomNavigation);
+    }
     const savedActiveTab = getSavedActiveSiteTab();
     setActiveSiteTab(savedActiveTab === 'purchases' ? 'purchases' : 'outs');
     loadPurchasesForCurrentSite();


### PR DESCRIPTION
### Motivation
- Le FAB de la page 2 restait positionné trop haut lorsque l'utilisateur n'est pas administrateur parce que l'onglet « Achat matériel » (et la barre de navigation) était masqué mais l'offset restait fixe.
- L'objectif est de calculer dynamiquement la position du FAB en fonction de la hauteur réelle de la barre de navigation visible afin d'éviter un espace vide sous le FAB.
- Le positionnement doit rester responsive, sans valeurs hardcodées, et sans modifier le style, la taille ou les animations du FAB.

### Description
- Remplace l'offset fixe de la page 2 par des variables CSS et utilise `--page2-visible-bottom-nav-height` pour calculer `bottom` et le `padding-bottom` dans `css/style.css` (ajout de `--page2-fab-bottom-gap` et `--page2-content-bottom-gap`).
- Ajoute `updateSiteDetailFloatingOffsets()` dans `js/app.js` qui mesure la hauteur effective de `.bottom-navigation` et expose la valeur via la variable CSS `--page2-visible-bottom-nav-height`.
- Appelle `updateSiteDetailFloatingOffsets()` lors du changement de rôle (`updateTabsByRole()`), et installe un `resize` listener et un `ResizeObserver` sur la navigation pour recalculer automatiquement lorsque la fenêtre ou la navigation change de taille/visibilité.
- Fichiers modifiés : `css/style.css`, `js/app.js`.

### Testing
- Exécution de `git diff --check` qui a retourné OK.
- Vérification syntaxique avec `node --check js/app.js && node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cbc5994b4833383e0a27f0b628992)