### PR TITLE
Renommer le rôle « Standard » en « Adjoint Admin » et lui donner les droits Administrateur

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -732,10 +732,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
   function buildPermissions(profile) {
     const username = String(profile?.username || '');
-    const role = String(profile?.role || 'limite').toLowerCase();
+    const role = String(profile?.role || 'limite').trim().toLowerCase();
     const userId = String(profile?.id || '').trim();
-    const isAdmin = username === 'Admin' || role === 'admin';
-    const isStandard = role === 'standard';
+    const isAdjointAdmin = role === 'standard' || role === 'adjoint' || role === 'adjoint admin';
+    const isAdmin = username === 'Admin' || role === 'admin' || isAdjointAdmin;
+    const isStandard = isAdjointAdmin;
     const isLecture = role === 'lecture';
     if (isAdmin) {
       return {
@@ -7518,7 +7519,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const maintenanceStatusText = requireElement('maintenanceStatusText');
     backButton?.addEventListener('click', () => UiService.navigate('index.html'));
 
-    const roleLabel = { standard: 'Standard', limite: 'Limité' };
+    const roleLabel = { standard: 'Adjoint Admin', limite: 'Limité' };
 
     function cleanText(value) {
       return String(value || '').trim();
@@ -7535,7 +7536,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function resolveRole(user) {
       const role = cleanText(user?.role).toLowerCase();
-      return role === 'standard' || role === 'adjoint' || role === 'admin' ? 'standard' : 'limite';
+      return role === 'standard' || role === 'adjoint' || role === 'adjoint admin' || role === 'admin' ? 'standard' : 'limite';
     }
 
     function resolveMaintenanceAuthorized(user) {

--- a/js/maintenance-banner.js
+++ b/js/maintenance-banner.js
@@ -35,7 +35,7 @@ function isPrimaryAdminEmail(email) {
 function resolveIsAdmin(profile, authUser) {
   const username = String(profile?.username || profile?.name || '').trim();
   const role = normalizeRole(profile?.role);
-  return username === 'Admin' || role === 'admin' || isPrimaryAdminEmail(profile?.email || authUser?.email);
+  return username === 'Admin' || role === 'admin' || role === 'standard' || role === 'adjoint' || role === 'adjoint admin' || isPrimaryAdminEmail(profile?.email || authUser?.email);
 }
 
 function ensureMaintenanceStyles() {

--- a/js/storage.js
+++ b/js/storage.js
@@ -43,7 +43,7 @@ function normalizeRole(value) {
   if (role === 'admin') {
     return 'admin';
   }
-  if (role === 'adjoint' || role === 'full' || role === 'standard') {
+  if (role === 'adjoint' || role === 'adjoint admin' || role === 'full' || role === 'standard') {
     return 'standard';
   }
   if (role === 'lecture') {
@@ -61,7 +61,7 @@ function serializeRole(role) {
     return 'admin';
   }
   if (normalized === 'standard') {
-    return 'Standard';
+    return 'Adjoint Admin';
   }
   return 'Limité';
 }
@@ -1511,7 +1511,8 @@ async function removeSite(siteId) {
   const profile = await getCurrentUserProfile();
   const currentUserId = String(state.userId || profile?.id || '').trim();
   const creatorId = String(siteToRemove?.createdBy || siteToRemove?.ownerId || '').trim();
-  const isAdmin = normalizeRole(profile?.role) === 'admin' || isAdminEmail(profile?.email);
+  const normalizedRole = normalizeRole(profile?.role);
+  const isAdmin = normalizedRole === 'admin' || normalizedRole === 'standard' || isAdminEmail(profile?.email);
   if (!isAdmin && (!currentUserId || !creatorId || currentUserId !== creatorId)) {
     return null;
   }
@@ -1640,7 +1641,8 @@ async function removeItem(siteId, itemId) {
   const profile = await getCurrentUserProfile();
   const currentUserId = String(state.userId || profile?.id || '').trim();
   const creatorId = String(itemToRemove?.createdBy || itemToRemove?.ownerId || '').trim();
-  const isAdmin = normalizeRole(profile?.role) === 'admin' || isAdminEmail(profile?.email);
+  const normalizedRole = normalizeRole(profile?.role);
+  const isAdmin = normalizedRole === 'admin' || normalizedRole === 'standard' || isAdminEmail(profile?.email);
   const shouldCountDeletion = !isAdmin && (!currentUserId || !creatorId || currentUserId !== creatorId);
   if (shouldCountDeletion && await hasReachedOutDeletionLimit(currentUserId)) {
     return { limitReached: true };

--- a/users.html
+++ b/users.html
@@ -151,7 +151,8 @@
       function isAdminUser(user) {
         const email = toLower(user?.email);
         const username = cleanString(user?.username || user?.name);
-        return email === 'andrainaaina@gmail.com' || username === 'Admin' || toLower(user?.role) === 'admin';
+        const role = toLower(user?.role);
+        return email === 'andrainaaina@gmail.com' || username === 'Admin' || role === 'admin' || role === 'standard' || role === 'adjoint' || role === 'adjoint admin';
       }
 
       function resolveRole(user) {
@@ -160,8 +161,8 @@
         if (normalized === 'admin') {
           return 'admin';
         }
-        if (normalized === 'standard' || normalized === 'adjoint') {
-          return 'Standard';
+        if (normalized === 'standard' || normalized === 'adjoint' || normalized === 'adjoint admin') {
+          return 'Adjoint Admin';
         }
         return 'Limité';
       }
@@ -310,7 +311,7 @@
                 <td>
                   ${isPrimaryAdmin ? 'admin' : `
                   <select class="users-role-select" data-user-role="${user.id}">
-                    <option value="Standard" ${role === 'Standard' ? 'selected' : ''}>Standard</option>
+                    <option value="Adjoint Admin" ${role === 'Adjoint Admin' ? 'selected' : ''}>Adjoint Admin</option>
                     <option value="Limité" ${role === 'Limité' ? 'selected' : ''}>Limité</option>
                   </select>`}
                 </td>
@@ -336,7 +337,7 @@
         tableBody.querySelectorAll('[data-user-role]').forEach((select) => {
           select.addEventListener('change', async () => {
             const userId = select.getAttribute('data-user-role');
-            const selected = toLower(select.value) === 'standard' ? 'Standard' : 'Limité';
+            const selected = toLower(select.value) === 'adjoint admin' ? 'Adjoint Admin' : 'Limité';
             try {
               await setDoc(
                 doc(firebaseDb, 'users', userId),


### PR DESCRIPTION
### Motivation
- Harmoniser l'affichage et la gestion des rôles en remplaçant le libellé « Standard » par « Adjoint Admin » partout dans l'application tout en conservant le rôle « Limité » inchangé.
- Faire en sorte que le rôle rebaptisé dispose exactement des mêmes permissions et de la même interface que l'Administrateur pour les vérifications d'accès et l'affichage.

### Description
- Remplacement du label et des options d'interface : le libellé `Standard` est devenu `Adjoint Admin` dans le rendu des sélecteurs et labels (modifications principalement dans `users.html` et `js/app.js`).
- Résolution et sérialisation des rôles : `normalizeRole` accepte désormais `adjoint admin` et `serializeRole` renvoie `Adjoint Admin` pour le rôle normalisé `standard` (modifications dans `js/storage.js`).
- Autorisations et affichages : les vérifications d'administration (affichage de l'UI, accès aux pages et actions réservées) traitent désormais les rôles `standard`, `adjoint` et `adjoint admin` comme ayant les droits d'Administrateur ; la construction des permissions (`buildPermissions`) a été adaptée pour exposer ces droits dans `js/app.js` et les vérifications de bannière de maintenance ont été ajustées (`js/maintenance-banner.js`).
- Persistance des changements de rôle : le flux de mise à jour de rôle côté UI enregistre `Adjoint Admin` dans Firestore et le mapping valeur/affichage a été adapté pour conserver un comportement identique à l'ancien rôle Standard (`users.html`, `js/storage.js`).

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check js/app.js && node --check js/storage.js && node --check js/maintenance-banner.js` a réussi sans erreurs.
- Contrôles statiques effectués : `git diff --check` et recherche de références (`rg`) ont été utilisés pour valider les remplacements et n'ont montré aucun problème détecté automatiquement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72e10d6f7483248db7869f27fd4eb9)