### PR TITLE
Ajouter colonne « Dernière activité » à la page Gestion Admin

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1014,6 +1014,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
       try {
+        await StorageService?.recordCurrentUserActivity?.();
         await signOut(firebaseAuth);
       } catch (_error) {
         message.textContent = "Impossible de se déconnecter pour l'instant.";
@@ -7100,6 +7101,49 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
     }
 
+    function parseActivityDate(value) {
+      if (!value) {
+        return null;
+      }
+      let normalizedValue = value;
+      if (typeof value?.toDate === 'function') {
+        normalizedValue = value.toDate();
+      } else if (typeof value?.seconds === 'number') {
+        normalizedValue = new Date(value.seconds * 1000);
+      }
+      const parsed = new Date(normalizedValue);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    function formatLastActivity(value, referenceDate = new Date()) {
+      const activityDate = parseActivityDate(value);
+      if (!activityDate) {
+        return '-';
+      }
+      const elapsedMs = Math.max(0, referenceDate.getTime() - activityDate.getTime());
+      const elapsedMinutes = Math.floor(elapsedMs / 60000);
+      if (elapsedMinutes < 5) {
+        return '🟢 En ligne';
+      }
+      if (elapsedMinutes < 60) {
+        return `Il y a ${elapsedMinutes} min`;
+      }
+      const elapsedHours = Math.floor(elapsedMinutes / 60);
+      if (elapsedHours < 24) {
+        return `Il y a ${elapsedHours} h`;
+      }
+      const elapsedDays = Math.floor(elapsedHours / 24);
+      if (elapsedDays < 7) {
+        return `Il y a ${elapsedDays} jour${elapsedDays > 1 ? 's' : ''}`;
+      }
+      const elapsedWeeks = Math.floor(elapsedDays / 7);
+      if (elapsedDays < 30) {
+        return `Il y a ${elapsedWeeks} semaine${elapsedWeeks > 1 ? 's' : ''}`;
+      }
+      const elapsedMonths = Math.max(1, Math.floor(elapsedDays / 30));
+      return `Il y a ${elapsedMonths} mois`;
+    }
+
     function sortUsersByPointsAndName(users, pointsByUser) {
       return [...users].sort((a, b) => {
         const pointsA = Number(pointsByUser?.[a.id] || 0);
@@ -7122,6 +7166,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       : `<span class="table-avatar table-avatar--fallback">${escapeHtml(getInitialsFromName(resolveDisplayName(user)).slice(0, 2))}</span>`}
             </td>
             <td>${escapeHtml(resolveDisplayName(user))}</td>
+            <td class="users-last-activity-cell">${escapeHtml(formatLastActivity(user.lastActivity))}</td>
             <td class="users-email-cell">${escapeHtml(cleanText(user.email) || '-')}</td>
             <td>
               ${cleanText(user.email).toLowerCase() === 'andrainaaina@gmail.com' ? 'admin' : `
@@ -7208,10 +7253,18 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     let currentUsers = [];
     let currentPointsByUser = {};
+    let lastActivityRefreshId = null;
 
     function renderCurrentUsers() {
       renderUsers(currentUsers, currentPointsByUser);
     }
+
+    lastActivityRefreshId = window.setInterval(renderCurrentUsers, 60000);
+    window.addEventListener('pagehide', () => {
+      if (lastActivityRefreshId) {
+        window.clearInterval(lastActivityRefreshId);
+      }
+    });
 
     try {
       const cleanupResult = await StorageService.cleanupInactiveUsers?.();

--- a/js/storage.js
+++ b/js/storage.js
@@ -367,7 +367,10 @@ async function saveUsername(username) {
 
   await setDoc(
     userDocRef(),
-    updates,
+    {
+      ...updates,
+      lastActivity: serverTimestamp(),
+    },
     { merge: true },
   );
 
@@ -537,6 +540,7 @@ async function deleteUser(userId) {
     return false;
   }
   await deleteDoc(userDocRef(targetId));
+  await recordCurrentUserActivity();
   return true;
 }
 
@@ -642,6 +646,7 @@ async function setMaintenanceState(enabled) {
     },
     { merge: true },
   );
+  await recordCurrentUserActivity();
   return true;
 }
 

--- a/users.html
+++ b/users.html
@@ -39,6 +39,7 @@
                   <th>Point</th>
                   <th>Photo</th>
                   <th>Nom</th>
+                  <th>Dernière activité</th>
                   <th>Email</th>
                   <th>Rôle</th>
                   <th>Autorisé (maintenance)</th>
@@ -128,6 +129,54 @@
         }
       }
 
+      function parseActivityDate(value) {
+        if (!value) {
+          return null;
+        }
+        let normalizedValue = value;
+        if (typeof value?.toDate === 'function') {
+          normalizedValue = value.toDate();
+        } else if (typeof value?.seconds === 'number') {
+          normalizedValue = new Date(value.seconds * 1000);
+        }
+        const parsed = new Date(normalizedValue);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      }
+
+      function formatLastActivity(value, referenceDate = new Date()) {
+        const activityDate = parseActivityDate(value);
+        if (!activityDate) {
+          return '-';
+        }
+
+        const elapsedMs = Math.max(0, referenceDate.getTime() - activityDate.getTime());
+        const elapsedMinutes = Math.floor(elapsedMs / 60000);
+        if (elapsedMinutes < 5) {
+          return '🟢 En ligne';
+        }
+        if (elapsedMinutes < 60) {
+          return `Il y a ${elapsedMinutes} min`;
+        }
+
+        const elapsedHours = Math.floor(elapsedMinutes / 60);
+        if (elapsedHours < 24) {
+          return `Il y a ${elapsedHours} h`;
+        }
+
+        const elapsedDays = Math.floor(elapsedHours / 24);
+        if (elapsedDays < 7) {
+          return `Il y a ${elapsedDays} jour${elapsedDays > 1 ? 's' : ''}`;
+        }
+
+        const elapsedWeeks = Math.floor(elapsedDays / 7);
+        if (elapsedDays < 30) {
+          return `Il y a ${elapsedWeeks} semaine${elapsedWeeks > 1 ? 's' : ''}`;
+        }
+
+        const elapsedMonths = Math.max(1, Math.floor(elapsedDays / 30));
+        return `Il y a ${elapsedMonths} mois`;
+      }
+
       function sortUsersByPointsAndName(users, pointsByUser) {
         return [...users].sort((a, b) => {
           const pointsA = Number(pointsByUser?.[a.id] || 0);
@@ -163,6 +212,7 @@
                 <td class="users-point-cell">${Number(pointsByUser?.[user.id] || 0)}</td>
                 <td>${avatarMarkup}</td>
                 <td>${displayName}</td>
+                <td class="users-last-activity-cell">${formatLastActivity(user.lastActivity)}</td>
                 <td class="users-email-cell">${email || '-'}</td>
                 <td>
                   ${isPrimaryAdmin ? 'admin' : `
@@ -203,6 +253,7 @@
                 },
                 { merge: true },
               );
+              await window.StorageService?.recordCurrentUserActivity?.();
               window.UiService?.showToast('Rôle mis à jour.');
             } catch (_error) {
               window.UiService?.showToast('Impossible de mettre à jour le rôle.');
@@ -224,6 +275,7 @@
                 },
                 { merge: true },
               );
