### PR TITLE
Gestion automatique des sites inactifs (overlay restaurer/supprimer, seuil configurable)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7440,3 +7440,22 @@ body[data-page="home"] .site-lock-status-message--locked {
 body[data-page="home"] .site-lock-status-message--unlocked {
   color: #16a34a;
 }
+
+body[data-page="home"] .inactive-site-card {
+  width: min(92vw, 26rem);
+}
+
+body[data-page="home"] .inactive-site-card p strong {
+  color: #111827;
+  font-weight: 800;
+}
+
+body[data-page="home"] .inactive-site-restore {
+  background: #16a34a;
+  color: #fff;
+}
+
+body[data-page="home"] .inactive-site-delete {
+  background: #dc2626;
+  color: #fff;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -2083,6 +2083,117 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       });
     }
 
+    function ensureInactiveSiteOverlay() {
+      let overlay = document.getElementById('inactiveSiteOverlay');
+      if (overlay) {
+        return overlay;
+      }
+      overlay = document.createElement('div');
+      overlay.id = 'inactiveSiteOverlay';
+      overlay.className = 'maintenance-overlay item-delete-confirm-overlay inactive-site-overlay';
+      overlay.hidden = true;
+      overlay.innerHTML = `
+        <article class="maintenance-card item-delete-confirm-card inactive-site-card" role="alertdialog" aria-modal="true" aria-labelledby="inactiveSiteTitle">
+          <h3 id="inactiveSiteTitle">⚠️ Site inactif</h3>
+          <p id="inactiveSiteText"></p>
+          <div class="modal-actions item-delete-confirm-actions inactive-site-actions">
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--cancel inactive-site-restore" id="inactiveSiteRestoreButton">🟢 Restaurer</button>
+            <button type="button" class="btn item-delete-confirm-button item-delete-confirm-button--danger inactive-site-delete" id="inactiveSiteDeleteButton">🔴 Supprimer</button>
+          </div>
+        </article>
+      `;
+      document.body.appendChild(overlay);
+      return overlay;
+    }
+
+    function openInactiveSiteOverlay(site) {
+      const overlay = ensureInactiveSiteOverlay();
+      const text = overlay.querySelector('#inactiveSiteText');
+      const restoreButton = overlay.querySelector('#inactiveSiteRestoreButton');
+      const deleteButton = overlay.querySelector('#inactiveSiteDeleteButton');
+      if (!text || !restoreButton || !deleteButton) {
+        return Promise.resolve('skipped');
+      }
+      restoreButton.disabled = false;
+      deleteButton.disabled = false;
+      const siteName = String(site?.nom || '').trim() || 'ce site';
+      text.innerHTML = `Nous avons remarqué que votre site <strong>${escapeHtml(siteName)}</strong> est resté inactif pendant ${StorageService.getSiteInactivityThresholdDays?.() || 30} jours en conservant <strong>0 OUT</strong>.<br><br>Souhaitez-vous le restaurer ou le supprimer définitivement ?`;
+
+      return new Promise((resolve) => {
+        let isClosing = false;
+        const cleanup = () => {
+          overlay.hidden = true;
+          overlay.classList.remove('is-open');
+          restoreButton.onclick = null;
+          deleteButton.onclick = null;
+          document.removeEventListener('keydown', handleKeyDown);
+        };
+        const close = (value) => {
+          if (isClosing) {
+            return;
+          }
+          isClosing = true;
+          overlay.classList.remove('is-open');
+          window.setTimeout(() => {
+            cleanup();
+            resolve(value);
+          }, 170);
+        };
+        const handleKeyDown = (event) => {
+          if (event.key === 'Escape') {
+            close('deferred');
+          }
+        };
+        restoreButton.onclick = async () => {
+          restoreButton.disabled = true;
+          deleteButton.disabled = true;
+          const result = await StorageService.restoreInactiveSite(site.id);
+          UiService.showToast(result?.ok ? 'Site restauré.' : 'Restauration impossible.');
+          close(result?.ok ? 'restored' : 'deferred');
+        };
+        deleteButton.onclick = async () => {
+          overlay.classList.remove('is-open');
+          overlay.hidden = true;
+          const shouldDelete = await askSiteDeleteConfirmation(siteName);
+          if (!shouldDelete) {
+            overlay.hidden = false;
+            window.requestAnimationFrame(() => overlay.classList.add('is-open'));
+            return;
+          }
+          restoreButton.disabled = true;
+          deleteButton.disabled = true;
+          const removedSnapshot = await StorageService.removeSite(site.id);
+          UiService.showToast(removedSnapshot ? 'Site supprimé définitivement.' : 'Suppression impossible.');
+          close(removedSnapshot ? 'deleted' : 'deferred');
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        overlay.hidden = false;
+        window.requestAnimationFrame(() => overlay.classList.add('is-open'));
+      });
+    }
+
+    let inactiveSitePromptRunning = false;
+    async function promptInactiveSitesForCreator() {
+      if (!authState?.isAuthenticated || inactiveSitePromptRunning) {
+        return;
+      }
+      inactiveSitePromptRunning = true;
+      try {
+        const sites = await StorageService.refreshSiteInactivityStates?.();
+        const pendingSites = Array.isArray(sites) ? sites : StorageService.listInactiveSitesForCurrentCreator?.() || [];
+        for (const site of pendingSites) {
+          const result = await openInactiveSiteOverlay(site);
+          if (result === 'deferred') {
+            break;
+          }
+        }
+      } catch (_error) {
+        UiService.showToast('Vérification des sites inactifs indisponible.');
+      } finally {
+        inactiveSitePromptRunning = false;
+      }
+    }
+
     function askSiteDeleteConfirmation(siteName) {
       const overlay = ensureSiteDeleteConfirmationDialog();
       const text = overlay.querySelector('#siteDeleteConfirmText');
@@ -3274,6 +3385,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         if (siteActionState.activeSiteId && typeof siteActionState.refreshSheetContent === 'function') {
           siteActionState.refreshSheetContent();
         }
+        promptInactiveSitesForCreator();
       },
       () => {
         UiService.showToast('Synchronisation indisponible.');

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,7 @@
+const APP_CONFIG = {
+  siteInactivity: {
+    thresholdDays: 30,
+  },
+};
+
+export { APP_CONFIG };

--- a/js/storage.js
+++ b/js/storage.js
@@ -15,9 +15,12 @@ import {
   updateDoc,
 } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
+import { APP_CONFIG } from './config.js';
 
 const OFFLINE_CACHE_KEY = 'suiviMateriel.offlineCache.v1';
 const OFFLINE_CACHE_TTL_MS = 180 * 1000;
+const SITE_INACTIVITY_THRESHOLD_DAYS = Number(APP_CONFIG?.siteInactivity?.thresholdDays) || 30;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 const state = {
   initialized: false,
@@ -972,6 +975,111 @@ async function init() {
   }
 }
 
+
+function getSiteInactivityThresholdDays() {
+  return SITE_INACTIVITY_THRESHOLD_DAYS;
+}
+
+function getSiteOutCount(siteId) {
+  return (state.itemsBySite.get(String(siteId || '')) || []).length;
+}
+
+function isCurrentUserSiteCreator(site) {
+  const currentUserId = String(state.userId || '').trim();
+  const creatorId = String(site?.createdBy || site?.ownerId || '').trim();
+  return Boolean(currentUserId && creatorId && currentUserId === creatorId);
+}
+
+function getInactiveSiteEligibleDate(site, referenceDate = new Date()) {
+  if (getSiteOutCount(site?.id) !== 0) {
+    return null;
+  }
+  const inactiveSince = parseFirestoreDate(site?.inactiveSince);
+  if (!inactiveSince) {
+    return null;
+  }
+  return new Date(inactiveSince.getTime() + SITE_INACTIVITY_THRESHOLD_DAYS * DAY_IN_MS);
+}
+
+function isSitePendingInactivityDecision(site, referenceDate = new Date()) {
+  if (!isCurrentUserSiteCreator(site)) {
+    return false;
+  }
+  const eligibleDate = getInactiveSiteEligibleDate(site, referenceDate);
+  return Boolean(eligibleDate && eligibleDate.getTime() <= referenceDate.getTime());
+}
+
+async function refreshSiteInactivityStates(referenceDate = new Date()) {
+  const updates = [];
+  const nowValue = referenceDate.toISOString();
+
+  for (const site of state.sites) {
+    const siteId = String(site?.id || '').trim();
+    if (!siteId) {
+      continue;
+    }
+    const outCount = getSiteOutCount(siteId);
+    const hasInactiveSince = Boolean(parseFirestoreDate(site?.inactiveSince));
+    if (outCount === 0 && !hasInactiveSince) {
+      const payload = {
+        inactiveSince: nowValue,
+        inactivityDecisionPending: false,
+        dateModification: site.dateModification || nowValue,
+      };
+      updates.push(setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true }));
+      Object.assign(site, payload);
+      continue;
+    }
+    if (outCount > 0 && (hasInactiveSince || site?.inactivityDecisionPending)) {
+      const payload = {
+        inactiveSince: deleteField(),
+        inactivityDecisionPending: deleteField(),
+        dateModification: site.dateModification || nowValue,
+      };
+      updates.push(setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true }));
+      delete site.inactiveSince;
+      delete site.inactivityDecisionPending;
+    }
+  }
+
+  if (updates.length) {
+    await Promise.all(updates);
+    persistOfflineState();
+    emitAll();
+  }
+  return listInactiveSitesForCurrentCreator(referenceDate);
+}
+
+function listInactiveSitesForCurrentCreator(referenceDate = new Date()) {
+  return clone(state.sites.filter((site) => isSitePendingInactivityDecision(site, referenceDate)));
+}
+
+async function restoreInactiveSite(siteId) {
+  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
+  if (siteIndex === -1 || !isCurrentUserSiteCreator(state.sites[siteIndex])) {
+    return { ok: false, reason: 'site_not_found' };
+  }
+  const timestamp = nowIso();
+  await setDoc(
+    doc(state.db, 'pages', 'page1', 'items', siteId),
+    {
+      inactiveSince: deleteField(),
+      inactivityDecisionPending: deleteField(),
+      inactivityRestoredAt: timestamp,
+      dateModification: timestamp,
+    },
+    { merge: true },
+  );
+  delete state.sites[siteIndex].inactiveSince;
+  delete state.sites[siteIndex].inactivityDecisionPending;
+  state.sites[siteIndex].inactivityRestoredAt = timestamp;
+  state.sites[siteIndex].dateModification = timestamp;
+  await appendHistoryEntry(`a restauré le site inactif ${state.sites[siteIndex].nom}`, { siteId, siteName: state.sites[siteIndex].nom });
+  persistOfflineState();
+  emitAll();
+  return { ok: true };
+}
+
 function getSite(siteId) {
   return clone(state.sites.find((site) => site.id === siteId) || null);
 }
