### PR TITLE
Simplify material purchase cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5949,7 +5949,19 @@ body[data-page="site-detail"] .purchase-card__content {
   display: grid;
   grid-template-columns: 72px minmax(0, 1fr);
   gap: 0.75rem;
-  align-items: start;
+  align-items: center;
+}
+
+body[data-page="site-detail"] .purchase-card__body {
+  min-width: 0;
+}
+
+body[data-page="site-detail"] .purchase-card__date {
+  margin: 0.34rem 0 0;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 0.86rem;
+  line-height: 1.32;
+  overflow-wrap: anywhere;
 }
 
 body[data-page="site-detail"] .purchase-card__media {

--- a/js/app.js
+++ b/js/app.js
@@ -4523,7 +4523,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const htmlParts = [];
       let previousLabel = null;
       purchases.forEach((purchase) => {
-        const purchaseStore = String(purchase?.store || purchase?.magasin || '').trim();
+        const createdLabel = formatPurchaseDateLabel(purchase);
         const currentLabel = resolveItemPeriodLabel({
           dateCreation: purchase?.createdAt || purchase?.dateAchat || purchase?.date || purchase?.dateCreation || purchase?.dateModification,
         });
@@ -4541,28 +4541,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
                     ? `<img src="${escapeHtml(purchase.imageUrl)}" alt="Photo achat matériel" />`
                     : '🖼️'}
                 </div>
-                <div>
+                <div class="purchase-card__body">
                   <h3 class="list-card__title">${escapeHtml(purchase?.designation || '-')}</h3>
-                  <div class="list-card__meta purchase-card__meta" role="list" aria-label="Informations achat matériel">
-                    <div class="purchase-info-row" role="listitem">
-                      <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
-                      <div class="purchase-value">${Number(purchase?.qty || 0)} ${escapeHtml(purchase?.unit || 'Pcs')}</div>
-                    </div>
-                    ${purchaseStore ? `
-                    <div class="purchase-info-row" role="listitem">
-                      <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
-                      <div class="purchase-value">${escapeHtml(purchaseStore)}</div>
-                    </div>
-                    ` : ''}
-                    <div class="purchase-info-row" role="listitem">
-                      <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date</span></div>
-                      <div class="purchase-value">${escapeHtml(formatPurchaseDateLabel(purchase))}</div>
-                    </div>
-                    <div class="purchase-info-row" role="listitem">
-                      <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Utilisateur</span></div>
-                      <div class="purchase-value">${escapeHtml(purchase?.createdBy || 'Utilisateur')}</div>
-                    </div>
-                  </div>
+                  <p class="purchase-card__date">Créé le ${escapeHtml(createdLabel)}</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Reduce visual noise in the material purchases list by showing only the product image, name, creation date and the existing actions menu on each card.
- Keep quantity, store, creator and other metadata available only in the purchase detail page to avoid duplication on the list view.

### Description
- Updated `js/app.js` to compute a `createdLabel` and render a simplified purchase card HTML that includes the product image, the designation and a single creation date line while preserving the existing actions menu and card click/keyboard navigation handlers.
- Removed rendering of quantity, store and creator fields from the list card markup so those values remain only in the detail view.
- Adjusted `css/style.css` to vertically center the card content and added `.purchase-card__body` and `.purchase-card__date` styles to align and style the new condensed layout.
- Kept the menu button and its behavior unchanged so existing actions (edit, delete, etc.) remain available.

### Testing
- Ran `git diff --check` which passed without issues.
- Ran `node --check js/app.js` which reported no syntax errors.
- Changes were committed locally; no additional automated test suite is present or was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a708334fc648329840b3890ad0f3e3b)