### PR TITLE
Réduction taille du bouton « Exporter » (page Tableau des données)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3656,11 +3656,17 @@ body[data-page="item-detail"] .detail-form-actions .btn {
 body[data-page="item-detail"] #exportDetailsButton.export-details-button {
   display: inline-flex;
   align-items: center;
+  align-self: center;
   justify-content: center;
-  gap: 0.45rem;
+  gap: 0.38rem;
+  min-height: 38px;
+  padding: 0.58rem 1.05rem;
+  line-height: 1.1;
+  white-space: nowrap;
   background: #ffffff;
   border: 1.5px solid #22c55e;
   color: #22c55e;
+  font-size: 0.93rem;
   font-weight: 600;
 }
 
@@ -3669,8 +3675,8 @@ body[data-page="item-detail"] #exportDetailsButton.export-details-button:hover {
 }
 
 body[data-page="item-detail"] .export-details-button__icon {
-  width: 1rem;
-  height: 1rem;
+  width: 0.9rem;
+  height: 0.9rem;
   object-fit: contain;
   flex-shrink: 0;
 }


### PR DESCRIPTION
### Motivation
- Rendre le bouton `Exporter` de la page « Tableau des données » légèrement plus compact et proportionné au titre sans modifier son apparence visuelle.
- Conserver les coins arrondis, la bordure/teinte verte et le comportement responsive (notamment sur Android) tout en améliorant l’alignement vertical avec le titre.

### Description
- Ajustement de la règle CSS `body[data-page="item-detail"] #exportDetailsButton.export-details-button` pour réduire l’espacement interne et la hauteur en ajoutant `min-height: 38px`, `padding: 0.58rem 1.05rem`, `gap: 0.38rem`, `font-size: 0.93rem`, `line-height: 1.1` et `white-space: nowrap` tout en conservant la bordure verte et le fond blanc.
- Ajout de `align-self: center` pour aligner verticalement le bouton avec le titre `Tableau des données`.
- Réduction légère de l’icône Excel dans `.export-details-button__icon` de `1rem` à `0.9rem` pour mieux proportionner le visuel.
- Aucun comportement JavaScript n’a été modifié; le changement est purement stylistique dans `css/style.css`.

### Testing
- Exécution de `git diff --check` a réussi sans erreurs de formatage automatique signalées.
- Vérification de l’état du dépôt avec `git status --short --branch` et création du commit `Refine export button sizing` ont réussi.
- Tentative de créer la PR via `gh pr create` a échoué en environnement CI car l’outil `gh` n’était pas authentifié (`gh auth login` ou `GH_TOKEN` requis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7566434654832a842770d1f5462104)