### PR TITLE
Masquer le filtre statut dans l'onglet Achat PDD

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3200,6 +3200,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const filterChipButtons = Array.from(document.querySelectorAll('[data-filter-chip]'));
     const itemStatusFilterButton = document.getElementById('itemStatusFilterButton');
     const itemStatusFilterMenu = document.getElementById('itemStatusFilterMenu');
+    const itemStatusFilterMenuWrap = itemStatusFilterButton?.closest('.page2-filter-menu-wrap');
     const itemStatusFilterOptions = Array.from(document.querySelectorAll('[data-item-status-filter]'));
     const itemProgressStatsCard = document.getElementById('itemProgressStatsCard');
     const itemProgressTotal = document.getElementById('itemProgressTotal');
@@ -4312,6 +4313,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       itemStatusFilterButton.setAttribute('aria-expanded', 'false');
     }
 
+    function updateItemStatusFilterVisibility(tabName) {
+      const shouldShowStatusFilter = tabName === 'outs';
+      itemStatusFilterMenuWrap?.classList.toggle('hidden', !shouldShowStatusFilter);
+      if (!shouldShowStatusFilter) {
+        closeItemStatusFilterMenu();
+      }
+    }
+
     function openItemStatusFilterMenu() {
       if (!itemStatusFilterMenu || !itemStatusFilterButton) return;
       itemStatusFilterMenu.hidden = false;
@@ -4690,6 +4699,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (safeTabName === 'purchases' && itemProgressStatsCard) {
         itemProgressStatsCard.hidden = true;
       }
+      updateItemStatusFilterVisibility(safeTabName);
       updateFabByActiveTab(safeTabName);
       updateHeaderExportButton(safeTabName);
       renderActiveTabContent();


### PR DESCRIPTION
### Motivation
- Cacher le bouton/menu de filtre de statut (icône entonnoir) lorsque l'onglet `Achat PDD` est actif tout en le conservant visible et fonctionnel dans l'onglet `OUT`.
- Permettre à la barre de recherche de s'étendre automatiquement pour occuper l'espace libéré quand le bouton de filtre est masqué.

### Description
- Ajout de la référence `itemStatusFilterMenuWrap = itemStatusFilterButton?.closest('.page2-filter-menu-wrap')` dans `js/app.js` pour cibler le conteneur du bouton/menu de filtre.
- Ajout de la fonction `updateItemStatusFilterVisibility(tabName)` qui bascule la visibilité du conteneur de filtre et ferme le menu si l'onglet actif n'est pas `outs`.
- Appel de `updateItemStatusFilterVisibility` depuis le changement d'onglet (`setActiveSiteTab`) afin d'appliquer la logique lors de la navigation entre `outs` et `purchases`.
- Aucune modification apportée à la logique de recherche, aux filtres de date, à la navigation entre onglets ni à l'onglet `OUT` lui‑même.

### Testing
- Exécution de `node --check js/app.js` pour vérifier la validité syntaxique du fichier modifié (succès).
- Exécution de `git diff --check` pour s'assurer qu'il n'y a pas d'erreurs de diff (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70c44755a883298b6e6905fbb18324)