### PR TITLE
Replace recipients checklist with closed dropdown multi-select

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2458,12 +2458,67 @@ body[data-page="users-management"] .admin-message-recipients legend {
   font-weight: 800;
 }
 
+body[data-page="users-management"] .admin-message-recipients-dropdown {
+  position: relative;
+  width: 100%;
+}
+
+body[data-page="users-management"] .admin-message-recipients-dropdown__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  border-radius: 0.85rem;
+  background: #fff;
+  color: #111827;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  text-align: left;
+}
+
+body[data-page="users-management"] .admin-message-recipients-dropdown__toggle:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.2);
+  border-color: #2563eb;
+}
+
+body[data-page="users-management"] .admin-message-recipients-dropdown__chevron {
+  flex: 0 0 auto;
+  transition: transform 0.18s ease;
+}
+
+body[data-page="users-management"] .admin-message-recipients-dropdown.is-open .admin-message-recipients-dropdown__chevron {
+  transform: rotate(180deg);
+}
+
+body[data-page="users-management"] .admin-message-recipients-dropdown__menu {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  display: grid;
+  gap: 0.55rem;
+  max-height: min(19rem, 55vh);
+  overflow-y: auto;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.95rem;
+  background: #fff;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
+}
+
+body[data-page="users-management"] .admin-message-recipients-dropdown__menu[hidden] {
+  display: none;
+}
+
 body[data-page="users-management"] .admin-message-recipients__list {
   display: grid;
   gap: 0.45rem;
-  max-height: 13.5rem;
-  overflow-y: auto;
-  padding-right: 0.25rem;
 }
 
 body[data-page="users-management"] .admin-message-recipient {
@@ -2471,6 +2526,7 @@ body[data-page="users-management"] .admin-message-recipient {
   align-items: center;
   gap: 0.65rem;
   min-height: 2.35rem;
+  padding: 0.15rem 0.1rem;
   color: #111827;
   font-weight: 700;
 }

--- a/users.html
+++ b/users.html
@@ -38,11 +38,19 @@
             <form id="adminMessageForm" class="admin-message-form">
               <fieldset class="admin-message-recipients" aria-labelledby="adminMessageRecipientsLegend">
                 <legend id="adminMessageRecipientsLegend">Destinataires</legend>
-                <label class="admin-message-recipient admin-message-recipient--all" for="adminMessageAllRecipients">
-                  <input id="adminMessageAllRecipients" type="checkbox" checked />
-                  <span>Tous les utilisateurs</span>
-                </label>
-                <div id="adminMessageRecipientsList" class="admin-message-recipients__list" aria-label="Liste des utilisateurs"></div>
+                <div id="adminMessageRecipientsDropdown" class="admin-message-recipients-dropdown">
+                  <button id="adminMessageRecipientsToggle" class="admin-message-recipients-dropdown__toggle" type="button" aria-expanded="false" aria-controls="adminMessageRecipientsMenu">
+                    <span id="adminMessageRecipientsSummary">Tous les utilisateurs</span>
+                    <span class="admin-message-recipients-dropdown__chevron" aria-hidden="true">▾</span>
+                  </button>
+                  <div id="adminMessageRecipientsMenu" class="admin-message-recipients-dropdown__menu" hidden>
+                    <label class="admin-message-recipient admin-message-recipient--all" for="adminMessageAllRecipients">
+                      <input id="adminMessageAllRecipients" type="checkbox" checked />
+                      <span>Tous les utilisateurs</span>
+                    </label>
+                    <div id="adminMessageRecipientsList" class="admin-message-recipients__list" aria-label="Liste des utilisateurs"></div>
+                  </div>
+                </div>
                 <p id="adminMessageRecipientsHint" class="admin-message-recipients__hint" hidden>Sélectionnez au moins un destinataire.</p>
               </fieldset>
               <label class="admin-message-field" for="adminMessageInputTitle">
@@ -372,6 +380,10 @@
       const adminMessageSendButton = document.getElementById('adminMessageSendButton');
       const adminMessageCancelButton = document.getElementById('adminMessageCancelButton');
       const adminMessageAllRecipients = document.getElementById('adminMessageAllRecipients');
+      const adminMessageRecipientsDropdown = document.getElementById('adminMessageRecipientsDropdown');
+      const adminMessageRecipientsToggle = document.getElementById('adminMessageRecipientsToggle');
+      const adminMessageRecipientsMenu = document.getElementById('adminMessageRecipientsMenu');
+      const adminMessageRecipientsSummary = document.getElementById('adminMessageRecipientsSummary');
       const adminMessageRecipientsList = document.getElementById('adminMessageRecipientsList');
       const adminMessageRecipientsHint = document.getElementById('adminMessageRecipientsHint');
 
@@ -390,6 +402,25 @@
           .filter(Boolean);
       }
 
