### PR TITLE
Fix page 3 vertical spacing (stretch table to full viewport)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7755,3 +7755,75 @@ body[data-page="item-detail"] .auth-required-card--embedded {
     --page3-content-gutter: 8px;
   }
 }
+
+/* Final page 3 height fix: remove vertical dead space and stretch the table. */
+body[data-page="item-detail"] {
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow: hidden;
+}
+
+body[data-page="item-detail"] .app-shell.app-shell--wide {
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body[data-page="item-detail"] .page-content.page-content--wide.main-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: calc(100dvh - var(--header-height));
+  padding-top: 8px !important;
+  padding-bottom: 0 !important;
+  overflow: hidden;
+}
+
+body[data-page="item-detail"] .main-content > .table-card {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 8px !important;
+  padding-bottom: 0 !important;
+}
+
+body[data-page="item-detail"] .section-heading--table,
+body[data-page="item-detail"] .page3-sub-info,
+body[data-page="item-detail"] .search-panel--inline,
+body[data-page="item-detail"] .auth-required-card--embedded {
+  flex: 0 0 auto;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+body[data-page="item-detail"] .page3-sub-info {
+  padding-top: 8px !important;
+}
+
+body[data-page="item-detail"] .page3 .page3-info-row + .search-panel,
+body[data-page="item-detail"] .page3-info-row + .search-panel {
+  margin-top: 0 !important;
+}
+
+body[data-page="item-detail"] .table-container--card {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+body[data-page="item-detail"] .table-wrapper--shared {
+  height: 100%;
+  max-height: none !important;
+  padding-bottom: 0 !important;
+}


### PR DESCRIPTION
### Motivation
- La page « Tableau des données » laissait un espace blanc en haut et en bas et le tableau n’utilisait pas toute la hauteur disponible, notamment sur Android viewport.
- Il fallait supprimer les `margin`/`padding` inutiles autour de l’`AppBar` et s’assurer que le conteneur principal occupe `100vh` (ou l’équivalent mobile `100dvh`).
- L’objectif est que le tableau commence juste sous la barre bleue avec un espacement uniforme (8 px) et s’étire jusqu’au bas de l’écran.

### Description
- Ajout d’un bloc CSS final dans `css/style.css` pour forcer `body[data-page="item-detail"]` et `.app-shell.app-shell--wide` à utiliser `100vh`/`100dvh` et supprimer le scroll global.
- Ajustement de la zone de contenu `body[data-page="item-detail"] .page-content.page-content--wide.main-content` pour utiliser `height: calc(100dvh - var(--header-height))`, `padding-top: 8px` et `padding-bottom: 0` afin d’éliminer l’espace sous l’AppBar.
- Conversion de la carte principale en layout flex via `body[data-page="item-detail"] .main-content > .table-card` pour `flex: 1` et `height: 100%` avec `gap: 8px` et suppression des marges haut/bas inutiles.
- Étendu le conteneur du tableau en lui donnant `flex: 1`, `height: 100%` et en désactivant la `max-height` sur `.table-wrapper--shared` pour que le tableau s’étende jusqu’au bas de l’écran.

### Testing
- `git diff --check` a été exécuté et n’a retourné aucun problème (succès).
- `git commit -m "Fix page 3 vertical spacing"` a été exécuté et a créé le commit avec les modifications sur `css/style.css` (succès).
- `git status --short` a confirmé l’état du dépôt après la modification (succès).
- Les tests d’affichage automatisés n’ont pas pu être exécutés car `playwright` et les binaires de navigateur (`chromium`/`google-chrome`/`firefox`) ne sont pas présents dans l’environnement, empêchant la capture de rendu Android (échec de l’environnement de test visuel).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a755f05212c832a800492bb25789b8d)