### PR TITLE
Harmonize admin message modal buttons

### DIFF
--- a/users.html
+++ b/users.html
@@ -44,9 +44,9 @@
                 <span>Corps du message</span>
                 <textarea id="adminMessageInputBody" rows="5" maxlength="1200" required></textarea>
               </label>
-              <div class="admin-message-actions">
-                <button id="adminMessageSendButton" type="submit" class="btn-primary">Envoyer</button>
-                <button id="adminMessageCancelButton" type="button" class="btn-secondary">Annuler</button>
+              <div class="admin-message-actions modal-actions modal-actions--site-create">
+                <button id="adminMessageSendButton" type="submit" class="btn btn-success">Envoyer</button>
+                <button id="adminMessageCancelButton" type="button" class="btn btn-neutral">Annuler</button>
               </div>
             </form>
           </section>


### PR DESCRIPTION
### Motivation
- Harmoniser le style des boutons de la fenêtre modale « Message aux utilisateurs » en réutilisant les classes de boutons existantes pour assurer une cohérence visuelle avec le reste de l'application sans toucher à la logique.

### Description
- Dans `users.html`, remplacer `btn-primary`/`btn-secondary` par `btn btn-success`/`btn btn-neutral` et ajouter les classes de mise en page `modal-actions modal-actions--site-create` au conteneur des actions pour réutiliser les styles et l'espacement existants, sans modifier de JavaScript, Firebase, Firestore ni ajouter de nouvelles règles CSS.

### Testing
- Exécution de la vérification statique `git diff --check` qui a indiqué qu'il n'y avait pas d'erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6eaa18481c8325ac41a4793648b81e)