### PR TITLE
Réorganiser les boutons de la modale « Message aux utilisateurs »

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2448,18 +2448,6 @@ body[data-page="users-management"] .admin-message-field textarea:focus {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
 }
 
-body[data-page="users-management"] .admin-message-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.75rem;
-}
-
-body[data-page="users-management"] .admin-message-actions .btn-primary,
-body[data-page="users-management"] .admin-message-actions .btn-secondary {
-  min-width: 7.5rem;
-}
-
 body[data-page="users-management"] .maintenance-card-header {
   display: flex;
   justify-content: space-between;

--- a/users.html
+++ b/users.html
@@ -44,9 +44,9 @@
                 <span>Corps du message</span>
                 <textarea id="adminMessageInputBody" rows="5" maxlength="1200" required></textarea>
               </label>
-              <div class="admin-message-actions modal-actions modal-actions--site-create">
-                <button id="adminMessageSendButton" type="submit" class="btn btn-success">Envoyer</button>
+              <div class="admin-message-actions modal-actions modal-actions--split modal-actions--site-create">
                 <button id="adminMessageCancelButton" type="button" class="btn btn-neutral">Annuler</button>
+                <button id="adminMessageSendButton" type="submit" class="btn btn-success">Envoyer</button>
               </div>
             </form>
           </section>


### PR DESCRIPTION
### Motivation
- Uniformiser la disposition des actions de la modale « Message aux utilisateurs » pour correspondre aux autres modales du projet et respecter les contraintes d’UI (Annuler à gauche, Envoyer à droite, mêmes dimensions et espacement).

### Description
- Modifié l’ordre et les classes du conteneur d’actions dans `users.html` pour utiliser `modal-actions modal-actions--split modal-actions--site-create` et placer `Annuler` avant `Envoyer` afin d’afficher les boutons sur une seule ligne avec `Annuler` à gauche et `Envoyer` à droite.
- Supprimé l’override CSS spécifique à la page dans `css/style.css` (`body[data-page="users-management"] .admin-message-actions`) pour permettre aux styles génériques de modales (`.modal-actions`, `.modal-actions--site-create`, `.modal-actions--split`) d’assurer largeur/hauteur identiques et espacement cohérent.
- Aucune logique JavaScript ou Firebase modifiée, seuls le HTML et le CSS ont été touchés.

### Testing
- Exécuté `git diff --check` pour s’assurer qu’il n’y a pas d’erreurs de formatage et le résultat est OK.
- Vérification automatisée de la présence d’outils de test de navigateur via `node -e` a indiqué l’absence de `playwright`/`puppeteer`, donc aucun test d’interface automatisé visuel n’a pu être exécuté dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6eace4f88083259fa22ad84cde886c)