### PR TITLE
Improve Cloudinary image deletion: signature, diagnostics, and safety

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3302,30 +3302,40 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function getCloudinaryUploadConfig() {
+      const cloudName = 'dskw13nem';
       return {
+        cloudName,
         uploadPreset: 'Suivi_matériel',
-        uploadUrl: 'https://api.cloudinary.com/v1_1/dskw13nem/image/upload',
+        uploadUrl: `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
       };
     }
 
-    function getCloudinaryPublicIdFromUrl(imageUrl) {
-      const rawUrl = String(imageUrl || '').trim();
-      if (!rawUrl) {
-        return '';
-      }
-      try {
-        const url = new URL(rawUrl);
-        const uploadMarker = '/image/upload/';
-        const markerIndex = url.pathname.indexOf(uploadMarker);
-        if (markerIndex === -1) {
-          return '';
-        }
-        const pathAfterUpload = decodeURIComponent(url.pathname.slice(markerIndex + uploadMarker.length));
-        const pathWithoutVersion = pathAfterUpload.replace(/^v\d+\//, '');
-        return pathWithoutVersion.replace(/\.[^/.]+$/, '').trim();
-      } catch (_error) {
-        return '';
-      }
+    function getCloudinaryDestroyConfig() {
+      const uploadConfig = getCloudinaryUploadConfig();
+      const runtimeConfig = window.CLOUDINARY_CONFIG || {};
+      const cloudName = String(runtimeConfig.cloudName || uploadConfig.cloudName || '').trim();
+      return {
+        cloudName,
+        apiKey: String(runtimeConfig.apiKey || '').trim(),
+        apiSecret: String(runtimeConfig.apiSecret || '').trim(),
+        destroyUrl: `https://api.cloudinary.com/v1_1/${cloudName}/image/destroy`,
+      };
+    }
+
+    async function createCloudinarySignature(params, apiSecret) {
+      const serializedParams = Object.keys(params)
+        .sort()
+        .map((key) => `${key}=${params[key]}`)
+        .join('&');
+      const payload = `${serializedParams}${apiSecret}`;
+      const digest = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(payload));
+      return Array.from(new Uint8Array(digest))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+    }
+
+    function getSavedCloudinaryPublicId(purchase) {
+      return String(purchase?.imagePublicId || purchase?.cloudinaryPublicId || '').trim();
     }
 
     async function uploadPurchaseImageToCloudinary(file) {
@@ -3363,16 +3373,38 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!purchase) {
         return;
       }
-      const publicId = String(purchase.imagePublicId || purchase.cloudinaryPublicId || '').trim()
-        || getCloudinaryPublicIdFromUrl(purchase.imageUrl);
-      if (!publicId) {
+      if (!purchase.imageUrl && !purchase.imagePublicId && !purchase.cloudinaryPublicId) {
         return;
       }
 
-      const { uploadUrl } = getCloudinaryUploadConfig();
-      const destroyUrl = uploadUrl.replace(/\/upload(?:\?.*)?$/, '/destroy');
+      const publicId = getSavedCloudinaryPublicId(purchase);
+      const { cloudName, apiKey, apiSecret, destroyUrl } = getCloudinaryDestroyConfig();
+      const logContext = {
+        cloud_name: cloudName,
+        api_key: apiKey,
+        public_id: publicId,
+        url: destroyUrl,
+      };
+
+      if (!publicId) {
+        console.error('Configuration suppression Cloudinary invalide : public_id enregistré introuvable.', logContext);
+        throw new Error('Suppression Cloudinary impossible : public_id enregistré introuvable.');
+      }
+      if (!cloudName || !apiKey || !apiSecret) {
+        console.error('Configuration suppression Cloudinary invalide : cloud_name, api_key ou api_secret manquant.', logContext);
+        throw new Error('Configuration Cloudinary incorrecte. Vérifiez le cloud_name, l’API Key et l’API Secret.');
+      }
+      if (!crypto?.subtle) {
+        throw new Error('Suppression Cloudinary impossible : signature SHA-1 indisponible.');
+      }
+
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const signature = await createCloudinarySignature({ public_id: publicId, timestamp }, apiSecret);
       const formData = new FormData();
       formData.append('public_id', publicId);
+      formData.append('timestamp', timestamp);
+      formData.append('api_key', apiKey);
+      formData.append('signature', signature);
 
       let response;
       try {
@@ -3381,14 +3413,23 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           body: formData,
         });
       } catch (error) {
-        console.error('Erreur réseau suppression Cloudinary :', error);
+        console.error('Erreur réseau suppression Cloudinary :', error, logContext);
         throw new Error('Suppression Cloudinary impossible. Vérifiez votre connexion puis réessayez.');
       }
 
       const data = await response.json().catch(() => ({}));
+      const cloudinaryDebug = { ...logContext, http_status: response.status, response: data };
+      console.info('Suppression Cloudinary :', cloudinaryDebug);
+
+      const errorMessage = String(data?.error?.message || '').trim();
+      if (errorMessage.toLowerCase().includes('unknown api key')) {
+        console.error('Configuration Cloudinary incorrecte : API Key inconnue.', cloudinaryDebug);
+        throw new Error('Configuration Cloudinary incorrecte : l’API Key est inconnue. La suppression en base de données a été annulée.');
+      }
+
       if (!response.ok || !['ok', 'not found'].includes(String(data?.result || '').toLowerCase())) {
-        console.error('Erreur suppression Cloudinary :', data);
-        throw new Error(data.error?.message || 'Suppression Cloudinary impossible.');
+        console.error('Erreur suppression Cloudinary :', cloudinaryDebug);
+        throw new Error(errorMessage || 'Suppression Cloudinary impossible.');
       }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure image deletion uses the correct Cloudinary configuration and signed request, provide actionable diagnostics when deletion fails, and avoid deleting DB records when Cloudinary authentication is invalid.
- Prefer the stored Cloudinary `public_id` over reconstructing it from the image URL to make deletions reliable.

### Description
- Introduced centralized upload/destroy configuration and support for runtime overrides via `window.CLOUDINARY_CONFIG`, and target the official `/image/destroy` endpoint.
- Require the saved `imagePublicId`/`cloudinaryPublicId` for deletions and generate a SHA-1 signature from `public_id` + `timestamp` using the configured `apiSecret`, while not logging the secret.
- Include `api_key`, `timestamp`, and `signature` in the destroy request and add detailed console diagnostics that log `cloud_name`, `api_key`, `public_id`, called URL, HTTP status and the full Cloudinary response (excluding `api_secret`).
- Detect Cloudinary errors containing "Unknown API key" and throw a descriptive error to stop subsequent database deletion.

### Testing
- Ran `node --check js/app.js` which completed successfully.
- No other automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70b4774f608329a99fcb4535fdbf30)