### PR TITLE
Améliore la messagerie administrateur

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2571,6 +2571,41 @@ body[data-page="users-management"] .admin-message-field textarea:focus {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
 }
 
+body[data-page="users-management"] #adminMessageSendButton {
+  position: relative;
+  justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+body[data-page="users-management"] #adminMessageSendButton .btn-label-loading {
+  display: none;
+}
+
+body[data-page="users-management"] #adminMessageSendButton .btn-loading-spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  display: none;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
+body[data-page="users-management"] #adminMessageSendButton.is-loading {
+  filter: saturate(0.95);
+}
+
+body[data-page="users-management"] #adminMessageSendButton.is-loading .btn-label-default {
+  display: none;
+}
+
+body[data-page="users-management"] #adminMessageSendButton.is-loading .btn-loading-spinner,
+body[data-page="users-management"] #adminMessageSendButton.is-loading .btn-label-loading {
+  display: inline-flex;
+}
+
 body[data-page="users-management"] .maintenance-card-header {
   display: flex;
   justify-content: space-between;

--- a/users.html
+++ b/users.html
@@ -63,7 +63,11 @@
               </label>
               <div class="admin-message-actions modal-actions modal-actions--split modal-actions--site-create">
                 <button id="adminMessageCancelButton" type="button" class="btn btn-neutral">Annuler</button>
-                <button id="adminMessageSendButton" type="submit" class="btn btn-success">Envoyer</button>
+                <button id="adminMessageSendButton" type="submit" class="btn btn-success">
+                  <span class="btn-label-default">Envoyer</span>
+                  <span class="btn-loading-spinner" aria-hidden="true"></span>
+                  <span class="btn-label-loading" aria-hidden="true">Envoi...</span>
+                </button>
               </div>
             </form>
           </section>
@@ -386,6 +390,9 @@
       const adminMessageRecipientsSummary = document.getElementById('adminMessageRecipientsSummary');
       const adminMessageRecipientsList = document.getElementById('adminMessageRecipientsList');
       const adminMessageRecipientsHint = document.getElementById('adminMessageRecipientsHint');
+      const ADMIN_MESSAGE_DRAFT_STORAGE_KEY = 'adminMessageDraft';
+      let isAdminMessageSending = false;
+      let isRestoringAdminMessageDraft = false;
 
       function getSelectableMessageRecipients() {
         return currentUsers
@@ -422,7 +429,7 @@
       }
 
       function updateAdminMessageRecipientState() {
-        const sendDisabled = !adminMessageAllRecipients?.checked && getSelectedRecipientIds().length === 0;
+        const sendDisabled = (!adminMessageAllRecipients?.checked && getSelectedRecipientIds().length === 0) || isAdminMessageSending;
         if (adminMessageSendButton) {
           adminMessageSendButton.disabled = sendDisabled;
         }
@@ -430,6 +437,81 @@
           adminMessageRecipientsHint.hidden = !sendDisabled;
         }
         updateAdminMessageRecipientSummary();
+      }
+
+      function persistAdminMessageDraft() {
+        if (isRestoringAdminMessageDraft) {
+          return;
+        }
+        try {
+          window.localStorage?.setItem(ADMIN_MESSAGE_DRAFT_STORAGE_KEY, JSON.stringify({
+            allRecipients: Boolean(adminMessageAllRecipients?.checked),
+            selectedRecipientIds: Array.from(adminMessageRecipientsList?.querySelectorAll('[data-admin-message-recipient]:checked') || [])
+              .map((checkbox) => checkbox.value)
+              .filter(Boolean),
+            title: adminMessageTitleInput?.value || '',
+            body: adminMessageBodyInput?.value || '',
+          }));
+        } catch (_error) {
+          // Ignore storage errors so messaging remains usable in private/restricted contexts.
+        }
+      }
+
+      function clearAdminMessageDraft() {
+        try {
+          window.localStorage?.removeItem(ADMIN_MESSAGE_DRAFT_STORAGE_KEY);
+        } catch (_error) {
+          // Ignore storage errors.
+        }
+      }
+
+      function getStoredAdminMessageDraft() {
+        try {
+          const rawDraft = window.localStorage?.getItem(ADMIN_MESSAGE_DRAFT_STORAGE_KEY);
+          return rawDraft ? JSON.parse(rawDraft) : null;
+        } catch (_error) {
+          return null;
+        }
+      }
+
+      function applyAdminMessageDraft() {
+        const draft = getStoredAdminMessageDraft();
+        if (!draft) {
+          return;
+        }
+        isRestoringAdminMessageDraft = true;
+        if (adminMessageTitleInput) {
+          adminMessageTitleInput.value = draft.title || '';
+        }
+        if (adminMessageBodyInput) {
+          adminMessageBodyInput.value = draft.body || '';
+        }
+        if (adminMessageAllRecipients) {
+          adminMessageAllRecipients.checked = draft.allRecipients !== false;
+        }
+        const selectedIds = new Set(Array.isArray(draft.selectedRecipientIds) ? draft.selectedRecipientIds.map(String) : []);
+        adminMessageRecipientsList?.querySelectorAll('[data-admin-message-recipient]').forEach((checkbox) => {
+          checkbox.checked = !adminMessageAllRecipients?.checked && selectedIds.has(checkbox.value);
+        });
+        isRestoringAdminMessageDraft = false;
+      }
+
+      function setAdminMessageSending(isSending) {
+        isAdminMessageSending = isSending;
+        adminMessageSendButton?.classList.toggle('is-loading', isSending);
+        adminMessageSendButton?.setAttribute('aria-busy', String(isSending));
+        updateAdminMessageRecipientState();
+      }
+
+      function enforceAdminMessageExclusiveSelection(source) {
+        if (source === 'all' && adminMessageAllRecipients?.checked) {
+          adminMessageRecipientsList?.querySelectorAll('[data-admin-message-recipient]').forEach((checkbox) => {
+            checkbox.checked = false;
+          });
+        }
+        if (source === 'individual' && adminMessageRecipientsList?.querySelector('[data-admin-message-recipient]:checked') && adminMessageAllRecipients) {
+          adminMessageAllRecipients.checked = false;
+        }
       }
 
       function setAdminMessageRecipientsDropdownOpen(isOpen) {
@@ -471,9 +553,6 @@
               `;
             }).join('')
           : '<p class="admin-message-recipients__empty">Aucun utilisateur disponible.</p>';
-        adminMessageRecipientsList.querySelectorAll('[data-admin-message-recipient]').forEach((checkbox) => {
-          checkbox.addEventListener('change', updateAdminMessageRecipientState);
-        });
         updateAdminMessageRecipientState();
       }
 
@@ -484,6 +563,7 @@
         adminMessageModal.hidden = false;
         document.body.classList.add('admin-message-modal-open');
         renderAdminMessageRecipients();
+        applyAdminMessageDraft();
         updateAdminMessageRecipientState();
         window.setTimeout(() => adminMessageTitleInput?.focus(), 0);
       }
@@ -497,6 +577,7 @@
           if (adminMessageAllRecipients) {
             adminMessageAllRecipients.checked = true;
           }
+          clearAdminMessageDraft();
           updateAdminMessageRecipientState();
         }
         setAdminMessageRecipientsDropdownOpen(false);
@@ -531,8 +612,20 @@
         }
       });
 
-      adminMessageAllRecipients?.addEventListener('change', updateAdminMessageRecipientState);
-      adminMessageRecipientsList?.addEventListener('change', updateAdminMessageRecipientState);
+      adminMessageAllRecipients?.addEventListener('change', () => {
+        enforceAdminMessageExclusiveSelection('all');
+        updateAdminMessageRecipientState();
+        persistAdminMessageDraft();
+      });
+      adminMessageRecipientsList?.addEventListener('change', (event) => {
+        if (event.target?.matches?.('[data-admin-message-recipient]')) {
+          enforceAdminMessageExclusiveSelection('individual');
+          updateAdminMessageRecipientState();
+          persistAdminMessageDraft();
+        }
+      });
+      adminMessageTitleInput?.addEventListener('input', persistAdminMessageDraft);
+      adminMessageBodyInput?.addEventListener('input', persistAdminMessageDraft);
 
       adminMessageCancelButton?.addEventListener('click', () => {
         closeAdminMessageModal();
@@ -553,9 +646,11 @@
           return;
         }
 
-        if (adminMessageSendButton) {
-          adminMessageSendButton.disabled = true;
+        if (isAdminMessageSending) {
+          return;
         }
+
+        setAdminMessageSending(true);
 
         try {
           await addDoc(collection(firebaseDb, 'adminMessages'), {
@@ -571,9 +666,7 @@
         } catch (_error) {
           window.UiService?.showToast('Impossible d’envoyer le message.');
         } finally {
-          if (adminMessageSendButton) {
-            adminMessageSendButton.disabled = false;
-          }
+          setAdminMessageSending(false);
         }
       });
 


### PR DESCRIPTION
### Motivation
- Rendre l'interface d'envoi d'un message administrateur plus robuste en empêchant la sélection simultanée de « Tous les utilisateurs » et d'utilisateurs individuels. 
- Préserver l'état du sélecteur et du message entre ouvertures via le LocalStorage pour éviter les pertes accidentelles. 
- Donner un retour visuel d'envoi et empêcher les doubles clics en réutilisant le spinner et les styles déjà présents dans l'application.

### Description
- Mise à jour du template : `users.html` remplace le bouton « Envoyer » par une structure réutilisant `btn-label-default`, `btn-loading-spinner` et `btn-label-loading` pour afficher temporairement `Envoi...` avec le spinner. 
- Ajout d'une persistance de brouillon en LocalStorage via la clé `adminMessageDraft` et des fonctions `persistAdminMessageDraft`, `getStoredAdminMessageDraft`, `applyAdminMessageDraft` et `clearAdminMessageDraft` pour sauvegarder/restaurer `allRecipients`, la liste des destinataires sélectionnés, le titre et le corps. 
- Implémentation de la sélection exclusive avec `enforceAdminMessageExclusiveSelection` et gestion des événements pour décocher automatiquement « Tous les utilisateurs » lorsqu'un destinataire individuel est coché et inversement. 
- Protection contre les doubles envois et animation de chargement via `setAdminMessageSending(isSending)` qui bascule la classe `is-loading`, définit `aria-busy` et désactive le bouton pendant l'envoi; l'état est pris en compte dans `updateAdminMessageRecipientState`. 
- Ajout de règles CSS dans `css/style.css` pour supporter l'affichage/masquage du spinner et du libellé `Envoi...` en s'appuyant sur l'animation et les classes existantes du projet.

### Testing
- Exécution automatisée `git diff --check` passée avec correction d'espaces blancs détectés. 
- Tentative d'exécution d'un test UI headless (Playwright / navigateur) détectée mais aucun navigateur disponible dans l'environnement d'intégration, donc les vérifications visuelles n'ont pas pu être exécutées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a707391cf048329b20ab358641567da)