### PR TITLE
Corriger l'espacement du footer de la sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6916,10 +6916,11 @@ body.sidebar-open {
 
 .sidebar-footer {
   flex: 0 0 auto;
-  margin-top: auto;
+  width: calc(100% + 32px);
+  margin: auto -16px -20px;
   padding: 14px 12px;
   border-top: 1px solid rgba(37, 99, 235, 0.16);
-  border-radius: 16px;
+  border-radius: 0 0 26px 0;
   text-align: center;
   font-size: 12px;
   line-height: 1.25;


### PR DESCRIPTION
### Motivation
- Le fond du footer du menu latéral ne remplissait pas toute la largeur et laissait des marges blanches à gauche, à droite et en bas, il faut coller le fond aux bords du panneau tout en conservant l'espacement interne.

### Description
- Modifié le fichier `css/style.css` pour ajuster la règle `.sidebar-footer` afin que son fond déborde du padding du panneau sans changer les couleurs ni le texte. 
- Ajouté `width: calc(100% + 32px);` pour compenser les `16px` de padding latéral du sidebar et supprimé `margin-top: auto` au profit de `margin: auto -16px -20px;` pour coller le footer aux bords gauche/droite et au bas. 
- Remplacé `border-radius: 16px;` par `border-radius: 0 0 26px 0;` pour conserver uniquement l'arrondi inférieur droit du panneau tout en supprimant l'arrondi qui créait un espace visuel; `padding: 14px 12px;` a été conservé pour l'espacement interne. 
- Aucun autre fichier, couleur, texte ou élément du sidebar n'a été modifié.

### Testing
- `python3` script de vérification des déclarations CSS (cherche `width`, `margin`, `padding`, `border-radius`) — réussi. 
- `python3` parser HTML pour vérifier la présence de `footer.sidebar-footer` dans `index.html` — réussi. 
- `git diff --check` — réussi. 
- Tentative d'exécution d'un test visuel via Playwright (`node -e ...`) a échoué car Playwright / navigateur headless n'est pas disponible dans l'environnement de CI — test visuel non réalisé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74608e55588323abf051ce97299636)