### PR TITLE
Connexion : masquer l'authentification par e‑mail et ne garder que Google

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -36,6 +36,19 @@ body {
 .login-card__header h1 { margin: 0; font-size: 1.35rem; color: #fff; line-height: 1.2; }
 .login-card__header p { margin: .25rem 0 .75rem; color: rgba(255,255,255,.88); font-size: .92rem; }
 .login-form { display: grid; gap: .62rem; }
+.login-form--google-only {
+  gap: 0;
+  margin-top: .9rem;
+}
+.login-form--google-only .email-auth-fields,
+.login-form--google-only .login-separator {
+  display: none;
+}
+.login-form--google-only .btn-google {
+  align-self: center;
+  width: 100%;
+  margin: .55rem 0;
+}
 .field-group { display: grid; gap: .32rem; color: #f8fafc; }
 .field-group input {
   width: 100%;

--- a/login.html
+++ b/login.html
@@ -14,30 +14,32 @@
           <p>Accédez à votre espace sécurisé.</p>
         </header>
 
-        <form id="loginForm" class="login-form" novalidate>
-          <label class="field-group" for="loginEmail">
-            <span>Entrer votre mail</span>
-            <input id="loginEmail" type="email" autocomplete="email" required />
-            <small id="emailError" class="field-error" aria-live="polite"></small>
-          </label>
+        <form id="loginForm" class="login-form login-form--google-only" novalidate>
+          <div class="email-auth-fields" aria-hidden="true">
+            <label class="field-group" for="loginEmail">
+              <span>Entrer votre mail</span>
+              <input id="loginEmail" type="email" autocomplete="email" required />
+              <small id="emailError" class="field-error" aria-live="polite"></small>
+            </label>
 
-          <label class="field-group" for="loginPassword">
-            <span>Mot de passe</span>
-            <div class="password-wrap">
-              <input id="loginPassword" type="password" autocomplete="current-password" required minlength="6" />
-              <button id="togglePasswordButton" class="password-toggle" type="button" aria-label="Afficher le mot de passe">
-                <img id="togglePasswordIcon" src="Icon/Eye_OFF.png" alt="Afficher/Cacher" />
-              </button>
-            </div>
-            <small id="passwordError" class="field-error" aria-live="polite"></small>
-          </label>
+            <label class="field-group" for="loginPassword">
+              <span>Mot de passe</span>
+              <div class="password-wrap">
+                <input id="loginPassword" type="password" autocomplete="current-password" required minlength="6" />
+                <button id="togglePasswordButton" class="password-toggle" type="button" aria-label="Afficher le mot de passe">
+                  <img id="togglePasswordIcon" src="Icon/Eye_OFF.png" alt="Afficher/Cacher" />
+                </button>
+              </div>
+              <small id="passwordError" class="field-error" aria-live="polite"></small>
+            </label>
 
-          <button id="emailLoginButton" class="btn btn-primary" type="submit">
-            <span class="btn__label">Se connecter</span>
-            <span class="btn__loader" aria-hidden="true"></span>
-          </button>
+            <button id="emailLoginButton" class="btn btn-primary" type="submit" tabindex="-1">
+              <span class="btn__label">Se connecter</span>
+              <span class="btn__loader" aria-hidden="true"></span>
+            </button>
+          </div>
 
-          <p class="login-separator">Ou</p>
+          <p class="login-separator" aria-hidden="true">Ou</p>
 
           <button id="googleLoginButton" class="btn btn-google" type="button">
             <img src="Icon/btn_google.png" alt="Google" />


### PR DESCRIPTION
### Motivation
- Basculer l'interface de connexion pour n'autoriser que la connexion via compte Google tout en conservant le code d'authentification par e‑mail/mot de passe pour réactivation future.
- Éviter les gros espaces vides et garder l'interface centrée et équilibrée dans la carte de connexion.
- Conserver le design, les animations et le comportement responsive existants.

### Description
- Ajout de la classe `login-form--google-only` au formulaire et regroupement des contrôles e‑mail/mot de passe dans une `div` `email-auth-fields` avec `aria-hidden="true"` pour les masquer sans les supprimer (fichier `login.html`).
- Ajout de `tabindex="-1"` sur le bouton d'authentification e‑mail pour éviter le focus clavier lorsque masqué (fichier `login.html`).
- Ajout de règles CSS dans `css/login.css` pour masquer `.email-auth-fields` et `.login-separator`, réduire l'espace vertical et centrer/mettre en pleine largeur le bouton Google afin d'ajuster automatiquement la hauteur de la carte (`.login-form--google-only`).
- Aucune suppression de code JavaScript liée à l'authentification et aucune autre fonctionnalité de la page modifiée.

### Testing
- Exécution d'un script d'assertions `python3` vérifiant la présence de la classe `login-form--google-only`, du conteneur `email-auth-fields` et des règles CSS de masquage, qui a réussi.
- Exécution de `git diff --check` pour valider l'absence d'erreurs de diff, qui a réussi.
- Vérification basique de l'état du dépôt avec `git status --short`, confirmant les fichiers modifiés attendus.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cd464b870833381d83f34f787bb8e)