### PR TITLE
Style purchase card detail hint

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5958,9 +5958,10 @@ body[data-page="site-detail"] .purchase-card__body {
 
 body[data-page="site-detail"] .purchase-card__hint {
   margin: 0.22rem 0 0;
-  color: rgba(255, 255, 255, 0.66);
+  color: var(--text-muted);
   font-size: 0.82rem;
   line-height: 1.32;
+  text-align: left;
   overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the small hint under each purchase/material name is visually muted, slightly smaller, left-aligned and retains spacing so the label reads clearly as “Appuyez pour voir les détails” without changing any behavior.

### Description
- Updated the purchase card hint styling in `css/style.css` to use the theme muted color (`--text-muted`) and explicitly set `text-align: left`, preserving the existing margin so the hint remains slightly smaller and spaced under the name.

### Testing
- Ran `git diff --check` to verify no style errors and the change passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a709ce501688329a98bed6190f1616b)