### PR TITLE
Fix site unlock history message

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7323,6 +7323,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return action;
     }
     const suffix = `site « ${siteName} »`;
+    if (/^a déverrouillé le site\b/i.test(action)) {
+      return `${action} « ${siteName} ».`;
+    }
     if (/^a créé le site\b/i.test(action) || /^a supprimé le site\b/i.test(action) || /\ble site\b/i.test(action)) {
       return `${action} dans le ${suffix}.`;
     }


### PR DESCRIPTION
### Motivation
- Corriger l’affichage des événements de déverrouillage pour supprimer uniquement les mots « dans le site » tout en conservant les guillemets français autour du nom du site et sans toucher aux autres types de messages.

### Description
- Ajout d’un cas spécifique dans la fonction `formatHistoryActionWithSite` pour détecter les actions correspondant à `a déverrouillé le site` et retourner `${action} « ${siteName} ».`.
- La modification est limitée au fichier `js/app.js` et n’impacte pas la structure, la date, le nom de l’utilisateur ni d’autres formats de message.
- Le changement s’applique globalement à l’affichage historique existant et futur via la logique centralisée de formatage.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` — succès.
- Exécution de `git diff --check` pour vérifier les problèmes de formatage — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e15c9f4bc8325bda0d1d5ecb45302)