### PR TITLE
Update admin message variable selector UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2463,79 +2463,42 @@ body[data-page="users-management"] .admin-message-field textarea {
   resize: vertical;
 }
 body[data-page="users-management"] .admin-message-body-field {
-  position: relative;
-}
-
-body[data-page="users-management"] .admin-message-body-field textarea {
-  padding-right: 3.25rem;
-}
-
-body[data-page="users-management"] .admin-message-variables__toggle {
-  position: absolute;
-  top: 0.55rem;
-  right: 0.55rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
-  border: 1px solid rgba(148, 163, 184, 0.55);
-  border-radius: 0.7rem;
-  background: rgba(248, 250, 252, 0.92);
-  color: #2563eb;
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.82rem;
-  font-weight: 900;
-  line-height: 1;
-  transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
-}
-
-body[data-page="users-management"] .admin-message-variables__toggle:hover,
-body[data-page="users-management"] .admin-message-variables__toggle:focus-visible {
-  border-color: #2563eb;
-  background: #fff;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
-  outline: none;
-}
-
-body[data-page="users-management"] .admin-message-variables__menu {
-  position: absolute;
-  z-index: 35;
-  top: 2.95rem;
-  right: 0.55rem;
   display: grid;
-  gap: 0.35rem;
-  min-width: 10rem;
-  padding: 0.6rem;
-  border: 1px solid rgba(148, 163, 184, 0.45);
+  gap: 0.75rem;
+}
+
+body[data-page="users-management"] .admin-message-variables {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(147, 197, 253, 0.65);
   border-radius: 0.95rem;
+  background: rgba(239, 246, 255, 0.95);
+}
+
+body[data-page="users-management"] .admin-message-variables button {
+  min-height: 2rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 999px;
   background: #fff;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
-}
-
-body[data-page="users-management"] .admin-message-variables__menu[hidden] {
-  display: none;
-}
-
-body[data-page="users-management"] .admin-message-variables__menu button {
-  width: 100%;
-  min-height: 2.15rem;
-  padding: 0.45rem 0.6rem;
-  border: 0;
-  border-radius: 0.65rem;
-  background: transparent;
-  color: #111827;
+  color: #1d4ed8;
   cursor: pointer;
   font: inherit;
+  font-size: 0.88rem;
   font-weight: 800;
-  text-align: left;
+  line-height: 1.2;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+  transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
 }
 
-body[data-page="users-management"] .admin-message-variables__menu button:hover,
-body[data-page="users-management"] .admin-message-variables__menu button:focus-visible {
-  background: rgba(37, 99, 235, 0.1);
-  color: #1d4ed8;
+body[data-page="users-management"] .admin-message-variables button:hover,
+body[data-page="users-management"] .admin-message-variables button:focus-visible {
+  border-color: #2563eb;
+  background: #dbeafe;
+  color: #1e40af;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
   outline: none;
 }
 

--- a/users.html
+++ b/users.html
@@ -61,8 +61,7 @@
                 <label for="adminMessageInputBody">Corps du message</label>
                 <div class="admin-message-body-field">
                   <textarea id="adminMessageInputBody" rows="5" maxlength="1200" required></textarea>
-                  <button id="adminMessageVariablesToggle" class="admin-message-variables__toggle" type="button" aria-expanded="false" aria-controls="adminMessageVariablesMenu" aria-label="Insérer une variable">{}</button>
-                  <div id="adminMessageVariablesMenu" class="admin-message-variables__menu" hidden>
+                  <div id="adminMessageVariablesMenu" class="admin-message-variables" aria-label="Variables disponibles">
                     <button type="button" data-admin-message-variable="{Nom}">{Nom}</button>
                     <button type="button" data-admin-message-variable="{Prénom}">{Prénom}</button>
                     <button type="button" data-admin-message-variable="{NomComplet}">{NomComplet}</button>
@@ -423,7 +422,6 @@
       const adminMessageRecipientsSummary = document.getElementById('adminMessageRecipientsSummary');
       const adminMessageRecipientsList = document.getElementById('adminMessageRecipientsList');
       const adminMessageRecipientsHint = document.getElementById('adminMessageRecipientsHint');
-      const adminMessageVariablesToggle = document.getElementById('adminMessageVariablesToggle');
       const adminMessageVariablesMenu = document.getElementById('adminMessageVariablesMenu');
       const ADMIN_MESSAGE_DRAFT_STORAGE_KEY = 'adminMessageDraft';
       const ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY = 'adminMessageRecipients';
@@ -647,14 +645,6 @@
         }
       }
 
