### PR TITLE
Replace admin message panel with FAB modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2361,15 +2361,54 @@ body[data-page="users-management"] .maintenance-access-checkbox {
 }
 
 
-body[data-page="users-management"] .admin-message-card {
-  display: grid;
-  visibility: visible;
-  opacity: 1;
-  gap: 1rem;
+body[data-page="users-management"] .main-content {
+  padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0px));
 }
 
-body[data-page="users-management"] .admin-message-card .section-title {
+body[data-page="users-management"] .admin-message-fab {
+  right: calc(1.25rem + env(safe-area-inset-right, 0px));
+  bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
+  z-index: 1100;
+  font-size: 1.55rem;
+  line-height: 1;
+}
+
+body[data-page="users-management"] .admin-message-modal[hidden] {
+  display: none;
+}
+
+body[data-page="users-management"] .admin-message-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+}
+
+body[data-page="users-management"] .admin-message-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.48);
+  backdrop-filter: blur(3px);
+}
+
+body[data-page="users-management"] .admin-message-modal__panel {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 34rem);
+  display: grid;
+  gap: 1rem;
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+}
+
+body[data-page="users-management"] .admin-message-modal__panel .section-title {
   margin: 0;
+}
+
+body.admin-message-modal-open {
+  overflow: hidden;
 }
 
 body[data-page="users-management"] .admin-message-form {

--- a/users.html
+++ b/users.html
@@ -30,23 +30,27 @@
             </div>
           </div>
         </section>
-        <section class="surface-card admin-message-card" aria-labelledby="adminMessageTitle">
-          <h2 id="adminMessageTitle" class="section-title">📢 Message aux utilisateurs</h2>
-          <form id="adminMessageForm" class="admin-message-form">
-            <label class="admin-message-field" for="adminMessageInputTitle">
-              <span>Titre du message</span>
-              <input id="adminMessageInputTitle" type="text" maxlength="120" autocomplete="off" required />
-            </label>
-            <label class="admin-message-field" for="adminMessageInputBody">
-              <span>Corps du message</span>
-              <textarea id="adminMessageInputBody" rows="5" maxlength="1200" required></textarea>
-            </label>
-            <div class="admin-message-actions">
-              <button id="adminMessageSendButton" type="submit" class="btn-primary">Envoyer</button>
-              <button id="adminMessageCancelButton" type="button" class="btn-secondary">Annuler</button>
-            </div>
-          </form>
-        </section>
+        <button id="adminMessageFab" class="fab admin-message-fab" type="button" aria-haspopup="dialog" aria-controls="adminMessageModal" aria-label="Envoyer un message aux utilisateurs">📢</button>
+        <div id="adminMessageModal" class="admin-message-modal" role="dialog" aria-modal="true" aria-labelledby="adminMessageTitle" hidden>
+          <div class="admin-message-modal__backdrop" data-admin-message-close></div>
+          <section class="admin-message-modal__panel surface-card" aria-label="Message aux utilisateurs">
+            <h2 id="adminMessageTitle" class="section-title">📢 Message aux utilisateurs</h2>
+            <form id="adminMessageForm" class="admin-message-form">
+              <label class="admin-message-field" for="adminMessageInputTitle">
+                <span>Titre du message</span>
+                <input id="adminMessageInputTitle" type="text" maxlength="120" autocomplete="off" required />
+              </label>
+              <label class="admin-message-field" for="adminMessageInputBody">
+                <span>Corps du message</span>
+                <textarea id="adminMessageInputBody" rows="5" maxlength="1200" required></textarea>
+              </label>
+              <div class="admin-message-actions">
+                <button id="adminMessageSendButton" type="submit" class="btn-primary">Envoyer</button>
+                <button id="adminMessageCancelButton" type="button" class="btn-secondary">Annuler</button>
+              </div>
+            </form>
+          </section>
+        </div>
         <section class="surface-card table-card">
           <h2 class="section-title">Tous les utilisateurs</h2>
           <div class="table-wrapper table-wrapper--users">
@@ -336,15 +340,49 @@
         }
       });
 
