### PR TITLE
Remove bottom nav icons and rename "Achat matériel" → "Achat PDD"

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -118,13 +118,11 @@
 
       <nav class="bottom-navigation" aria-label="Navigation des onglets">
         <button class="bottom-nav-item active" data-tab="outs" type="button">
-          <span class="bottom-nav-icon"><img src="Icon/OUT.png" alt="" aria-hidden="true" /></span>
           <span class="bottom-nav-label">OUT</span>
         </button>
 
         <button class="bottom-nav-item admin-only hidden" data-tab="purchases" type="button">
-          <span class="bottom-nav-icon"><img src="Icon/Chariot.png" alt="" aria-hidden="true" /></span>
-          <span class="bottom-nav-label">Achat matériel</span>
+          <span class="bottom-nav-label">Achat PDD</span>
         </button>
       </nav>
 


### PR DESCRIPTION
### Motivation
- Ajuster uniquement l'apparence de la barre de navigation inférieure en supprimant les icônes des onglets et en renommant le libellé du second onglet sans toucher à la navigation, aux routes, aux événements ou au comportement existant.

### Description
- Modifié `page2.html` pour retirer les éléments `<span class="bottom-nav-icon">...<img .../></span>` des boutons `data-tab="outs"` et `data-tab="purchases"` et pour remplacer le texte `Achat matériel` par `Achat PDD` sur le bouton `purchases`.

### Testing
- Exécuté une vérification de différences (`git diff --check`) qui a réussi; aucun warning de formatage détecté.
- Vérifié l'état du dépôt (`git status --short`) confirmant la mise à jour unique du fichier `page2.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70ab1eee1c83299480b97231ed0c4a)