### PR TITLE
Normalize escaped '\n' to real newlines in admin message editors

### DIFF
--- a/users.html
+++ b/users.html
@@ -609,6 +609,18 @@
         }
       }
 
+      function replaceEscapedNewlinesBeforeCaret(message, caretOffset) {
+        const safeCaretOffset = Math.max(0, Math.min(Number(caretOffset) || 0, message.length));
+        const beforeCaret = message.slice(0, safeCaretOffset);
+        const afterCaret = message.slice(safeCaretOffset);
+        const normalizedBeforeCaret = beforeCaret.replace(/\\n/g, '\n');
+        const normalizedAfterCaret = afterCaret.replace(/\\n/g, '\n');
+        return {
+          message: `${normalizedBeforeCaret}${normalizedAfterCaret}`,
+          caretOffset: normalizedBeforeCaret.length,
+        };
+      }
+
       function normalizeAdminMessageEditor(editor) {
         if (!editor) {
           return;
@@ -616,8 +628,9 @@
         const maxLength = Number(editor.dataset.maxlength || 0);
         const caretOffset = getAdminMessageCaretOffset(editor);
         const message = getAdminMessageEditorText(editor);
-        const normalizedMessage = maxLength > 0 ? message.slice(0, maxLength) : message;
-        renderAdminMessageEditor(editor, normalizedMessage, Math.min(caretOffset, normalizedMessage.length));
+        const newlineNormalizedMessage = replaceEscapedNewlinesBeforeCaret(message, caretOffset);
+        const normalizedMessage = maxLength > 0 ? newlineNormalizedMessage.message.slice(0, maxLength) : newlineNormalizedMessage.message;
+        renderAdminMessageEditor(editor, normalizedMessage, Math.min(newlineNormalizedMessage.caretOffset, normalizedMessage.length));
       }
 
       function renderAdminMessageTitle() {


### PR DESCRIPTION
### Motivation
- Allow users to type the literal sequence `\n` in the message title or body and have it immediately converted to a real newline while keeping the cursor at the start of the new line and preserving the variable system.

### Description
- Added `replaceEscapedNewlinesBeforeCaret(message, caretOffset)` to convert `\n` sequences into real newlines and compute the new caret offset.
- Updated `normalizeAdminMessageEditor` to run the newline normalizer before trimming to `data-maxlength` and to position the caret using the normalized offset.
- The change integrates into the existing editor rendering flow so the behavior applies equally to the Title and Body editors without touching the variable/token parsing logic.

### Testing
- Performed a syntax check on the extracted script with `node --check /tmp/users_script_4.js`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72217516c083258c970912b603e7f0)