### PR TITLE
Limit admin user messages to 3 most recent unread

### DIFF
--- a/js/maintenance-banner.js
+++ b/js/maintenance-banner.js
@@ -8,7 +8,8 @@ const MAINTENANCE_DOC_REF = doc(firebaseDb, 'appSettings', 'maintenance');
 const PRIMARY_ADMIN_EMAIL = 'andrainaaina@gmail.com';
 const BODY_LOCK_CLASS = 'global-maintenance-modal-open';
 const USER_MESSAGE_MODAL_ID = 'globalUserMessageModal';
-const USER_MESSAGES_QUERY = query(collection(firebaseDb, 'adminMessages'), orderBy('createdAt', 'desc'), limit(20));
+const RECENT_USER_MESSAGES_LIMIT = 3;
+const USER_MESSAGES_QUERY = query(collection(firebaseDb, 'adminMessages'), orderBy('createdAt', 'desc'), limit(RECENT_USER_MESSAGES_LIMIT));
 
 let maintenanceEnabled = false;
 let authResolved = false;
@@ -311,7 +312,7 @@ function renderUserMessageModal() {
 }
 
 function choosePendingUserMessage(messages) {
-  receivedUserMessages = messages;
+  receivedUserMessages = messages.slice(0, RECENT_USER_MESSAGES_LIMIT);
   if (!currentUser || !userProfileResolved || currentUserIsAdmin) {
     pendingUserMessage = null;
     renderUserMessageModal();
@@ -319,7 +320,7 @@ function choosePendingUserMessage(messages) {
   }
 
   const readMessages = getReadMessages(currentUserProfile);
-  pendingUserMessage = messages.find((message) => isMessageForCurrentUser(message) && !readMessages.includes(message.id)) || null;
+  pendingUserMessage = receivedUserMessages.find((message) => isMessageForCurrentUser(message) && !readMessages.includes(message.id)) || null;
   renderUserMessageModal();
 }
 
@@ -334,6 +335,7 @@ async function acknowledgeCurrentUserMessage() {
   pendingUserMessage = null;
   renderUserMessageModal();
   currentUserProfile = { ...(currentUserProfile || {}), readMessages: [...new Set([...getReadMessages(currentUserProfile), messageId])] };
+  choosePendingUserMessage(receivedUserMessages);
 
   try {
     await setDoc(doc(firebaseDb, 'users', currentUser.uid), { readMessages: arrayUnion(messageId) }, { merge: true });


### PR DESCRIPTION
### Motivation
- Limiter le nombre de messages administrateur affichés lors de la reconnexion pour éviter d’inonder l’utilisateur avec des messages anciens et ne garder que les plus récents.
- S’assurer que seuls les messages non lus parmi ces derniers sont affichés et que les messages plus anciens ne sont jamais présentés.
- Conserver le fonctionnement en temps réel via les listeners Firestore `onSnapshot` existants.

### Description
- Ajout de la constante `RECENT_USER_MESSAGES_LIMIT = 3` et modification de la requête `USER_MESSAGES_QUERY` pour utiliser `limit(RECENT_USER_MESSAGES_LIMIT)`.
- Dans `choosePendingUserMessage` on restreint `receivedUserMessages` à `messages.slice(0, RECENT_USER_MESSAGES_LIMIT)` et la sélection du message en attente se fait désormais depuis ce tableau tout en conservant le filtrage par destinataires et l’exclusion des administrateurs.
- Après l’appui sur `OK`, le message est marqué localement dans `currentUserProfile.readMessages` puis `choosePendingUserMessage(receivedUserMessages)` est appelé avant la persistance `setDoc(...)` pour passer immédiatement au prochain message non lu dans la fenêtre des 3 derniers.

### Testing
- Exécuté `git diff --check` et aucune erreur signalée.
- Exécuté `git status --short` et `git log -1 --oneline` pour vérifier que la modification a été commitée correctement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70714a04ec83299d88631967324016)