### PR TITLE
Masquer l'auteur du verrouillage sur la carte et ajouter une modal de détail

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7415,3 +7415,28 @@ body[data-page="purchase-detail"] .purchase-detail-save-spinner {
 body[data-page="purchase-detail"] .purchase-detail-save-spinner.is-visible {
   display: block;
 }
+
+body[data-page="home"] .list-card__status[data-site-lock-status] {
+  cursor: pointer;
+  width: fit-content;
+}
+
+body[data-page="home"] .list-card__status[data-site-lock-status]:hover .list-card__status-main,
+body[data-page="home"] .list-card__status[data-site-lock-status]:focus-visible .list-card__status-main {
+  text-decoration: underline;
+}
+
+body[data-page="home"] .site-lock-status-message {
+  margin: 0.35rem 0 1.1rem;
+  font-weight: 800;
+  line-height: 1.45;
+  text-align: center;
+}
+
+body[data-page="home"] .site-lock-status-message--locked {
+  color: #dc2626;
+}
+
+body[data-page="home"] .site-lock-status-message--unlocked {
+  color: #16a34a;
+}

--- a/index.html
+++ b/index.html
@@ -237,6 +237,18 @@
         </form>
       </dialog>
 
+      <dialog id="siteLockStatusDialog" class="modal-card">
+        <div class="modal-content modal-content--site-lock-status">
+          <div class="modal-header">
+            <h2>Détail du statut</h2>
+          </div>
+          <p id="siteLockStatusMessage" class="site-lock-status-message" aria-live="polite"></p>
+          <div class="modal-actions modal-actions--split">
+            <button id="siteLockStatusCloseButton" type="button" class="btn" data-close-dialog>Fermer</button>
+          </div>
+        </div>
+      </dialog>
+
       <dialog id="siteUnlockDialog" class="modal-card">
         <form class="modal-content" id="siteUnlockForm">
           <div class="modal-header">

--- a/js/app.js
+++ b/js/app.js
@@ -1123,6 +1123,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     const siteLockConfirmPasswordError = requireElement('siteLockConfirmPasswordError');
     const siteLockStrengthIndicator = requireElement('siteLockStrengthIndicator');
     const siteLockStrengthLabel = requireElement('siteLockStrengthLabel');
+    const siteLockStatusDialog = requireElement('siteLockStatusDialog');
+    const siteLockStatusMessage = requireElement('siteLockStatusMessage');
+    const siteLockStatusCloseButton = requireElement('siteLockStatusCloseButton');
     const siteUnlockDialog = requireElement('siteUnlockDialog');
     const siteUnlockForm = requireElement('siteUnlockForm');
     const siteUnlockPasswordInput = requireElement('siteUnlockPasswordInput');
@@ -2437,11 +2440,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           const createdBy = resolveActorLabel(site?.createdBy, userNamesById, site?.createdByName);
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
           const siteIsLocked = isSiteLocked(site);
-          const lockActorLabel = siteIsLocked
-            ? resolveSiteLockActorLabel(site?.lockedBy, site?.lockedByName, userNamesByEmail)
-            : resolveSiteLockActorLabel(site?.unlockedBy, site?.unlockedByName, userNamesByEmail);
           const lockLabel = siteIsLocked ? 'Verrouillé' : 'Déverrouillé';
-          const lockLabelWithActor = lockActorLabel ? `${lockLabel} par` : lockLabel;
           const canShowSiteActions = isAuthenticated;
           return `
             <article class="list-card">
@@ -2463,11 +2462,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
                   </span>
                 </div>
                 <span class="list-card__divider" aria-hidden="true"></span>
-                <span class="list-card__status ${siteIsLocked ? 'list-card__status--locked' : 'list-card__status--unlocked'}">
+                <span class="list-card__status ${siteIsLocked ? 'list-card__status--locked' : 'list-card__status--unlocked'}" data-site-lock-status="${site.id}" aria-label="Voir l'auteur du statut ${escapeHtml(lockLabel)}">
                   <img src="${lockIconSrc}" alt="" aria-hidden="true" class="list-card__status-icon" />
                   <span class="list-card__status-text">
-                    <span class="list-card__status-main">${escapeHtml(lockLabelWithActor)}</span>
-                    ${lockActorLabel ? `<span class="list-card__status-actor">${escapeHtml(lockActorLabel)}</span>` : ''}
+                    <span class="list-card__status-main">${escapeHtml(lockLabel)}</span>
                   </span>
                 </span>
               </button>
@@ -2483,7 +2481,26 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           event.preventDefault();
         });
 
-        button.addEventListener('click', () => {
+        button.addEventListener('click', (event) => {
+          const statusTarget = event.target.closest('[data-site-lock-status]');
+          if (statusTarget) {
+            event.preventDefault();
+            event.stopPropagation();
+            const targetSite = getLatestSiteState(statusTarget.dataset.siteLockStatus);
+            const targetIsLocked = isSiteLocked(targetSite);
+            const actorLabel = targetIsLocked
+              ? resolveSiteLockActorLabel(targetSite?.lockedBy, targetSite?.lockedByName, userNamesByEmail)
+              : resolveSiteLockActorLabel(targetSite?.unlockedBy, targetSite?.unlockedByName, userNamesByEmail);
+            const icon = targetIsLocked ? '🔒' : '🔓';
+            const actionLabel = targetIsLocked ? 'verrouillé' : 'déverrouillé';
+            if (siteLockStatusMessage) {
+              siteLockStatusMessage.textContent = `${icon} Site ${actionLabel} par ${actorLabel || 'Utilisateur inconnu'}`;
+              siteLockStatusMessage.classList.toggle('site-lock-status-message--locked', targetIsLocked);
+              siteLockStatusMessage.classList.toggle('site-lock-status-message--unlocked', !targetIsLocked);
+            }
+            siteLockStatusDialog?.showModal();
+            return;
+          }
           const targetSite = getLatestSiteState(siteId);
           if (!isSiteLocked(targetSite)) {
             UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
@@ -3011,6 +3028,17 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     siteLockConfirmPasswordInput?.addEventListener('input', () => {
       clearSiteLockFieldErrorState(siteLockConfirmPasswordInput, siteLockConfirmPasswordError);
+    });
+
+
+    siteLockStatusCloseButton?.addEventListener('click', () => {
+      siteLockStatusDialog?.close();
+    });
+
+    siteLockStatusDialog?.addEventListener('click', (event) => {
+      if (event.target === siteLockStatusDialog) {
+        siteLockStatusDialog.close();
+      }
     });
 
     siteUnlockPasswordInput?.addEventListener('input', () => {


### PR DESCRIPTION
### Motivation

- Alléger l'affichage des cartes en ne montrant plus directement le nom de l'utilisateur ayant verrouillé/déverrouillé un site, tout en permettant d'accéder à cette information à la demande.
- Conserver les icônes existantes et les couleurs rouge/vert pour indiquer l'état, et rendre la ligne de statut cliquable pour afficher l'auteur.

### Description

- La carte principale affiche désormais uniquement « Verrouillé » ou « Déverrouillé » (avec les mêmes icônes et couleurs) et ne montre plus le nom de l'utilisateur directement; le HTML généré a été modifié pour remplacer le libellé intégrant l'auteur par un simple label de statut (fichier modifié : `js/app.js`).
- Ajout d'un attribut `data-site-lock-status` sur l'élément de statut pour le rendre cliquable et accessible, et ajout d'un `aria-label` pour l'accessibilité (modification dans `js/app.js`).
- Ajout d'une modal (`<dialog id="siteLockStatusDialog">`) contenant un message dynamique (`🔒 Site verrouillé par {nom}` ou `🔓 Site déverrouillé par {nom}`) et un bouton « Fermer », ainsi que la logique d'ouverture/fermeture (clic sur bouton, clic à l'extérieur, touche Échap) (fichier modifié : `index.html` et `js/app.js`).
- Ajout de styles pour marquer la ligne de statut comme cliquable et pour conserver les couleurs rouge/vert dans la modal (fichier modifié : `css/style.css`).

### Testing

- `node --check js/app.js` a été exécuté et a réussi sans erreur de syntaxe.
- `git diff --check` a été exécuté et n'a révélé aucun problème de formatage dans le diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f136d150832497112fd71e839851)