### PR TITLE
Aligner 'Appuyez pour voir les détails' en bas des cards Achat matériel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5971,15 +5971,19 @@ body[data-page="site-detail"] .purchase-card__content {
   display: grid;
   grid-template-columns: 72px minmax(0, 1fr);
   gap: 0.75rem;
-  align-items: center;
+  align-items: stretch;
 }
 
 body[data-page="site-detail"] .purchase-card__body {
+  display: flex;
+  flex-direction: column;
   min-width: 0;
+  height: 100%;
 }
 
 body[data-page="site-detail"] .purchase-card__hint {
-  margin: 0.22rem 0 0;
+  order: 2;
+  margin: auto 0 0;
   color: var(--text-muted);
   font-size: 0.82rem;
   line-height: 1.32;
@@ -5988,6 +5992,7 @@ body[data-page="site-detail"] .purchase-card__hint {
 }
 
 body[data-page="site-detail"] .purchase-card__date {
+  order: 1;
   margin: 0.28rem 0 0;
   color: rgba(255, 255, 255, 0.88);
   font-size: 0.86rem;


### PR DESCRIPTION
### Motivation
- Garantir que le libellé « Appuyez pour voir les détails » soit aligné en bas de l'image produit sur la page « Achat matériel » sans changer les autres comportements ni styles existants.
- Utiliser Flexbox côté droit de la card pour pousser automatiquement le libellé vers le bas et préserver l'image à gauche et le menu ⋮ à droite.

### Description
- Modifié `css/style.css` pour que `.purchase-card__content` utilise `align-items: stretch` afin que le bloc de droite occupe toute la hauteur disponible.
- Transformé `.purchase-card__body` en conteneur Flex avec `display: flex`, `flex-direction: column` et `height: 100%` pour organiser verticalement le titre, la date et le libellé.
- Ajusté `.purchase-card__hint` avec `order: 2` et `margin: auto 0 0` pour que le texte « Appuyez pour voir les détails » soit poussé en bas du bloc et reste aligné horizontalement avec le bas de l'image.
- Positionné `.purchase-card__date` avec `order: 1` pour conserver l’ordre visuel et éviter le centrage vertical entre le titre et le bas de la card.

### Testing
- Exécuté `git diff --check` pour valider l’absence d’erreurs de style dans le diff, et la commande a réussi.
- Exécuté `git status --short` pour confirmer les fichiers modifiés, et la commande a réussi.
- Exécuté `git log -1 --oneline` pour vérifier l’état du dépôt après modification, et la commande a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71cf1676188325890f4215cbecf7f6)