### PR TITLE
Overlay de bienvenue après connexion Google

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,6 +21,112 @@
   --app-shell-max-width: var(--content-max-width);
 }
 
+
+.google-welcome-overlay[hidden] {
+  display: none;
+}
+
+.google-welcome-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.25rem, 4vw, 2rem);
+  background: rgba(7, 23, 42, 0.42);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.google-welcome-overlay.is-visible {
+  opacity: 1;
+}
+
+.google-welcome-card {
+  width: min(100%, 28rem);
+  padding: clamp(1.8rem, 6vw, 2.45rem);
+  border-radius: 24px;
+  color: #ffffff;
+  text-align: center;
+  background: linear-gradient(135deg, #42A5F5 0%, #1E88E5 50%, #1565C0 100%);
+  box-shadow: 0 24px 60px rgba(7, 23, 42, 0.28), 0 8px 20px rgba(21, 101, 192, 0.24);
+  transform: translateY(12px) scale(0.94);
+  opacity: 0;
+  transition: transform 220ms cubic-bezier(0.2, 0.9, 0.3, 1.12), opacity 180ms ease;
+}
+
+.google-welcome-overlay.is-visible .google-welcome-card {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+.google-welcome-card__icon {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1rem;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22);
+  font-size: 2.1rem;
+}
+
+.google-welcome-card__title {
+  margin: 0 0 0.9rem;
+  font-size: clamp(1.45rem, 6vw, 2rem);
+  line-height: 1.15;
+  font-weight: 800;
+  color: #ffffff;
+}
+
+.google-welcome-card__message {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0 auto 1.6rem;
+  color: rgba(255, 255, 255, 0.86);
+  font-size: clamp(1rem, 3.4vw, 1.08rem);
+  line-height: 1.55;
+}
+
+.google-welcome-card__message p {
+  margin: 0;
+}
+
+.google-welcome-card__message strong {
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.google-welcome-card__button {
+  min-width: 9.5rem;
+  min-height: 3rem;
+  padding: 0.82rem 1.5rem;
+  border: 0;
+  border-radius: 999px;
+  color: #ffffff;
+  background: #1976D2;
+  box-shadow: 0 10px 22px rgba(13, 71, 161, 0.26);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+}
+
+.google-welcome-card__button:hover,
+.google-welcome-card__button:focus-visible {
+  background: #1565C0;
+  box-shadow: 0 14px 28px rgba(13, 71, 161, 0.32);
+  transform: translateY(-1px);
+}
+
+.google-welcome-card__button:active {
+  transform: translateY(1px) scale(0.98);
+  box-shadow: 0 7px 16px rgba(13, 71, 161, 0.24);
+}
+
 /* Unified premium header system - final overrides */
 .app-header {
   min-height: var(--header-height);

--- a/index.html
+++ b/index.html
@@ -71,6 +71,15 @@
       </aside>
 
 
+      <div id="googleWelcomeOverlay" class="google-welcome-overlay" role="dialog" aria-modal="true" aria-labelledby="googleWelcomeTitle" aria-describedby="googleWelcomeMessage" hidden>
+        <section class="google-welcome-card" role="document">
+          <div id="googleWelcomeIcon" class="google-welcome-card__icon" aria-hidden="true">👋</div>
+          <h2 id="googleWelcomeTitle" class="google-welcome-card__title">👋 Heureux de vous revoir !</h2>
+          <div id="googleWelcomeMessage" class="google-welcome-card__message"></div>
+          <button id="googleWelcomeButton" class="google-welcome-card__button" type="button">OK</button>
+        </section>
+      </div>
+
       <main class="page-content main-content">
         <section class="search-panel search-panel--inline section">
           <label class="input-group">

--- a/js/app.js
+++ b/js/app.js
@@ -440,6 +440,97 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     };
   }
 
+  const GOOGLE_WELCOME_KEY = 'suiviMateriel.googleWelcome.v1';
+  const GOOGLE_WELCOME_MAX_AGE_MS = 5 * 60 * 1000;
+
+  function readGoogleWelcomePayload() {
+    try {
+      const rawPayload = window.sessionStorage.getItem(GOOGLE_WELCOME_KEY);
+      if (!rawPayload) {
+        return null;
+      }
+      const payload = JSON.parse(rawPayload);
+      const isFresh = Date.now() - Number(payload?.createdAt || 0) <= GOOGLE_WELCOME_MAX_AGE_MS;
+      if (payload?.source !== 'google' || !isFresh) {
+        window.sessionStorage.removeItem(GOOGLE_WELCOME_KEY);
+        return null;
+      }
+      return payload;
+    } catch (_error) {
+      window.sessionStorage.removeItem(GOOGLE_WELCOME_KEY);
+      return null;
+    }
+  }
+
+  function resolveWelcomeDisplayName(payload, authUser) {
+    const userData = normalizeAuthUserData(authUser);
+    const payloadName = String(payload?.displayName || '').trim();
+    const authName = String(userData?.displayName || userData?.name || '').trim();
+    const emailName = String(payload?.email || userData?.email || '')
+      .split('@')[0]
+      .replace(/[._-]+/g, ' ')
+      .trim();
+    return payloadName || authName || emailName || 'Utilisateur';
+  }
+
+  function showGoogleWelcomeOverlay(authUser) {
+    const payload = readGoogleWelcomePayload();
+    if (!payload) {
+      return;
+    }
+
+    const overlay = document.getElementById('googleWelcomeOverlay');
+    const icon = document.getElementById('googleWelcomeIcon');
+    const title = document.getElementById('googleWelcomeTitle');
+    const message = document.getElementById('googleWelcomeMessage');
+    const button = document.getElementById('googleWelcomeButton');
+    if (!overlay || !icon || !title || !message || !button) {
+      window.sessionStorage.removeItem(GOOGLE_WELCOME_KEY);
+      return;
+    }
+
+    const isNewUser = Boolean(payload.isNewUser);
+    const displayName = resolveWelcomeDisplayName(payload, authUser);
+    const strongName = document.createElement('strong');
+    strongName.textContent = displayName;
+    const strongAppName = document.createElement('strong');
+    strongAppName.textContent = 'Suivi Matériel';
+
+    icon.textContent = isNewUser ? '🎉' : '👋';
+    title.textContent = isNewUser ? '🎉 Bienvenue !' : '👋 Heureux de vous revoir !';
+    button.textContent = isNewUser ? 'Commencer' : 'OK';
+    message.replaceChildren();
+
+    if (isNewUser) {
+      const firstLine = document.createElement('p');
+      firstLine.append('Bienvenue ', strongName, ' dans ', strongAppName, '.');
+      const secondLine = document.createElement('p');
+      secondLine.textContent = 'Votre espace a été créé avec succès. Vous pouvez maintenant commencer à enregistrer et gérer vos sites en toute simplicité.';
+      message.append(firstLine, secondLine);
+    } else {
+      const greeting = document.createElement('p');
+      greeting.append('Bonjour ', strongName, ',');
+      const secondLine = document.createElement('p');
+      secondLine.textContent = 'Nous sommes ravis de vous retrouver. Votre espace Suivi Matériel est prêt';
+      message.append(greeting, secondLine);
+    }
+
+    const closeOverlay = () => {
+      overlay.classList.remove('is-visible');
+      window.sessionStorage.removeItem(GOOGLE_WELCOME_KEY);
+      window.setTimeout(() => {
+        overlay.hidden = true;
+      }, 180);
+    };
+
+    button.onclick = closeOverlay;
+    overlay.hidden = false;
+    window.requestAnimationFrame(() => {
+      overlay.classList.add('is-visible');
+      button.focus({ preventScroll: true });
+    });
+  }
+
   function renderHomeAccessControls({ authUser, onAvatarClick }) {
     const avatarButton = document.getElementById('userAvatarButton');
     const loginButton = document.getElementById('openLoginButton');
@@ -2894,6 +2985,9 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     mettreAJourHeaderUtilisateur(authState?.authUser || null);
     mettreAJourPermissionsUI(currentPermissions);
+    if (isAuthenticated) {
+      showGoogleWelcomeOverlay(authState?.authUser || firebaseAuth.currentUser);
+    }
     onAuthStateChanged(firebaseAuth, (user) => {
       isAuthenticated = Boolean(user);
       renderUserAvatar(user || null);

--- a/js/login.js
+++ b/js/login.js
@@ -1,6 +1,7 @@
 import {
   GoogleAuthProvider,
   browserLocalPersistence,
+  getAdditionalUserInfo,
   fetchSignInMethodsForEmail,
   onAuthStateChanged,
   setPersistence,
@@ -12,6 +13,10 @@ import { firebaseAuth } from './firebase-core.js';
 const auth = firebaseAuth;
 const provider = new GoogleAuthProvider();
 provider.setCustomParameters({ prompt: 'select_account' });
+
+const STORAGE_KEY = 'suiviMateriel.loginMemo.v1';
+const GOOGLE_WELCOME_KEY = 'suiviMateriel.googleWelcome.v1';
+let googleSignInPending = false;
 
 function isInAppBrowser() {
   return /FBAN|FBAV|Instagram|Messenger|WhatsApp/i.test(navigator.userAgent);
@@ -36,15 +41,15 @@ const authReadyPromise = setPersistence(auth, browserLocalPersistence)
           photoURL: user.photoURL || '',
         };
         localStorage.setItem('suiviMateriel.authUser.v1', JSON.stringify(authPayload));
-        window.location.replace('index.html');
+        if (!googleSignInPending) {
+          window.location.replace('index.html');
+        }
       }
     });
   })
   .catch(() => {
     globalError.textContent = 'Une erreur est survenue lors de la préparation de la connexion. Veuillez réessayer.';
   });
