### PR TITLE
Masquer le menu « Historiques » aux utilisateurs non-Admin

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2557,7 +2557,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const isStandard = normalizedRole === 'standard';
       const isLimited = normalizedRole === 'limité' || normalizedRole === 'limite' || normalizedRole === 'limited';
 
-      setSidebarItemVisible('#sidebarHistoryBtn', true);
+      setSidebarItemVisible('#sidebarHistoryBtn', isAdmin);
       setSidebarItemVisible('#sidebarAllMaterialsBtn', isConnected);
       
 


### PR DESCRIPTION
### Motivation
- Rendre le bouton `Historiques` visible uniquement pour les utilisateurs qui ont déjà la vérification `isAdmin` existante afin de réutiliser la logique de rôle existante sans toucher aux autres menus ou droits.

### Description
- Dans `js/app.js` la fonction `updateSidebarPermissions` a été modifiée pour remplacer `setSidebarItemVisible('#sidebarHistoryBtn', true)` par `setSidebarItemVisible('#sidebarHistoryBtn', isAdmin)`, sans autre modification fonctionnelle.

### Testing
- Vérification statique avec `node --check js/app.js` exécutée et passée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d71f996483299f0b2a5a5a7facbb)