### PR TITLE
Add materials Excel export, permissions event, and export UI to materials page

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -831,6 +831,36 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     };
   }
 
+  function buildMaterialsExcelContent(title, rows, siteName) {
+    return async () => {
+      const ExcelJS = await getExcelJsModule();
+      const workbook = new ExcelJS.Workbook();
+      const worksheet = workbook.addWorksheet(String(title || 'Export').slice(0, 31));
+      worksheet.columns = [
+        { header: 'Code', key: 'code', width: 24 },
+        { header: 'Désignation', key: 'designation', width: 56 },
+      ];
+      rows.forEach((row) => {
+        worksheet.addRow({
+          code: formatExcelCellValue(row.code),
+          designation: formatExcelCellValue(row.designation),
+        });
+      });
+      worksheet.spliceRows(1, 0, [], [], [], []);
+      applyExcelProfessionalHeader(worksheet, siteName);
+      applyProfessionalExcelStyling(worksheet, 5);
+      return workbook;
+    };
+  }
+
+  window.AppExcelExport = {
+    buildPage2ExportFileName,
+    buildMaterialsExcelContent,
+    buildSiteExcelContent,
+    downloadExcelFile,
+    saveExportFileNameToHistory,
+  };
+
 
 
   function buildPermissions(profile) {
@@ -8587,6 +8617,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     profile = resolveConnectedProfile(profile, isAuthenticated);
 
     const permissions = buildPermissions(profile);
+    window.AppPermissions = permissions;
+    window.dispatchEvent(new CustomEvent('app:permissions-ready', { detail: { permissions } }));
 
     initMaintenanceGate(permissions, profile);
 

--- a/js/materiels.js
+++ b/js/materiels.js
@@ -9,6 +9,7 @@ import { firebaseDb } from './firebase-core.js';
   let materialCart = [];
   let lastRequestMeta = null;
   let isRequestPngDownloading = false;
+  let displayedMaterials = [];
 
   function getCartItemKey(item = {}) {
     return String(item.code || item.manualKey || '');
@@ -258,6 +259,48 @@ import { firebaseDb } from './firebase-core.js';
       btn.disabled = isEmpty;
       btn.classList.toggle('is-disabled-soft', isEmpty);
     });
+  }
+
+  function canExportMaterials() {
+    return Boolean(window.AppPermissions?.canImportExport);
+  }
+
+  function syncMaterialsExportButtonVisibility() {
+    const exportButton = requireElement('materialsExportBtn');
+    if (!exportButton) {
+      return;
+    }
+    const canExport = canExportMaterials();
+    exportButton.hidden = !canExport;
+    exportButton.classList.toggle('hidden', !canExport);
+  }
+
+  function buildMaterialsExportRows(materials) {
+    return (Array.isArray(materials) ? materials : []).map((material) => ({
+      code: material.code,
+      designation: material.designation,
+    }));
+  }
+
+  function exportDisplayedMaterials() {
+    if (!canExportMaterials()) {
+      window.UiService?.showToast?.('Action non autorisée.');
+      return;
+    }
+    if (!displayedMaterials.length) {
+      window.UiService?.showToast?.('Aucun matériel à exporter.');
+      return;
+    }
+    const excelExport = window.AppExcelExport;
+    if (!excelExport?.buildMaterialsExcelContent || !excelExport?.downloadExcelFile) {
+      window.UiService?.showToast?.('Export Excel indisponible.');
+      return;
+    }
+    const rows = buildMaterialsExportRows(displayedMaterials);
+    const fileName = excelExport.buildPage2ExportFileName?.('demande-materiels', 'xlsx') || 'demande-materiels.xlsx';
+    const workbook = excelExport.buildMaterialsExcelContent('Demande matériels', rows, 'Demande matériels');
+    excelExport.downloadExcelFile(fileName, 'Export Excel', workbook);
+    excelExport.saveExportFileNameToHistory?.(fileName);
   }
 
   function renderMaterialCart() {
@@ -889,6 +932,7 @@ import { firebaseDb } from './firebase-core.js';
     }
 
     const safeMaterials = Array.isArray(materials) ? materials : [];
+    displayedMaterials = safeMaterials;
     const countNumber = document.querySelector('#materialsCount .count-number');
     const emptyState = requireElement('materialsEmptyState');
     const table = requireElement('materialsDataTable');
@@ -953,6 +997,7 @@ import { firebaseDb } from './firebase-core.js';
     const backButton = requireElement('materialsBackButton');
     const searchInput = requireElement('materialsSearchInput');
     const clearSearchBtn = requireElement('materialsClearSearchBtn');
+    const exportButton = requireElement('materialsExportBtn');
     let allMaterials = [];
 
     backButton?.addEventListener('click', () => {
@@ -993,6 +1038,9 @@ import { firebaseDb } from './firebase-core.js';
     });
 
     toggleClearButton();
+    syncMaterialsExportButtonVisibility();
+    window.addEventListener('app:permissions-ready', syncMaterialsExportButtonVisibility);
+    exportButton?.addEventListener('click', exportDisplayedMaterials);
 
     initMaterialsHint();
 

--- a/materiels.html
+++ b/materiels.html
@@ -364,6 +364,20 @@
         pointer-events: none;
       }
 
+      .materials-page .page3-sub-info {
+        align-items: center;
+        display: flex;
+        gap: 0.65rem;
+      }
+
+      .materials-page .materials-export-btn {
+        min-height: 30px;
+        padding: 0.28rem 0.72rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+        line-height: 1;
+      }
+
       @keyframes request-png-spin {
         to { transform: rotate(360deg); }
       }
@@ -398,6 +412,9 @@
               <span class="count-number page3-count-number">0</span>
               <span class="count-label page3-count-label">Matériels</span>
             </div>
+            <button id="materialsExportBtn" class="btn btn-export materials-export-btn hidden" type="button" hidden>
+              Exporter
+            </button>
           </div>
           <div id="materialsHint" class="materials-hint hidden">
             <span>👋 Astuce : appuyez sur un matériel pour l’ajouter à votre demande.</span>
@@ -518,6 +535,7 @@
     <script type="module" src="js/maintenance-banner.js"></script>
     <script type="module" src="js/storage.js"></script>
     <script src="js/ui.js"></script>
+    <script type="module" src="js/app.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script type="module" src="js/materiels.js"></script>
   </body>


### PR DESCRIPTION
### Motivation
- Provide an Excel export for the materials list and enable UI control based on user permissions. 
- Expose application permissions and a ready event so pages can react to permission state asynchronously.

### Description
- Added `buildMaterialsExcelContent` to `js/app.js` and exposed `window.AppExcelExport` so materials export logic can build and download workbooks via the existing Excel helpers. 
- Published calculated permissions to `window.AppPermissions` and dispatched a `CustomEvent('app:permissions-ready')` from `bootstrap()` to notify pages when permissions are available. 
- Implemented client-side export support in `js/materiels.js`, including `displayedMaterials` tracking, permission checks, `exportDisplayedMaterials()` action, and UI sync helpers (`syncMaterialsExportButtonVisibility`). 
- Updated `materiels.html` to add the export button markup/CSS and include `js/app.js` so the export and permissions features are available on the page. 

### Testing
- Ran project linting via `npm run lint` which completed successfully. 
- Built the frontend with `npm run build` and the build succeeded without errors. 
- Executed the test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7358778eac8326b30d1b903b84e44f)