### PR TITLE
Style: update 'Suppression impossible' overlay (creator name + email, OK button blue)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5406,6 +5406,28 @@ body[data-page="site-detail"] .item-delete-confirm-button--danger {
   color: #fff;
 }
 
+body[data-page="site-detail"] .site-delete-forbidden-creator {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin: 0.35rem 0 0.25rem;
+}
+
+body[data-page="site-detail"] .site-delete-forbidden-creator strong {
+  color: var(--text);
+  font-weight: 800;
+}
+
+body[data-page="site-detail"] .site-delete-forbidden-creator span {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+body[data-page="site-detail"] .site-delete-forbidden-close-button {
+  background: var(--primary-color);
+  color: #fff;
+}
+
 body[data-page="site-detail"] .list-card__button:active {
   transform: scale(0.98);
   transition: transform 0.2s ease;

--- a/js/app.js
+++ b/js/app.js
@@ -1132,6 +1132,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let currentSites = [];
     let itemCountsBySite = {};
     let userNamesById = {};
+    let userEmailsById = {};
     let currentPermissions = permissions;
     let isAuthenticated = Boolean(authState?.isAuthenticated);
     let siteIdPendingLock = null;
@@ -1722,8 +1723,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           }
           return accumulator;
         }, {});
+        userEmailsById = users.reduce((accumulator, user) => {
+          const email = String(user?.email || '').trim();
+          if (user?.id && email) {
+            accumulator[user.id] = email;
+          }
+          return accumulator;
+        }, {});
       } catch (_error) {
         userNamesById = {};
+        userEmailsById = {};
       }
       renderSites();
     }
@@ -1970,6 +1979,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return String(site?.createdByName || '').trim() || resolveActorLabel(site?.createdBy, userNamesById, 'Utilisateur');
     }
 
+    function getSiteCreatorEmail(site) {
+      return String(site?.createdByEmail || '').trim() || userEmailsById?.[String(site?.createdBy || '')] || '';
+    }
+
     function canCurrentUserDeleteSite(site) {
       if (currentPermissions?.isAdmin) {
         return true;
@@ -1990,19 +2003,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           <article class="maintenance-card item-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="siteDeleteForbiddenTitle">
             <h3 id="siteDeleteForbiddenTitle">Suppression impossible.</h3>
             <p>Seul le créateur du site peut supprimer ce site.</p>
-            <p id="siteDeleteForbiddenCreator"></p>
+            <div class="site-delete-forbidden-creator" id="siteDeleteForbiddenCreator">
+              <strong id="siteDeleteForbiddenCreatorName"></strong>
+              <span id="siteDeleteForbiddenCreatorEmail"></span>
+            </div>
             <div class="modal-actions item-delete-confirm-actions">
-              <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--cancel" id="siteDeleteForbiddenCloseButton">OK</button>
+              <button type="button" class="btn item-delete-confirm-button site-delete-forbidden-close-button" id="siteDeleteForbiddenCloseButton">OK</button>
             </div>
           </article>
         `;
         document.body.appendChild(overlay);
       }
 
-      const creator = overlay.querySelector('#siteDeleteForbiddenCreator');
+      const creatorName = overlay.querySelector('#siteDeleteForbiddenCreatorName');
+      const creatorEmail = overlay.querySelector('#siteDeleteForbiddenCreatorEmail');
       const closeButton = overlay.querySelector('#siteDeleteForbiddenCloseButton');
-      if (creator) {
-        creator.textContent = `Créateur : ${getSiteCreatorName(site)}`;
+      if (creatorName) {
+        creatorName.textContent = getSiteCreatorName(site);
+      }
+      if (creatorEmail) {
+        creatorEmail.textContent = getSiteCreatorEmail(site);
       }
 
       const close = () => {


### PR DESCRIPTION
### Motivation
- Adapter uniquement le rendu de l’overlay « Suppression impossible » pour afficher le nom du créateur en gras et son e‑mail en dessous, sans modifier la logique de suppression ni son comportement.

### Description
- Remplacement du paragraphe `#siteDeleteForbiddenCreator` par une structure avec `#siteDeleteForbiddenCreatorName` (`<strong>`) et `#siteDeleteForbiddenCreatorEmail` (`<span>`) dans `js/app.js` pour séparer visuellement le nom et l’e‑mail.
- Ajout de la fonction `getSiteCreatorEmail(site)` et d’une table `userEmailsById` alimentée dans `loadUserNames()` pour afficher l’e‑mail du créateur sans changer la logique d’autorisation existante.
- Modification de la classe du bouton de fermeture pour appliquer le style spécifique `site-delete-forbidden-close-button` sans altérer le comportement du `onclick` ni la fermeture de l’overlay.
- Ajout de styles scoped dans `css/style.css` pour afficher le nom en gras, l’e‑mail en gris avec une taille légèrement plus petite, et pour rendre le bouton `OK` en bleu principal avec texte blanc (`var(--primary-color)`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` qui a réussi.
- Exécution de `git diff --check` pour détecter problèmes de diff/whitespace qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72c6deb81c83278a6d631c4e832e41)