### PR TITLE
Réduire les marges latérales de la page "Tableau des données"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7642,3 +7642,15 @@ body[data-page="home"] .site-creator-select {
   font: inherit;
   padding: 4px 8px;
 }
+
+/* Page "Tableau des données" : keep the main card nearly edge-to-edge. */
+body[data-page="item-detail"] .app-shell.app-shell--wide {
+  width: 100% !important;
+  max-width: 100% !important;
+  margin-inline: 0 !important;
+}
+
+body[data-page="item-detail"] .page-content.page-content--wide.main-content {
+  padding-left: clamp(5px, 1.8vw, 9px) !important;
+  padding-right: clamp(5px, 1.8vw, 9px) !important;
+}


### PR DESCRIPTION
### Motivation
- Réduire l'espace vide latéral important autour du conteneur principal sur la page « Tableau des données » afin que la carte occupe presque toute la largeur disponible tout en conservant les coins arrondis et le design existant.

### Description
- Ajout de règles CSS dans `css/style.css` pour forcer `body[data-page="item-detail"] .app-shell.app-shell--wide` à utiliser `width: 100%` et pour réduire les gouttières horizontales de `body[data-page="item-detail"] .page-content.page-content--wide.main-content` en appliquant `padding-left` / `padding-right: clamp(5px, 1.8vw, 9px)`, sans toucher aux éléments internes du conteneur.

### Testing
- Exécution de `git diff --check` n'a révélé aucun problème et le changement a été commité; la création automatique de la PR via `gh` a échoué en raison d'une authentification manquante.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74cfbe243883238f5312a07bc82551)