### PR TITLE
Remove dotted underline from clickable creator name

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7607,9 +7607,7 @@ body[data-page="home"] .inactive-site-delete {
 body[data-page="home"] .site-creator-edit {
   color: inherit;
   cursor: pointer;
-  text-decoration: underline;
-  text-decoration-style: dotted;
-  text-underline-offset: 3px;
+  text-decoration: none;
 }
 
 body[data-page="home"] .site-creator-edit:hover,


### PR DESCRIPTION
### Motivation
- Remove the dotted underline shown for the clickable creator name while keeping the text fully clickable and preserving color, font, size and behavior for Admin/Adjoint Admin roles.

### Description
- Change in `css/style.css`: set `body[data-page="home"] .site-creator-edit { text-decoration: none; }` and keep `color: inherit` and `cursor: pointer` so only the visual dotted underline is removed.

### Testing
- Confirmed occurrences with `rg -n "site-creator-edit|text-decoration" css/style.css js/app.js`, inspected the `git diff -- css/style.css`, and committed the change; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a740c3743088326888d18dc7fc8bab7)