### PR TITLE
Journaliser les exportations Excel réussies dans Historiques

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -643,9 +643,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       document.body.removeChild(link);
       window.setTimeout(() => URL.revokeObjectURL(link.href), 0);
       UiService.showToast(`${title} lancé.`);
+      return true;
     } catch (error) {
       console.error('Erreur export Excel :', error);
       UiService.showToast('Impossible de générer le fichier Excel.');
+      return false;
     }
   }
 
@@ -4208,7 +4210,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const title = `SUIVI MATERIEL . ${currentSite.nom}`;
       const workbook = buildSiteExcelContent(title, sortedRows, currentSite?.nom);
       const fileName = buildPage2ExportFileName(currentSite?.nom, 'xlsx');
-      downloadExcelFile(fileName, 'Export Excel', workbook);
+      const exported = await downloadExcelFile(fileName, 'Export Excel', workbook);
+      if (!exported) {
+        return;
+      }
+      await StorageService.recordExcelExportHistory(siteId, currentSite?.nom);
       saveExportFileNameToHistory(fileName);
     }
 
@@ -7028,7 +7034,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       countLabel.textContent = `${filteredCount > 1 ? 'Articles' : 'Article'} / ${totalCount}`;
     }
 
-    function exportDetails(fileNameOverride) {
+    async function exportDetails(fileNameOverride) {
       if (!currentItem || !currentSite) {
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
         return;
@@ -7042,7 +7048,11 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
       const workbook = buildDetailExcelContent(`${currentSite.nom} · ${currentItem.numero}`, filteredDetails, currentSite?.nom);
       const fileName = buildPage2ExportFileName(currentSite?.nom, 'xlsx');
-      downloadExcelFile(fileName, 'Export Excel', workbook);
+      const exported = await downloadExcelFile(fileName, 'Export Excel', workbook);
+      if (!exported) {
+        return;
+      }
+      await StorageService.recordExcelExportHistory(siteId, currentSite?.nom);
       saveExportFileNameToHistory(fileName);
     }
 
@@ -7756,7 +7766,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         detailExportSubmitButton.disabled = true;
         detailExportSubmitButton.classList.add('is-loading');
         try {
-          exportDetails(fileName);
+          await exportDetails(fileName);
           closeDetailExportDialog();
         } catch (_error) {
           detailExportSubmitButton.disabled = false;

--- a/js/storage.js
+++ b/js/storage.js
@@ -1461,6 +1461,14 @@ async function recordSiteUnlockHistory(siteId) {
   await appendHistoryEntry('a déverrouillé le site', { siteId });
 }
 
+async function recordExcelExportHistory(siteId, siteName = '') {
+  const resolvedSiteName = resolveSiteNameForHistory(siteId, siteName);
+  const action = resolvedSiteName
+    ? `a exporté un fichier depuis le site « ${resolvedSiteName} ».`
+    : 'a exporté un fichier Excel.';
+  await appendHistoryEntry(action, { siteId, siteName: resolvedSiteName, actionType: 'export_excel' });
+}
+
 function getAuthenticatedUnlockProtectionUid() {
   return String(state.authUser?.uid || state.userId || firebaseAuth.currentUser?.uid || '').trim();
 }
@@ -2059,6 +2067,7 @@ function resolveSiteNameForHistory(siteId, fallbackName = '') {
 
 async function appendHistoryEntry(actionText, context = {}) {
   const action = sanitizeText(actionText, false);
+  const actionType = sanitizeText(context?.actionType, false);
   if (!action) {
     return;
   }
@@ -2071,6 +2080,7 @@ async function appendHistoryEntry(actionText, context = {}) {
       userId: profile?.id || state.userId || null,
       userName: username,
       action,
+      actionType: actionType || null,
       siteId: siteId || null,
       siteName: siteName || null,
       createdAt: serverTimestamp(),
@@ -2102,6 +2112,7 @@ async function listHistoriques() {
       userId: sanitizeText(data.userId, false),
       userName: normalizeUsername(data.userName) || 'Utilisateur inconnu',
       action: sanitizeText(data.action, false),
+      actionType: sanitizeText(data.actionType, false),
       siteId: sanitizeText(data.siteId, false),
       siteName: resolveSiteNameForHistory(data.siteId, data.siteName),
       createdAt: data.createdAt || null,
@@ -2317,6 +2328,7 @@ window.StorageService = {
   updateDetail,
   removeDetail,
   recordSiteUnlockHistory,
+  recordExcelExportHistory,
   exportData,
   importData,
   ensureCurrentUser,


### PR DESCRIPTION
### Motivation
- Ajouter un enregistrement automatique dans la collection des historiques après chaque exportation Excel réussie en réutilisant l'infrastructure d'historique existante.
- Conserver le même format de message que les autres historiques: "{Nom de l'utilisateur} a exporté un fichier depuis le site « {Nom du site} ».".
- S'assurer que le log n'est créé qu'après un export réellement réussi afin d'éviter les doublons en cas d'erreur.

### Description
- `downloadExcelFile` renvoie maintenant un booléen de succès (`true`/`false`) pour indiquer si le fichier a bien été généré et lancé (`js/app.js`).
- Les fonctions d'export (`exportItems` et `exportDetails`) attendent le retour de `downloadExcelFile` et n'appellent la journalisation qu'en cas de succès, via `StorageService.recordExcelExportHistory(siteId, siteName)` (`js/app.js`).
- Ajout de `recordExcelExportHistory(siteId, siteName)` dans `js/storage.js` qui construit le message au format demandé et appelle `appendHistoryEntry(...)` avec `actionType: 'export_excel'` (réutilisation de la logique d'`appendHistoryEntry`).
- `appendHistoryEntry` a été étendu pour accepter et enregistrer un champ `actionType`, et `listHistoriques` lit désormais aussi `actionType`, sans modifier l'affichage ou le tri de la page Historique; la nouvelle méthode a été exposée dans `window.StorageService`.

### Testing
- Exécution de `node --check js/app.js` pour vérifier la validité syntaxique du fichier modifié, résultat: succès.
- Exécution de `node --check js/storage.js` pour vérifier la validité syntaxique du fichier modifié, résultat: succès.
- Exécution de `git diff --check` pour détecter les erreurs de patch, résultat: aucun problème détecté.
- Vérification `git status --short` pour confirmer les fichiers modifiés, résultat: OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73130bd4b48328a431ba6cb42443e7)