### PR TITLE
Améliorer le footer de la sidebar : divider et fond coloré

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6914,11 +6914,14 @@ body.sidebar-open {
 .sidebar-footer {
   flex: 0 0 auto;
   margin-top: auto;
-  padding-top: 14px;
+  padding: 14px 12px;
+  border-top: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 16px;
   text-align: center;
   font-size: 12px;
   line-height: 1.25;
-  color: #8a94a6;
+  color: #475569;
+  background: linear-gradient(180deg, #eef5ff 0%, #e7f0ff 100%);
 }
 
 .sidebar-footer p {


### PR DESCRIPTION
### Motivation
- Améliorer la visibilité et la lisibilité du pied de page du menu latéral en distinguant clairement le footer du reste du contenu tout en respectant le style existant.

### Description
- Mise à jour du style de `.sidebar-footer` dans `css/style.css` pour ajouter un divider avec `border-top: 1px solid rgba(37, 99, 235, 0.16)`.
- Ajout d'un fond coloré en dégradé via `background: linear-gradient(180deg, #eef5ff 0%, #e7f0ff 100%)`, ajustement de la couleur du texte à `#475569`, et réglage du `padding: 14px 12px` et `border-radius: 16px` pour conserver les coins arrondis et les espacements du design.
- Aucune autre partie du menu latéral n'a été modifiée.

### Testing
- Vérification automatisée par un court script `python3` confirmant la présence des nouvelles règles CSS (réussie).
- Test automatisé de disponibilité de Playwright via `node -e` (échoué car Playwright/navigateur absent dans l'environnement, donc aucune capture d'écran générée).
- Vérifications locales de style après modification n'ont révélé aucune erreur automatisée supplémentaire.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7353dc836c83268e0e72cc32f9f3da)