### PR TITLE
Persistance de la sélection des destinataires du message admin

### DIFF
--- a/users.html
+++ b/users.html
@@ -391,6 +391,7 @@
       const adminMessageRecipientsList = document.getElementById('adminMessageRecipientsList');
       const adminMessageRecipientsHint = document.getElementById('adminMessageRecipientsHint');
       const ADMIN_MESSAGE_DRAFT_STORAGE_KEY = 'adminMessageDraft';
+      const ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY = 'adminMessageRecipients';
       let isAdminMessageSending = false;
       let isRestoringAdminMessageDraft = false;
 
@@ -439,16 +440,29 @@
         updateAdminMessageRecipientSummary();
       }
 
-      function persistAdminMessageDraft() {
+      function getCurrentAdminMessageRecipientsDraft() {
+        return {
+          allRecipients: Boolean(adminMessageAllRecipients?.checked),
+          selectedRecipientIds: Array.from(adminMessageRecipientsList?.querySelectorAll('[data-admin-message-recipient]:checked') || [])
+            .map((checkbox) => checkbox.value)
+            .filter(Boolean),
+        };
+      }
+
+      function persistAdminMessageRecipientsDraft() {
         if (isRestoringAdminMessageDraft) {
           return;
         }
         try {
+          window.localStorage?.setItem(ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY, JSON.stringify(getCurrentAdminMessageRecipientsDraft()));
+        } catch (_error) {
+          // Ignore storage errors so messaging remains usable in private/restricted contexts.
+        }
+      }
+
+      function persistAdminMessageDraft() {
+        try {
           window.localStorage?.setItem(ADMIN_MESSAGE_DRAFT_STORAGE_KEY, JSON.stringify({
-            allRecipients: Boolean(adminMessageAllRecipients?.checked),
-            selectedRecipientIds: Array.from(adminMessageRecipientsList?.querySelectorAll('[data-admin-message-recipient]:checked') || [])
-              .map((checkbox) => checkbox.value)
-              .filter(Boolean),
             title: adminMessageTitleInput?.value || '',
             body: adminMessageBodyInput?.value || '',
           }));
@@ -465,35 +479,67 @@
         }
       }
 
-      function getStoredAdminMessageDraft() {
+      function readAdminMessageStorage(key) {
         try {
-          const rawDraft = window.localStorage?.getItem(ADMIN_MESSAGE_DRAFT_STORAGE_KEY);
+          const rawDraft = window.localStorage?.getItem(key);
           return rawDraft ? JSON.parse(rawDraft) : null;
         } catch (_error) {
           return null;
         }
       }
 
-      function applyAdminMessageDraft() {
-        const draft = getStoredAdminMessageDraft();
-        if (!draft) {
+      function getStoredAdminMessageDraft() {
+        return readAdminMessageStorage(ADMIN_MESSAGE_DRAFT_STORAGE_KEY);
+      }
+
+      function getStoredAdminMessageRecipientsDraft() {
+        const recipientsDraft = readAdminMessageStorage(ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY);
+        if (recipientsDraft) {
+          return recipientsDraft;
+        }
+        const legacyDraft = getStoredAdminMessageDraft();
+        if (legacyDraft && ('allRecipients' in legacyDraft || 'selectedRecipientIds' in legacyDraft)) {
+          return legacyDraft;
+        }
+        return null;
+      }
+
+      function migrateLegacyAdminMessageRecipientsDraft(recipientsDraft) {
+        if (!recipientsDraft || readAdminMessageStorage(ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY)) {
           return;
         }
+        try {
+          window.localStorage?.setItem(ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY, JSON.stringify({
+            allRecipients: recipientsDraft.allRecipients !== false,
+            selectedRecipientIds: Array.isArray(recipientsDraft.selectedRecipientIds) ? recipientsDraft.selectedRecipientIds.map(String) : [],
+          }));
+        } catch (_error) {
+          // Ignore storage errors.
+        }
+      }
+
+      function applyAdminMessageDraft() {
+        const draft = getStoredAdminMessageDraft();
+        const recipientsDraft = getStoredAdminMessageRecipientsDraft();
         isRestoringAdminMessageDraft = true;
-        if (adminMessageTitleInput) {
-          adminMessageTitleInput.value = draft.title || '';
+        try {
+          if (adminMessageTitleInput) {
+            adminMessageTitleInput.value = draft?.title || '';
+          }
+          if (adminMessageBodyInput) {
+            adminMessageBodyInput.value = draft?.body || '';
+          }
+          if (adminMessageAllRecipients) {
+            adminMessageAllRecipients.checked = recipientsDraft?.allRecipients !== false;
+          }
+          const selectedIds = new Set(Array.isArray(recipientsDraft?.selectedRecipientIds) ? recipientsDraft.selectedRecipientIds.map(String) : []);
+          adminMessageRecipientsList?.querySelectorAll('[data-admin-message-recipient]').forEach((checkbox) => {
+            checkbox.checked = !adminMessageAllRecipients?.checked && selectedIds.has(checkbox.value);
+          });
+        } finally {
+          isRestoringAdminMessageDraft = false;
         }
-        if (adminMessageBodyInput) {
-          adminMessageBodyInput.value = draft.body || '';
-        }
-        if (adminMessageAllRecipients) {
-          adminMessageAllRecipients.checked = draft.allRecipients !== false;
-        }
-        const selectedIds = new Set(Array.isArray(draft.selectedRecipientIds) ? draft.selectedRecipientIds.map(String) : []);
-        adminMessageRecipientsList?.querySelectorAll('[data-admin-message-recipient]').forEach((checkbox) => {
-          checkbox.checked = !adminMessageAllRecipients?.checked && selectedIds.has(checkbox.value);
-        });
-        isRestoringAdminMessageDraft = false;
+        migrateLegacyAdminMessageRecipientsDraft(recipientsDraft);
       }
 
       function setAdminMessageSending(isSending) {
@@ -615,13 +661,13 @@
       adminMessageAllRecipients?.addEventListener('change', () => {
         enforceAdminMessageExclusiveSelection('all');
         updateAdminMessageRecipientState();
-        persistAdminMessageDraft();
+        persistAdminMessageRecipientsDraft();
       });
       adminMessageRecipientsList?.addEventListener('change', (event) => {
         if (event.target?.matches?.('[data-admin-message-recipient]')) {
           enforceAdminMessageExclusiveSelection('individual');
           updateAdminMessageRecipientState();
-          persistAdminMessageDraft();
+          persistAdminMessageRecipientsDraft();
         }
       });
       adminMessageTitleInput?.addEventListener('input', persistAdminMessageDraft);
@@ -660,7 +706,14 @@
             recipientIds: selectedRecipientIds || [],
             createdAt: serverTimestamp(),
           });
-          closeAdminMessageModal();
+          if (adminMessageTitleInput) {
+            adminMessageTitleInput.value = '';
+          }
+          if (adminMessageBodyInput) {
+            adminMessageBodyInput.value = '';
+          }
+          clearAdminMessageDraft();
+          closeAdminMessageModal({ reset: false });
           await window.StorageService?.recordCurrentUserActivity?.();
           window.UiService?.showToast('Message envoyé aux utilisateurs.');
         } catch (_error) {


### PR DESCRIPTION
### Motivation
- Corriger le comportement du `localStorage` pour que la sélection des destinataires soit persistante à travers l'envoi, le rechargement, la fermeture/réouverture du navigateur et les retours sur la page.
- Ne plus effacer la sélection des destinataires après l'envoi d'un message tout en continuant à vider uniquement le titre et le corps du message.

### Description
- Ajout d'une clé dédiée `ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY = 'adminMessageRecipients'` pour stocker séparément la sélection des destinataires afin qu'elle survive aux envois et aux resets du formulaire.
- Implémentation de `getCurrentAdminMessageRecipientsDraft()` et `persistAdminMessageRecipientsDraft()` pour n'écrire le `localStorage` des destinataires que lors d'un changement explicite de sélection (option "Tous les utilisateurs" ou utilisateurs individuels).
- Lecture unifiée via `readAdminMessageStorage()` avec migration des anciens brouillons contenant déjà des destinataires et restauration automatique de la dernière sélection dans `applyAdminMessageDraft()`.
- Après un envoi réussi, seuls les champs titre et corps sont vidés et la modale est fermée sans réinitialiser la sélection des destinataires (`clearAdminMessageDraft()` pour le texte et `closeAdminMessageModal({ reset: false })`).

### Testing
- Vérification de syntaxe du script extrait avec `node --check /tmp/users-script.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70777b66588329a179370b3f9e5947)