### PR TITLE
Ajouter bouton d’édition de l’image sur la page Achat matériel (admin)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6934,8 +6934,14 @@ body[data-page="purchase-detail"] .purchase-detail-image-wrap {
   justify-content: center;
 }
 
+body[data-page="purchase-detail"] .purchase-detail-image-frame {
+  position: relative;
+  display: inline-flex;
+}
+
 body[data-page="purchase-detail"] .purchase-detail-image-button[hidden],
-body[data-page="purchase-detail"] .purchase-detail-image[hidden] {
+body[data-page="purchase-detail"] .purchase-detail-image[hidden],
+body[data-page="purchase-detail"] .purchase-detail-image-edit[hidden] {
   display: none;
 }
 
@@ -6959,6 +6965,38 @@ body[data-page="purchase-detail"] .purchase-detail-image {
   color: #64748b;
   font-size: 3rem;
   box-shadow: 0 16px 34px rgba(15, 23, 42, 0.14);
+}
+
+
+body[data-page="purchase-detail"] .purchase-detail-image-edit {
+  position: absolute;
+  right: 0.6rem;
+  bottom: 0.6rem;
+  width: 38px;
+  height: 38px;
+  min-width: 38px;
+  min-height: 38px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 2;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.24);
+}
+
+body[data-page="purchase-detail"] .purchase-detail-image-edit:hover {
+  transform: scale(1.04);
+}
+
+body[data-page="purchase-detail"] .purchase-detail-image-edit:active {
+  transform: scale(0.95);
+}
+
+body[data-page="purchase-detail"] .purchase-detail-image-input {
+  display: none;
 }
 
 body[data-page="purchase-detail"] .purchase-detail-info-card {

--- a/js/app.js
+++ b/js/app.js
@@ -7508,6 +7508,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const imageButton = requireElement('purchaseDetailImageButton');
     const image = requireElement('purchaseDetailImage');
     const imagePlaceholder = requireElement('purchaseDetailImagePlaceholder');
+    const imageEditButton = requireElement('purchaseDetailImageEditButton');
+    const imageInput = requireElement('purchaseDetailImageInput');
     const qty = requireElement('purchaseDetailQty');
     const store = requireElement('purchaseDetailStore');
     const remarkRow = requireElement('purchaseDetailRemarkRow');
@@ -7546,6 +7548,35 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       field.readOnly = !canEditPurchase;
       field.toggleAttribute('aria-readonly', !canEditPurchase);
       field.tabIndex = canEditPurchase ? 0 : -1;
+    }
+
+    async function savePurchaseImageFile(file) {
+      if (!canEditPurchase || !currentPurchase || isSavingPurchase || !file) return;
+      const previousPurchase = { ...currentPurchase };
+      setPurchaseSaving(true);
+      try {
+        const uploadedImage = await uploadPurchaseImageToCloudinary(file);
+        if (!uploadedImage?.imageUrl) {
+          throw new Error('Upload Cloudinary échoué');
+        }
+        const updates = {
+          imageUrl: uploadedImage.imageUrl,
+          imagePublicId: uploadedImage.publicId,
+        };
+        await updateDoc(doc(firebaseDb, 'sites', siteId, 'achatsMateriels', purchaseId), updates);
+        currentPurchase = { ...currentPurchase, ...updates };
+        renderPurchaseDetail(currentPurchase);
+      } catch (error) {
+        console.error('Erreur mise à jour image achat matériel :', error);
+        currentPurchase = previousPurchase;
+        renderPurchaseDetail(previousPurchase);
+        UiService.showToast?.('Erreur lors de l’enregistrement de l’achat matériel.');
+      } finally {
+        if (imageInput) {
+          imageInput.value = '';
+        }
+        setPurchaseSaving(false);
+      }
     }
 
     async function saveInlinePurchaseField(fieldName, input) {
@@ -7664,6 +7695,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         imageButton.hidden = true;
         imagePlaceholder.hidden = false;
       }
