### PR TITLE
Corrige espacement et supprime le placeholder du champ « Remarque » dans le modal d’ajout d’achat

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -249,10 +249,11 @@
           <label class="input-group input-group--site-create">
             <span>Magasin</span>
             <input id="purchaseStore" type="text" placeholder="Ex : Titan I" />
+            <p class="form-error form-error--field" aria-hidden="true"></p>
           </label>
           <label class="input-group input-group--site-create">
             <span>Remarque</span>
-            <textarea id="purchaseRemark" rows="2" placeholder="Ex : Livraison urgente pour le chantier."></textarea>
+            <textarea id="purchaseRemark" rows="2"></textarea>
             <p id="purchaseRemarkError" class="form-error form-error--field" aria-live="polite"></p>
           </label>
           <label class="input-group input-group--site-create">


### PR DESCRIPTION
### Motivation
- Harmoniser le rythme vertical du formulaire d’`Ajouter un achat matériel` en introduisant le même espace entre le champ `Magasin` et le titre `Remarque` et supprimer le texte d’exemple non désiré dans la zone `Remarque`.

### Description
- Ajout d’un nœud d’espacement identique aux autres champs en insérant une balise `<p class="form-error form-error--field" aria-hidden="true"></p>` après l’`input` `#purchaseStore` dans `page2.html` pour conserver la même marge verticale.
- Suppression du `placeholder` de la zone de texte `#purchaseRemark` dans `page2.html` pour laisser la `textarea` vide par défaut et ne plus afficher de texte d’exemple.
- Aucun autre style, bordure, taille, couleur ou animation n’a été modifié dans le CSS ou dans d’autres composants.

### Testing
- Le fichier HTML est correctement parsé avec un petit script `python3` utilisant `html.parser` et la lecture de `page2.html`, et l’opération a réussi.
- Exécution de `git diff --check` pour valider l’absence d’erreurs de formatage dans la diff, et l’outil a signalé aucun problème.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71de4719308325a2099904d4d427a4)