### PR TITLE
Display real-time total and online user counts in Admin users header

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7100,6 +7100,27 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return Number.isNaN(parsed.getTime()) ? null : parsed;
     }
 
+    function isUserOnline(user, referenceDate = new Date()) {
+      if (user?.online === true || cleanText(user?.presence).toLowerCase() === 'online' || cleanText(user?.status).toLowerCase() === 'online') {
+        return true;
+      }
+      const lastSeenDate = parseActivityDate(user?.lastSeen || user?.lastActivity);
+      if (!lastSeenDate) {
+        return false;
+      }
+      return Math.max(0, referenceDate.getTime() - lastSeenDate.getTime()) < 5 * 60000;
+    }
+
+    function updateUsersCardHeader(users) {
+      const usersCardHeader = document.getElementById('usersCardHeader');
+      if (!usersCardHeader) {
+        return;
+      }
+      const referenceDate = new Date();
+      const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
+      usersCardHeader.innerHTML = `Tous les utilisateurs : ${users.length}<br />En ligne : ${onlineCount}`;
+    }
+
     function formatLastActivity(value, referenceDate = new Date()) {
       const activityDate = parseActivityDate(value);
       if (!activityDate) {
@@ -7241,6 +7262,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let lastActivityRefreshId = null;
 
     function renderCurrentUsers() {
+      updateUsersCardHeader(currentUsers);
       renderUsers(currentUsers, currentPointsByUser);
     }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -441,6 +441,10 @@ async function listUsers() {
         maintenanceAuthorized: normalizeMaintenanceAuthorized(data),
         createdAt: data.createdAt || null,
         lastActivity: data.lastActivity || null,
+        lastSeen: data.lastSeen || null,
+        online: data.online === true,
+        presence: data.presence || null,
+        status: data.status || null,
       };
     });
 }
@@ -612,6 +616,10 @@ function subscribeUsers(onChange, onError) {
               maintenanceAuthorized: normalizeMaintenanceAuthorized(data),
               createdAt: data.createdAt || null,
               lastActivity: data.lastActivity || null,
+              lastSeen: data.lastSeen || null,
+              online: data.online === true,
+              presence: data.presence || null,
+              status: data.status || null,
             };
           });
         onChange(users);

--- a/users.html
+++ b/users.html
@@ -73,7 +73,7 @@
           </section>
         </div>
         <section class="surface-card table-card">
-          <h2 class="section-title">Tous les utilisateurs</h2>
+          <h2 class="section-title" id="usersCardHeader">Tous les utilisateurs : 0<br />En ligne : 0</h2>
           <div class="table-wrapper table-wrapper--users">
             <table class="data-table">
               <thead>
@@ -199,6 +199,27 @@
         }
         const parsed = new Date(normalizedValue);
         return Number.isNaN(parsed.getTime()) ? null : parsed;
+      }
+
+      function isUserOnline(user, referenceDate = new Date()) {
+        if (user?.online === true || toLower(user?.presence) === 'online' || toLower(user?.status) === 'online') {
+          return true;
+        }
+        const lastSeenDate = parseActivityDate(user?.lastSeen || user?.lastActivity);
+        if (!lastSeenDate) {
+          return false;
+        }
+        return Math.max(0, referenceDate.getTime() - lastSeenDate.getTime()) < 5 * 60000;
+      }
+
+      function updateUsersCardHeader(users) {
+        const usersCardHeader = document.getElementById('usersCardHeader');
+        if (!usersCardHeader) {
+          return;
+        }
+        const referenceDate = new Date();
+        const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
+        usersCardHeader.innerHTML = `Tous les utilisateurs : ${users.length}<br />En ligne : ${onlineCount}`;
       }
 
       function formatLastActivity(value, referenceDate = new Date()) {
@@ -366,6 +387,7 @@
       let lastActivityRefreshId = null;
 
       function renderCurrentUsers() {
+        updateUsersCardHeader(currentUsers);
         renderUsers(currentUsers, currentPointsByUser);
       }
 


### PR DESCRIPTION
### Motivation
- Make the "Gestion Admin" users card header show the total number of users and the number currently online, updating in real time without changing existing presence logic.

### Description
- Replace the static section title with a header element `id="usersCardHeader"` that shows `Tous les utilisateurs : {total}` and `En ligne : {online}` in `users.html`.
- Add an `isUserOnline(user)` helper and `updateUsersCardHeader(users)` to compute online users using existing presence fields (`online`, `presence`, `status`, `lastSeen`, `lastActivity`) and call it from `renderCurrentUsers` in both `js/app.js` and `users.html` script paths.
- Extend `StorageService` outputs in `js/storage.js` (`listUsers` and `subscribeUsers`) to include `lastSeen`, `online`, `presence`, and `status` so the real-time snapshot contains the existing presence information.
- Preserve all existing functionality and do not introduce a new presence system; administrators remain included in both counts.

### Testing
- Performed static syntax checks with `node --check js/app.js` and `node --check js/storage.js`, which passed. 
- Ran `git diff --check` to validate whitespace and diff issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a707bdaf57c8329b2b069b19886ba99)