### PR TITLE
Affiche les informations d'achat sur une ligne dans la page "Achat matériel(s)"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7213,8 +7213,36 @@ body[data-page="purchase-detail"] .purchase-detail-info-card {
   gap: 0.72rem;
 }
 
+body[data-page="purchase-detail"] .purchase-info-row {
+  display: grid;
+  grid-template-columns: minmax(7.9rem, auto) minmax(0, 1fr);
+  align-items: start;
+  column-gap: 0.7rem;
+}
+
 body[data-page="purchase-detail"] .purchase-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  min-width: 0;
   color: var(--primary-color);
+}
+
+body[data-page="purchase-detail"] .purchase-label .icon {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+body[data-page="purchase-detail"] .purchase-label span {
+  font-weight: 600;
+}
+
+body[data-page="purchase-detail"] .purchase-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  line-height: 1.32;
 }
 
 body[data-page="purchase-detail"] .purchase-image-dialog {

--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -46,23 +46,23 @@
 
           <article class="surface-card section purchase-detail-info-card" aria-label="Informations achat matériel">
             <div class="purchase-info-row" role="listitem">
-              <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité</span></div>
+              <div class="purchase-label"><img src="Icon/Article.png" alt="" aria-hidden="true" class="icon" /><span>Quantité :</span></div>
               <div class="purchase-value purchase-value--inline"><input id="purchaseDetailQty" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div class="purchase-info-row" role="listitem">
-              <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin</span></div>
+              <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin :</span></div>
               <div class="purchase-value purchase-value--inline"><input id="purchaseDetailStore" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div id="purchaseDetailRemarkRow" class="purchase-info-row" role="listitem" hidden>
-              <div class="purchase-label"><span aria-hidden="true" class="icon">📝</span><span>Remarque</span></div>
+              <div class="purchase-label"><span aria-hidden="true" class="icon">📝</span><span>Remarque :</span></div>
               <div class="purchase-value purchase-value--inline"><textarea id="purchaseDetailRemark" class="purchase-inline-field purchase-inline-field--textarea" rows="1" readonly></textarea></div>
             </div>
             <div class="purchase-info-row" role="listitem">
-              <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Créé par</span></div>
+              <div class="purchase-label"><img src="Icon/Utilisateur.png" alt="" aria-hidden="true" class="icon" /><span>Créé par :</span></div>
               <div id="purchaseDetailUser" class="purchase-value">Utilisateur</div>
             </div>
             <div class="purchase-info-row" role="listitem">
-              <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date</span></div>
+              <div class="purchase-label"><img src="Icon/Date et Heure.png" alt="" aria-hidden="true" class="icon" /><span>Date :</span></div>
               <div id="purchaseDetailFullDate" class="purchase-value">Date non définie</div>
             </div>
           </article>


### PR DESCRIPTION
### Motivation
- Rendre la carte d'information de la page `purchase-detail` plus compacte en affichant chaque libellé et sa valeur sur une seule ligne tout en conservant les icônes existantes.

### Description
- Ajout de règles CSS ciblées sous `body[data-page="purchase-detail"]` pour transformer chaque `.purchase-info-row` en grille à deux colonnes et aligner l'icône + libellé et la valeur sur une même ligne.
- Mise à jour de `purchase-detail.html` pour ajouter les deux-points après les libellés `Quantité`, `Magasin`, `Remarque`, `Créé par` et `Date` afin d'homogénéiser l'affichage.
- Aucune modification de la logique JavaScript, des données, des comportements des composants existants ou du responsive n'a été effectuée.

### Testing
- `git diff --check` et `git status` ont été exécutés et n'ont pas signalé d'erreur.
- Un serveur local a été lancé avec `python3 -m http.server` pour une vérification rapide (processus démarré avec succès).
- La vérification de l'environnement d'exécution a montré que `playwright` n'est pas installé (`playwright no`) et qu'aucun navigateur headless n'est disponible, donc les captures visuelles automatisées n'ont pas été exécutées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7229f02b088327b04f4df3f32ed2df)