### PR TITLE
Remplacer les emoji Magasin/Remarque par Icon/Shop.png et Icon/Remarque.png

### DIFF
--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -50,11 +50,11 @@
               <div class="purchase-value purchase-value--inline"><input id="purchaseDetailQty" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div class="purchase-info-row" role="listitem">
-              <div class="purchase-label"><span aria-hidden="true" class="icon">🏪</span><span>Magasin :</span></div>
+              <div class="purchase-label"><img src="Icon/Shop.png" alt="" aria-hidden="true" class="icon" /><span>Magasin :</span></div>
               <div class="purchase-value purchase-value--inline"><input id="purchaseDetailStore" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div id="purchaseDetailRemarkRow" class="purchase-info-row" role="listitem" hidden>
-              <div class="purchase-label"><span aria-hidden="true" class="icon">📝</span><span>Remarque :</span></div>
+              <div class="purchase-label"><img src="Icon/Remarque.png" alt="" aria-hidden="true" class="icon" /><span>Remarque :</span></div>
               <div class="purchase-value purchase-value--inline"><textarea id="purchaseDetailRemark" class="purchase-inline-field purchase-inline-field--textarea" rows="1" readonly></textarea></div>
             </div>
             <div class="purchase-info-row" role="listitem">


### PR DESCRIPTION
### Motivation
- Remplacer les emoji utilisés sur la page `Achat matériel(s)` par des images du dépôt afin d’uniformiser le chargement des icônes et conserver taille, alignement et espacement via le système d’assets existant.

### Description
- Modifié `purchase-detail.html` pour remplacer la span emoji du champ `Magasin` par `<img src="Icon/Shop.png" alt="" aria-hidden="true" class="icon" />` et la span emoji du champ `Remarque` par `<img src="Icon/Remarque.png" alt="" aria-hidden="true" class="icon" />`, en réutilisant la classe `icon` pour préserver le rendu.

### Testing
- Vérifications automatisées effectuées : `git diff --check` et `git status --short` ont réussi et le changement a été commité, la tentative de création de PR via `gh pr create` a échoué à cause de l’authentification manquante, et une inspection du répertoire `Icon/` montre que les fichiers `Icon/Shop.png` et `Icon/Remarque.png` ne sont pas présents dans ce checkout (à valider dans le dépôt cible).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74400353f4832682e1a4411473854a)