### PR TITLE
Masquer les sites inactifs en attente de décision du créateur

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7441,6 +7441,41 @@ body[data-page="home"] .site-lock-status-message--unlocked {
   color: #16a34a;
 }
 
+
+body[data-page="home"] .list-card--pending-decision {
+  border-color: #f59e0b;
+  box-shadow: 0 10px 26px rgba(245, 158, 11, 0.18);
+}
+
+body[data-page="home"] .list-card__pending-decision-badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: fit-content;
+  margin: -0.2rem 0 0.45rem;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+}
+
+body[data-page="home"] .list-card__pending-decision-badge::before {
+  content: "!";
+  display: inline-grid;
+  place-items: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  background: #f59e0b;
+  color: #fff;
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
 body[data-page="home"] .inactive-site-card {
   width: min(92vw, 26rem);
 }

--- a/js/app.js
+++ b/js/app.js
@@ -2553,11 +2553,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           const siteIsLocked = isSiteLocked(site);
           const lockLabel = siteIsLocked ? 'Verrouillé' : 'Déverrouillé';
           const canShowSiteActions = isAuthenticated;
+          const isPendingCreatorDecision = Boolean(StorageService.isSitePendingInactivityDecision?.(site));
+          const pendingDecisionBadge = isPendingCreatorDecision
+            ? '<span class="list-card__pending-decision-badge">En attente de votre décision</span>'
+            : '';
           return `
-            <article class="list-card">
+            <article class="list-card ${isPendingCreatorDecision ? 'list-card--pending-decision' : ''}">
               ${canShowSiteActions ? `<button class="list-card__menu-button" type="button" data-site-menu="${site.id}" aria-label="Plus d'actions" title="Plus d'actions"><img src="Icon/Trois point.png" alt="" aria-hidden="true" class="list-card__menu-icon" /></button>` : ''}
               <button class="list-card__button" type="button" data-site-open="${site.id}">
                 <h3 class="list-card__title">${escapeHtml(site.nom)}</h3>
+                ${pendingDecisionBadge}
                 <div class="list-card__meta">
                   <span class="list-card__meta-item list-card__meta-item--outs">
                     <img src="Icon/OUT.png" alt="" aria-hidden="true" class="icon" />

--- a/js/storage.js
+++ b/js/storage.js
@@ -922,7 +922,7 @@ function emitForSite(siteId) {
 }
 
 function emitAll() {
-  state.listeners.sites.forEach((listener) => listener(clone(state.sites)));
+  state.listeners.sites.forEach((listener) => listener(filterSitesVisibleToCurrentUser()));
 
   const itemCounts = {};
   state.itemsBySite.forEach((items, siteId) => {
@@ -1002,11 +1002,22 @@ function getInactiveSiteEligibleDate(site, referenceDate = new Date()) {
 }
 
 function isSitePendingInactivityDecision(site, referenceDate = new Date()) {
-  if (!isCurrentUserSiteCreator(site)) {
+  if (!site) {
     return false;
+  }
+  if (site?.inactivityDecisionPending === true) {
+    return true;
   }
   const eligibleDate = getInactiveSiteEligibleDate(site, referenceDate);
   return Boolean(eligibleDate && eligibleDate.getTime() <= referenceDate.getTime());
+}
+
+function isSiteVisibleToCurrentUser(site, referenceDate = new Date()) {
+  return !isSitePendingInactivityDecision(site, referenceDate) || isCurrentUserSiteCreator(site);
+}
+
+function filterSitesVisibleToCurrentUser(sites = state.sites, referenceDate = new Date()) {
+  return clone((Array.isArray(sites) ? sites : []).filter((site) => isSiteVisibleToCurrentUser(site, referenceDate)));
 }
 
 async function refreshSiteInactivityStates(referenceDate = new Date()) {
@@ -1030,15 +1041,28 @@ async function refreshSiteInactivityStates(referenceDate = new Date()) {
       Object.assign(site, payload);
       continue;
     }
+    const pendingEligibleDate = getInactiveSiteEligibleDate(site, referenceDate);
+    if (outCount === 0 && pendingEligibleDate && pendingEligibleDate.getTime() <= referenceDate.getTime() && site?.inactivityDecisionPending !== true) {
+      const payload = {
+        inactivityDecisionPending: true,
+        inactivityDecisionPendingAt: nowValue,
+        dateModification: site.dateModification || nowValue,
+      };
+      updates.push(setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true }));
+      Object.assign(site, payload);
+      continue;
+    }
     if (outCount > 0 && (hasInactiveSince || site?.inactivityDecisionPending)) {
       const payload = {
         inactiveSince: deleteField(),
         inactivityDecisionPending: deleteField(),
+        inactivityDecisionPendingAt: deleteField(),
         dateModification: site.dateModification || nowValue,
       };
       updates.push(setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true }));
       delete site.inactiveSince;
       delete site.inactivityDecisionPending;
+      delete site.inactivityDecisionPendingAt;
     }
   }
 
@@ -1051,7 +1075,7 @@ async function refreshSiteInactivityStates(referenceDate = new Date()) {
 }
 
 function listInactiveSitesForCurrentCreator(referenceDate = new Date()) {
-  return clone(state.sites.filter((site) => isSitePendingInactivityDecision(site, referenceDate)));
+  return clone(state.sites.filter((site) => isCurrentUserSiteCreator(site) && isSitePendingInactivityDecision(site, referenceDate)));
 }
 
 async function restoreInactiveSite(siteId) {
@@ -1065,6 +1089,7 @@ async function restoreInactiveSite(siteId) {
     {
       inactiveSince: deleteField(),
       inactivityDecisionPending: deleteField(),
+      inactivityDecisionPendingAt: deleteField(),
       inactivityRestoredAt: timestamp,
       dateModification: timestamp,
     },
@@ -1072,6 +1097,7 @@ async function restoreInactiveSite(siteId) {
   );
   delete state.sites[siteIndex].inactiveSince;
   delete state.sites[siteIndex].inactivityDecisionPending;
+  delete state.sites[siteIndex].inactivityDecisionPendingAt;
   state.sites[siteIndex].inactivityRestoredAt = timestamp;
   state.sites[siteIndex].dateModification = timestamp;
   await appendHistoryEntry(`a restauré le site inactif ${state.sites[siteIndex].nom}`, { siteId, siteName: state.sites[siteIndex].nom });
@@ -1081,11 +1107,12 @@ async function restoreInactiveSite(siteId) {
 }
 
 function getSite(siteId) {
-  return clone(state.sites.find((site) => site.id === siteId) || null);
+  const site = state.sites.find((item) => item.id === siteId) || null;
+  return site && isSiteVisibleToCurrentUser(site) ? clone(site) : null;
 }
 
 function getSites() {
-  return clone(state.sites);
+  return filterSitesVisibleToCurrentUser();
 }
 
 function getItem(siteId, itemId) {
@@ -1105,7 +1132,7 @@ function subscribeFactory(registry, key, onChange) {
 function subscribeSites(onChange, onError) {
   try {
     state.listeners.sites.add(onChange);
-    onChange(clone(state.sites));
+    onChange(filterSitesVisibleToCurrentUser());
     return () => state.listeners.sites.delete(onChange);
   } catch (error) {
     if (typeof onError === 'function') {
@@ -1692,9 +1719,10 @@ async function createItem(siteId, numberValue, options = {}) {
 
   const siteIndex = state.sites.findIndex((site) => site.id === siteId);
   if (siteIndex !== -1 && (state.sites[siteIndex].inactiveSince || state.sites[siteIndex].inactivityDecisionPending)) {
-    await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), { inactiveSince: deleteField(), inactivityDecisionPending: deleteField(), dateModification: timestamp }, { merge: true });
+    await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), { inactiveSince: deleteField(), inactivityDecisionPending: deleteField(), inactivityDecisionPendingAt: deleteField(), dateModification: timestamp }, { merge: true });
     delete state.sites[siteIndex].inactiveSince;
     delete state.sites[siteIndex].inactivityDecisionPending;
+    delete state.sites[siteIndex].inactivityDecisionPendingAt;
     state.sites[siteIndex].dateModification = timestamp;
   }
 
@@ -2257,6 +2285,7 @@ window.StorageService = {
   init,
   getSites,
   getSiteInactivityThresholdDays,
+  isSitePendingInactivityDecision,
   refreshSiteInactivityStates,
   listInactiveSitesForCurrentCreator,
   restoreInactiveSite,


### PR DESCRIPTION
### Motivation
- Implémenter la règle métier qui masque automatiquement les sites restés à 0 OUT pendant le seuil d'inactivité et qui sont en attente de la décision du créateur afin qu'aucun autre utilisateur ne puisse y accéder. 
- Préserver pour le créateur la visibilité de sa carte avec un indicateur et afficher l'overlay de choix (restaurer / supprimer) à chaque connexion.

### Description
- Côté stockage, ajout de la logique d'état : `inactivityDecisionPending` et `inactivityDecisionPendingAt` sont positionnés automatiquement après le seuil, et sont nettoyés lors d'une restauration ou dès qu'un OUT est créé (fichier modifié : `js/storage.js`).
- Ajout des helpers `isSiteVisibleToCurrentUser` et `filterSitesVisibleToCurrentUser`, et modification de `getSites()`, `getSite()`, `subscribeSites()` et `emitAll()` pour n'exposer les sites en attente qu'au créateur (fichier modifié : `js/storage.js`).
- Mise à jour du rendu de la page d'accueil pour afficher un badge visuel "En attente de votre décision" sur la carte côté créateur et appliquer une classe visuelle à la carte (fichier modifié : `js/app.js`).
- Ajout de styles CSS pour le badge et l'apparence de la carte en attente (fichier modifié : `css/style.css`).

### Testing
- Vérification statique des scripts JS avec `node --check js/app.js` (succès). 
- Vérification statique des scripts JS avec `node --check js/storage.js` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72ffec28148328a622aeb3b83daf65)