+      const adminMessageFab = document.getElementById('adminMessageFab');
+      const adminMessageModal = document.getElementById('adminMessageModal');
       const adminMessageForm = document.getElementById('adminMessageForm');
       const adminMessageTitleInput = document.getElementById('adminMessageInputTitle');
       const adminMessageBodyInput = document.getElementById('adminMessageInputBody');
       const adminMessageSendButton = document.getElementById('adminMessageSendButton');
       const adminMessageCancelButton = document.getElementById('adminMessageCancelButton');
 
+      function openAdminMessageModal() {
+        if (!adminMessageModal) {
+          return;
+        }
+        adminMessageModal.hidden = false;
+        document.body.classList.add('admin-message-modal-open');
+        window.setTimeout(() => adminMessageTitleInput?.focus(), 0);
+      }
+
+      function closeAdminMessageModal(options = {}) {
+        if (!adminMessageModal) {
+          return;
+        }
+        if (options.reset !== false) {
+          adminMessageForm?.reset();
+        }
+        adminMessageModal.hidden = true;
+        document.body.classList.remove('admin-message-modal-open');
+        adminMessageFab?.focus();
+      }
+
+      adminMessageFab?.addEventListener('click', openAdminMessageModal);
+
+      adminMessageModal?.querySelectorAll('[data-admin-message-close]').forEach((element) => {
+        element.addEventListener('click', () => closeAdminMessageModal());
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && adminMessageModal && !adminMessageModal.hidden) {
+          closeAdminMessageModal();
+        }
+      });
+
       adminMessageCancelButton?.addEventListener('click', () => {
-        adminMessageForm?.reset();
-        adminMessageTitleInput?.focus();
+        closeAdminMessageModal();
       });
 
       adminMessageForm?.addEventListener('submit', async (event) => {
@@ -366,7 +404,7 @@
             body,
             createdAt: serverTimestamp(),
           });
-          adminMessageForm.reset();
+          closeAdminMessageModal();
           await window.StorageService?.recordCurrentUserActivity?.();
           window.UiService?.showToast('Message envoyé aux utilisateurs.');
         } catch (_error) {


### PR DESCRIPTION
### Motivation
- Simplifier l’interface de la page « Gestion Admin » en remplaçant le grand conteneur d’envoi de message par un FAB aligné au style existant, tout en évitant que le bouton ne masque le contenu de la page. 
- Conserver intégralement la logique d’envoi et de réception des messages (accès Firestore, `onSnapshot`, règles de visibilité pour admins/non-admins, affichage modal bloquant côté utilisateur). 

### Description
- Remplacé la section `.admin-message-card` par un bouton `#adminMessageFab` et une modale `#adminMessageModal` contenant le formulaire existant (`#adminMessageForm`) dans `users.html`, sans modifier les champs obligatoires ni les boutons `Envoyer` / `Annuler`.
- Ajouté le code JavaScript d’ouverture/fermeture de la modale (focus management, backdrop close via `[data-admin-message-close]`, touche `Escape`, et le bouton Annuler) et remplacé l’appel `adminMessageForm.reset()` par une fermeture de la modale après envoi réussi, tout en conservant l’appel à `addDoc(collection(firebaseDb, 'adminMessages'), ...)` pour l’envoi.
- Ajouté des règles CSS dans `css/style.css` pour positionner le FAB (`.admin-message-fab`), afficher la modale en overlay (`.admin-message-modal*`), bloquer le scroll du fond (`body.admin-message-modal-open`) et ajouter un `padding-bottom` à la page pour que le FAB n’occulte pas le contenu.
- Modifications limitées à l’interface d’administration (`users.html` et `css/style.css`) sans toucher à la logique serveur/Firestore ni aux listeners `onSnapshot` existants (réception/affichage des messages inchangés).

### Testing
- Validé le HTML en utilisant `python3` avec `html.parser` pour parser `users.html`, et la vérification a réussi. 
- Executé les contrôles statiques `node --check js/app.js`, `node --check js/ui.js` et `node --check js/maintenance-banner.js`, et tous sont passés sans erreur. 
- Exécuté `git diff --check` et aucune erreur de diff n’a été détectée. 
- Remarque : aucun headless browser / runner (`chromium` / `playwright`) n’était disponible dans l’environnement, donc les vérifications visuelles automatisées (captures/visual tests) n’ont pas été effectuées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ea1cb39108325a9bc0a276a7f65d9)