### PR TITLE
Ajouter l'icône existante au menu latéral « Demande matériels »

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6887,9 +6887,12 @@ body.sidebar-open {
 
 .sidebar-item__icon {
   width: 20px;
+  height: 20px;
   color: #2563eb;
   font-size: 18px;
   text-align: center;
+  object-fit: contain;
+  flex: 0 0 20px;
 }
 
 .sidebar-item:hover {

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
             Historiques
           </button>
           <button id="sidebarAllMaterialsBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="materiels.html">
+            <img src="Icon/Demande matériel.png" alt="" aria-hidden="true" class="sidebar-item__icon" />
             Demande matériels
           </button>
           <button id="sidebarImportBtn" class="header-menu__option sidebar-item" type="button" role="menuitem">


### PR DESCRIPTION
### Motivation
- Afficher une icône à gauche de l'élément « Demande matériels » en réutilisant l'image déjà présente dans le dépôt pour améliorer la cohérence visuelle du Sidebar sans modifier le reste du menu.

### Description
- Insère l'image `Icon/Demande matériel.png` à gauche du libellé dans `index.html` et ajuste la classe `sidebar-item__icon` dans `css/style.css` pour imposer une taille fixe (`20×20`), `object-fit: contain` et un comportement `flex` garantissant espacement et alignement cohérents avec les autres éléments du menu.

### Testing
- Vérifications automatisées réussies: le fichier `Icon/Demande matériel.png` est présent, la référence est bien ajoutée dans `index.html`, l'accès fichier via Node a réussi et le parse HTML de `index.html` est OK, et la vérification de style/structure a été appliquée; la capture visuelle automatisée via `Playwright` n'a pas pu être réalisée car `Playwright` / navigateur headless n'était pas disponible dans l'environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7429d8127c8326b4035d97639a19ee)