### PR TITLE
Surbrillance des variables dans le corps du message (UI uniquement)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2474,6 +2474,79 @@ body[data-page="users-management"] .admin-message-field textarea {
   min-height: 8rem;
   resize: vertical;
 }
+
+body[data-page="users-management"] .admin-message-highlighted-input {
+  position: relative;
+}
+
+body[data-page="users-management"] .admin-message-highlighted-input textarea {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+  color: transparent;
+  caret-color: #111827;
+}
+
+body[data-page="users-management"] .admin-message-highlighted-input textarea::selection {
+  background: rgba(37, 99, 235, 0.24);
+  color: transparent;
+}
+
+body[data-page="users-management"] .admin-message-highlighted-input__highlights {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 0.8rem;
+  padding: 0.75rem 0.85rem;
+  background: #fff;
+  color: #111827;
+  font: inherit;
+  font-weight: 600;
+  line-height: normal;
+  pointer-events: none;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+body[data-page="users-management"] .admin-message-variable-token {
+  border-radius: 0.45rem;
+  padding: 0.05rem 0.18rem;
+  color: #1e40af;
+  background: #dbeafe;
+  font-weight: 800;
+}
+
+body[data-page="users-management"] .admin-message-variable-token--nom {
+  color: #1e40af;
+  background: #dbeafe;
+}
+
+body[data-page="users-management"] .admin-message-variable-token--prenom {
+  color: #7e22ce;
+  background: #f3e8ff;
+}
+
+body[data-page="users-management"] .admin-message-variable-token--nom-complet {
+  color: #047857;
+  background: #d1fae5;
+}
+
+body[data-page="users-management"] .admin-message-variable-token--mail {
+  color: #b45309;
+  background: #fef3c7;
+}
+
+body[data-page="users-management"] .admin-message-variable-token--role {
+  color: #be123c;
+  background: #ffe4e6;
+}
+
+body[data-page="users-management"] .admin-message-variable-token--point {
+  color: #0f766e;
+  background: #ccfbf1;
+}
+
 body[data-page="users-management"] .admin-message-body-field {
   display: grid;
   gap: 0.75rem;
@@ -2505,6 +2578,32 @@ body[data-page="users-management"] .admin-message-variables button {
   transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
 }
 
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Prénom}"] {
+  border-color: rgba(126, 34, 206, 0.18);
+  color: #7e22ce;
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{NomComplet}"] {
+  border-color: rgba(4, 120, 87, 0.18);
+  color: #047857;
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Mail}"] {
+  border-color: rgba(180, 83, 9, 0.18);
+  color: #b45309;
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Role}"] {
+  border-color: rgba(190, 18, 60, 0.18);
+  color: #be123c;
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Point}"] {
+  border-color: rgba(15, 118, 110, 0.18);
+  color: #0f766e;
+}
+
 body[data-page="users-management"] .admin-message-variables button:hover,
 body[data-page="users-management"] .admin-message-variables button:focus-visible,
 body[data-page="users-management"] .admin-message-variables button.is-active {
@@ -2515,6 +2614,52 @@ body[data-page="users-management"] .admin-message-variables button.is-active {
   outline: none;
 }
 
+
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Prénom}"]:hover,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Prénom}"]:focus-visible,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Prénom}"].is-active {
+  border-color: #7e22ce;
+  background: #f3e8ff;
+  color: #7e22ce;
+  box-shadow: 0 0 0 3px rgba(126, 34, 206, 0.14);
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{NomComplet}"]:hover,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{NomComplet}"]:focus-visible,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{NomComplet}"].is-active {
+  border-color: #047857;
+  background: #d1fae5;
+  color: #047857;
+  box-shadow: 0 0 0 3px rgba(4, 120, 87, 0.14);
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Mail}"]:hover,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Mail}"]:focus-visible,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Mail}"].is-active {
+  border-color: #b45309;
+  background: #fef3c7;
+  color: #b45309;
+  box-shadow: 0 0 0 3px rgba(180, 83, 9, 0.14);
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Role}"]:hover,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Role}"]:focus-visible,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Role}"].is-active {
+  border-color: #be123c;
+  background: #ffe4e6;
+  color: #be123c;
+  box-shadow: 0 0 0 3px rgba(190, 18, 60, 0.14);
+}
+
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Point}"]:hover,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Point}"]:focus-visible,
+body[data-page="users-management"] .admin-message-variables button[data-admin-message-variable="{Point}"].is-active {
+  border-color: #0f766e;
+  background: #ccfbf1;
+  color: #0f766e;
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.14);
+}
 
 body[data-page="users-management"] .admin-message-recipients {
   display: grid;

--- a/users.html
+++ b/users.html
@@ -60,7 +60,10 @@
               <div class="admin-message-field">
                 <label for="adminMessageInputBody">Corps du message</label>
                 <div class="admin-message-body-field">
-                  <textarea id="adminMessageInputBody" rows="5" maxlength="1200" required></textarea>
+                  <div class="admin-message-highlighted-input">
+                    <div id="adminMessageBodyHighlights" class="admin-message-highlighted-input__highlights" aria-hidden="true"></div>
+                    <textarea id="adminMessageInputBody" rows="5" maxlength="1200" required></textarea>
+                  </div>
                   <div id="adminMessageVariablesMenu" class="admin-message-variables" aria-label="Variables disponibles">
                     <button type="button" data-admin-message-variable="{Nom}">{Nom}</button>
                     <button type="button" data-admin-message-variable="{Prénom}">{Prénom}</button>
@@ -413,6 +416,7 @@
       const adminMessageForm = document.getElementById('adminMessageForm');
       const adminMessageTitleInput = document.getElementById('adminMessageInputTitle');
       const adminMessageBodyInput = document.getElementById('adminMessageInputBody');
+      const adminMessageBodyHighlights = document.getElementById('adminMessageBodyHighlights');
       const adminMessageSendButton = document.getElementById('adminMessageSendButton');
       const adminMessageCancelButton = document.getElementById('adminMessageCancelButton');
       const adminMessageAllRecipients = document.getElementById('adminMessageAllRecipients');
@@ -429,6 +433,14 @@
       let isAdminMessageSending = false;
       let isRestoringAdminMessageDraft = false;
       const ADMIN_MESSAGE_VARIABLES = ['{Nom}', '{Prénom}', '{NomComplet}', '{Mail}', '{Role}', '{Point}'];
+      const ADMIN_MESSAGE_VARIABLE_CLASS_BY_NAME = {
+        '{Nom}': 'admin-message-variable-token--nom',
+        '{Prénom}': 'admin-message-variable-token--prenom',
+        '{NomComplet}': 'admin-message-variable-token--nom-complet',
+        '{Mail}': 'admin-message-variable-token--mail',
+        '{Role}': 'admin-message-variable-token--role',
+        '{Point}': 'admin-message-variable-token--point',
+      };
 
       function getSelectableMessageRecipients() {
         return currentUsers
@@ -486,6 +498,34 @@
         return ADMIN_MESSAGE_VARIABLES.reduce((message, variable) => message.split(variable).join(variables[variable] || ''), body);
       }
 
+      function renderAdminMessageBodyHighlights() {
+        if (!adminMessageBodyInput || !adminMessageBodyHighlights) {
+          return;
+        }
+        const message = adminMessageBodyInput.value;
+        let highlightedMessage = '';
+        for (let index = 0; index < message.length;) {
+          const matchingVariable = ADMIN_MESSAGE_VARIABLES.find((variable) => message.startsWith(variable, index));
+          if (matchingVariable) {
+            const tokenClass = ADMIN_MESSAGE_VARIABLE_CLASS_BY_NAME[matchingVariable] || '';
+            highlightedMessage += `<mark class="admin-message-variable-token ${tokenClass}">${escapeHtml(matchingVariable)}</mark>`;
+            index += matchingVariable.length;
+          } else {
+            highlightedMessage += escapeHtml(message[index]);
+            index += 1;
+          }
+        }
+        adminMessageBodyHighlights.innerHTML = `${highlightedMessage}
+`;
+      }
+
+      function syncAdminMessageBodyHighlightsScroll() {
+        if (!adminMessageBodyInput || !adminMessageBodyHighlights) {
+          return;
+        }
+        adminMessageBodyHighlights.scrollTop = adminMessageBodyInput.scrollTop;
+        adminMessageBodyHighlights.scrollLeft = adminMessageBodyInput.scrollLeft;
+      }
 
       function setActiveAdminMessageVariableButton(activeButton) {
         adminMessageVariableButtons.forEach((button) => {
@@ -622,6 +662,7 @@
           }
           if (adminMessageBodyInput) {
             adminMessageBodyInput.value = draft?.body || '';
+            renderAdminMessageBodyHighlights();
           }
           if (adminMessageAllRecipients) {
             adminMessageAllRecipients.checked = recipientsDraft?.allRecipients !== false;
@@ -661,6 +702,7 @@
         const start = adminMessageBodyInput.selectionStart ?? adminMessageBodyInput.value.length;
         const end = adminMessageBodyInput.selectionEnd ?? start;
         adminMessageBodyInput.setRangeText(variable, start, end, 'end');
+        renderAdminMessageBodyHighlights();
         adminMessageBodyInput.focus();
         persistAdminMessageDraft();
       }
@@ -729,6 +771,7 @@
             adminMessageAllRecipients.checked = true;
           }
           clearAdminMessageDraft();
+          renderAdminMessageBodyHighlights();
           updateAdminMessageRecipientState();
           setActiveAdminMessageVariableButton(null);
         }
@@ -777,7 +820,11 @@
         }
       });
       adminMessageTitleInput?.addEventListener('input', persistAdminMessageDraft);
