### PR TITLE
Historique : corrige la mise en page pour occuper toute la largeur

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7205,6 +7205,7 @@ body[data-page="item-detail"] .search-highlight {
   }
 }
 
+
 /* =========================================================
    RESPONSIVE UI SCALING
    Premium scaling for tablet / desktop / Chrome desktop mode
@@ -7653,4 +7654,36 @@ body[data-page="item-detail"] .app-shell.app-shell--wide {
 body[data-page="item-detail"] .page-content.page-content--wide.main-content {
   padding-left: clamp(5px, 1.8vw, 9px) !important;
   padding-right: clamp(5px, 1.8vw, 9px) !important;
+}
+
+/* Final history layout override: keep the page flush with the viewport edges. */
+body[data-page="history"] .app-shell {
+  width: 100% !important;
+  max-width: none !important;
+  margin-inline: 0 !important;
+}
+
+body[data-page="history"] .app-header,
+body[data-page="history"] .app-header--detail,
+body[data-page="history"] .page-content--history,
+body[data-page="history"] .main-content,
+body[data-page="history"] .history-list,
+body[data-page="history"] .history-list__items {
+  width: 100% !important;
+  max-width: none !important;
+}
+
+body[data-page="history"] .page-content--history {
+  padding-inline: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  gap: 0 !important;
+}
+
+body[data-page="history"] .history-list {
+  box-shadow: none !important;
+}
+
+body[data-page="history"] .history-list__item {
+  padding: 0.75rem 0.75rem;
 }


### PR DESCRIPTION
### Motivation

- Supprimer l'espace blanc latéral et faire en sorte que la page "Historique" occupe 100 % de la largeur de l'écran. 
- Aligner le fond bleu de l'AppBar avec le contenu principal et supprimer les marges externes inutiles autour de la liste d'historiques. 
- Conserver uniquement un léger padding interne pour chaque élément de la liste afin de garder une lecture confortable.

### Description

- Ajout d'overrides CSS ciblés dans `css/style.css` pour `body[data-page="history"]` afin de forcer `.app-shell`, `.app-header`, `.page-content--history`, `.main-content`, `.history-list` et `.history-list__items` à `width: 100%` et `max-width: none`. 
- Suppression des paddings externes de la page historique en réglant `padding-inline`, `padding-top` et `padding-bottom` à `0` pour `.page-content--history`. 
- Suppression de l'ombre du conteneur et réduction des marges visuelles en supprimant le `box-shadow` sur `.history-list`. 
- Réduction du padding des lignes d'historique à un padding interne léger (`padding: 0.75rem 0.75rem`) pour respecter l'espacement demandé.

### Testing

- Vérification de la structure CSS avec un script Python pour s'assurer que les accolades sont équilibrées (`python3` check du fichier `css/style.css`) — réussi. 
- Démarrage d'un serveur statique pour validation visuelle via `python3 -m http.server` — réussi. 
- Tentative d'une capture d'écran automatisée via Playwright a échoué car le module `playwright` n'est pas installé dans l'environnement, empêchant la génération de la preuve visuelle automatisée — échoué.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a755699413483239655dba62ac54350)