### PR TITLE
Amélioration des suggestions du champ « Magasin » (persistance, tri, déduplication)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3402,10 +3402,55 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
 
+    function normalizePurchaseStoreSuggestionKey(store) {
+      return String(store || '').trim().toLowerCase();
+    }
+
+    function buildPurchaseStoreSuggestionList(extraSuggestions = []) {
+      const suggestionsByKey = new Map();
+      [...defaultPurchaseStoreSuggestions, ...extraSuggestions].forEach((store) => {
+        const cleanStore = String(store || '').trim();
+        const key = normalizePurchaseStoreSuggestionKey(cleanStore);
+        if (!key || suggestionsByKey.has(key)) {
+          return;
+        }
+        suggestionsByKey.set(key, cleanStore);
+      });
+      return Array.from(suggestionsByKey.values()).sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
+    }
+
+    function loadStoredPurchaseStoreSuggestions() {
+      try {
+        const storedValue = window.localStorage.getItem(purchaseStoreSuggestionsStorageKey);
+        const parsedValue = JSON.parse(storedValue || '[]');
+        return Array.isArray(parsedValue) ? parsedValue : [];
+      } catch (_error) {
+        return [];
+      }
+    }
+
+    function savePurchaseStoreSuggestions() {
+      try {
+        window.localStorage.setItem(purchaseStoreSuggestionsStorageKey, JSON.stringify(purchaseStoreSuggestionSource));
+      } catch (_error) {
+        // Ignore localStorage restrictions.
+      }
+    }
+
+    function addPurchaseStoreSuggestion(store) {
+      const cleanStore = String(store || '').trim();
+      const key = normalizePurchaseStoreSuggestionKey(cleanStore);
+      if (!key || purchaseStoreSuggestionSource.some((suggestion) => normalizePurchaseStoreSuggestionKey(suggestion) === key)) {
+        return;
+      }
+      purchaseStoreSuggestionSource = buildPurchaseStoreSuggestionList([cleanStore, ...purchaseStoreSuggestionSource]);
+      savePurchaseStoreSuggestions();
+    }
+
     function getPurchaseStoreMatches(query) {
       const normalizedQuery = String(query || '').trim().toLowerCase();
       if (!normalizedQuery) {
-        return [];
+        return purchaseStoreSuggestionSource.slice(0, 8);
       }
 
       return purchaseStoreSuggestionSource
@@ -3670,6 +3715,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           collection(firebaseDb, 'sites', siteId, 'achatsMateriels'),
           purchasePayload,
         );
+        addPurchaseStoreSuggestion(store);
         purchaseModal?.close();
         resetPurchaseForm();
         await loadPurchasesForCurrentSite();
@@ -4517,7 +4563,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let hasBlockingItemNumberError = false;
     let itemStoreOtherHideTimer = null;
     const itemStoreOtherTransitionDurationMs = 200;
-    const purchaseStoreSuggestionSource = ['ABC', 'SANIFER', 'AQUAMAD', 'OCEAN TRADE', 'MASTER TRADE', 'BATIMAX', 'METAPRO'];
+    const defaultPurchaseStoreSuggestions = ['ABC', 'SANIFER', 'AQUAMAD', 'OCEAN TRADE', 'MASTER TRADE', 'BATIMAX', 'METAPRO'];
+    const purchaseStoreSuggestionsStorageKey = 'purchaseStoreSuggestions';
+    let purchaseStoreSuggestionSource = buildPurchaseStoreSuggestionList(loadStoredPurchaseStoreSuggestions());
     let visiblePurchaseStoreSuggestions = [];
     let activePurchaseStoreSuggestionIndex = -1;
     const ITEM_DIALOG_MODE_CREATE = 'create';
@@ -5177,10 +5225,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (purchaseStore && purchaseStoreSuggestions) {
       purchaseStore.addEventListener('focus', () => {
-        if (!String(purchaseStore.value || '').trim()) {
-          hidePurchaseStoreSuggestions();
-          return;
-        }
         renderPurchaseStoreSuggestions(purchaseStore.value);
       });
 


### PR DESCRIPTION
### Motivation
- Améliorer l'expérience du champ « Magasin » dans l'onglet Achat en conservant le système de suggestions existant tout en permettant d'ajouter et de réutiliser des magasins saisis librement.
- Garantir l'absence de doublons en ignorant la casse et les espaces en début/fin pour les suggestions.
- Rendre les suggestions persistantes entre rechargements et les trier automatiquement par ordre alphabétique.

### Description
- Ajout de la liste par défaut `defaultPurchaseStoreSuggestions` contenant `['ABC','SANIFER','AQUAMAD','OCEAN TRADE','MASTER TRADE','BATIMAX','METAPRO']` et conservation de la logique de filtrage/affichage existante dans le champ `purchaseStore` (fichier modifié : `js/app.js`).
- Implémentation de la persistance via `localStorage` avec la clé `purchaseStoreSuggestions`, et fonctions utilitaires `normalizePurchaseStoreSuggestionKey`, `buildPurchaseStoreSuggestionList`, `loadStoredPurchaseStoreSuggestions`, `savePurchaseStoreSuggestions` et `addPurchaseStoreSuggestion` pour normaliser, dédupliquer (insensible à la casse et aux espaces) et trier les suggestions.
- Modification de `getPurchaseStoreMatches` pour afficher les suggestions par défaut (jusqu'à 8) lorsque la saisie est vide et maintien du filtrage en cours de saisie et du rendu mis en surbrillance via `buildPurchaseStoreHighlightedText`.
- Ajout d'un appel à `addPurchaseStoreSuggestion(store)` uniquement après l'enregistrement réussi d'un achat pour ajouter automatiquement le nouveau magasin aux suggestions sans modifier d'autres comportements ou styles.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/app.js` qui a réussi.
- Vérification des différences et des erreurs avec `git diff --check` qui a réussi.
- Le changement a été commité localement (`Improve purchase store suggestions`) et n'affecte que `js/app.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72bef0c1648327aadb0e565289a2ea)