### PR TITLE
Équilibrer l'espacement vertical du conteneur (page détail)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7777,7 +7777,7 @@ body[data-page="item-detail"] .page-content.page-content--wide.main-content {
   min-height: 0;
   height: calc(100dvh - var(--header-height));
   padding-top: 8px !important;
-  padding-bottom: 0 !important;
+  padding-bottom: 8px !important;
   overflow: hidden;
 }
 


### PR DESCRIPTION
### Motivation
- Ajuster uniquement l'espacement vertical du conteneur blanc principal sur la page de détail pour conserver le petit espace (~8px) entre la barre bleue et le conteneur en haut et ajouter exactement le même espace en bas sans modifier la hauteur du tableau ni la position des autres éléments.

### Description
- Modifié `css/style.css` pour ajouter `padding-bottom: 8px !important;` à la règle `body[data-page="item-detail"] .page-content.page-content--wide.main-content`, équilibrant la marge haute et basse du conteneur blanc (aucune autre règle de mise en page touchée).

### Testing
- Exécuté `git diff --check` sur les changements et la vérification est passée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75628a61c0832a8c0f008d078dba91)