### PR TITLE
Fix admin message variable editor flow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2482,16 +2482,10 @@ body[data-page="users-management"] .admin-message-highlighted-input {
 body[data-page="users-management"] .admin-message-highlighted-input input,
 body[data-page="users-management"] .admin-message-highlighted-input textarea {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   background: transparent;
-  color: transparent;
+  color: #111827;
   caret-color: #111827;
-}
-
-body[data-page="users-management"] .admin-message-highlighted-input input::selection,
-body[data-page="users-management"] .admin-message-highlighted-input textarea::selection {
-  background: rgba(37, 99, 235, 0.24);
-  color: transparent;
 }
 
 body[data-page="users-management"] .admin-message-highlighted-input--title .admin-message-highlighted-input__highlights {
@@ -2500,13 +2494,14 @@ body[data-page="users-management"] .admin-message-highlighted-input--title .admi
 
 body[data-page="users-management"] .admin-message-highlighted-input__highlights {
   position: absolute;
+  z-index: 1;
   inset: 0;
   overflow: hidden;
   border: 1px solid transparent;
   border-radius: 0.8rem;
   padding: 0.75rem 0.85rem;
   background: #fff;
-  color: #111827;
+  color: transparent;
   font: inherit;
   font-weight: 600;
   line-height: normal;

--- a/users.html
+++ b/users.html
@@ -522,6 +522,8 @@
         }
         highlights.innerHTML = `${highlightedMessage}
 `;
+        highlights.scrollTop = input.scrollTop;
+        highlights.scrollLeft = input.scrollLeft;
       }
 
       function renderAdminMessageTitleHighlights() {


### PR DESCRIPTION
### Motivation
- Corriger le comportement où les variables (ex. `{NomComplet}`) se comportent comme des éléments fixes devant le curseur au lieu de suivre les modifications de texte, sans toucher à la logique d'envoi ni au remplacement des variables.

### Description
- Ajustement CSS pour placer le champ de saisie au-dessus du calque de highlights (`z-index` inversés) et rendre le calque de highlights transparent afin que le texte natif pilote le curseur tout en conservant la coloration des tokens `<mark>`.
- Synchronisation côté JS du calque de highlights avec la position de scroll de l'input/textarea en ajoutant `highlights.scrollTop = input.scrollTop;` et `highlights.scrollLeft = input.scrollLeft;` dans `renderAdminMessageHighlights`.
- Fichiers modifiés : `css/style.css` et `users.html`.

### Testing
- Exécution de la vérification de syntaxe JS via `node --check js/app.js && node --check js/ui.js && node --check js/materiels.js && node --check js/login.js && node --check js/maintenance-banner.js && node --check js/storage.js && node --check js/firebase-core.js` qui a réussi.
- Aucun autre test automatique présent n'a échoué après les modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72172f96908325bcef6d998378df8c)