### PR TITLE
Limiter à 6 suppressions/jour les OUT non-créés par l’utilisateur

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4113,6 +4113,78 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    function ensureOutDeleteLimitDialog() {
+      let overlay = document.getElementById('outDeleteLimitOverlay');
+      if (overlay) {
+        return overlay;
+      }
+
+      overlay = document.createElement('div');
+      overlay.id = 'outDeleteLimitOverlay';
+      overlay.className = 'maintenance-overlay item-delete-confirm-overlay';
+      overlay.hidden = true;
+      overlay.innerHTML = `
+        <article class="maintenance-card item-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="outDeleteLimitTitle">
+          <h3 id="outDeleteLimitTitle">Limite de suppression atteinte</h3>
+          <p>Vous avez atteint la limite de <strong>6 suppressions de OUT par jour</strong></p>
+          <p>Veuillez réessayer demain.</p>
+          <div class="modal-actions item-delete-confirm-actions">
+            <button type="button" class="btn item-delete-confirm-button site-delete-forbidden-close-button" id="outDeleteLimitCloseButton">OK</button>
+          </div>
+        </article>
+      `;
+      document.body.appendChild(overlay);
+      return overlay;
+    }
+
+    function showOutDeleteLimitDialog() {
+      const overlay = ensureOutDeleteLimitDialog();
+      const closeButton = overlay.querySelector('#outDeleteLimitCloseButton');
+      if (!closeButton) {
+        return;
+      }
+
+      const closeAnimationDurationMs = 170;
+      let closeAnimationTimer = null;
+      let isClosing = false;
+      const cleanup = () => {
+        if (closeAnimationTimer) {
+          window.clearTimeout(closeAnimationTimer);
+          closeAnimationTimer = null;
+        }
+        overlay.hidden = true;
+        overlay.classList.remove('is-open');
+        overlay.onclick = null;
+        closeButton.onclick = null;
+        document.removeEventListener('keydown', handleKeyDown);
+      };
+      const close = () => {
+        if (isClosing) {
+          return;
+        }
+        isClosing = true;
+        overlay.classList.remove('is-open');
+        closeAnimationTimer = window.setTimeout(cleanup, closeAnimationDurationMs);
+      };
+      const handleKeyDown = (event) => {
+        if (event.key === 'Escape') {
+          close();
+        }
+      };
+
+      closeButton.onclick = close;
+      overlay.onclick = (event) => {
+        if (event.target === overlay) {
+          close();
+        }
+      };
+      document.addEventListener('keydown', handleKeyDown);
+      overlay.hidden = false;
+      window.requestAnimationFrame(() => {
+        overlay.classList.add('is-open');
+      });
+    }
+
     function closeActiveTransientLayer() {
       if (typeof itemActionState.closeConfirmation === 'function') {
         itemActionState.closeConfirmation();
@@ -4260,6 +4332,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             return;
           }
           const removedSnapshot = await StorageService.removeItem(siteId, itemId);
+          if (removedSnapshot?.limitReached) {
+            showOutDeleteLimitDialog();
+            return;
+          }
           if (!removedSnapshot) {
             UiService.showToast('Suppression impossible.');
             return;

--- a/js/storage.js
+++ b/js/storage.js
@@ -738,6 +738,45 @@ function makePageItemsCollection(pageName) {
   return collection(state.db, 'pages', pageName, 'items');
 }
 
+function getOutDeletionLimitDateKey(referenceDate = new Date()) {
+  const year = referenceDate.getFullYear();
+  const month = String(referenceDate.getMonth() + 1).padStart(2, '0');
+  const day = String(referenceDate.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function outDeletionLimitDocRef(userId, dateKey = getOutDeletionLimitDateKey()) {
+  return doc(state.db, 'users', userId, 'outDeletionLimits', dateKey);
+}
+
+async function hasReachedOutDeletionLimit(userId, limit = 6) {
+  if (!userId) {
+    return true;
+  }
+  const limitSnap = await getDoc(outDeletionLimitDocRef(userId));
+  const currentCount = Number(limitSnap.exists() ? limitSnap.data()?.count : 0);
+  return currentCount >= limit;
+}
+
+async function recordOutDeletionLimitUsage(userId) {
+  if (!userId) {
+    return;
+  }
+  const dateKey = getOutDeletionLimitDateKey();
+  const limitRef = outDeletionLimitDocRef(userId, dateKey);
+  const limitSnap = await getDoc(limitRef);
+  const currentCount = Number(limitSnap.exists() ? limitSnap.data()?.count : 0);
+  await setDoc(
+    limitRef,
+    {
+      date: dateKey,
+      count: currentCount + 1,
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+}
+
 function historyCollection() {
   return collection(state.db, 'historiques');
 }
@@ -1597,12 +1636,25 @@ async function removeItem(siteId, itemId) {
     return null;
   }
 
+  const itemToRemove = items[itemIndex];
+  const profile = await getCurrentUserProfile();
+  const currentUserId = String(state.userId || profile?.id || '').trim();
+  const creatorId = String(itemToRemove?.createdBy || itemToRemove?.ownerId || '').trim();
+  const isAdmin = normalizeRole(profile?.role) === 'admin' || isAdminEmail(profile?.email);
+  const shouldCountDeletion = !isAdmin && (!currentUserId || !creatorId || currentUserId !== creatorId);
+  if (shouldCountDeletion && await hasReachedOutDeletionLimit(currentUserId)) {
+    return { limitReached: true };
+  }
+
   await deleteDoc(doc(state.db, 'pages', 'page2', 'items', itemId));
 
   const [item] = items.splice(itemIndex, 1);
   const detailsKey = `${siteId}:${itemId}`;
   const details = clone(state.detailsByItem.get(detailsKey) || []);
   state.detailsByItem.delete(detailsKey);
+  if (shouldCountDeletion) {
+    await recordOutDeletionLimitUsage(currentUserId);
+  }
 
   await appendHistoryEntry(`a supprimé ${item.numero}`, { siteId });
   persistOfflineState();


### PR DESCRIPTION
### Motivation
- Ajouter une règle de quota qui empêche les utilisateurs non-administrateurs et non-créateurs d’effacer plus de 6 OUT par jour, tout en laissant les administrateurs et les créateurs libres de supprimer sans limite.

### Description
- Ajout d’un compteur journalier stocké en Firestore sous `users/{userId}/outDeletionLimits/{YYYY-MM-DD}` et de fonctions utilitaires `getOutDeletionLimitDateKey`, `outDeletionLimitDocRef`, `hasReachedOutDeletionLimit` et `recordOutDeletionLimitUsage` dans `js/storage.js`.
- Mise à jour de `removeItem` (dans `js/storage.js`) pour détecter si l’utilisateur est administrateur ou créateur, compter uniquement les suppressions d’OUT où l’utilisateur n’est pas le créateur, bloquer la suppression lorsqu’il a atteint la limite et incrémenter le compteur après une suppression autorisée.
- Ajout d’un overlay d’information dans `js/app.js` (`ensureOutDeleteLimitDialog` / `showOutDeleteLimitDialog`) affichant le message demandé (« Limite de suppression atteinte ») et branchement de cet overlay au flux de suppression pour informer l’utilisateur quand la limite est atteinte.
- Modifications limitées aux fichiers `js/storage.js` et `js/app.js` et conçues pour ne pas altérer les autres fonctionnalités, styles ou la logique existante (achat matériel et autres suppressions conservent leur comportement).

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check js/storage.js && node --check js/app.js`, qui a réussi. 
- Aucun autre test automatisé ajouté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72ca0cbb308327a46c3895c09170e5)