### PR TITLE
Disable browser autocomplete and suggestions for OUT number input

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -133,7 +133,7 @@
       </div>
 
       <dialog id="itemDialog" class="modal-card">
-        <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="itemForm">
+        <form method="dialog" class="modal-content modal-content--site-create modal-content--item-create" id="itemForm" autocomplete="off">
           <div class="modal-header">
             <h2>Nouveau numéro OUT <span class="required-star" aria-hidden="true">*</span></h2>
           </div>
@@ -148,6 +148,10 @@
               type="text"
               inputmode="numeric"
               pattern="[0-9]*"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+              spellcheck="false"
               maxlength="10"
               minlength="4"
               placeholder="Exemple : 26050200"


### PR DESCRIPTION
### Motivation
- Prevent the browser/keyboard from displaying previously entered values under the "Numéro OUT" field while preserving the exact prior behavior and numeric keyboard.

### Description
- Added `autocomplete="off"` on the create/edit item form and added `autocomplete="off"`, `autocorrect="off"`, `autocapitalize="off"`, and `spellcheck="false"` to the `#itemNumberInput` in `page2.html` while keeping `inputmode="numeric"` and `pattern="[0-9]*"` unchanged.

### Testing
- Ran `git diff --check` which reported no issues and confirmed the `page2.html` edit was applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7202342ea48325be07e1891cd70cc0)