### PR TITLE
Use Icon/Image.png as fallback image for purchases

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -22,6 +22,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
+  const DEFAULT_PURCHASE_IMAGE_SRC = 'Icon/Image.png';
+
   const EXPORT_FILE_NAME_HISTORY_KEY = 'suiviMateriel.exportFileNames.v1';
   const EXPORT_FILE_NAME_HISTORY_LIMIT = 24;
 
@@ -5360,7 +5362,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
                 <div class="purchase-card__media" aria-hidden="true">
                   ${String(purchase?.imageUrl || '').trim()
                     ? `<img src="${escapeHtml(purchase.imageUrl)}" alt="Photo achat matériel" />`
-                    : '🖼️'}
+                    : `<img src="${escapeHtml(DEFAULT_PURCHASE_IMAGE_SRC)}" alt="" aria-hidden="true" />`}
                 </div>
                 <div class="purchase-card__body">
                   <h3 class="list-card__title">${escapeHtml(purchase?.designation || '-')}</h3>
@@ -8597,7 +8599,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       summaryCreatedAt.textContent = dateLabel;
       summaryMedia.innerHTML = imageUrl
         ? `<img src="${escapeHtml(imageUrl)}" alt="Photo achat matériel" />`
-        : '<span>🖼️</span>';
+        : `<img src="${escapeHtml(DEFAULT_PURCHASE_IMAGE_SRC)}" alt="" aria-hidden="true" />`;
       qty.value = `${Number(purchase?.qty || 0)} ${String(purchase?.unit || 'Pcs')}`;
       store.value = purchaseStore;
       if (purchaseRemark) {

--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -23,7 +23,7 @@
       <main class="page-content main-content purchase-detail-content">
         <section id="purchaseDetailSummary" class="surface-card section purchase-detail-summary" aria-live="polite">
           <div class="purchase-detail-summary__media" aria-hidden="true">
-            <span>🖼️</span>
+            <img src="Icon/Image.png" alt="" aria-hidden="true" />
           </div>
           <div class="purchase-detail-summary__body">
             <h2 class="section-title purchase-detail-summary__title"><input id="purchaseDetailName" class="purchase-inline-field" type="text" value="Chargement..." readonly /></h2>
@@ -38,7 +38,7 @@
               <button id="purchaseDetailImageButton" class="purchase-detail-image-button" type="button" aria-label="Afficher l’image en grand" hidden>
                 <img id="purchaseDetailImage" class="purchase-detail-image" alt="Photo achat matériel" />
               </button>
-              <div id="purchaseDetailImagePlaceholder" class="purchase-detail-image purchase-detail-image--placeholder" aria-hidden="true">🖼️</div>
+              <img id="purchaseDetailImagePlaceholder" class="purchase-detail-image purchase-detail-image--placeholder" src="Icon/Image.png" alt="" aria-hidden="true" />
               <button id="purchaseDetailImageEditButton" class="purchase-detail-image-edit fab" type="button" aria-label="Modifier l’image" hidden>✏️</button>
               <input id="purchaseDetailImageInput" class="purchase-detail-image-input" type="file" accept="image/*" hidden />
             </div>


### PR DESCRIPTION
### Motivation
- Replace the current emoji/default placeholder on the Achat matériel(s) page with the existing repository asset `Icon/Image.png` so the app uses a project image instead of an emoji while keeping the current visual design. 
- Ensure the real purchase photo is still shown when present and do not change any other behaviour or layout of the page.

### Description
- Added a `DEFAULT_PURCHASE_IMAGE_SRC = 'Icon/Image.png'` constant in `js/app.js` to centralize the fallback asset reference. 
- Updated the purchase list card rendering in `js/app.js` to use an `<img src="${escapeHtml(DEFAULT_PURCHASE_IMAGE_SRC)}" .../>` fallback when `purchase.imageUrl` is absent. 
- Updated the purchase detail summary rendering in `js/app.js` to use the same `DEFAULT_PURCHASE_IMAGE_SRC` fallback when `imageUrl` is absent. 
- Replaced the placeholder emoji in `purchase-detail.html` with an `<img id="purchaseDetailImagePlaceholder" ... src="Icon/Image.png"/>` element while keeping existing classes and structure so dimensions, alignment and styling are preserved.

### Testing
- Ran `node --check js/app.js` and it completed successfully. 
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74429f08248326b8bbcf0f17e3da98)