### PR TITLE
Remove history list outer border

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1093,8 +1093,7 @@ body[data-page="history"] .list-grid {
   flex: 1 1 auto;
   min-height: 0;
   background: rgba(255, 255, 255, 0.88);
-  border-block: 1px solid rgba(182, 206, 232, 0.8);
-  border-inline: 0;
+  border: 0;
   border-radius: 0;
   box-shadow: var(--shadow);
   overflow-y: auto;


### PR DESCRIPTION
### Motivation
- Supprimer la bordure extérieure du conteneur principal de la page « Historiques » tout en conservant les séparateurs horizontaux entre éléments, les coins arrondis, les marges, les espacements, les couleurs et l'ombre, sans toucher aux fonctionnalités ni aux données.

### Description
- Modifié `css/style.css` pour remplacer les règles `border-block: 1px solid rgba(182, 206, 232, 0.8);` et `border-inline: 0;` de la classe `.history-list` par `border: 0;`, en conservant le `background`, les séparateurs (`.history-list__item + .history-list__item`), le `box-shadow` et le comportement de défilement.

### Testing
- Exécuté `git diff --check` (aucune erreur), vérifié `git status --short` (affiche `M css/style.css`) et confirmé le commit avec `git commit`, et une tentative de création de PR via `gh pr create` a échoué parce que l'outil CLI n'est pas authentifié dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74c87126308323a08a51da4f4e1523)