### PR TITLE
Corrige l'édition des variables dans le titre et le corps du message

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2517,10 +2517,10 @@ body[data-page="users-management"] .admin-message-highlighted-input__highlights 
 
 body[data-page="users-management"] .admin-message-variable-token {
   border-radius: 0.45rem;
-  padding: 0.05rem 0.18rem;
   color: #1e40af;
   background: #dbeafe;
-  font-weight: 800;
+  font: inherit;
+  font-weight: 600;
 }
 
 body[data-page="users-management"] .admin-message-variable-token--nom {

--- a/users.html
+++ b/users.html
@@ -741,9 +741,11 @@
         }
         const start = targetInput.selectionStart ?? targetInput.value.length;
         const end = targetInput.selectionEnd ?? start;
+        const nextCursorPosition = start + variable.length;
         targetInput.setRangeText(variable, start, end, 'end');
-        renderActiveAdminMessageVariableFieldHighlights(targetInput);
         targetInput.focus();
+        targetInput.setSelectionRange(nextCursorPosition, nextCursorPosition);
+        renderActiveAdminMessageVariableFieldHighlights(targetInput);
         persistAdminMessageDraft();
       }
 


### PR DESCRIPTION
### Motivation
- Corriger le comportement où les variables insérées (ex. `{NomComplet}`) restaient « figées » et ne suivaient pas le texte quand on ajoutait/supprimait des caractères autour d'elles.
- Les variables doivent se comporter comme du texte normal tout en restant surlignées (highlight) visuellement, sans changer la logique d'envoi ni le remplacement des variables.
- Appliquer la correction aux deux champs `Titre du message` et `Corps du message`.

### Description
- Modifie la fonction `insertAdminMessageVariable` dans `users.html` pour repositionner explicitement le curseur juste après la variable insérée en calculant `nextCursorPosition = start + variable.length`, en appelant `setRangeText(...)`, puis `setSelectionRange(nextCursorPosition, nextCursorPosition)` et enfin le rendu des highlights et la persistance du brouillon.
- Ajuste le style de `.admin-message-variable-token` dans `css/style.css` pour supprimer le padding/poids de police qui modifiait la métrique de texte et appliquer `font: inherit` et `font-weight: 600` afin que le token n'affecte plus la mise en page du texte sous-jacent.
- Les opérations de remplacement de variables et la logique d'envoi restent inchangées; la modification porte uniquement sur le comportement de l'éditeur et du rendu visuel.

### Testing
- Exécuté `git diff --check` qui a retourné sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72138594008325b3b275f2258d13e6)