### PR TITLE
Remplacer la bannière de maintenance par une modale globale bloquante

### DIFF
--- a/js/maintenance-banner.js
+++ b/js/maintenance-banner.js
@@ -1,9 +1,33 @@
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
 import { doc, onSnapshot } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
-import { firebaseDb } from './firebase-core.js';
+import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
-const MAINTENANCE_BANNER_ID = 'globalMaintenanceBanner';
-const MAINTENANCE_STYLE_ID = 'globalMaintenanceBannerStyles';
+const MAINTENANCE_MODAL_ID = 'globalMaintenanceModal';
+const MAINTENANCE_STYLE_ID = 'globalMaintenanceModalStyles';
 const MAINTENANCE_DOC_REF = doc(firebaseDb, 'appSettings', 'maintenance');
+const PRIMARY_ADMIN_EMAIL = 'andrainaaina@gmail.com';
+const BODY_LOCK_CLASS = 'global-maintenance-modal-open';
+
+let maintenanceEnabled = false;
+let authResolved = false;
+let currentUserIsAdmin = false;
+let unsubscribeUserProfile = null;
+let modalVisible = false;
+let blockedSiblings = [];
+
+function normalizeRole(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function isPrimaryAdminEmail(email) {
+  return String(email || '').trim().toLowerCase() === PRIMARY_ADMIN_EMAIL;
+}
+
+function resolveIsAdmin(profile, authUser) {
+  const username = String(profile?.username || profile?.name || '').trim();
+  const role = normalizeRole(profile?.role);
+  return username === 'Admin' || role === 'admin' || isPrimaryAdminEmail(profile?.email || authUser?.email);
+}
 
 function ensureMaintenanceStyles() {
   if (document.getElementById(MAINTENANCE_STYLE_ID)) {
@@ -13,140 +37,242 @@ function ensureMaintenanceStyles() {
   const style = document.createElement('style');
   style.id = MAINTENANCE_STYLE_ID;
   style.textContent = `
-    .global-maintenance-banner {
-      width: min(100% - 2rem, 72rem);
-      margin: 1rem auto 0;
-      padding: 0 0.25rem;
-      animation: globalMaintenanceBannerIn 180ms ease-out both;
+    body.${BODY_LOCK_CLASS} {
+      overflow: hidden !important;
+      touch-action: none;
     }
 
-    .global-maintenance-banner[hidden] {
+    .global-maintenance-modal {
+      position: fixed;
+      inset: 0;
+      z-index: 2147483000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(1rem, 4vw, 2rem);
+      background: rgba(2, 6, 23, 0.68);
+      backdrop-filter: blur(2px);
+      overscroll-behavior: contain;
+      animation: globalMaintenanceOverlayIn 180ms ease-out both;
+    }
+
+    .global-maintenance-modal[hidden] {
       display: none !important;
     }
 
-    .global-maintenance-banner__card {
-      display: flex;
-      align-items: flex-start;
-      gap: 0.85rem;
-      border: 1px solid #fb923c;
-      border-left: 0.38rem solid #f97316;
-      border-radius: 1rem;
-      background: linear-gradient(135deg, #fff7ed 0%, #fef3c7 100%);
-      box-shadow: 0 14px 32px rgba(180, 83, 9, 0.16);
-      color: #7c2d12;
-      padding: 1rem 1.1rem;
+    .global-maintenance-modal__dialog {
+      width: min(100%, 30rem);
+      border-radius: 1.35rem;
+      background: #ffffff;
+      box-shadow: 0 24px 70px rgba(15, 23, 42, 0.24);
+      padding: clamp(1.35rem, 5vw, 2.1rem);
+      text-align: center;
+      color: #0f172a;
+      animation: globalMaintenanceDialogIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
     }
 
-    .global-maintenance-banner__icon {
-      flex: 0 0 auto;
+    .global-maintenance-modal__icon {
       display: inline-grid;
       place-items: center;
-      width: 2.25rem;
-      height: 2.25rem;
+      width: clamp(3rem, 12vw, 4rem);
+      height: clamp(3rem, 12vw, 4rem);
+      margin: 0 auto 0.9rem;
       border-radius: 999px;
-      background: rgba(251, 146, 60, 0.18);
-      font-size: 1.2rem;
+      background: #fff7ed;
+      font-size: clamp(1.65rem, 7vw, 2.2rem);
       line-height: 1;
     }
 
-    .global-maintenance-banner__title {
-      margin: 0 0 0.35rem;
-      font-size: clamp(1rem, 2.4vw, 1.18rem);
-      line-height: 1.25;
+    .global-maintenance-modal__title {
+      margin: 0 0 0.85rem;
+      font-size: clamp(1.35rem, 5vw, 1.75rem);
+      line-height: 1.2;
       font-weight: 800;
-      color: #9a3412;
+      color: #111827;
     }
 
-    .global-maintenance-banner__message {
+    .global-maintenance-modal__message {
       margin: 0;
-      color: #7c2d12;
-      font-size: clamp(0.92rem, 2.2vw, 1rem);
-      line-height: 1.5;
+      color: #374151;
+      font-size: clamp(0.98rem, 3.5vw, 1.08rem);
       font-weight: 600;
+      line-height: 1.65;
     }
 
-    @keyframes globalMaintenanceBannerIn {
+    @keyframes globalMaintenanceOverlayIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    @keyframes globalMaintenanceDialogIn {
       from {
         opacity: 0;
-        transform: translateY(-0.5rem);
+        transform: scale(0.94) translateY(0.5rem);
       }
       to {
         opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    @media (max-width: 640px) {
-      .global-maintenance-banner {
-        width: 100%;
-        margin-top: 0.75rem;
-        padding: 0 0.75rem;
-      }
-
-      .global-maintenance-banner__card {
-        gap: 0.7rem;
-        padding: 0.9rem;
+        transform: scale(1) translateY(0);
       }
     }
   `;
   document.head.appendChild(style);
 }
 
-function ensureMaintenanceBanner() {
-  const existingBanner = document.getElementById(MAINTENANCE_BANNER_ID);
-  if (existingBanner) {
-    return existingBanner;
+function ensureMaintenanceModal() {
+  const existingModal = document.getElementById(MAINTENANCE_MODAL_ID);
+  if (existingModal) {
+    return existingModal;
   }
 
   ensureMaintenanceStyles();
 
-  const banner = document.createElement('section');
-  banner.id = MAINTENANCE_BANNER_ID;
-  banner.className = 'global-maintenance-banner';
-  banner.hidden = true;
-  banner.setAttribute('aria-live', 'polite');
-  banner.innerHTML = `
-    <div class="global-maintenance-banner__card" role="status" aria-labelledby="globalMaintenanceTitle">
-      <span class="global-maintenance-banner__icon" aria-hidden="true">🔧</span>
-      <div class="global-maintenance-banner__content">
-        <h2 id="globalMaintenanceTitle" class="global-maintenance-banner__title">🔧 Maintenance en cours</h2>
-        <p class="global-maintenance-banner__message">
-          La page est actuellement en cours de maintenance.<br />
-          Certaines fonctionnalités peuvent être temporairement indisponibles.<br />
-          Veuillez réessayer dans quelques instants.
-        </p>
-      </div>
-    </div>
+  const modal = document.createElement('section');
+  modal.id = MAINTENANCE_MODAL_ID;
+  modal.className = 'global-maintenance-modal';
+  modal.hidden = true;
+  modal.setAttribute('aria-labelledby', 'globalMaintenanceTitle');
+  modal.setAttribute('aria-describedby', 'globalMaintenanceDescription');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('role', 'alertdialog');
+  modal.setAttribute('tabindex', '-1');
+  modal.innerHTML = `
+    <article class="global-maintenance-modal__dialog">
+      <div class="global-maintenance-modal__icon" aria-hidden="true">🔧</div>
+      <h2 id="globalMaintenanceTitle" class="global-maintenance-modal__title">🔧 Maintenance en cours</h2>
+      <p id="globalMaintenanceDescription" class="global-maintenance-modal__message">
+        La plateforme est actuellement en cours de maintenance.<br />
+        Certaines fonctionnalités sont temporairement indisponibles.<br />
+        Veuillez patienter quelques instants.<br />
+        Nous vous remercions de votre compréhension.
+      </p>
+    </article>
   `;
 
-  const mainContent = document.querySelector('.main-content, main');
-  if (mainContent?.parentNode) {
-    mainContent.parentNode.insertBefore(banner, mainContent);
-  } else {
-    document.body.prepend(banner);
+  modal.addEventListener('wheel', (event) => event.preventDefault(), { passive: false });
+  modal.addEventListener('touchmove', (event) => event.preventDefault(), { passive: false });
+  document.body.appendChild(modal);
+  return modal;
+}
+
+function setPageBlocked(modal, shouldBlock) {
+  if (modalVisible === shouldBlock) {
+    return;
   }
 
-  return banner;
-}
+  modalVisible = shouldBlock;
+  document.body.classList.toggle(BODY_LOCK_CLASS, shouldBlock);
 
-function updateMaintenanceBanner(snapshot) {
-  const banner = ensureMaintenanceBanner();
-  const enabled = Boolean(snapshot.exists() && snapshot.data()?.enabled);
-  banner.hidden = !enabled;
-}
+  if (shouldBlock) {
+    blockedSiblings = Array.from(document.body.children).filter((child) => child !== modal);
+    blockedSiblings.forEach((child) => {
+      child.setAttribute('aria-hidden', 'true');
+      if ('inert' in child) {
+        child.inert = true;
+      }
+    });
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    modal.focus({ preventScroll: true });
+    return;
+  }
 
-function initGlobalMaintenanceBanner() {
-  ensureMaintenanceBanner();
-  return onSnapshot(MAINTENANCE_DOC_REF, updateMaintenanceBanner, () => {
-    const banner = document.getElementById(MAINTENANCE_BANNER_ID);
-    if (banner) {
-      banner.hidden = true;
+  blockedSiblings.forEach((child) => {
+    child.removeAttribute('aria-hidden');
+    if ('inert' in child) {
+      child.inert = false;
     }
   });
+  blockedSiblings = [];
+}
+
+function renderMaintenanceModal() {
+  const modal = ensureMaintenanceModal();
+  const shouldShow = authResolved && maintenanceEnabled && !currentUserIsAdmin;
+  modal.hidden = !shouldShow;
+  setPageBlocked(modal, shouldShow);
+}
+
+function clearUserProfileSubscription() {
+  if (typeof unsubscribeUserProfile === 'function') {
+    unsubscribeUserProfile();
+  }
+  unsubscribeUserProfile = null;
+}
+
+function subscribeToCurrentUserRole(user) {
+  clearUserProfileSubscription();
+  if (!user) {
+    authResolved = true;
+    currentUserIsAdmin = false;
+    renderMaintenanceModal();
+    return;
+  }
+
+  currentUserIsAdmin = isPrimaryAdminEmail(user.email);
+  authResolved = true;
+  renderMaintenanceModal();
+
+  unsubscribeUserProfile = onSnapshot(
+    doc(firebaseDb, 'users', user.uid),
+    (snapshot) => {
+      currentUserIsAdmin = resolveIsAdmin(snapshot.exists() ? snapshot.data() : null, user);
+      renderMaintenanceModal();
+    },
+    () => {
+      currentUserIsAdmin = isPrimaryAdminEmail(user.email);
+      renderMaintenanceModal();
+    },
+  );
+}
+
+function blockPageInteraction(event) {
+  if (!modalVisible) {
+    return;
+  }
+
+  const modal = document.getElementById(MAINTENANCE_MODAL_ID);
+  if (event.type === 'keydown' || !modal?.contains(event.target)) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+}
+
+function initGlobalMaintenanceModal() {
+  ensureMaintenanceModal();
+
+  document.addEventListener('click', blockPageInteraction, true);
+  document.addEventListener('keydown', blockPageInteraction, true);
+  document.addEventListener('submit', blockPageInteraction, true);
+
+  const unsubscribeMaintenance = onSnapshot(
+    MAINTENANCE_DOC_REF,
+    (snapshot) => {
+      maintenanceEnabled = Boolean(snapshot.exists() && snapshot.data()?.enabled);
+      renderMaintenanceModal();
+    },
+    () => {
+      maintenanceEnabled = false;
+      renderMaintenanceModal();
+    },
+  );
+
+  const unsubscribeAuth = onAuthStateChanged(firebaseAuth, subscribeToCurrentUserRole, () => {
+    clearUserProfileSubscription();
+    authResolved = true;
+    currentUserIsAdmin = false;
+    renderMaintenanceModal();
+  });
+
+  window.addEventListener('pagehide', () => {
+    unsubscribeMaintenance();
+    unsubscribeAuth();
+    clearUserProfileSubscription();
+  }, { once: true });
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initGlobalMaintenanceBanner, { once: true });
+  document.addEventListener('DOMContentLoaded', initGlobalMaintenanceModal, { once: true });
 } else {
-  initGlobalMaintenanceBanner();
+  initGlobalMaintenanceModal();
 }


### PR DESCRIPTION
### Motivation
- Remplacer l’affichage discret (bannière) par une vraie fenêtre modale centrée qui bloque totalement l’application lors d’une maintenance globale.
- Afficher/masquer la modale en temps réel via Firestore `onSnapshot` et n’afficher la modale que pour les utilisateurs non-admins.
- Empêcher toute interaction utilisateur (clics, scroll, formulaires, touches, FAB, champs) et interdire la fermeture locale de la modale pour garantir que seule la désactivation serveur/administrateur la ferme.

### Description
- Remplacement complet de la logique et du rendu dans `js/maintenance-banner.js` : la bannière a été remplacée par une section modale (`globalMaintenanceModal`) avec styles intégrés, animation `fade+scale` responsive et icône `🔧`.
- Ajout de la dépendance `onAuthStateChanged` et abonnement en temps réel à `appSettings/maintenance` et au profil utilisateur pour déterminer si l’utilisateur courant est admin (`onSnapshot` + vérification de rôle/email) avant d’afficher la modale.
- Blocage total des interactions côté client via ajout/suppression d’une classe de verrouillage sur `body`, utilisation d’`inert` et `aria-hidden` sur les autres enfants du document, prévention des événements (`click`, `submit`, `keydown`, wheel/touchmove`) et gestion du focus pour forcer l’attention sur la modale.
- Comportement non-fermant : pas de bouton « Fermer », pas de fermeture au clic extérieur, pas d’Échap ; la modale disparaît uniquement quand la valeur `enabled` dans Firestore passe à `false`.

### Testing
- Exécution de `node --check js/maintenance-banner.js` qui a réussi sans erreur.
- Exécution de `git diff --check` qui a renvoyé aucun problème détecté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e1ecae71c8325b2dca88eba91b923)