### PR TITLE
Page 3 (Tableau des données) — corrige la mise en page pour occuper 100% de la largeur

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7687,3 +7687,70 @@ body[data-page="history"] .history-list {
 body[data-page="history"] .history-list__item {
   padding: 0.75rem 0.75rem;
 }
+
+/* Final page 3 width fix: make the data table page flush with Android viewport edges. */
+body[data-page="item-detail"] {
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  overflow-x: hidden;
+}
+
+body[data-page="item-detail"] .app-shell.app-shell--wide {
+  width: 100% !important;
+  max-width: none !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+body[data-page="item-detail"] .app-header.app-header--detail,
+body[data-page="item-detail"] .page-content.page-content--wide.main-content,
+body[data-page="item-detail"] .table-card,
+body[data-page="item-detail"] .table-container--card,
+body[data-page="item-detail"] .table-wrapper--shared,
+body[data-page="item-detail"] .data-table {
+  width: 100% !important;
+  max-width: none !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+body[data-page="item-detail"] .page-content.page-content--wide.main-content {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  gap: 0.5rem;
+}
+
+body[data-page="item-detail"] .table-card {
+  border-left: 0;
+  border-right: 0;
+  border-radius: 0;
+  padding: 10px !important;
+}
+
+body[data-page="item-detail"] .section-heading--table,
+body[data-page="item-detail"] .page3-sub-info,
+body[data-page="item-detail"] .search-panel--inline,
+body[data-page="item-detail"] .auth-required-card--embedded,
+body[data-page="item-detail"] .table-container--card {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+body[data-page="item-detail"] .search-panel--inline,
+body[data-page="item-detail"] .auth-required-card--embedded {
+  padding-left: 10px !important;
+  padding-right: 10px !important;
+}
+
+@media (max-width: 480px) {
+  body[data-page="item-detail"] .table-card {
+    padding: 8px !important;
+  }
+
+  body[data-page="item-detail"] .search-panel--inline,
+  body[data-page="item-detail"] .auth-required-card--embedded {
+    padding-left: 8px !important;
+    padding-right: 8px !important;
+  }
+}


### PR DESCRIPTION
### Motivation

- Éliminer les espaces blancs à gauche et à droite de la page 3 (Tableau des données) afin que l'AppBar, le fond bleu et le contenu soient parfaitement alignés avec les bords de l'écran et que la page occupe 100% de la largeur sur Android et autres tailles d'écran.

### Description

- Ajout d'overrides CSS dans `css/style.css` ciblant `body[data-page="item-detail"]` et les éléments enfants (`.app-shell.app-shell--wide`, `.app-header.app-header--detail`, `.page-content.page-content--wide.main-content`, `.table-card`, `.table-container--card`, `.table-wrapper--shared`, `.data-table`) pour forcer `width: 100%`/`max-width: none` et supprimer les marges horizontales externes.
- Suppression du padding horizontal externe pour le contenu principal et réduction des marges des blocs internes, en conservant un padding interne de `10px` (et `8px` sur petits écrans via media query) pour respecter la contrainte de 8–12 px.
- Suppression des bordures latérales et des rayons d'angle sur la carte principale afin d'obtenir un rendu bord-à-bord.

### Testing

- Exécution d'une vérification statique par script Python confirmant la présence de `data-page="item-detail"` dans `page3.html` et des règles ajoutées dans `css/style.css`, qui a réussi (`static checks passed`).
- Exécution de `git diff --check` pour détecter les problèmes de format/espaces, qui n'a retourné aucune erreur.
- Tentative d'un test visuel automatisé avec Playwright a échoué car `playwright` n'est pas installé et aucun navigateur (Chrome/Chromium/Firefox) n'est disponible dans l'environnement, donc aucune capture visuelle n'a été réalisée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a755a7a402c832a9223fd4a58bb1c37)