### PR TITLE
Édition inline des détails d'achat matériel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7010,3 +7010,57 @@ body[data-page="purchase-detail"] .purchase-image-dialog__close {
     grid-template-columns: minmax(6.9rem, auto) minmax(0, 1fr);
   }
 }
+
+body[data-page="purchase-detail"] .purchase-inline-field {
+  background: transparent;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  border-radius: 0;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+body[data-page="purchase-detail"] .purchase-inline-field:focus,
+body[data-page="purchase-detail"] .purchase-inline-field:focus-visible {
+  background: transparent;
+  border: none;
+  outline: none;
+  box-shadow: none;
+}
+
+body[data-page="purchase-detail"] .purchase-inline-field[readonly] {
+  cursor: default;
+}
+
+body[data-page="purchase-detail"] .purchase-inline-field--textarea {
+  display: block;
+  min-height: 1.32em;
+  resize: none;
+  overflow: hidden;
+}
+
+body[data-page="purchase-detail"] .purchase-value--inline {
+  display: flex;
+  min-width: 0;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-save-spinner {
+  display: none;
+  width: 1rem;
+  height: 1rem;
+  margin: 0.45rem auto 0;
+  border: 2px solid rgba(37, 99, 235, 0.22);
+  border-top-color: var(--primary-color);
+  border-radius: 999px;
+  animation: btn-spinner-rotate 0.7s linear infinite;
+}
+
+body[data-page="purchase-detail"] .purchase-detail-save-spinner.is-visible {
+  display: block;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -7489,7 +7489,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   }
 
 
-  function initPurchaseDetailPage() {
+  function initPurchaseDetailPage(permissions) {
     initAuthRequiredNoticeCard();
 
     const params = UiService.getQueryParams();
@@ -7517,6 +7517,110 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const imageDialog = requireElement('purchaseImageDialog');
     const imageDialogImage = requireElement('purchaseImageDialogImage');
     const imageDialogClose = requireElement('purchaseImageDialogClose');
+    const saveSpinner = requireElement('purchaseDetailSaveSpinner');
+    const canEditPurchase = Boolean(permissions?.isAdmin);
+    let currentPurchase = null;
+    let isSavingPurchase = false;
+
+    function setPurchaseSaving(isSaving) {
+      isSavingPurchase = isSaving;
+      saveSpinner?.classList.toggle('is-visible', isSaving);
+    }
+
+    function normalizePurchaseQtyInput(value) {
+      const parsed = Number.parseInt(String(value || '').replace(',', '.').match(/\d+/)?.[0] || '', 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return null;
+      }
+      return Math.min(parsed, 9999);
+    }
+
+    function resizeInlineTextarea(field) {
+      if (!field || field.tagName !== 'TEXTAREA') return;
+      field.style.height = 'auto';
+      field.style.height = `${field.scrollHeight}px`;
+    }
+
+    function setEditableState(field) {
+      if (!field) return;
+      field.readOnly = !canEditPurchase;
+      field.toggleAttribute('aria-readonly', !canEditPurchase);
+      field.tabIndex = canEditPurchase ? 0 : -1;
+    }
+
+    async function saveInlinePurchaseField(fieldName, input) {
+      if (!canEditPurchase || !currentPurchase || isSavingPurchase || !input) return;
+      const previousPurchase = { ...currentPurchase };
+      const previousInputValue = input.value;
+      let updates = null;
+
+      if (fieldName === 'designation') {
+        const designation = String(input.value || '').trim();
+        if (!designation) {
+          input.value = String(previousPurchase.designation || 'Achat matériel');
+          return;
+        }
+        if (designation === String(previousPurchase.designation || '').trim()) return;
+        updates = { designation };
+      }
+
+      if (fieldName === 'qty') {
+        const qtyValue = normalizePurchaseQtyInput(input.value);
+        if (!qtyValue) {
+          input.value = `${Number(previousPurchase.qty || 0)} ${String(previousPurchase.unit || 'Pcs')}`;
+          return;
+        }
+        if (qtyValue === Number(previousPurchase.qty || 0)) {
+          input.value = `${qtyValue} ${String(previousPurchase.unit || 'Pcs')}`;
+          return;
+        }
+        updates = { qty: qtyValue };
+      }
+
+      if (fieldName === 'magasin') {
+        const magasin = String(input.value || '').trim();
+        const oldStore = String(previousPurchase.store || previousPurchase.magasin || '').trim();
+        if (magasin === oldStore) return;
+        updates = { magasin, store: magasin };
+      }
+
+      if (fieldName === 'remarque') {
+        const remarque = String(input.value || '').trim();
+        if (remarque === String(previousPurchase.remarque || previousPurchase.remark || '').trim()) return;
+        updates = { remarque, remark: remarque };
+      }
+
+      if (!updates) return;
+      setPurchaseSaving(true);
+      try {
+        await updateDoc(doc(firebaseDb, 'sites', siteId, 'achatsMateriels', purchaseId), updates);
+        currentPurchase = { ...currentPurchase, ...updates };
+        renderPurchaseDetail(currentPurchase);
+        resizeInlineTextarea(input);
+      } catch (error) {
+        console.error('Erreur mise à jour achat matériel :', error);
+        currentPurchase = previousPurchase;
+        input.value = previousInputValue;
+        renderPurchaseDetail(previousPurchase);
+        resizeInlineTextarea(input);
+        UiService.showToast?.('Erreur lors de l’enregistrement de l’achat matériel.');
+      } finally {
+        setPurchaseSaving(false);
+      }
+    }
+
+    function bindInlinePurchaseField(input, fieldName) {
+      setEditableState(input);
+      resizeInlineTextarea(input);
+      input?.addEventListener('input', () => resizeInlineTextarea(input));
+      input?.addEventListener('blur', () => saveInlinePurchaseField(fieldName, input));
+      input?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && input.tagName !== 'TEXTAREA') {
+          event.preventDefault();
+          input.blur();
+        }
+      });
+    }
 
     backButton?.addEventListener('click', () => {
       UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
@@ -7532,22 +7636,24 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const purchaseStore = String(purchase?.store || purchase?.magasin || '').trim() || '-';
       const purchaseRemark = String(purchase?.remarque || purchase?.remark || '').trim();
 
-      summaryName.textContent = String(purchase?.designation || 'Achat matériel');
+      currentPurchase = purchase;
+      summaryName.value = String(purchase?.designation || 'Achat matériel');
       summaryCreatedAt.textContent = dateLabel;
       summaryMedia.innerHTML = imageUrl
         ? `<img src="${escapeHtml(imageUrl)}" alt="Photo achat matériel" />`
         : '<span>🖼️</span>';
-      qty.textContent = `${Number(purchase?.qty || 0)} ${String(purchase?.unit || 'Pcs')}`;
-      store.textContent = purchaseStore;
+      qty.value = `${Number(purchase?.qty || 0)} ${String(purchase?.unit || 'Pcs')}`;
+      store.value = purchaseStore;
       if (purchaseRemark) {
-        remark.textContent = purchaseRemark;
+        remark.value = purchaseRemark;
         remarkRow.hidden = false;
       } else {
-        remark.textContent = '';
-        remarkRow.hidden = true;
+        remark.value = '';
+        remarkRow.hidden = !canEditPurchase;
       }
       user.textContent = String(purchase?.createdBy || 'Utilisateur');
       fullDate.textContent = dateLabel;
+      resizeInlineTextarea(remark);
 
       if (imageUrl) {
         image.src = imageUrl;
@@ -7559,6 +7665,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         imagePlaceholder.hidden = false;
       }
     }
+
+    bindInlinePurchaseField(summaryName, 'designation');
+    bindInlinePurchaseField(qty, 'qty');
+    bindInlinePurchaseField(store, 'magasin');
+    bindInlinePurchaseField(remark, 'remarque');
 
     imageButton?.addEventListener('click', () => {
       const imageUrl = String(image?.src || '').trim();
@@ -7620,7 +7731,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       initItemDetailPage(permissions);
     }
     if (page === 'purchase-detail') {
-      initPurchaseDetailPage();
+      initPurchaseDetailPage(permissions);
     }
     if (page === 'users-management') {
       await initUsersPage(permissions);

--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -26,7 +26,8 @@
             <span>🖼️</span>
           </div>
           <div class="purchase-detail-summary__body">
-            <h2 id="purchaseDetailName" class="section-title purchase-detail-summary__title">Chargement...</h2>
+            <h2 class="section-title purchase-detail-summary__title"><input id="purchaseDetailName" class="purchase-inline-field" type="text" value="Chargement..." readonly /></h2>
+            <span id="purchaseDetailSaveSpinner" class="btn-loading-spinner purchase-detail-save-spinner" aria-hidden="true"></span>
             <p id="purchaseDetailCreatedAt" class="purchase-detail-summary__date">Date non définie</p>
           </div>
         </section>
@@ -42,15 +43,15 @@
           <article class="surface-card section purchase-detail-info-card" aria-label="Informations achat matériel">
             <div class="purchase-info-row" role="listitem">
               <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
-              <div id="purchaseDetailQty" class="purchase-value">-</div>
+              <div class="purchase-value purchase-value--inline"><input id="purchaseDetailQty" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div class="purchase-info-row" role="listitem">
               <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
-              <div id="purchaseDetailStore" class="purchase-value">-</div>
+              <div class="purchase-value purchase-value--inline"><input id="purchaseDetailStore" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div id="purchaseDetailRemarkRow" class="purchase-info-row" role="listitem" hidden>
               <div class="purchase-label"><span aria-hidden="true" class="icon">📝</span><span>Remarque</span></div>
-              <div id="purchaseDetailRemark" class="purchase-value"></div>
+              <div class="purchase-value purchase-value--inline"><textarea id="purchaseDetailRemark" class="purchase-inline-field purchase-inline-field--textarea" rows="1" readonly></textarea></div>
             </div>
             <div class="purchase-info-row" role="listitem">
               <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Créé par</span></div>


### PR DESCRIPTION
### Motivation
- Permettre la modification directe des informations d’un achat matériel sans ouvrir de popup/modal, tout en conservant le rendu et la mise en page actuels.
- Restreindre l’édition aux administrateurs et garder un affichage identique pour les autres utilisateurs en lecture seule.

### Description
- Remplacé les textes affichés dans la page `purchase-detail.html` par des champs éditables en place : `<input>` pour le titre, la quantité et le magasin, et `<textarea>` pour la remarque, sans modifier la structure principale de la page (`purchase-detail.html`).
- Ajouté la logique côté client dans `js/app.js` pour : détecter le rôle via `permissions`, rendre les champs readonly pour les non-admins, gérer l’édition immédiate au clavier, et binder les événements `blur` et `Enter` (sauf pour `textarea`) pour lancer la sauvegarde.
- Implémenté une sauvegarde automatique vers Firestore avec `updateDoc(doc(firebaseDb, 'sites', siteId, 'achatsMateriels', purchaseId), updates)` et restitution de l’ancienne valeur en cas d’erreur, tout en affichant uniquement le spinner de sauvegarde existant pendant l’opération.
- Ajouté des styles spécifiques dans `css/style.css` pour garantir que les champs inline n’ont aucun fond, bord, outline, box-shadow ou effet de focus et qu’ils conservent exactement le rendu typographique (`.purchase-inline-field`, `.purchase-inline-field--textarea`, `.purchase-detail-save-spinner`).

### Testing
- `node --check js/app.js` a été exécuté et a réussi pour valider la syntaxe du script JavaScript.
- `git commit` a été exécuté avec succès pour enregistrer les modifications locales.
- Tentative de création de PR via `gh pr create` a échoué pour cause d’authentification (`gh auth login` requis) dans cet environnement d’exécution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71d130195c8325bd29d1a8e25da2db)