-      adminMessageBodyInput?.addEventListener('input', persistAdminMessageDraft);
+      adminMessageBodyInput?.addEventListener('input', () => {
+        persistAdminMessageDraft();
+        renderAdminMessageBodyHighlights();
+      });
+      adminMessageBodyInput?.addEventListener('scroll', syncAdminMessageBodyHighlightsScroll);
       adminMessageVariablesMenu?.addEventListener('click', (event) => {
         const variableButton = event.target?.closest?.('[data-admin-message-variable]');
         if (!variableButton) {
@@ -832,6 +879,7 @@
           }
           if (adminMessageBodyInput) {
             adminMessageBodyInput.value = '';
+            renderAdminMessageBodyHighlights();
           }
           clearAdminMessageDraft();
           closeAdminMessageModal({ reset: false });


### PR DESCRIPTION
### Motivation
- Améliorer l’expérience d’édition du formulaire « Message aux utilisateurs » en rendant les variables insérées (`{Nom}`, `{Prénom}`, `{NomComplet}`, `{Mail}`, `{Role}`, `{Point}`) visuellement distinctes dans le champ `Corps du message` sans modifier la logique d’insertion, de remplacement ou d’envoi.
- Conserver le `textarea` existant comme source de vérité pour la valeur du message tout en offrant une couche d’affichage qui met en évidence chaque variable avec une couleur correspondante au badge cliquable.

### Description
- Ajout d’un wrapper HTML `admin-message-highlighted-input` avec une couche de rendu `adminMessageBodyHighlights` superposée au `textarea` existant pour afficher les surlignages des variables (aucune logique serveur/modification de l’insertion n’a été touchée). 
- Ajout d’une table de classes `ADMIN_MESSAGE_VARIABLE_CLASS_BY_NAME` et des styles CSS pour des tokens de variables colorés ainsi que des styles de badges variables assortis (`css/style.css`).
- Implémentation de `renderAdminMessageBodyHighlights()` et `syncAdminMessageBodyHighlightsScroll()` pour rendre les variables dans l’overlay et synchroniser le défilement, et appel de `renderAdminMessageBodyHighlights()` lors de l’insertion (`insertAdminMessageVariable`), de la saisie, du défilement, de la restauration de brouillon et du reset modal.
- Ajustements CSS pour rendre le `textarea` transparent (la valeur reste éditable et copiée/collée normalement) et styliser chaque token variable avec un fond léger et une couleur de texte dédiée.

### Testing
- Exécution de la vérification du module inline avec `node --check /tmp/users-inline.mjs` qui a réussi. 
- Exécution de `git diff --check` pour s’assurer qu’il n’y a pas d’erreurs de diff qui bloquent, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f9fc750c83259778f25272c1448e)