### PR TITLE
Masquer les statistiques dans l'onglet Achat matériel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4305,7 +4305,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const koCount = Number(countsByFilterKey.ko || 0);
       const total = doneCount + todoCount + fixCount + koCount;
 
-      itemProgressStatsCard.hidden = total <= 0;
+      itemProgressStatsCard.hidden = activeSiteTab !== 'outs' || total <= 0;
       if (itemProgressTotal) {
         itemProgressTotal.textContent = `Total • ${total} ARTICLE${total > 1 ? 'S' : ''}`;
       }
@@ -4725,6 +4725,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         itemCount.innerHTML = `<span class="outs-number">0</span><span class="outs-label">OUTS</span>`;
       } else {
         itemCount.innerHTML = `<span class="outs-number">0</span><span class="outs-label">Achat</span>`;
+      }
+      if (safeTabName === 'purchases' && itemProgressStatsCard) {
+        itemProgressStatsCard.hidden = true;
       }
       updateFabByActiveTab(safeTabName);
       updateHeaderExportButton(safeTabName);


### PR DESCRIPTION
### Motivation
- Masquer la section des statistiques/progression lorsque l'utilisateur affiche l'onglet "Achat matériel" afin que la liste des achats commence directement sous les filtres sans espace vide, tout en conservant les statistiques dans l'onglet "OUT".

### Description
- Modifié `js/app.js` pour que `updateItemProgressStatsCard` masque la carte de statistiques si `activeSiteTab !== 'outs'` et ajouté un masquage explicite de `itemProgressStatsCard` lors du basculement vers l'onglet `purchases` dans `setActiveSiteTab`.

### Testing
- Exécuté la vérification de syntaxe JavaScript avec `node --check js/app.js` et la vérification des diffs avec `git diff --check`, les deux commandes ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70a9140a9c8329bfc6b08df336f967)