### PR TITLE
Conserver le badge de variable sélectionné en surbrillance

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2494,7 +2494,8 @@ body[data-page="users-management"] .admin-message-variables button {
 }
 
 body[data-page="users-management"] .admin-message-variables button:hover,
-body[data-page="users-management"] .admin-message-variables button:focus-visible {
+body[data-page="users-management"] .admin-message-variables button:focus-visible,
+body[data-page="users-management"] .admin-message-variables button.is-active {
   border-color: #2563eb;
   background: #dbeafe;
   color: #1e40af;

--- a/users.html
+++ b/users.html
@@ -423,6 +423,7 @@
       const adminMessageRecipientsList = document.getElementById('adminMessageRecipientsList');
       const adminMessageRecipientsHint = document.getElementById('adminMessageRecipientsHint');
       const adminMessageVariablesMenu = document.getElementById('adminMessageVariablesMenu');
+      const adminMessageVariableButtons = Array.from(adminMessageVariablesMenu?.querySelectorAll('[data-admin-message-variable]') || []);
       const ADMIN_MESSAGE_DRAFT_STORAGE_KEY = 'adminMessageDraft';
       const ADMIN_MESSAGE_RECIPIENTS_STORAGE_KEY = 'adminMessageRecipients';
       let isAdminMessageSending = false;
@@ -485,6 +486,14 @@
         return ADMIN_MESSAGE_VARIABLES.reduce((message, variable) => message.split(variable).join(variables[variable] || ''), body);
       }
 
+
+      function setActiveAdminMessageVariableButton(activeButton) {
+        adminMessageVariableButtons.forEach((button) => {
+          const isActive = button === activeButton;
+          button.classList.toggle('is-active', isActive);
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
 
       function getSelectedRecipientIds() {
         if (adminMessageAllRecipients?.checked) {
@@ -721,6 +730,7 @@
           }
           clearAdminMessageDraft();
           updateAdminMessageRecipientState();
+          setActiveAdminMessageVariableButton(null);
         }
         setAdminMessageRecipientsDropdownOpen(false);
         adminMessageModal.hidden = true;
@@ -773,6 +783,7 @@
         if (!variableButton) {
           return;
         }
+        setActiveAdminMessageVariableButton(variableButton);
         insertAdminMessageVariable(variableButton.getAttribute('data-admin-message-variable'));
       });
 


### PR DESCRIPTION
### Motivation
- Garder visuellement actif le badge de variable sélectionné dans le formulaire « Message aux utilisateurs » lorsque le champ « Corps du message » reçoit le focus ou que l'utilisateur saisit du texte. 
- Ne modifier aucune logique d'insertion, de remplacement ou d'envoi du message et n'introduire que des changements d'interface utilisateur.

### Description
- Ajout d'une collection de boutons `adminMessageVariableButtons` et d'une fonction `setActiveAdminMessageVariableButton` dans `users.html` pour gérer l'état visuel actif et l'attribut `aria-pressed` des badges. 
- Appel de `setActiveAdminMessageVariableButton(variableButton)` lors du clic sur un badge pour le marquer actif et inertie visuelle conservée tant qu'un autre badge n'est pas cliqué. 
- Réinitialisation visuelle du badge actif lors de la fermeture/réinitialisation du modal avec `setActiveAdminMessageVariableButton(null)`. 
- Extension du style existant en `css/style.css` pour appliquer la même mise en évidence que `:hover`/`:focus-visible` aux badges marqués `.is-active` afin qu'ils conservent la couleur de sélection pendant la saisie.

### Testing
- Exécution de `git diff --check` qui a réussi sans erreurs de style détectées. 
- Exécution de `git status --short` pour vérifier les modifications et l'état du dépôt qui a confirmé les fichiers modifiés. 
- Tentative automatisée de création de PR via `gh pr create` qui a échoué à cause d'une absence d'authentification GitHub CLI (`gh auth login` / `GH_TOKEN` requis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f5a6c83c83258be55169dee71140)