### PR TITLE
Ajouter une recherche instantanée sur la page « Gestion Admin »

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2296,6 +2296,35 @@ body[data-page="users-management"] .pending-user-card__actions {
   justify-content: flex-end;
 }
 
+
+body[data-page="users-management"] .users-search-field {
+  margin-bottom: 0.85rem;
+}
+
+body[data-page="users-management"] .users-search-field__control {
+  position: relative;
+  width: min(100%, 28rem);
+}
+
+body[data-page="users-management"] .users-search-field__icon {
+  position: absolute;
+  left: 0.95rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  line-height: 1;
+}
+
+body[data-page="users-management"] .users-search-field input {
+  padding-left: 2.65rem;
+}
+
+body[data-page="users-management"] .users-empty-cell {
+  color: var(--text-muted);
+  font-weight: 700;
+  text-align: center;
+}
+
 body[data-page="users-management"] .table-wrapper--users {
   flex: 1 1 auto;
   min-height: 0;

--- a/js/app.js
+++ b/js/app.js
@@ -7514,6 +7514,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     const tableBody = requireElement('usersTableBody');
+    const usersSearchInput = document.getElementById('usersSearchInput');
     const backButton = requireElement('usersBackButton');
     const maintenanceToggle = requireElement('maintenanceToggle');
     const maintenanceStatusText = requireElement('maintenanceStatusText');
@@ -7523,6 +7524,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     function cleanText(value) {
       return String(value || '').trim();
+    }
+
+    function normalizeSearchText(value) {
+      return cleanText(value)
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();
     }
 
     function resolveDisplayName(user) {
@@ -7537,6 +7545,40 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     function resolveRole(user) {
       const role = cleanText(user?.role).toLowerCase();
       return role === 'standard' || role === 'adjoint' || role === 'adjoint admin' || role === 'admin' ? 'standard' : 'limite';
+    }
+
+    function splitFullName(value) {
+      return cleanText(value).replace(/\s+/g, ' ').split(' ').filter(Boolean);
+    }
+
+    function resolveFirstName(user) {
+      const explicitFirstName = cleanText(user?.firstName || user?.prenom || user?.['prénom']);
+      if (explicitFirstName) {
+        return explicitFirstName;
+      }
+      const nameParts = splitFullName(resolveDisplayName(user));
+      return nameParts.length > 1 ? nameParts.slice(0, -1).join(' ') : nameParts[0] || '';
+    }
+
+    function resolveLastName(user) {
+      const explicitLastName = cleanText(user?.lastName || user?.nom);
+      if (explicitLastName) {
+        return explicitLastName;
+      }
+      const nameParts = splitFullName(resolveDisplayName(user));
+      return nameParts.length > 1 ? nameParts[nameParts.length - 1] : resolveDisplayName(user);
+    }
+
+    function userMatchesSearch(user, query) {
+      if (!query) {
+        return true;
+      }
+      return [
+        resolveLastName(user),
+        resolveFirstName(user),
+        resolveDisplayName(user),
+        user?.email,
+      ].some((value) => normalizeSearchText(value).includes(query));
     }
 
     function resolveMaintenanceAuthorized(user) {
@@ -7634,7 +7676,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     }
 
     function renderUsers(users, pointsByUser = {}) {
-      tableBody.innerHTML = sortUsersByPointsAndName(users, pointsByUser)
+      const sortedUsers = sortUsersByPointsAndName(users, pointsByUser);
+      if (!sortedUsers.length) {
+        tableBody.innerHTML = '<tr><td colspan="8" class="users-empty-cell">Aucun utilisateur trouvé.</td></tr>';
+        return;
+      }
+
+      tableBody.innerHTML = sortedUsers
         .map((user) => `
           <tr>
             <td class="users-point-cell">${Number(pointsByUser?.[user.id] || 0)}</td>
@@ -7731,12 +7779,19 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     let currentUsers = [];
     let currentPointsByUser = {};
+    let currentUsersSearchQuery = '';
     let lastActivityRefreshId = null;
 
     function renderCurrentUsers() {
       updateUsersCardHeader(currentUsers);
-      renderUsers(currentUsers, currentPointsByUser);
+      const filteredUsers = currentUsers.filter((user) => userMatchesSearch(user, currentUsersSearchQuery));
+      renderUsers(filteredUsers, currentPointsByUser);
     }
+
+    usersSearchInput?.addEventListener('input', () => {
+      currentUsersSearchQuery = normalizeSearchText(usersSearchInput.value);
+      renderCurrentUsers();
+    });
 
     lastActivityRefreshId = window.setInterval(renderCurrentUsers, 60000);
     window.addEventListener('pagehide', () => {

--- a/users.html
+++ b/users.html
@@ -88,6 +88,13 @@
         </div>
         <section class="surface-card table-card">
           <h2 class="section-title" id="usersCardHeader">Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">0</span><br />En ligne : <span class="users-card-stat users-card-stat--online">0</span></h2>
+          <div class="users-search-field input-group">
+            <label class="visually-hidden" for="usersSearchInput">Rechercher un utilisateur</label>
+            <div class="users-search-field__control">
+              <span class="users-search-field__icon" aria-hidden="true">🔍</span>
+              <input id="usersSearchInput" type="search" autocomplete="off" placeholder="Rechercher un utilisateur..." />
+            </div>
+          </div>
           <div class="table-wrapper table-wrapper--users">
             <table class="data-table">
               <thead>
@@ -123,6 +130,13 @@
 
       function toLower(value) {
         return cleanString(value).toLowerCase();
+      }
+
+      function normalizeSearchText(value) {
+        return cleanString(value)
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .toLowerCase();
       }
 
       function escapeHtml(value) {
@@ -271,6 +285,40 @@
         return `Il y a ${elapsedMonths} mois`;
       }
 
+      function splitFullName(value) {
+        return cleanString(value).replace(/\s+/g, ' ').split(' ').filter(Boolean);
+      }
+
+      function resolveFirstName(user) {
+        const explicitFirstName = cleanString(user.firstName || user.prenom || user['prénom']);
+        if (explicitFirstName) {
+          return explicitFirstName;
+        }
+        const nameParts = splitFullName(resolveDisplayName(user));
+        return nameParts.length > 1 ? nameParts.slice(0, -1).join(' ') : nameParts[0] || '';
+      }
+
+      function resolveLastName(user) {
+        const explicitLastName = cleanString(user.lastName || user.nom);
+        if (explicitLastName) {
+          return explicitLastName;
+        }
+        const nameParts = splitFullName(resolveDisplayName(user));
+        return nameParts.length > 1 ? nameParts[nameParts.length - 1] : resolveDisplayName(user);
+      }
+
+      function userMatchesSearch(user, query) {
+        if (!query) {
+          return true;
+        }
+        return [
+          resolveLastName(user),
+          resolveFirstName(user),
+          resolveDisplayName(user),
+          user.email,
+        ].some((value) => normalizeSearchText(value).includes(query));
+      }
+
       function sortUsersByPointsAndName(users, pointsByUser) {
         return [...users].sort((a, b) => {
           const pointsA = Number(pointsByUser?.[a.id] || 0);
@@ -288,7 +336,13 @@
           return;
         }
 
-        const rows = sortUsersByPointsAndName(users, pointsByUser)
+        const sortedUsers = sortUsersByPointsAndName(users, pointsByUser);
+        if (!sortedUsers.length) {
+          tableBody.innerHTML = '<tr><td colspan="8" class="users-empty-cell">Aucun utilisateur trouvé.</td></tr>';
+          return;
+        }
+
+        const rows = sortedUsers
           .map((user) => {
             const displayName = resolveDisplayName(user);
             const email = cleanString(user.email);
@@ -399,11 +453,13 @@
 
       let currentUsers = [];
       let currentPointsByUser = {};
+      let currentUsersSearchQuery = '';
       let lastActivityRefreshId = null;
 
       function renderCurrentUsers() {
         updateUsersCardHeader(currentUsers);
-        renderUsers(currentUsers, currentPointsByUser);
+        const filteredUsers = currentUsers.filter((user) => userMatchesSearch(user, currentUsersSearchQuery));
+        renderUsers(filteredUsers, currentPointsByUser);
       }
 
       lastActivityRefreshId = window.setInterval(renderCurrentUsers, 60000);
@@ -411,6 +467,12 @@
         if (lastActivityRefreshId) {
           window.clearInterval(lastActivityRefreshId);
         }
+      });
+
+      const usersSearchInput = document.getElementById('usersSearchInput');
+      usersSearchInput?.addEventListener('input', () => {
+        currentUsersSearchQuery = normalizeSearchText(usersSearchInput.value);
+        renderCurrentUsers();
       });
 
       const adminMessageFab = document.getElementById('adminMessageFab');
@@ -460,28 +522,6 @@
         }
         const selectedIds = new Set(selectedRecipientIds.map(String));
         return recipients.filter((user) => selectedIds.has(String(user.id)));
-      }
-
-      function splitFullName(value) {
-        return cleanString(value).replace(/\s+/g, ' ').split(' ').filter(Boolean);
-      }
-
-      function resolveFirstName(user) {
-        const explicitFirstName = cleanString(user.firstName || user.prenom || user['prénom']);
-        if (explicitFirstName) {
-          return explicitFirstName;
-        }
-        const nameParts = splitFullName(resolveDisplayName(user));
-        return nameParts.length > 1 ? nameParts.slice(0, -1).join(' ') : nameParts[0] || '';
-      }
-
-      function resolveLastName(user) {
-        const explicitLastName = cleanString(user.lastName || user.nom);
-        if (explicitLastName) {
-          return explicitLastName;
-        }
-        const nameParts = splitFullName(resolveDisplayName(user));
-        return nameParts.length > 1 ? nameParts[nameParts.length - 1] : resolveDisplayName(user);
       }
 
       function buildAdminMessageVariables(user) {


### PR DESCRIPTION
### Motivation
- Permettre aux administrateurs de retrouver rapidement des utilisateurs depuis la page "Gestion Admin" sans modifier les autres comportements ni l'ordre de tri existant.

### Description
- Ajout d'un champ de recherche au-dessus de la liste des utilisateurs dans `users.html` avec le placeholder `Rechercher un utilisateur...` et l'icône `🔍` à gauche, en réutilisant la classe `input-group` pour conserver le style existant.
- Implémentation du filtrage instantané côté client dans `js/app.js` en ajoutant la normalisation `normalizeSearchText` (suppression des accents via `NFD` + suppression des diacritiques) et une fonction `userMatchesSearch` qui recherche dans le `Nom`, `Prénom`, `Nom complet` et `Adresse e-mail` sans tenir compte des majuscules/accents.
- Le rendu utilise le filtrage avant d'appeler le tri existant (`sortUsersByPointsAndName`) afin de conserver le tri actuel (points puis nom) inchangé.
- Si aucun utilisateur ne correspond, affiche la ligne `Aucun utilisateur trouvé.`; si le champ est vide, tous les utilisateurs sont affichés.
- Styles ajoutés dans `css/style.css` pour positionner l'icône et assurer l'alignement/espacement identiques aux autres champs.

### Testing
- `node --check /tmp/users-inline.js` — succès (vérification syntaxique du script inline modifié). 
- `node --check js/app.js` — succès (vérification syntaxique du module principal modifié).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72e4046c6c8324a3af5e6e9d19babe)