### PR TITLE
Enregistrer un historique pour tentatives d'ouverture de site avec mot de passe incorrect

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3412,6 +3412,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         const passwordHash = await hashPassword(passwordValue);
         if (passwordHash !== targetSite.passwordHash) {
           const failure = await StorageService.registerSiteUnlockFailure(siteIdPendingUnlock);
+          await StorageService.recordSiteUnlockFailureHistory(siteIdPendingUnlock, failure?.attemptsRemaining);
           clearSiteUnlockAttemptsInfo();
           if (failure?.isBlocked) {
             setSiteUnlockBlockedState(true);
@@ -8291,7 +8292,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     if (!action || !siteName) {
       return action;
     }
-    if (/\bsite\s+«[^»]+»[.!?]?$/i.test(action) || /\bdans le site\s+«[^»]+»[.!?]?$/i.test(action) || /\bdu site\s+«[^»]+»[.!?]?$/i.test(action)) {
+    if (/\bsite\s+«[^»]+»/i.test(action) || /\bdans le site\s+«[^»]+»[.!?]?$/i.test(action) || /\bdu site\s+«[^»]+»[.!?]?$/i.test(action)) {
       return action;
     }
     const suffix = `site « ${siteName} »`;

--- a/js/storage.js
+++ b/js/storage.js
@@ -1498,6 +1498,22 @@ async function recordSiteUnlockHistory(siteId) {
   await appendHistoryEntry('a déverrouillé le site', { siteId });
 }
 
+function formatSiteUnlockFailureAttemptsMessage(attemptsRemaining) {
+  const count = Math.max(0, Number(attemptsRemaining) || 0);
+  if (count === 0) {
+    return 'Il ne reste plus aucun essai.';
+  }
+  return `Il reste ${count} ${count === 1 ? 'essai' : 'essais'}.`;
+}
+
+async function recordSiteUnlockFailureHistory(siteId, attemptsRemaining) {
+  const profile = await getCurrentUserProfile();
+  const username = normalizeUsername(profile?.username) || normalizeUsername(state.authUser?.displayName) || 'Utilisateur inconnu';
+  const siteName = resolveSiteNameForHistory(siteId);
+  const action = `${username} a essayé d'ouvrir le site « ${siteName || 'Site inconnu'} » avec un mot de passe incorrect. ${formatSiteUnlockFailureAttemptsMessage(attemptsRemaining)}`;
+  await appendHistoryEntry(action, { siteId, siteName });
+}
+
 async function recordExcelExportHistory(siteId, siteName = '') {
   const resolvedSiteName = resolveSiteNameForHistory(siteId, siteName);
   const action = resolvedSiteName
@@ -2363,6 +2379,7 @@ window.StorageService = {
   updateDetail,
   removeDetail,
   recordSiteUnlockHistory,
+  recordSiteUnlockFailureHistory,
   recordExcelExportHistory,
   exportData,
   importData,


### PR DESCRIPTION
### Motivation
- Enregistrer automatiquement dans la page `Historiques` chaque tentative d'ouverture de site où le mot de passe est incorrect. 
- Réutiliser exactement le mécanisme d'historique existant (même structure, même horodatage serveur et même logique utilisateur). 
- Enregistrer le log immédiatement après que la vérification du mot de passe a déterminé l'échec et en réutilisant le calcul des essais restants. 

### Description
- Appel à `StorageService.recordSiteUnlockFailureHistory(siteId, attemptsRemaining)` ajouté dans `js/app.js` juste après `registerSiteUnlockFailure(...)` pour créer un historique à chaque échec de mot de passe. 
- Nouvelles fonctions `formatSiteUnlockFailureAttemptsMessage` et `recordSiteUnlockFailureHistory` ajoutées dans `js/storage.js` pour construire le message requis en français et réutiliser `appendHistoryEntry` afin de conserver la même structure et horodatage serveur. 
- Export de la nouvelle fonction via l'objet `StorageService` dans `js/storage.js` pour qu'elle soit utilisable depuis l'UI. 
- Ajustement mineur de `formatHistoryActionWithSite` dans `js/app.js` pour éviter d'ajouter automatiquement un suffixe de site lorsque l'action contient déjà `site « ... »`, afin de conserver le message formaté tel quel. 

### Testing
- `node --check js/storage.js` exécuté et réussi. 
- `node --check js/app.js` exécuté et réussi. 
- `git diff --check` exécuté et aucun problème détecté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74d4c733148323ae05df8c7a2147ef)