### PR TITLE
Add Point column to Gestion Admin and compute user points from OUT creations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2299,7 +2299,7 @@ body[data-page="users-management"] .table-wrapper--users .data-table th {
   color: #3b4a5f;
 }
 
-body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(2) {
+body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(3) {
   min-width: 0;
   max-width: 15rem;
   overflow: hidden;
@@ -2307,8 +2307,15 @@ body[data-page="users-management"] .table-wrapper--users .data-table td:nth-chil
   white-space: nowrap;
 }
 
-body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(4) select {
+body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(5) select {
   max-width: 100%;
+}
+
+
+body[data-page="users-management"] .users-point-cell {
+  font-weight: 700;
+  text-align: center;
+  color: #1f2a44;
 }
 
 body[data-page="users-management"] .table-wrapper--users .data-table td:last-child {

--- a/js/app.js
+++ b/js/app.js
@@ -7093,10 +7093,22 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
     }
 
-    function renderUsers(users) {
-      tableBody.innerHTML = users
+    function sortUsersByPointsAndName(users, pointsByUser) {
+      return [...users].sort((a, b) => {
+        const pointsA = Number(pointsByUser?.[a.id] || 0);
+        const pointsB = Number(pointsByUser?.[b.id] || 0);
+        if (pointsA !== pointsB) {
+          return pointsB - pointsA;
+        }
+        return resolveDisplayName(a).localeCompare(resolveDisplayName(b), 'fr', { sensitivity: 'base' });
+      });
+    }
+
+    function renderUsers(users, pointsByUser = {}) {
+      tableBody.innerHTML = sortUsersByPointsAndName(users, pointsByUser)
         .map((user) => `
           <tr>
+            <td class="users-point-cell">${Number(pointsByUser?.[user.id] || 0)}</td>
             <td>
               ${cleanText(user.avatarUrl)
       ? `<img class="table-avatar" src="${escapeHtml(user.avatarUrl)}" alt="Avatar de ${escapeHtml(resolveDisplayName(user))}" />`
@@ -7187,9 +7199,21 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
     });
 
+    let currentUsers = [];
+    let currentPointsByUser = {};
+
+    function renderCurrentUsers() {
+      renderUsers(currentUsers, currentPointsByUser);
+    }
+
     try {
-      const initialUsers = await StorageService.listUsers();
-      renderUsers(initialUsers);
+      const [initialUsers, initialPointsByUser] = await Promise.all([
+        StorageService.listUsers(),
+        StorageService.listOutCreationPoints(),
+      ]);
+      currentUsers = initialUsers;
+      currentPointsByUser = initialPointsByUser;
+      renderCurrentUsers();
     } catch (_error) {
       UiService.showToast('Impossible de charger les utilisateurs.');
     }
@@ -7205,10 +7229,21 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             maintenanceAuthorized: resolveMaintenanceAuthorized(user),
           });
         });
-        renderUsers(users);
+        currentUsers = users;
+        renderCurrentUsers();
       },
       () => {
         UiService.showToast('Synchronisation des utilisateurs indisponible.');
+      },
+    );
+
+    StorageService.subscribeOutCreationPoints(
+      (pointsByUser) => {
+        currentPointsByUser = pointsByUser;
+        renderCurrentUsers();
+      },
+      () => {
+        UiService.showToast('Synchronisation des points indisponible.');
       },
     );
   }

--- a/js/storage.js
+++ b/js/storage.js
@@ -401,6 +401,45 @@ async function listUsers() {
     });
 }
 
+
+function normalizeOutCreationPointsSnapshot(snapshot) {
+  return snapshot.docs.reduce((pointsByUser, snap) => {
+    const data = snap.data() || {};
+    const creatorId = String(data.createdBy || data.ownerId || '').trim();
+    if (!creatorId) {
+      return pointsByUser;
+    }
+    pointsByUser[creatorId] = (pointsByUser[creatorId] || 0) + 1;
+    return pointsByUser;
+  }, {});
+}
+
+async function listOutCreationPoints() {
+  const snapshot = await getDocs(makePageItemsCollection('page2'));
+  return normalizeOutCreationPointsSnapshot(snapshot);
+}
+
+function subscribeOutCreationPoints(onChange, onError) {
+  try {
+    return onSnapshot(
+      makePageItemsCollection('page2'),
+      (snapshot) => {
+        onChange(normalizeOutCreationPointsSnapshot(snapshot));
+      },
+      (error) => {
+        if (typeof onError === 'function') {
+          onError(error);
+        }
+      },
+    );
+  } catch (error) {
+    if (typeof onError === 'function') {
+      onError(error);
+    }
+    return () => {};
+  }
+}
+
 async function updateUserRole(userId, role) {
   const nextRole = normalizeRole(role);
   await setDoc(
@@ -1975,6 +2014,8 @@ window.StorageService = {
   updateAvatarUrl,
   listUsers,
   subscribeUsers,
+  listOutCreationPoints,
+  subscribeOutCreationPoints,
   updateUserRole,
   updateUserMaintenanceAccess,
   deleteUser,

--- a/users.html
+++ b/users.html
@@ -36,6 +36,7 @@
             <table class="data-table">
               <thead>
                 <tr>
+                  <th>Point</th>
                   <th>Photo</th>
                   <th>Nom</th>
                   <th>Email</th>
@@ -127,13 +128,24 @@
         }
       }
 
-      function renderUsers(users) {
+      function sortUsersByPointsAndName(users, pointsByUser) {
+        return [...users].sort((a, b) => {
+          const pointsA = Number(pointsByUser?.[a.id] || 0);
+          const pointsB = Number(pointsByUser?.[b.id] || 0);
+          if (pointsA !== pointsB) {
+            return pointsB - pointsA;
+          }
+          return resolveDisplayName(a).localeCompare(resolveDisplayName(b), 'fr', { sensitivity: 'base' });
+        });
+      }
+
+      function renderUsers(users, pointsByUser = {}) {
         const tableBody = document.getElementById('usersTableBody');
         if (!tableBody) {
           return;
         }
 
-        const rows = users
+        const rows = sortUsersByPointsAndName(users, pointsByUser)
           .map((user) => {
             const displayName = resolveDisplayName(user);
             const email = cleanString(user.email);
@@ -148,6 +160,7 @@
 
             return `
               <tr data-user-id="${user.id}">
+                <td class="users-point-cell">${Number(pointsByUser?.[user.id] || 0)}</td>
                 <td>${avatarMarkup}</td>
                 <td>${displayName}</td>
                 <td class="users-email-cell">${email || '-'}</td>
@@ -238,16 +251,43 @@
         });
       }
 
+      let currentUsers = [];
+      let currentPointsByUser = {};
+
+      function renderCurrentUsers() {
+        renderUsers(currentUsers, currentPointsByUser);
+      }
+
       const usersRef = collection(firebaseDb, 'users');
+      const outsRef = collection(firebaseDb, 'pages', 'page2', 'items');
       onSnapshot(
         usersRef,
         (snapshot) => {
           const users = snapshot.docs.map((entry) => ({ id: entry.id, ...(entry.data() || {}) }));
           users.forEach(syncDefaults);
-          renderUsers(users);
+          currentUsers = users;
+          renderCurrentUsers();
         },
         () => {
           window.UiService?.showToast('Impossible de charger la liste des utilisateurs.');
+        },
+      );
+
+      onSnapshot(
+        outsRef,
+        (snapshot) => {
+          currentPointsByUser = snapshot.docs.reduce((pointsByUser, entry) => {
+            const data = entry.data() || {};
+            const creatorId = cleanString(data.createdBy || data.ownerId);
+            if (creatorId) {
+              pointsByUser[creatorId] = (pointsByUser[creatorId] || 0) + 1;
+            }
+            return pointsByUser;
+          }, {});
+          renderCurrentUsers();
+        },
+        () => {
+          window.UiService?.showToast('Impossible de charger les points utilisateurs.');
         },
       );
     </script>


### PR DESCRIPTION
### Motivation
- Afficher un classement des utilisateurs dans la page « Gestion Admin » basé sur le nombre de créations d’OUT réalisées par chaque utilisateur. 
- Calculer les points à partir des OUT existants sur tous les sites (collection `pages/page2/items`) et mettre à jour automatiquement lors de nouvelles créations. 
- Conserver l’apparence et le comportement actuels de la page en ajoutant simplement la colonne « Point » en début de tableau.

### Description
- Ajout de la colonne `<th>Point</th>` en première position dans `users.html` et insertion de la cellule des points (`<td class="users-point-cell">`) devant la photo pour chaque ligne. 
- Ajout dans `js/storage.js` de `normalizeOutCreationPointsSnapshot`, `listOutCreationPoints` et `subscribeOutCreationPoints`, et exposition de ces fonctions via `window.StorageService` pour compter 1 point par OUT en utilisant les champs `createdBy` / `ownerId`. 
- Mise à jour de `js/app.js` pour accepter et afficher les points : tri des utilisateurs par points décroissants puis par nom (`sortUsersByPointsAndName`), rendu de la colonne Point, chargement initial via `StorageService.listOutCreationPoints()` et abonnement temps réel via `StorageService.subscribeOutCreationPoints()` pour rafraîchir automatiquement le tableau. 
- Ajustements CSS (`css/style.css`) pour réindexer les colonnes (nth-child) et ajouter le style `.users-point-cell` afin de préserver la mise en page existante.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/storage.js` qui a réussi. 
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` qui a réussi. 
- Exécution de `git diff --check` pour détecter les problèmes de format et conflits qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cc0961b788333909ed31d987ba104)