### PR TITLE
Enregistrer un événement dans l'historique lors d'un export Excel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4144,6 +4144,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return;
       }
 
+      StorageService.recordExcelExportHistory(siteId, currentSite?.nom).catch(() => {});
+
       let rows = buildSiteExportRows();
       if (!rows.length) {
         try {
@@ -7033,6 +7035,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         UiService.navigate(`page2.html?siteId=${encodeURIComponent(siteId)}`);
         return;
       }
+
+      StorageService.recordExcelExportHistory(siteId, currentSite?.nom).catch(() => {});
 
       const filteredDetails = getFilteredDetails(currentDetails);
       if (!filteredDetails.length) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -1461,6 +1461,14 @@ async function recordSiteUnlockHistory(siteId) {
   await appendHistoryEntry('a déverrouillé le site', { siteId });
 }
 
+async function recordExcelExportHistory(siteId, siteName = '') {
+  const resolvedSiteName = resolveSiteNameForHistory(siteId, siteName);
+  const action = resolvedSiteName
+    ? `a exporté un fichier depuis le site « ${resolvedSiteName} ».`
+    : 'a exporté un fichier depuis le site.';
+  await appendHistoryEntry(action, { siteId, siteName: resolvedSiteName });
+}
+
 function getAuthenticatedUnlockProtectionUid() {
   return String(state.authUser?.uid || state.userId || firebaseAuth.currentUser?.uid || '').trim();
 }
@@ -2317,6 +2325,7 @@ window.StorageService = {
   updateDetail,
   removeDetail,
   recordSiteUnlockHistory,
+  recordExcelExportHistory,
   exportData,
   importData,
   ensureCurrentUser,


### PR DESCRIPTION
### Motivation
- Enregistrer immédiatement dans la page « Historiques » chaque action d’export Excel déclenchée par l’utilisateur sans attendre le succès de l’export. 
- Réutiliser exactement le mécanisme d’historique existant pour conserver la même structure, utilisateur et format d’affichage. 
- Garantir un seul log par action d’export et ne modifier aucune autre logique d’export ou de rendu de la page Historiques.

### Description
- Ajout de `recordExcelExportHistory(siteId, siteName)` dans `js/storage.js`, qui résout le nom du site et appelle `appendHistoryEntry` avec le message `a exporté un fichier depuis le site « {Nom du site} ».`, en conservant la structure et le `serverTimestamp()` existants. 
- Exposition de la fonction via `window.StorageService.recordExcelExportHistory` pour réutilisation depuis les écrans. 
- Appels placés dans `js/app.js` juste au démarrage des flux d’export (`exportItems` et `exportDetails`) afin d’enregistrer immédiatement l’événement; l’appel utilise `.catch(() => {})` pour ne pas bloquer l’export en cas d’erreur d’écriture de l’historique. 
- Aucun changement visuel ni modification du flux d’export ou de la page Historiques n’a été effectué.

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check js/app.js && node --check js/storage.js`, succès. 
- Contrôle de cohérence du diff effectué avec `git diff --check`, aucun problème détecté. 
- Vérification d’état du dépôt réalisée via `git status` et inspection du dernier log, opérations locales terminées sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73276217fc832693455cd6ab8dd896)