### PR TITLE
Remove outer borders from page 3 table container

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3233,6 +3233,13 @@ body[data-page="item-detail"] .auth-required-card--embedded {
   margin-bottom: 20px;
 }
 
+body[data-page="item-detail"] .main-content > .table-card {
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+}
+
+
 body[data-page="item-detail"] .section-heading--table {
   display: block;
 }


### PR DESCRIPTION
### Motivation
- Supprimer les bordures extérieures (haut, gauche, droite) du conteneur principal de la page 3 (« Tableau des données ») pour appliquer la même retouche visuelle qu’ailleurs tout en conservant le design et le comportement actuels.

### Description
- Ajout d'une règle CSS dans `css/style.css` ciblant `body[data-page="item-detail"] .main-content > .table-card` définissant `border-top: 0; border-left: 0; border-right: 0;`, sans modifier les bordures internes du tableau, les coins arrondis, les ombres, les marges ou le défilement horizontal.

### Testing
- Exécuté `git diff --check` et `git status --short` (résultats OK) et commité la modification; la tentative automatique de création de PR via `gh pr create` a échoué en raison d'une authentification manquante (requiert `gh auth login` ou `GH_TOKEN`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74ca8b314c8323a59286ea18a326e7)