### PR TITLE
Adjust admin users layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2183,7 +2183,9 @@ body[data-page="users-management"] .pending-users-list--scroll {
 body[data-page="users-management"] .table-card {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   min-height: 0;
+  height: 100%;
 }
 
 body[data-page="users-management"] {
@@ -2200,9 +2202,11 @@ body[data-page="users-management"] .page-content--wide {
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.15rem;
   min-height: 0;
+  height: 100%;
   flex: 1 1 auto;
   padding-inline: clamp(0.9rem, 2vw, 1.2rem);
   padding-bottom: clamp(0.75rem, 1.8vw, 1.25rem);
+  overflow: hidden;
 }
 
 body[data-page="users-management"] .surface-card {
@@ -2211,6 +2215,14 @@ body[data-page="users-management"] .surface-card {
   border-radius: clamp(16px, 2vw, 22px);
   box-shadow: 0 10px 28px rgba(31, 42, 55, 0.1);
   overflow: hidden;
+}
+
+body[data-page="users-management"] .main-content > .details-card {
+  grid-row: 1;
+}
+
+body[data-page="users-management"] .main-content > .table-card {
+  grid-row: 2;
 }
 
 body[data-page="users-management"] .table-card .section-title {
@@ -2370,13 +2382,14 @@ body[data-page="users-management"] .maintenance-access-checkbox {
 
 
 body[data-page="users-management"] .main-content {
-  padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0px));
+  padding-bottom: clamp(0.75rem, 1.8vw, 1.25rem);
 }
 
 body[data-page="users-management"] .admin-message-fab {
+  position: fixed;
   right: calc(1.25rem + env(safe-area-inset-right, 0px));
   bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
-  z-index: 1100;
+  z-index: 1200;
   font-size: 1.55rem;
   line-height: 1;
 }


### PR DESCRIPTION
### Motivation
- Garantir que le conteneur "Tous les utilisateurs" occupe toute la hauteur disponible et que le tableau défile uniquement à l'intérieur de ce conteneur sans laisser de grands espaces vides sous le tableau.
- Conserver le header fixé et maintenir le bouton FAB "Message aux utilisateurs" toujours flottant et au-dessus du contenu.

### Description
- Modifications uniquement du fichier `css/style.css` pour ajuster le layout de la page `users-management` sans toucher au HTML/JS ni au design visuel existant.
- Rendre la carte utilisateur extensible en hauteur en ajoutant `flex: 1 1 auto` et `height: 100%` à `.table-card` afin qu'elle utilise l'espace restant disponible.
- Forcer la grille de la page (`.page-content--wide`) à occuper la hauteur disponible avec `height: 100%` et `overflow: hidden` pour éviter le scroll de page et déléguer le défilement au conteneur interne.
- Positionner explicitement les blocs dans la grille avec `main-content > .details-card { grid-row: 1 }` et `main-content > .table-card { grid-row: 2 }` pour garantir que la section de table occupe la zone restante.
- Ajuster le padding bas de `.main-content` pour réduire l’espace vide et préserver le style/animation existants du FAB tout en renforçant son positionnement (`position: fixed` et `z-index: 1200`).

### Testing
- Exécuté `git diff --check` and it passed with no whitespace errors.
- Vérifié l’état du dépôt avec `git status --short` and changes are committed.
- Le commit a été créé successfully (`git commit`) including the CSS changes; no automated UI/browser tests were available in the environment (no Playwright/Chromium installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71d992db9c8325a0de7e093663fafa)