### PR TITLE
Add purchase material detail page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6833,3 +6833,146 @@ body[data-page="item-detail"] .search-highlight {
     box-sizing: border-box;
   }
 }
+
+body[data-page="purchase-detail"] .purchase-detail-content {
+  gap: clamp(1rem, 3vw, 1.35rem);
+}
+
+body[data-page="purchase-detail"] .purchase-detail-summary {
+  width: min(100%, var(--content-max-width));
+  margin-inline: auto;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  gap: 0.85rem;
+  align-items: center;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-summary__media {
+  width: 64px;
+  height: 64px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  font-size: 1.55rem;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-summary__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-summary__body {
+  min-width: 0;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-summary__title {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-summary__date {
+  margin: 0.28rem 0 0;
+  color: #64748b;
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-main {
+  width: min(100%, var(--content-max-width));
+  margin-inline: auto;
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.3rem);
+}
+
+body[data-page="purchase-detail"] .purchase-detail-image-wrap {
+  display: flex;
+  justify-content: center;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-image-button[hidden],
+body[data-page="purchase-detail"] .purchase-detail-image[hidden] {
+  display: none;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-image-button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: zoom-in;
+  border-radius: 20px;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-image {
+  width: clamp(220px, 62vw, 280px);
+  aspect-ratio: 1 / 1;
+  border-radius: 20px;
+  object-fit: cover;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+  color: #64748b;
+  font-size: 3rem;
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.14);
+}
+
+body[data-page="purchase-detail"] .purchase-detail-info-card {
+  display: grid;
+  gap: 0.72rem;
+}
+
+body[data-page="purchase-detail"] .purchase-image-dialog {
+  width: min(92vw, 720px);
+  max-width: 92vw;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+body[data-page="purchase-detail"] .purchase-image-dialog__image {
+  width: 100%;
+  max-height: 86vh;
+  object-fit: contain;
+  border-radius: 20px;
+  display: block;
+  background: #0f172a;
+}
+
+body[data-page="purchase-detail"] .purchase-image-dialog__close {
+  position: absolute;
+  top: -0.9rem;
+  right: -0.7rem;
+  width: 2.45rem;
+  height: 2.45rem;
+  border: 0;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 1.5rem;
+  line-height: 1;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.22);
+  cursor: pointer;
+  z-index: 1;
+}
+
+@media (max-width: 520px) {
+  body[data-page="purchase-detail"] .purchase-detail-summary {
+    grid-template-columns: 58px minmax(0, 1fr);
+  }
+
+  body[data-page="purchase-detail"] .purchase-detail-summary__media {
+    width: 58px;
+    height: 58px;
+  }
+
+  body[data-page="purchase-detail"] .purchase-info-row {
+    grid-template-columns: minmax(6.9rem, auto) minmax(0, 1fr);
+  }
+}

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
-import { addDoc, collection, deleteDoc, doc, getDocs, orderBy, query, serverTimestamp, updateDoc } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+import { addDoc, collection, deleteDoc, doc, getDoc, getDocs, orderBy, query, serverTimestamp, updateDoc } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
 (function () {
@@ -4532,7 +4532,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         }
         previousLabel = currentLabel;
         htmlParts.push(`
-          <article class="list-card purchase-card">
+          <article class="list-card purchase-card" data-purchase-open="${escapeHtml(purchase.id)}" tabindex="0" role="button" aria-label="Voir le détail de ${escapeHtml(purchase?.designation || 'cet achat matériel')}">
             ${permissions.canDelete && !permissions.isLecture ? `<button class="list-card__menu-button" type="button" data-purchase-menu="${purchase.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
             <div class="list-card__button">
               <div class="purchase-card__content">
@@ -4570,6 +4570,20 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         `);
       });
       purchasesList.innerHTML = htmlParts.join('');
+      purchasesList.querySelectorAll('[data-purchase-open]').forEach((card) => {
+        const openPurchaseDetail = () => {
+          const purchaseId = String(card.dataset.purchaseOpen || '').trim();
+          if (!purchaseId) return;
+          UiService.navigate(`purchase-detail.html?siteId=${encodeURIComponent(siteId)}&purchaseId=${encodeURIComponent(purchaseId)}`);
+        };
+        card.addEventListener('click', openPurchaseDetail);
+        card.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            openPurchaseDetail();
+          }
+        });
+      });
       purchasesList.querySelectorAll('[data-purchase-menu]').forEach((button) => {
         button.addEventListener('click', (event) => {
           event.stopPropagation();
@@ -7417,6 +7431,96 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return nextProfile;
   }
 
+
+  function initPurchaseDetailPage() {
+    initAuthRequiredNoticeCard();
+
+    const params = UiService.getQueryParams();
+    const siteId = params.get('siteId');
+    const purchaseId = params.get('purchaseId');
+    if (!siteId || !purchaseId) {
+      UiService.navigate('index.html');
+      return;
+    }
+
+    const backButton = requireElement('purchaseDetailBackButton');
+    const summary = requireElement('purchaseDetailSummary');
+    const summaryName = requireElement('purchaseDetailName');
+    const summaryCreatedAt = requireElement('purchaseDetailCreatedAt');
+    const summaryMedia = summary?.querySelector('.purchase-detail-summary__media');
+    const imageButton = requireElement('purchaseDetailImageButton');
+    const image = requireElement('purchaseDetailImage');
+    const imagePlaceholder = requireElement('purchaseDetailImagePlaceholder');
+    const qty = requireElement('purchaseDetailQty');
+    const store = requireElement('purchaseDetailStore');
+    const user = requireElement('purchaseDetailUser');
+    const fullDate = requireElement('purchaseDetailFullDate');
+    const imageDialog = requireElement('purchaseImageDialog');
+    const imageDialogImage = requireElement('purchaseImageDialogImage');
+    const imageDialogClose = requireElement('purchaseImageDialogClose');
+
+    backButton?.addEventListener('click', () => {
+      UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
+    });
+
+    function formatPurchaseDateLabel(purchase) {
+      return buildDateAndTimeLabel(purchase?.createdAt || purchase?.dateAchat || purchase?.date || purchase?.dateCreation || purchase?.dateModification);
+    }
+
+    function renderPurchaseDetail(purchase) {
+      const imageUrl = String(purchase?.imageUrl || '').trim();
+      const dateLabel = formatPurchaseDateLabel(purchase);
+      const purchaseStore = String(purchase?.store || purchase?.magasin || '').trim() || '-';
+
+      summaryName.textContent = String(purchase?.designation || 'Achat matériel');
+      summaryCreatedAt.textContent = dateLabel;
+      summaryMedia.innerHTML = imageUrl
+        ? `<img src="${escapeHtml(imageUrl)}" alt="Photo achat matériel" />`
+        : '<span>🖼️</span>';
+      qty.textContent = `${Number(purchase?.qty || 0)} ${String(purchase?.unit || 'Pcs')}`;
+      store.textContent = purchaseStore;
+      user.textContent = String(purchase?.createdBy || 'Utilisateur');
+      fullDate.textContent = dateLabel;
+
+      if (imageUrl) {
+        image.src = imageUrl;
+        imageButton.hidden = false;
+        imagePlaceholder.hidden = true;
+      } else {
+        image.removeAttribute('src');
+        imageButton.hidden = true;
+        imagePlaceholder.hidden = false;
+      }
+    }
+
+    imageButton?.addEventListener('click', () => {
+      const imageUrl = String(image?.src || '').trim();
+      if (!imageUrl || !imageDialog || !imageDialogImage) return;
+      imageDialogImage.src = imageUrl;
+      imageDialog.showModal();
+    });
+    imageDialogClose?.addEventListener('click', () => imageDialog?.close());
+    imageDialog?.addEventListener('click', (event) => {
+      if (event.target === imageDialog) {
+        imageDialog.close();
+      }
+    });
+
+    getDoc(doc(firebaseDb, 'sites', siteId, 'achatsMateriels', purchaseId))
+      .then((snapshot) => {
+        if (!snapshot.exists()) {
+          UiService.showToast?.('Achat matériel introuvable.');
+          UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
+          return;
+        }
+        renderPurchaseDetail({ id: snapshot.id, ...snapshot.data() });
+      })
+      .catch((error) => {
+        console.error('Erreur chargement détail achat matériel :', error);
+        UiService.showToast?.('Erreur lors du chargement de l’achat matériel.');
+      });
+  }
+
   async function bootstrap() {
     UiService.bindDialogCloser();
     setupBackButtons();
@@ -7447,6 +7551,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
     if (page === 'item-detail') {
       initItemDetailPage(permissions);
+    }
+    if (page === 'purchase-detail') {
+      initPurchaseDetailPage();
     }
     if (page === 'users-management') {
       await initUsersPage(permissions);

--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Achat matériel(s) - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body data-page="purchase-detail" class="page2 purchase-detail-page">
+    <div class="app-shell">
+      <header class="app-header app-header--detail page2-header purchase-detail-header">
+        <div class="app-header__side app-header__side--left">
+          <button class="back-button back-btn" type="button" id="purchaseDetailBackButton" aria-label="Retour">
+            <img src="Icon/btn-retour.png" alt="retour" class="btn-retour" />
+          </button>
+        </div>
+        <div class="app-header__center page2-header-center">
+          <h1 id="purchaseDetailTitle" class="page2-title">Achat matériel(s)</h1>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
+      </header>
+
+      <main class="page-content main-content purchase-detail-content">
+        <section id="purchaseDetailSummary" class="surface-card section purchase-detail-summary" aria-live="polite">
+          <div class="purchase-detail-summary__media" aria-hidden="true">
+            <span>🖼️</span>
+          </div>
+          <div class="purchase-detail-summary__body">
+            <h2 id="purchaseDetailName" class="section-title purchase-detail-summary__title">Chargement...</h2>
+            <p id="purchaseDetailCreatedAt" class="purchase-detail-summary__date">Date non définie</p>
+          </div>
+        </section>
+
+        <section id="purchaseDetailMain" class="purchase-detail-main" aria-live="polite">
+          <div class="purchase-detail-image-wrap">
+            <button id="purchaseDetailImageButton" class="purchase-detail-image-button" type="button" aria-label="Afficher l’image en grand" hidden>
+              <img id="purchaseDetailImage" class="purchase-detail-image" alt="Photo achat matériel" />
+            </button>
+            <div id="purchaseDetailImagePlaceholder" class="purchase-detail-image purchase-detail-image--placeholder" aria-hidden="true">🖼️</div>
+          </div>
+
+          <article class="surface-card section purchase-detail-info-card" aria-label="Informations achat matériel">
+            <div class="purchase-info-row" role="listitem">
+              <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
+              <div id="purchaseDetailQty" class="purchase-value">-</div>
+            </div>
+            <div class="purchase-info-row" role="listitem">
+              <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
+              <div id="purchaseDetailStore" class="purchase-value">-</div>
+            </div>
+            <div class="purchase-info-row" role="listitem">
+              <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Créé par</span></div>
+              <div id="purchaseDetailUser" class="purchase-value">Utilisateur</div>
+            </div>
+            <div class="purchase-info-row" role="listitem">
+              <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date</span></div>
+              <div id="purchaseDetailFullDate" class="purchase-value">Date non définie</div>
+            </div>
+          </article>
+        </section>
+      </main>
+    </div>
+
+    <dialog id="purchaseImageDialog" class="modal-card purchase-image-dialog">
+      <button id="purchaseImageDialogClose" class="purchase-image-dialog__close" type="button" aria-label="Fermer">×</button>
+      <img id="purchaseImageDialogImage" class="purchase-image-dialog__image" alt="Photo achat matériel en grand" />
+    </dialog>
+
+    <script type="module" src="js/storage.js"></script>
+    <script type="module" src="js/ui.js"></script>
+    <script type="module" src="js/firebase-core.js"></script>
+    <script type="module" src="js/app.js"></script>
+    <script type="module" src="js/maintenance-banner.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide a dedicated detail view for material purchases titled `Achat matériel(s)` that opens when a user clicks a purchase card and highlights the product image as the primary element. 
- Match the existing app/detail header style and reuse existing UI components and icons while simplifying the summary card to only image, name and creation date. 
- Display purchase details in the requested order (Image, Quantité, Magasin, Créé par, Date) with a centered square image and an option to view the image fullscreen. 

### Description

- Added a new `purchase-detail.html` page that implements the header, a summary card (thumbnail, name, creation date) and the main detail layout with a centered 1:1 image and an info card showing `Quantité`, `Magasin`, `Créé par`, and `Date` in that order. 
- Updated `js/app.js` to: add `data-purchase-open` to purchase list cards, attach click and keyboard (Enter/Space) handlers to open the new detail page, import `getDoc` from Firestore, and register an `initPurchaseDetailPage()` function that fetches a single purchase, renders the summary and info fields, supports back navigation, and implements the image preview dialog. 
- Extended `css/style.css` with responsive styles for the purchase detail page, including the summary card, centered square image (responsive width ~220–280px), rounded corners, spacing, and full-size image dialog; also hide image controls when no image is available. 
- Preserved existing overflow menu (⋮) behavior and list rendering so the purchase list and other functionality remain unchanged. 

### Testing

- Ran `node --check js/app.js` to validate the updated JS and it completed successfully. 
- Ran `git diff --check` to verify there are no whitespace/merge issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a708070625083298266ba70478df807)