### PR TITLE
Ajouter pied de page fixe en bas de la sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6688,8 +6688,7 @@ body[data-page="home"] #homeMenuButton {
   transform: translateX(-105%);
   transition: transform 300ms cubic-bezier(0.22, 1, 0.36, 1);
   z-index: 1999;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .header-menu__drawer.is-open {
@@ -6759,6 +6758,10 @@ body.sidebar-open {
   flex-direction: column;
   gap: 8px;
   margin-top: 10px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .sidebar-item {
@@ -6800,6 +6803,28 @@ body.sidebar-open {
 
 .sidebar-item.active {
   background: #eef5fb;
+}
+
+.sidebar-footer {
+  flex: 0 0 auto;
+  margin-top: auto;
+  padding-top: 14px;
+  text-align: center;
+  font-size: 12px;
+  line-height: 1.25;
+  color: #8a94a6;
+}
+
+.sidebar-footer p {
+  margin: 0;
+}
+
+.sidebar-footer p + p {
+  margin-top: 3px;
+}
+
+.sidebar-footer__title {
+  font-weight: 600;
 }
 
 html,

--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
             Gestion des utilisateurs
           </button>
         </div>
+        <footer class="sidebar-footer" role="none">
+          <p class="sidebar-footer__title">Suivi matériel © 2026</p>
+          <p>Tous droits réservés</p>
+        </footer>
       </aside>
 
 


### PR DESCRIPTION
### Motivation
- Ajouter un pied de page visible en permanence en bas du menu latéral affichant «Suivi matériel © 2026» et «Tous droits réservés» sans modifier le comportement ou la disposition existante.
- Le pied doit être centré, petite taille (12px–13px), couleur gris discrète, première ligne semi-grasse et rester fixé pendant que la liste du menu défile.

### Description
- Ajouté un élément `footer` avec la classe `sidebar-footer` dans `index.html` contenant les deux lignes demandées.
- Changé le conteneur de la drawer pour éviter les scrolls conflictuels en remplaçant `overflow-y: auto; overflow-x: hidden;` par `overflow: hidden;` sur `.header-menu__drawer` dans `css/style.css`.
- Rendu la zone des actions défilable en ajoutant `flex: 1 1 auto; min-height: 0; overflow-y: auto; overflow-x: hidden;` sur `.sidebar-actions` pour que le contenu du menu défile indépendamment du pied de page.
- Ajouté les styles de `.sidebar-footer` (centrage, `font-size: 12px`, couleur gris, espacement entre lignes, et `font-weight: 600` pour la première ligne) et règles associées pour respecter les exigences visuelles.

### Testing
- Exécuté `git diff --check` et le contrôle s'est terminé sans erreurs.
- Vérifié l'état avec `git status --short` et validé les modifications puis réalisé le commit avec message `Add fixed sidebar footer` (commit créé avec succès).
- Démarré un serveur statique local via `python3 -m http.server` et inspecté le début des fichiers `index.html` et `css/style.css` pour confirmer l'injection du HTML et du CSS modifiés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72e7b21a948324853dc4acc239f837)