### PR TITLE
Use displayName/username for site lock/unlock actors on page 1

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -133,9 +133,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return username || 'Utilisateur';
   }
 
-  function resolveCreatorLockLabel(site, userMap) {
-    const creatorName = resolveActorLabel(site?.createdBy || site?.ownerId, userMap, site?.createdByName);
-    return creatorName === 'Utilisateur' ? 'Utilisateur inconnu' : creatorName;
+  function resolveSiteLockActorLabel(actorEmail, fallbackName, userMapByEmail) {
+    const directName = String(fallbackName || '').trim();
+    if (directName) {
+      return directName;
+    }
+    const emailKey = String(actorEmail || '').trim().toLowerCase();
+    if (emailKey && userMapByEmail?.[emailKey]) {
+      return userMapByEmail[emailKey];
+    }
+    return 'Utilisateur inconnu';
   }
 
   function buildDateAndTimeLabel(dateValue) {
@@ -1138,6 +1145,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     let currentSites = [];
     let itemCountsBySite = {};
     let userNamesById = {};
+    let userNamesByEmail = {};
     let userEmailsById = {};
     let currentPermissions = permissions;
     let isAuthenticated = Boolean(authState?.isAuthenticated);
@@ -1729,6 +1737,14 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           }
           return accumulator;
         }, {});
+        userNamesByEmail = users.reduce((accumulator, user) => {
+          const email = String(user?.email || '').trim().toLowerCase();
+          const displayName = String(user?.displayName || user?.rawUsername || user?.name || '').trim();
+          if (email && displayName) {
+            accumulator[email] = displayName;
+          }
+          return accumulator;
+        }, {});
         userEmailsById = users.reduce((accumulator, user) => {
           const email = String(user?.email || '').trim();
           if (user?.id && email) {
@@ -1738,6 +1754,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         }, {});
       } catch (_error) {
         userNamesById = {};
+        userNamesByEmail = {};
         userEmailsById = {};
       }
       renderSites();
@@ -2421,8 +2438,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
           const siteIsLocked = isSiteLocked(site);
           const lockActorLabel = siteIsLocked
-            ? resolveCreatorLockLabel(site, userNamesById)
-            : String(site?.unlockedBy || '').trim();
+            ? resolveSiteLockActorLabel(site?.lockedBy, site?.lockedByName, userNamesByEmail)
+            : resolveSiteLockActorLabel(site?.unlockedBy, site?.unlockedByName, userNamesByEmail);
           const lockLabel = siteIsLocked ? 'Verrouillé' : 'Déverrouillé';
           const lockLabelWithActor = lockActorLabel ? `${lockLabel} par` : lockLabel;
           const canShowSiteActions = isAuthenticated;

--- a/js/storage.js
+++ b/js/storage.js
@@ -434,6 +434,9 @@ async function listUsers() {
       return {
         id: snap.id,
         username: normalizeUsername(data.username || data.displayName || data.name || fallbackName),
+        rawUsername: normalizeUsername(data.username),
+        displayName: normalizeUsername(data.displayName),
+        name: normalizeUsername(data.name),
         email,
         avatarUrl: normalizeAvatarUrl(data.photoURL || data.avatarUrl || data.avatar),
         role: normalizeRole(data.role),
@@ -1234,7 +1237,8 @@ async function setSiteLock(siteId, lockPayload) {
   }
 
   const timestamp = nowIso();
-  const lockerName = (await resolveCurrentUserName()) || 'Utilisateur';
+  const resolvedLockerName = await resolveCurrentUserName();
+  const lockerName = resolvedLockerName && resolvedLockerName !== 'Utilisateur' ? resolvedLockerName : 'Utilisateur inconnu';
   const lockerEmail = resolveCurrentUserEmail();
   const nextLockState = {
     isLocked: true,
@@ -1276,6 +1280,8 @@ async function clearSiteLock(siteId) {
   }
 
   const timestamp = nowIso();
+  const resolvedUnlockerName = await resolveCurrentUserName();
+  const unlockerName = resolvedUnlockerName && resolvedUnlockerName !== 'Utilisateur' ? resolvedUnlockerName : 'Utilisateur inconnu';
   const unlockerEmail = resolveCurrentUserEmail();
   const nextLockState = {
     isLocked: false,
@@ -1284,6 +1290,7 @@ async function clearSiteLock(siteId) {
     lockedByName: deleteField(),
     lockedBy: deleteField(),
     unlockedBy: unlockerEmail,
+    unlockedByName: unlockerName,
     unlockAttemptsRemaining: deleteField(),
     unlockBlockedUntil: deleteField(),
     dateModification: timestamp,
@@ -1303,6 +1310,7 @@ async function clearSiteLock(siteId) {
     lockedBy: '',
     lockedByName: '',
     unlockedBy: unlockerEmail,
+    unlockedByName: unlockerName,
     unlockAttemptsRemaining: null,
     unlockBlockedUntil: null,
     dateModification: timestamp,


### PR DESCRIPTION
### Motivation
- Replace showing raw e‑mails for site lock/unlock actors with the associated user display name/username on the page 1 site list to improve readability and meet UI requirements.
- Provide a deterministic fallback when no name is available so the label never shows an e‑mail.

### Description
- Added `resolveSiteLockActorLabel(actorEmail, fallbackName, userMapByEmail)` in `js/app.js` to prefer a saved display name, then resolve an actor by e‑mail to a loaded user display name, and finally return `Utilisateur inconnu` if none found.
- Populate a `userNamesByEmail` map by extending `loadUserNames()` in `js/app.js` so legacy `lockedBy`/`unlockedBy` e‑mail values can be mapped to a display name when available.
- Updated page 1 rendering in `renderSites()` (`js/app.js`) to use `resolveSiteLockActorLabel(...)` for both locked and unlocked states so the UI shows the display name/username instead of e‑mail while keeping icons, colours and layout unchanged.
- Extended `StorageService.listUsers()` in `js/storage.js` to expose raw display/name fields and added `rawUsername`, `displayName`, and `name` properties for richer resolution.
- When locking/unlocking a site, save `lockedByName` and `unlockedByName` in `js/storage.js` via `setSiteLock()` and `clearSiteLock()` using `resolveCurrentUserName()` and fallback to `Utilisateur inconnu` if no usable name exists.
- Preserved existing behaviour for everything else (icons, colours, font sizes and layout were not modified).

### Testing
- Ran a static syntax check with `node --check js/app.js && node --check js/storage.js`, which succeeded.
- Render path exercised by `loadUserNames()` and `renderSites()` was validated locally by reloading the updated scripts (no automated UI tests available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72edfd1ab883249ec89d23501214e9)