-      function setAdminMessageVariablesMenuOpen(isOpen) {
-        if (!adminMessageVariablesMenu || !adminMessageVariablesToggle) {
-          return;
-        }
-        adminMessageVariablesMenu.hidden = !isOpen;
-        adminMessageVariablesToggle.setAttribute('aria-expanded', String(isOpen));
-      }
-
       function insertAdminMessageVariable(variable) {
         if (!adminMessageBodyInput || !ADMIN_MESSAGE_VARIABLES.includes(variable)) {
           return;
@@ -733,7 +723,6 @@
           updateAdminMessageRecipientState();
         }
         setAdminMessageRecipientsDropdownOpen(false);
-        setAdminMessageVariablesMenuOpen(false);
         adminMessageModal.hidden = true;
         document.body.classList.remove('admin-message-modal-open');
         adminMessageFab?.focus();
@@ -763,9 +752,6 @@
         if (adminMessageRecipientsDropdown && !adminMessageRecipientsDropdown.contains(event.target)) {
           setAdminMessageRecipientsDropdownOpen(false);
         }
-        if (adminMessageVariablesMenu && adminMessageVariablesToggle && !adminMessageVariablesMenu.contains(event.target) && !adminMessageVariablesToggle.contains(event.target)) {
-          setAdminMessageVariablesMenuOpen(false);
-        }
       });
 
       adminMessageAllRecipients?.addEventListener('change', () => {
@@ -782,17 +768,12 @@
       });
       adminMessageTitleInput?.addEventListener('input', persistAdminMessageDraft);
       adminMessageBodyInput?.addEventListener('input', persistAdminMessageDraft);
-      adminMessageVariablesToggle?.addEventListener('click', () => {
-        const isOpen = adminMessageVariablesToggle.getAttribute('aria-expanded') === 'true';
-        setAdminMessageVariablesMenuOpen(!isOpen);
-      });
       adminMessageVariablesMenu?.addEventListener('click', (event) => {
         const variableButton = event.target?.closest?.('[data-admin-message-variable]');
         if (!variableButton) {
           return;
         }
         insertAdminMessageVariable(variableButton.getAttribute('data-admin-message-variable'));
-        setAdminMessageVariablesMenuOpen(false);
       });
 
       adminMessageCancelButton?.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Replace the hidden dropdown variable picker and the `{}` toggle with a permanently visible variable list under the "Corps du message" field. 
- Present variables as clickable badges inside a light colored rounded box to improve discoverability while keeping existing insertion behaviour. 
- Only touch the UI: do not change variable names, insertion logic, database, or backend behaviour. 

### Description
- Updated `users.html` to remove the `{}` toggle button and the hidden dropdown, and added a persistent container `#adminMessageVariablesMenu` with the same `data-admin-message-variable` buttons so variable names remain unchanged. 
- Removed references to the removed toggle and the `setAdminMessageVariablesMenuOpen` helper where they were no longer needed, while preserving the `insertAdminMessageVariable` call path. 
- Updated `css/style.css` to add `.admin-message-variables` styles that render the container with a light-blue background, rounded corners and clickable variable badges styled as pills. 
- Kept the existing insertion implementation (`insertAdminMessageVariable`) and all other message sending and personalization logic unchanged. 

### Testing
- Ran `git diff --check` with no check failures reported. 
- Verified repository status with `git status --short` and created a commit containing the changes to `users.html` and `css/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f32501e4832595aed3cca20ee74a)