### PR TITLE
Add bottom navigation tab separator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4851,6 +4851,20 @@ body[data-page="home"] #siteDialog #siteCreateSubmitButton.is-loading {
   box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.08);
 }
 
+.bottom-navigation::before {
+  content: "|";
+  position: absolute;
+  left: 50%;
+  top: calc((64px + env(safe-area-inset-bottom)) / 2);
+  transform: translate(-50%, -50%);
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .bottom-nav-item {
   flex: 1;
   height: 50px;


### PR DESCRIPTION
### Motivation
- Add a centered, non-interactive vertical separator between the "OUT" and "Achat PDD" bottom navigation tabs without changing any tab behavior, events, visual states, FAB, or nav height.

### Description
- Add a CSS pseudo-element on `.bottom-navigation::before` in `css/style.css` that renders a thin `|` centered vertically, uses `var(--text-muted)` with reduced opacity, and sets `pointer-events: none` so it is not clickable.

### Testing
- Ran `git diff --check` and `git status --short` and both succeeded, showing the single intended change to `css/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d10fe2a88329b6456a9cbfa9edcc)