### PR TITLE
Fix purchase-detail icon asset paths

### DIFF
--- a/purchase-detail.html
+++ b/purchase-detail.html
@@ -50,11 +50,11 @@
               <div class="purchase-value purchase-value--inline"><input id="purchaseDetailQty" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div class="purchase-info-row" role="listitem">
-              <div class="purchase-label"><img src="Icon/Shop.png" alt="" aria-hidden="true" class="icon" /><span>Magasin :</span></div>
+              <div class="purchase-label"><img src="Icon/Site.png" alt="" aria-hidden="true" class="icon" /><span>Magasin :</span></div>
               <div class="purchase-value purchase-value--inline"><input id="purchaseDetailStore" class="purchase-inline-field" type="text" value="-" readonly /></div>
             </div>
             <div id="purchaseDetailRemarkRow" class="purchase-info-row" role="listitem" hidden>
-              <div class="purchase-label"><img src="Icon/Remarque.png" alt="" aria-hidden="true" class="icon" /><span>Remarque :</span></div>
+              <div class="purchase-label"><img src="Icon/crayon-de-blog.png" alt="" aria-hidden="true" class="icon" /><span>Remarque :</span></div>
               <div class="purchase-value purchase-value--inline"><textarea id="purchaseDetailRemark" class="purchase-inline-field purchase-inline-field--textarea" rows="1" readonly></textarea></div>
             </div>
             <div class="purchase-info-row" role="listitem">


### PR DESCRIPTION
### Motivation
- Corriger les icônes cassées sur la page `purchase-detail.html` en pointant vers des assets déjà présents dans le dépôt afin d’éviter les images manquantes et conserver le mécanisme d’import centralisé existant.

### Description
- Remplacement de `Icon/Shop.png` par l’asset existant `Icon/Site.png` pour l’icône « Magasin » dans `purchase-detail.html`.
- Remplacement de `Icon/Remarque.png` par l’asset existant `Icon/crayon-de-blog.png` pour l’icône « Remarque » dans `purchase-detail.html`.

### Testing
- Exécution d’un petit parseur HTML pour lister toutes les sources d’images et vérifier qu’il n’existe plus de références vers des fichiers manquants, test passé (aucune image cassée détectée). 
- Vérification d’existence des fichiers ciblés via script (`Icon/Site.png` et `Icon/crayon-de-blog.png` existent, `Icon/Shop.png` et `Icon/Remarque.png` sont absents), résultat conforme aux attentes.
- Inspection du fichier `css/style.css` pour confirmer que la classe ` .icon` applique la même taille/alignement que les autres icônes, et que le rendu restera cohérent, vérification manuelle réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7456b22fe88323a031987f8507bbad)