+      function updateAdminMessageRecipientSummary() {
+        if (!adminMessageRecipientsSummary) {
+          return;
+        }
+        if (adminMessageAllRecipients?.checked) {
+          adminMessageRecipientsSummary.textContent = 'Tous les utilisateurs';
+          return;
+        }
+        const selectedIds = getSelectedRecipientIds();
+        if (selectedIds.length === 1) {
+          const selectedUser = getSelectableMessageRecipients().find((user) => user.id === selectedIds[0]);
+          adminMessageRecipientsSummary.textContent = selectedUser ? resolveDisplayName(selectedUser) : '1 utilisateur sélectionné';
+          return;
+        }
+        adminMessageRecipientsSummary.textContent = selectedIds.length > 1
+          ? `${selectedIds.length} utilisateurs sélectionnés`
+          : 'Sélectionner des destinataires';
+      }
+
       function updateAdminMessageRecipientState() {
         const sendDisabled = !adminMessageAllRecipients?.checked && getSelectedRecipientIds().length === 0;
         if (adminMessageSendButton) {
@@ -397,6 +428,19 @@
         }
         if (adminMessageRecipientsHint) {
           adminMessageRecipientsHint.hidden = !sendDisabled;
+        }
+        updateAdminMessageRecipientSummary();
+      }
+
+      function setAdminMessageRecipientsDropdownOpen(isOpen) {
+        if (!adminMessageRecipientsMenu || !adminMessageRecipientsToggle) {
+          return;
+        }
+        adminMessageRecipientsMenu.hidden = !isOpen;
+        adminMessageRecipientsToggle.setAttribute('aria-expanded', String(isOpen));
+        adminMessageRecipientsDropdown?.classList.toggle('is-open', isOpen);
+        if (!isOpen) {
+          updateAdminMessageRecipientSummary();
         }
       }
 
@@ -455,6 +499,7 @@
           }
           updateAdminMessageRecipientState();
         }
+        setAdminMessageRecipientsDropdownOpen(false);
         adminMessageModal.hidden = true;
         document.body.classList.remove('admin-message-modal-open');
         adminMessageFab?.focus();
@@ -469,6 +514,20 @@
       document.addEventListener('keydown', (event) => {
         if (event.key === 'Escape' && adminMessageModal && !adminMessageModal.hidden) {
           closeAdminMessageModal();
+        }
+      });
+
+      adminMessageRecipientsToggle?.addEventListener('click', () => {
+        const isOpen = adminMessageRecipientsToggle.getAttribute('aria-expanded') === 'true';
+        setAdminMessageRecipientsDropdownOpen(!isOpen);
+      });
+
+      document.addEventListener('click', (event) => {
+        if (!adminMessageRecipientsDropdown || adminMessageModal?.hidden) {
+          return;
+        }
+        if (!adminMessageRecipientsDropdown.contains(event.target)) {
+          setAdminMessageRecipientsDropdownOpen(false);
         }
       });
 


### PR DESCRIPTION
### Motivation
- Replace the always-visible recipient checklist with a compact, closed-by-default dropdown to improve UX while keeping all existing recipient semantics. 
- Keep existing Firestore message sending logic, admin filtering, and multi/single/all recipient behaviors unchanged. 

### Description
- Replaced the visible recipients list in `users.html` with a dropdown multi-select component that is closed by default and shows a summary text (`Tous les utilisateurs`, a single user name, or `N utilisateurs sélectionnés`) when closed. 
- Added keyboard/ARIA attributes and outside-click handling so the menu closes when clicking outside and the toggle reflects `aria-expanded`. 
- Preserved the existing selection logic so `Tous les utilisateurs` remains checked by default, administrators are excluded from selectable recipients, multiple selections are remembered while the modal is open, and an empty selection disables the `Envoyer` button and shows a hint. 
- Implemented responsive, scrollable menu styling and integrated with existing CSS classes by updating `css/style.css` and `users.html` only. 

### Testing
- Ran `node --check` on extracted inline scripts from `users.html` which completed successfully. 
- Validated `users.html` parsing with Python `HTMLParser`, which succeeded. 
- `npm test` could not be executed because there is no `package.json` in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a706e4d8d5c8329823a4b0853bf7269)