### PR TITLE
Supprimer le soulignement en pointillés du nom du créateur

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7610,6 +7610,12 @@ body[data-page="home"] .site-creator-edit {
   text-decoration: none;
 }
 
+body[data-page="home"] .site-creator-name {
+  border-bottom: 0;
+  background-image: none;
+  text-decoration: none;
+}
+
 body[data-page="home"] .site-creator-edit:hover,
 body[data-page="home"] .site-creator-edit:focus-visible {
   color: #2563eb;

--- a/js/app.js
+++ b/js/app.js
@@ -2679,8 +2679,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           const createdBy = resolveActorLabel(site?.createdBy, userNamesById, site?.createdByName);
           const canChangeCreator = canCurrentUserChangeSiteCreator();
           const creatorMarkup = canChangeCreator
-            ? `<span class="site-creator-edit" data-site-creator="${escapeHtml(site.id)}" role="button" tabindex="0" title="Modifier le créateur" aria-label="Modifier le créateur du site ${escapeHtml(site.nom)}">${escapeHtml(createdBy)}</span>`
-            : `<span>${escapeHtml(createdBy)}</span>`;
+            ? `<span class="site-creator-name site-creator-edit" data-site-creator="${escapeHtml(site.id)}" role="button" tabindex="0" title="Modifier le créateur" aria-label="Modifier le créateur du site ${escapeHtml(site.nom)}">${escapeHtml(createdBy)}</span>`
+            : `<span class="site-creator-name">${escapeHtml(createdBy)}</span>`;
           const lockIconSrc = isSiteLocked(site) ? 'Icon/Cadenas_close.png' : 'Icon/Cadenas_Open.png';
           const siteIsLocked = isSiteLocked(site);
           const lockLabel = siteIsLocked ? 'Verrouillé' : 'Déverrouillé';


### PR DESCRIPTION
### Motivation
- Retirer uniquement l’effet visuel de soulignement en pointillés affiché sous le nom du créateur sur les cartes de la page d’accueil tout en conservant toutes les interactions existantes (clic, lien, infobulle, accessibilité).
- Ne modifier ni la couleur, ni la taille, ni la police, ni l’alignement ou l’espacement du nom, ni aucune autre partie du design.

### Description
- Ajout de la classe `site-creator-name` aux éléments de rendu du créateur dans `js/app.js` pour l’appliquer aux variantes éditables et non éditables sans toucher aux attributs interactifs (`data-site-creator`, `role`, `tabindex`, `title`, `aria-label`).
- Ajout d’une règle CSS ciblée dans `css/style.css` (`body[data-page="home"] .site-creator-name`) qui neutralise l’effet de soulignement (`border-bottom: 0`, `background-image: none`, `text-decoration: none`) sans changer les autres styles.
- Aucune autre règle visuelle ni composant n’a été modifié.

### Testing
- Exécution de la vérification de syntaxe JavaScript via `node --check js/app.js` qui a réussi et n’a révélé aucune erreur de syntaxe.
- Tentative d’exécution de tests de rendu navigateur automatisés via Playwright a échoué car Playwright/Chromium n’est pas disponible dans l’environnement (échec attendu dans cet environnement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a740ebd908c832695b79888ea798628)