### PR TITLE
UI: Colorer les nombres de la section "Gestion Admin"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -561,6 +561,18 @@ body.app-content-loading .item-detail-fab-row {
   color: var(--text-muted);
 }
 
+.users-card-stat {
+  font-weight: 700;
+}
+
+.users-card-stat--total {
+  color: var(--primary-color);
+}
+
+.users-card-stat--online {
+  color: #15803d;
+}
+
 .switch {
   position: relative;
   display: inline-flex;

--- a/js/app.js
+++ b/js/app.js
@@ -7189,7 +7189,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const referenceDate = new Date();
       const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
-      usersCardHeader.innerHTML = `Tous les utilisateurs : ${users.length}<br />En ligne : ${onlineCount}`;
+      usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br />En ligne : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
     }
 
     function formatLastActivity(value, referenceDate = new Date()) {

--- a/users.html
+++ b/users.html
@@ -83,7 +83,7 @@
           </section>
         </div>
         <section class="surface-card table-card">
-          <h2 class="section-title" id="usersCardHeader">Tous les utilisateurs : 0<br />En ligne : 0</h2>
+          <h2 class="section-title" id="usersCardHeader">Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">0</span><br />En ligne : <span class="users-card-stat users-card-stat--online">0</span></h2>
           <div class="table-wrapper table-wrapper--users">
             <table class="data-table">
               <thead>
@@ -229,7 +229,7 @@
         }
         const referenceDate = new Date();
         const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
-        usersCardHeader.innerHTML = `Tous les utilisateurs : ${users.length}<br />En ligne : ${onlineCount}`;
+        usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br />En ligne : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
       }
 
       function formatLastActivity(value, referenceDate = new Date()) {


### PR DESCRIPTION
### Motivation
- Améliorer l'affichage visuel de la carte « Gestion Admin » en mettant en évidence uniquement les valeurs numériques des compteurs sans toucher à la logique des compteurs.
- Conserver les libellés (`Tous les utilisateurs :` et `En ligne :`) avec leur couleur actuelle et sans modifier les calculs ni le rafraîchissement des valeurs.

### Description
- Ajout de classes CSS `users-card-stat`, `users-card-stat--total` et `users-card-stat--online` dans `css/style.css` pour styliser et colorer séparément les nombres.
- Modification du rendu initial dans `users.html` en enveloppant les nombres dans des `span` avec `class="users-card-stat users-card-stat--total"` et `class="users-card-stat users-card-stat--online"` pour le compte total et le compte en ligne respectivement.
- Mise à jour de l'endroit où l'en-tête est reconstruit dynamiquement pour conserver le calcul existant et n'insérer que les `span` autour de `${users.length}` et `${onlineCount}` dans `js/app.js` (aucune logique ou calcul modifié).

### Testing
- Exécution de `git diff --check` qui n'a retourné aucune erreur et a réussi.
- Exécution de `git status --short` pour vérifier les fichiers modifiés qui a confirmé les changements attendus et a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f81b7f6483259575f8fa158f327c)