### PR TITLE
Add optional 'Remarque' field to purchases (create, edit, detail, and styles)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -803,6 +803,7 @@ body.app-content-loading .item-detail-fab-row {
 
 .input-group input,
 .input-group select,
+.input-group textarea,
 .cell-input,
 .cell-textarea {
   width: 100%;
@@ -816,10 +817,17 @@ body.app-content-loading .item-detail-fab-row {
 
 .input-group input:focus,
 .input-group select:focus,
+.input-group textarea:focus,
 .cell-input:focus,
 .cell-textarea:focus {
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(89, 184, 255, 0.18);
+}
+
+.input-group textarea {
+  min-height: calc(2lh + 1.7rem);
+  max-height: calc(4lh + 1.7rem);
+  resize: vertical;
 }
 
 .typeahead {

--- a/js/app.js
+++ b/js/app.js
@@ -3144,6 +3144,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const purchaseQty = requireElement('purchaseQty');
     const purchaseUnit = requireElement('purchaseUnit');
     const purchaseStore = requireElement('purchaseStore');
+    const purchaseRemark = requireElement('purchaseRemark');
     const purchasePhotoInput = requireElement('purchasePhotoInput');
     const purchasePhotoPreviewWrap = requireElement('purchasePhotoPreviewWrap');
     const purchasePhotoPreview = requireElement('purchasePhotoPreview');
@@ -3151,12 +3152,15 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const purchaseDesignationError = requireElement('purchaseDesignationError');
     const purchaseQtyError = requireElement('purchaseQtyError');
     const purchaseUnitError = requireElement('purchaseUnitError');
+    const purchaseRemarkError = requireElement('purchaseRemarkError');
     const cancelPurchaseBtn = requireElement('cancelPurchaseBtn');
     const savePurchaseBtn = requireElement('savePurchaseBtn');
     const editPurchaseModal = document.getElementById('editPurchaseModal');
     const editPurchaseForm = document.getElementById('editPurchaseForm');
     const editPurchaseNameInput = document.getElementById('editPurchaseNameInput');
     const editPurchaseNameCounter = document.getElementById('editPurchaseNameCounter');
+    const editPurchaseRemarkInput = document.getElementById('editPurchaseRemarkInput');
+    const editPurchaseRemarkError = document.getElementById('editPurchaseRemarkError');
     const editPurchaseFormError = document.getElementById('editPurchaseFormError');
     const cancelEditPurchaseBtn = document.getElementById('cancelEditPurchaseBtn');
     const saveEditPurchaseBtn = document.getElementById('saveEditPurchaseBtn');
@@ -3285,6 +3289,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       clearPurchaseFieldError(purchaseDesignation, purchaseDesignationError);
       clearPurchaseFieldError(purchaseQty, purchaseQtyError);
       clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
+      clearPurchaseFieldError(purchaseRemark, purchaseRemarkError);
       selectedPurchasePhotoFile = null;
       if (selectedPurchasePhotoPreviewUrl) {
         URL.revokeObjectURL(selectedPurchasePhotoPreviewUrl);
@@ -3502,6 +3507,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       selectedPurchaseId = purchase.id;
       selectedPurchaseData = purchase;
       editPurchaseNameInput.value = String(purchase.designation || '');
+      if (editPurchaseRemarkInput) {
+        editPurchaseRemarkInput.value = String(purchase.remarque || purchase.remark || '').trim();
+      }
       clearEditPurchaseFieldError();
       updateEditPurchaseCounter();
       editPurchaseModal.showModal();
@@ -3512,6 +3520,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       clearPurchaseFieldError(purchaseDesignation, purchaseDesignationError);
       clearPurchaseFieldError(purchaseQty, purchaseQtyError);
       clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
+      clearPurchaseFieldError(purchaseRemark, purchaseRemarkError);
       if (purchaseFormError) {
         purchaseFormError.textContent = '';
       }
@@ -3519,6 +3528,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const qty = Number(purchaseQty?.value);
       const unit = String(purchaseUnit?.value || '').trim();
       const store = String(purchaseStore?.value || '').trim();
+      const remark = String(purchaseRemark?.value || '').trim();
       if (!designation) {
         showPurchaseFieldError(purchaseDesignation, purchaseDesignationError, 'Désignation obligatoire');
         return;
@@ -3547,6 +3557,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           unit,
           store,
           magasin: store,
+          remarque: remark,
+          remark,
           createdAt: serverTimestamp(),
           createdBy: currentUserName || 'Utilisateur',
           createdByEmail: currentUserEmail || '',
@@ -5081,6 +5093,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       updateEditPurchaseCounter();
     });
 
+    editPurchaseRemarkInput?.addEventListener('input', () => {
+      clearPurchaseFieldError(editPurchaseRemarkInput, editPurchaseRemarkError);
+    });
+
     cancelEditPurchaseBtn?.addEventListener('click', () => {
       editPurchaseModal?.close();
     });
@@ -5089,17 +5105,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       event.preventDefault();
       if (!selectedPurchaseId || !editPurchaseNameInput) return;
       const newName = String(editPurchaseNameInput.value || '').trim();
+      const newRemark = String(editPurchaseRemarkInput?.value || '').trim();
       if (!newName) {
         showEditPurchaseFieldError('Nom obligatoire');
         editPurchaseNameInput.focus();
         return;
       }
       clearEditPurchaseFieldError();
+      clearPurchaseFieldError(editPurchaseRemarkInput, editPurchaseRemarkError);
       setEditPurchaseSubmitLoadingState(true);
       try {
         await updateDoc(
           doc(firebaseDb, 'sites', siteId, 'achatsMateriels', selectedPurchaseId),
-          { designation: newName },
+          { designation: newName, remarque: newRemark, remark: newRemark },
         );
         editPurchaseModal?.close();
         await loadPurchasesForCurrentSite();
@@ -7499,6 +7517,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const imagePlaceholder = requireElement('purchaseDetailImagePlaceholder');
     const qty = requireElement('purchaseDetailQty');
     const store = requireElement('purchaseDetailStore');
+    const remarkRow = requireElement('purchaseDetailRemarkRow');
+    const remark = requireElement('purchaseDetailRemark');
     const user = requireElement('purchaseDetailUser');
     const fullDate = requireElement('purchaseDetailFullDate');
     const imageDialog = requireElement('purchaseImageDialog');
@@ -7517,6 +7537,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const imageUrl = String(purchase?.imageUrl || '').trim();
       const dateLabel = formatPurchaseDateLabel(purchase);
       const purchaseStore = String(purchase?.store || purchase?.magasin || '').trim() || '-';
+      const purchaseRemark = String(purchase?.remarque || purchase?.remark || '').trim();
 
       summaryName.textContent = String(purchase?.designation || 'Achat matériel');
       summaryCreatedAt.textContent = dateLabel;
@@ -7525,6 +7546,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         : '<span>🖼️</span>';
       qty.textContent = `${Number(purchase?.qty || 0)} ${String(purchase?.unit || 'Pcs')}`;
       store.textContent = purchaseStore;
+      if (purchaseRemark) {
+        remark.textContent = purchaseRemark;
+        remarkRow.hidden = false;
+      } else {
+        remark.textContent = '';
+        remarkRow.hidden = true;
+      }
       user.textContent = String(purchase?.createdBy || 'Utilisateur');
       fullDate.textContent = dateLabel;
 

--- a/page2.html
+++ b/page2.html
@@ -251,6 +251,11 @@
             <input id="purchaseStore" type="text" placeholder="Ex : Titan I" />
           </label>
           <label class="input-group input-group--site-create">
+            <span>Remarque</span>
+            <textarea id="purchaseRemark" rows="2" placeholder="Ex : Livraison urgente pour le chantier."></textarea>
+            <p id="purchaseRemarkError" class="form-error form-error--field" aria-live="polite"></p>
+          </label>
+          <label class="input-group input-group--site-create">
             <span>Photo</span>
             <input id="purchasePhotoInput" type="file" accept="image/*" />
           </label>
@@ -281,6 +286,11 @@
               <p id="editPurchaseFormError" class="form-error error-message" aria-live="polite"></p>
               <span id="editPurchaseNameCounter" class="input-char-counter" aria-live="polite">0 / 25</span>
             </div>
+          </label>
+          <label class="input-group input-group--site-create input-group--item-create">
+            <span>Remarque</span>
+            <textarea id="editPurchaseRemarkInput" rows="2" placeholder="Ex : Livraison urgente pour le chantier."></textarea>
+            <p id="editPurchaseRemarkError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
           <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
             <button type="button" class="btn btn-neutral" id="cancelEditPurchaseBtn">Annuler</button>

--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -48,6 +48,10 @@
               <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
               <div id="purchaseDetailStore" class="purchase-value">-</div>
             </div>
+            <div id="purchaseDetailRemarkRow" class="purchase-info-row" role="listitem" hidden>
+              <div class="purchase-label"><span aria-hidden="true" class="icon">📝</span><span>Remarque</span></div>
+              <div id="purchaseDetailRemark" class="purchase-value"></div>
+            </div>
             <div class="purchase-info-row" role="listitem">
               <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Créé par</span></div>
               <div id="purchaseDetailUser" class="purchase-value">Utilisateur</div>


### PR DESCRIPTION
### Motivation
- Allow users to add an optional remark/note to purchases and persist it with the purchase record.
- Ensure the remark is editable and visible on the purchase detail page while keeping backward compatibility with existing records.

### Description
- Added a `Remarque` textarea to the purchase creation form and the edit purchase modal in `page2.html` and wired error elements (`purchaseRemark`, `purchaseRemarkError`, `editPurchaseRemarkInput`, `editPurchaseRemarkError`).
- Added textarea styles to `css/style.css` for proper min/max height and vertical resize support and included textarea in the shared input focus rules.
- Updated `js/app.js` to reference the new elements, clear remark field errors in `resetPurchaseForm`, populate `editPurchaseRemarkInput` in `openEditPurchaseModal`, include `remark`/`remarque` in the payload when creating purchases, and update documents with `remarque`/`remark` when editing purchases.
- Updated purchase detail rendering and `purchase-detail.html` to show/hide a `purchaseDetailRemarkRow` and display the remark when present.

### Testing
- Ran the project's automated test and lint commands (`npm test` and `npm run lint`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70ae57540c83298dd0df1866680305)