### PR TITLE
Ajouter un libellé d'affordance sur les cartes d'achat matériel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5956,8 +5956,16 @@ body[data-page="site-detail"] .purchase-card__body {
   min-width: 0;
 }
 
+body[data-page="site-detail"] .purchase-card__hint {
+  margin: 0.22rem 0 0;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 0.82rem;
+  line-height: 1.32;
+  overflow-wrap: anywhere;
+}
+
 body[data-page="site-detail"] .purchase-card__date {
-  margin: 0.34rem 0 0;
+  margin: 0.28rem 0 0;
   color: rgba(255, 255, 255, 0.88);
   font-size: 0.86rem;
   line-height: 1.32;

--- a/js/app.js
+++ b/js/app.js
@@ -4543,6 +4543,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
                 </div>
                 <div class="purchase-card__body">
                   <h3 class="list-card__title">${escapeHtml(purchase?.designation || '-')}</h3>
+                  <p class="purchase-card__hint">Appuyez pour voir les détails</p>
                   <p class="purchase-card__date">Créé le ${escapeHtml(createdLabel)}</p>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Rendre explicite que chaque carte dans l'onglet « Achat matériel » est cliquable en ajoutant un indice visuel sous le nom du matériel.
- Ne pas remplacer la date de création, mais l'afficher sous ce nouveau libellé pour conserver l'ordre d'information.
- Respecter le style et l'espacement existants du projet en utilisant des classes CSS déjà cohérentes avec la page détail du site.

### Description
- Ajout du paragraphe indicateur `<p class="purchase-card__hint">Appuyez pour voir les détails</p>` sous le titre de la carte dans `js/app.js` afin d'insérer l'élément au bon emplacement dans le rendu de la liste.
- Ajout de la règle CSS `body[data-page="site-detail"] .purchase-card__hint { ... }` et ajustement de la marge de `purchase-card__date` dans `css/style.css` pour définir une couleur grise secondaire, une taille de police légèrement plus petite et des espacements cohérents.
- Aucun autre comportement ou fonctionnalité de l'onglet « Achat matériel » n'a été modifié.

### Testing
- Exécution de `node --check js/app.js` : succès.
- Exécution de `git diff --check` : succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a708e9908f483299518738452c9e2c7)