-
-const STORAGE_KEY = 'suiviMateriel.loginMemo.v1';
 
 const form = document.getElementById('loginForm');
 const emailInput = document.getElementById('loginEmail');
@@ -110,11 +115,36 @@ function setLoading(isLoading, sourceButton = emailLoginButton) {
   }
 }
 
+function saveGoogleWelcomePayload(result) {
+  const user = result?.user;
+  if (!user) {
+    return;
+  }
+
+  const additionalUserInfo = getAdditionalUserInfo(result);
+  const payload = {
+    source: 'google',
+    uid: user.uid || '',
+    displayName: user.displayName || '',
+    email: user.email || '',
+    isNewUser: Boolean(additionalUserInfo?.isNewUser),
+    createdAt: Date.now(),
+  };
+  sessionStorage.setItem(GOOGLE_WELCOME_KEY, JSON.stringify(payload));
+}
+
 async function startGoogleSignIn() {
   await authReadyPromise;
   // signInWithRedirect est évité ici car le projet est hébergé sur GitHub Pages et non sur Firebase Hosting.
-  await signInWithPopup(auth, provider);
-  window.location.replace('index.html');
+  googleSignInPending = true;
+  try {
+    const result = await signInWithPopup(auth, provider);
+    saveGoogleWelcomePayload(result);
+    window.location.replace('index.html');
+  } catch (error) {
+    googleSignInPending = false;
+    throw error;
+  }
 }
 
 function encodeMemo(email, password) {


### PR DESCRIPTION
### Motivation
- Améliorer l’expérience utilisateur immédiatement après une connexion Google réussie en affichant une carte de bienvenue avant le rendu normal de la page "Suivi Matériel".
- Différencier le message selon que le compte est nouveau ou déjà enregistré, et préserver l’accessibilité et la lisibilité du contenu.

### Description
- Ajout d’un enregistrement temporaire de la session pour les connexions Google via `sessionStorage` (`suiviMateriel.googleWelcome.v1`) contenant `displayName`, `email`, `isNewUser` et un timestamp afin de piloter l’affichage de l’overlay (`js/login.js`).
- Protection du flux d’authentification pour laisser le temps d’enregistrer la payload avant la redirection en introduisant le drapeau `googleSignInPending` et en ajustant le comportement de redirection (`js/login.js`).
- Ajout du markup HTML de l’Overlay Card sur la page d’accueil (`index.html`) avec attributs ARIA pour accessibilité et structure `dialog` + `section` + bouton d’action.
- Ajout de la logique côté UI pour lire la payload, déterminer le nom d’affichage, choisir la variante (🎉 nouvel utilisateur / 👋 retour) et afficher/fermer l’overlay (`js/app.js`), avec une validité temporelle (TTL 5 minutes).
- Ajout des styles pour l’overlay et la carte : dégradé demandé, coins arrondis, ombre Material, blur du backdrop, animation fade+scale, bouton primaire bleu avec états hover/active (`css/style.css`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/login.js` — réussite.
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js` — réussite.
- Démarrage d’un serveur HTTP local pour tests manuels (fichiers servis), et tentative d’aperçu automatisé par script, mais la capture d’écran headless a échoué car `playwright` n’est pas installé et aucun navigateur headless n’était disponible dans l’environnement (test non réalisé).
- Aucun test automatisé d’intégration UI disponible dans cet environnement; vérifications manuelles locales recommandées pour valider les interactions réelles (connexion Google, nouveaux comptes vs comptes existants, fermeture de l’overlay).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73053ce4f08328a3dda1bbd8b1eba5)