### PR TITLE
Corrige l'alignement horizontal de la page 3 (Tableau des données)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7722,10 +7722,11 @@ body[data-page="item-detail"] .page-content.page-content--wide.main-content {
 }
 
 body[data-page="item-detail"] .table-card {
+  --page3-content-gutter: 10px;
   border-left: 0;
   border-right: 0;
   border-radius: 0;
-  padding: 10px !important;
+  padding: var(--page3-content-gutter) !important;
 }
 
 body[data-page="item-detail"] .section-heading--table,
@@ -7733,24 +7734,24 @@ body[data-page="item-detail"] .page3-sub-info,
 body[data-page="item-detail"] .search-panel--inline,
 body[data-page="item-detail"] .auth-required-card--embedded,
 body[data-page="item-detail"] .table-container--card {
+  box-sizing: border-box;
+  width: 100% !important;
   margin-left: 0 !important;
   margin-right: 0 !important;
 }
 
-body[data-page="item-detail"] .search-panel--inline,
+body[data-page="item-detail"] .search-panel--inline {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
 body[data-page="item-detail"] .auth-required-card--embedded {
-  padding-left: 10px !important;
-  padding-right: 10px !important;
+  padding-left: 0.82rem !important;
+  padding-right: 0.82rem !important;
 }
 
 @media (max-width: 480px) {
   body[data-page="item-detail"] .table-card {
-    padding: 8px !important;
-  }
-
-  body[data-page="item-detail"] .search-panel--inline,
-  body[data-page="item-detail"] .auth-required-card--embedded {
-    padding-left: 8px !important;
-    padding-right: 8px !important;
+    --page3-content-gutter: 8px;
   }
 }


### PR DESCRIPTION
### Motivation
- Assurer que le titre, les statistiques, la barre de recherche/filtre et le tableau partagent exactement la même largeur visuelle et que les bords du champ « Recherche » et du bouton « Filtre » s’alignent parfaitement avec les bords du tableau, notamment sur écrans Android.

### Description
- Introduit la variable CSS `--page3-content-gutter` et l’applique à `body[data-page="item-detail"] .table-card` pour centraliser la marge interne de la page 3 dans `css/style.css`.
- Force `box-sizing: border-box` et `width: 100% !important` sur `section-heading--table`, `.page3-sub-info`, `.search-panel--inline`, `.auth-required-card--embedded` et `.table-container--card` pour garantir des marges horizontales identiques.
- Supprime le padding horizontal sur `.search-panel--inline` et standardise le padding de `.auth-required-card--embedded` à `0.82rem` pour que le champ recherche et le bouton filtre s’alignent pile avec le tableau.
- Ajoute un override responsive qui réduit `--page3-content-gutter` à `8px` pour petits écrans (`@media (max-width: 480px)`).

### Testing
- Exécuté `git diff --check`, qui a réussi sans erreurs de formatage.
- Exécuté `git status --short` pour vérifier la modification et ensuite `git commit` pour enregistrer le changement (commit: "Fix page 3 table alignment").
- Aucun linter CSS automatisé supplémentaire n’a été exécuté dans cet environnement CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a755d59b50c832ab06ca125691363ed)