@@ -1525,7 +1633,18 @@ async function removeSite(siteId) {
     return null;
   }
 
-  await deleteDoc(doc(state.db, 'pages', 'page1', 'items', siteId));
+  const itemsToDelete = clone(state.itemsBySite.get(siteId) || []);
+  const detailDeletePromises = [];
+  Array.from(state.detailsByItem.entries()).forEach(([key, details]) => {
+    if (key.startsWith(`${siteId}:`)) {
+      details.forEach((detail) => detailDeletePromises.push(deleteDoc(doc(state.db, 'pages', 'page3', 'items', detail.id))));
+    }
+  });
+  await Promise.all([
+    ...detailDeletePromises,
+    ...itemsToDelete.map((item) => deleteDoc(doc(state.db, 'pages', 'page2', 'items', item.id))),
+    deleteDoc(doc(state.db, 'pages', 'page1', 'items', siteId)),
+  ]);
 
   const [site] = state.sites.splice(siteIndex, 1);
   const items = clone(state.itemsBySite.get(siteId) || []);
@@ -1570,6 +1689,14 @@ async function createItem(siteId, numberValue, options = {}) {
   };
   const created = await addDoc(makePageItemsCollection('page2'), itemPayload);
   const item = { id: created.id, ...itemPayload };
+
+  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
+  if (siteIndex !== -1 && (state.sites[siteIndex].inactiveSince || state.sites[siteIndex].inactivityDecisionPending)) {
+    await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), { inactiveSince: deleteField(), inactivityDecisionPending: deleteField(), dateModification: timestamp }, { merge: true });
+    delete state.sites[siteIndex].inactiveSince;
+    delete state.sites[siteIndex].inactivityDecisionPending;
+    state.sites[siteIndex].dateModification = timestamp;
+  }
 
   if (!state.itemsBySite.has(siteId)) {
     state.itemsBySite.set(siteId, []);
@@ -2129,6 +2256,10 @@ async function importData(payload) {
 window.StorageService = {
   init,
   getSites,
+  getSiteInactivityThresholdDays,
+  refreshSiteInactivityStates,
+  listInactiveSitesForCurrentCreator,
+  restoreInactiveSite,
   getSite,
   getItem,
   subscribeSites,


### PR DESCRIPTION
### Motivation
- Ajouter une gestion automatique des sites restés à `0 OUT` pendant une durée configurable (30 jours par défaut) sans les supprimer automatiquement.
- Alerter uniquement le créateur du site à sa prochaine connexion et lui laisser choisir de `Restaurer` ou `Supprimer` définitivement avec confirmation, en réaffichant l'overlay jusqu'à décision.
- Préserver le design Material existant et permettre de modifier facilement la durée d’inactivité via la configuration centrale.

### Description
- Ajout de la configuration `js/config.js` exposant `APP_CONFIG.siteInactivity.thresholdDays` (par défaut `30`).
- Ajout dans `js/storage.js` de la logique de seuil et des helpers : `getSiteInactivityThresholdDays`, `getSiteOutCount`, `isCurrentUserSiteCreator`, `getInactiveSiteEligibleDate`, `isSitePendingInactivityDecision`, `refreshSiteInactivityStates`, `listInactiveSitesForCurrentCreator` et `restoreInactiveSite`, plus import de `APP_CONFIG` et constantes `SITE_INACTIVITY_THRESHOLD_DAYS`/`DAY_IN_MS`.
- Mise à jour de `createItem` pour réinitialiser l’état d’inactivité d’un site quand un `OUT` est ajouté, et renforcement de `removeSite` pour supprimer en cascade les documents `page2` (OUT) et `page3` (détails) associés avant de supprimer le site Firestore.
- Exposition des nouvelles fonctions via `window.StorageService` pour usage par l'UI (`refreshSiteInactivityStates`, `listInactiveSitesForCurrentCreator`, `restoreInactiveSite`, `getSiteInactivityThresholdDays`).
- Ajout dans `js/app.js` d’une Overlay Card Material-style réutilisant le pattern existant (`ensureInactiveSiteOverlay`, `openInactiveSiteOverlay`, `promptInactiveSitesForCreator`) qui s’affiche uniquement au créateur, propose `🟢 Restaurer` et `🔴 Supprimer` (avec confirmation irréversible) et se réaffiche à chaque connexion jusqu’à décision.
- Ajout de styles CSS mineurs dans `css/style.css` pour respecter l’apparence actuelle et les boutons danger/success existants.

### Testing
- `node --check js/app.js` — réussi.
- `node --check js/storage.js` — réussi.
- `node --check js/config.js` — réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f52699848324b81b6304dbc2160a)