### PR TITLE
Trier les cartes des sites par ordre alphabétique

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1127,7 +1127,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let isSiteNameEditPending = false;
     let siteNameAvailabilityDebounceTimer = null;
     let isSiteCreateInputValid = false;
+    const siteNameCollator = new Intl.Collator('fr', { sensitivity: 'base', numeric: true });
     const siteLockFieldStateTimers = new WeakMap();
+
+    function compareSitesByName(siteA, siteB) {
+      return siteNameCollator.compare(String(siteA?.nom || ''), String(siteB?.nom || ''));
+    }
     let isSiteUnlockPending = false;
     let siteUnlockBlockTimer = null;
     let siteUnlockCountdownTimer = null;
@@ -2268,7 +2273,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function renderSites() {
       const query = searchInput.value.trim().toUpperCase();
-      const sites = currentSites.filter((site) => String(site.nom || '').toUpperCase().includes(query));
+      const sites = currentSites
+        .filter((site) => String(site.nom || '').toUpperCase().includes(query))
+        .sort(compareSitesByName);
       siteCount.textContent = String(sites.length);
 
       if (!sites.length) {


### PR DESCRIPTION
### Motivation
- Afficher les cartes des sites en ordre alphabétique A→Z sur la page d’accueil sans modifier les données dans Firebase. 
- Rendre le tri insensible aux majuscules et aux accents et appliquer automatiquement lors du chargement et des mises à jour (création / renommage). 

### Description
- Ajout d’un `Intl.Collator` configuré pour le français (`fr`, `sensitivity: 'base', numeric: true`) et d’une fonction `compareSitesByName` dans `js/app.js` pour les comparaisons de noms de sites. 
- Application du tri côté affichage : la liste filtrée `sites` est triée avec `compareSitesByName` juste avant le rendu dans la fonction `renderSites` de `js/app.js`, ce qui ne modifie pas l’ordre stocké côté `storage`. 
- Le tri s’applique automatiquement quand la page est re-rendue (chargement, `emitAll` après création ou renommage), sans écrire dans Firebase ni changer d’autres fonctionnalités ou données. 

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js`, qui a réussi. 
- Exécution de `git diff --check` pour vérifier les changements, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cdb45094c83339441db42ca209c64)