+              await window.StorageService?.recordCurrentUserActivity?.();
               window.UiService?.showToast('Accès maintenance mis à jour.');
             } catch (_error) {
               checkbox.checked = !checked;
@@ -253,10 +305,18 @@
 
       let currentUsers = [];
       let currentPointsByUser = {};
+      let lastActivityRefreshId = null;
 
       function renderCurrentUsers() {
         renderUsers(currentUsers, currentPointsByUser);
       }
+
+      lastActivityRefreshId = window.setInterval(renderCurrentUsers, 60000);
+      window.addEventListener('pagehide', () => {
+        if (lastActivityRefreshId) {
+          window.clearInterval(lastActivityRefreshId);
+        }
+      });
 
       const usersRef = collection(firebaseDb, 'users');
       const outsRef = collection(firebaseDb, 'pages', 'page2', 'items');


### PR DESCRIPTION
### Motivation
- Permettre à l’administrateur de voir rapidement la dernière activité de chaque utilisateur à partir du champ Firestore `lastActivity` et afficher un statut « En ligne » quand pertinent.
- Mettre à jour automatiquement l’affichage sans recharger la page afin d’avoir des labels relatifs (minutes/heures/jours/semaines/mois) cohérents pour tous les utilisateurs.

### Description
- Ajout de la colonne « Dernière activité » dans le tableau « Tous les utilisateurs » après la colonne « Nom » pour respecter l’ordre demandé (POINT | PHOTO | NOM | DERNIÈRE ACTIVITÉ). (modifié : `users.html`).
- Ajout de fonctions de parsing/formatage `parseActivityDate` et `formatLastActivity` et rendu de la valeur `user.lastActivity` dans les lignes utilisateur, avec la logique « 🟢 En ligne » (< 5 min) puis libellés relatifs pour les minutes/heures/jours/semaines/mois (modifié : `users.html`, `js/app.js`).
- Rafraîchissement automatique de l’affichage toutes les 60 secondes via un `setInterval` et nettoyage sur `pagehide` pour maintenir les labels à jour sans rechargement de page (modifié : `users.html`, `js/app.js`).
- Mise à jour de `lastActivity` côté Storage pour couvrir actions importantes en enregistrant `lastActivity = serverTimestamp()` lors de la sauvegarde du nom d’utilisateur, suppression d’utilisateur, changement d’état de maintenance et en appelant `recordCurrentUserActivity()` depuis les actions UI (modifié : `js/storage.js`, `js/app.js`, `users.html`).
- Les modifications conservent le tri existant (par points puis nom) et n’impactent pas les autres colonnes ni le design actuel.

### Testing
- Vérification de la syntaxe JavaScript avec `node --check js/app.js` qui a réussi.
- Vérification de la syntaxe JavaScript avec `node --check js/storage.js` qui a réussi.
- Vérification statique avec `git diff --check` (no trailing-space/merge problems) qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ce29a948883338a2d78fd914c55d3)