+      if (imageEditButton) {
+        imageEditButton.hidden = !canEditPurchase;
+      }
     }
 
     bindInlinePurchaseField(summaryName, 'designation');
@@ -7676,6 +7710,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       if (!imageUrl || !imageDialog || !imageDialogImage) return;
       imageDialogImage.src = imageUrl;
       imageDialog.showModal();
+    });
+    imageEditButton?.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!canEditPurchase || isSavingPurchase) return;
+      imageInput?.click();
+    });
+    imageInput?.addEventListener('change', () => {
+      const file = imageInput.files?.[0];
+      if (!file) return;
+      savePurchaseImageFile(file);
     });
     imageDialogClose?.addEventListener('click', () => imageDialog?.close());
     imageDialog?.addEventListener('click', (event) => {

--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -34,10 +34,14 @@
 
         <section id="purchaseDetailMain" class="purchase-detail-main" aria-live="polite">
           <div class="purchase-detail-image-wrap">
-            <button id="purchaseDetailImageButton" class="purchase-detail-image-button" type="button" aria-label="Afficher l’image en grand" hidden>
-              <img id="purchaseDetailImage" class="purchase-detail-image" alt="Photo achat matériel" />
-            </button>
-            <div id="purchaseDetailImagePlaceholder" class="purchase-detail-image purchase-detail-image--placeholder" aria-hidden="true">🖼️</div>
+            <div class="purchase-detail-image-frame">
+              <button id="purchaseDetailImageButton" class="purchase-detail-image-button" type="button" aria-label="Afficher l’image en grand" hidden>
+                <img id="purchaseDetailImage" class="purchase-detail-image" alt="Photo achat matériel" />
+              </button>
+              <div id="purchaseDetailImagePlaceholder" class="purchase-detail-image purchase-detail-image--placeholder" aria-hidden="true">🖼️</div>
+              <button id="purchaseDetailImageEditButton" class="purchase-detail-image-edit fab" type="button" aria-label="Modifier l’image" hidden>✏️</button>
+              <input id="purchaseDetailImageInput" class="purchase-detail-image-input" type="file" accept="image/*" hidden />
+            </div>
           </div>
 
           <article class="surface-card section purchase-detail-info-card" aria-label="Informations achat matériel">


### PR DESCRIPTION
### Motivation
- Permettre aux administrateurs de remplacer l’image d’un achat matériel directement depuis la page de détail sans recharger la page ni ajouter d’overlay supplémentaire.

### Description
- Ajout d’un bouton circulaire d’édition ✏️ et d’un champ fichier caché dans le conteneur image de `purchase-detail.html` (`#purchaseDetailImageEditButton`, `#purchaseDetailImageInput`).
- Ajout de styles dans `css/style.css` pour positionner le bouton en bas à droite de l’image (taille ~38px, forme circulaire, légère ombre) et réutiliser le style existant de `fab` afin de rester cohérent avec l’UI.
- Implémentation du flux côté client dans `js/app.js` : sélection du fichier via le bouton, ouverture du sélecteur de fichiers, upload via la fonction existante `uploadPurchaseImageToCloudinary`, mise à jour Firestore avec `updateDoc`, affichage du spinner existant via `setPurchaseSaving(true)` pendant l’opération, et remplacement immédiat de l’image avec `renderPurchaseDetail` sans recharger la page.
- Affichage conditionnel du bouton : visible uniquement si `permissions.isAdmin` (`canEditPurchase`), et en cas d’erreur l’ancienne image est conservée et le toast d’erreur habituel est affiché.

### Testing
- `git diff --check` exécuté et sans erreurs.
- `node --check js/app.js` exécuté et sans erreurs.
- Validation de présence/modification des fichiers suivis (`purchase-detail.html`, `css/style.css`, `js/app.js`) et commit local effectué avec le message `Add purchase image edit control`.
All tests automatiques lancés dans la session ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71d339363c8325846f5babf765b04e)