### PR TITLE
Add 'Paquet' unit option for purchases

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3521,7 +3521,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         showPurchaseFieldError(purchaseQty, purchaseQtyError, 'Quantité invalide');
         return;
       }
-      if (!['Pcs', 'm'].includes(unit)) {
+      if (!['Pcs', 'm', 'Paquet'].includes(unit)) {
         showPurchaseFieldError(purchaseUnit, purchaseUnitError, 'Unité invalide');
         return;
       }
@@ -5053,7 +5053,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     purchaseUnit?.addEventListener('change', () => {
       const unit = String(purchaseUnit.value || '').trim();
-      if (['Pcs', 'm'].includes(unit)) {
+      if (['Pcs', 'm', 'Paquet'].includes(unit)) {
         clearPurchaseFieldError(purchaseUnit, purchaseUnitError);
       }
     });

--- a/page2.html
+++ b/page2.html
@@ -246,6 +246,7 @@
               <select id="purchaseUnit">
                 <option value="Pcs">Pcs</option>
                 <option value="m">m</option>
+                <option value="Paquet">Paquet</option>
               </select>
               <p id="purchaseUnitError" class="form-error form-error--field" aria-live="polite"></p>
             </label>


### PR DESCRIPTION
### Motivation
- Add a new unit option `Paquet` to the "Achat matériel" unit selector so it can be selected, saved, shown and modified like existing units without changing business logic, database structure or selector styling.
- Maintain existing behavior and validation paths so `Paquet` is accepted wherever units are validated or used.

### Description
- Inserted `<option value="Paquet">Paquet</option>` into the purchase unit `<select>` in `page2.html` so the option appears in the UI.
- Updated unit validation and change handling in `js/app.js` to include `Paquet` by changing checks to `['Pcs', 'm', 'Paquet']` so saving and error-clearing behave identically to other units.
- No other files, business logic, database schema, or CSS/styles were modified.

### Testing
- Ran `git diff --check` on the changes which produced no warnings or errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72b89b1060832791691ebcbc7ff4d6)