### PR TITLE
Fix admin management layout gutters

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7833,3 +7833,54 @@ body[data-page="item-detail"] .table-wrapper--shared {
   max-height: none !important;
   padding-bottom: 0 !important;
 }
+
+/* Gestion Admin: keep the admin page aligned with the app's compact mobile gutters. */
+body[data-page="users-management"] .app-shell.app-shell--wide {
+  width: 100%;
+  max-width: 100%;
+  margin-inline: 0;
+}
+
+body[data-page="users-management"] .page-content.page-content--wide.main-content {
+  width: 100%;
+  max-width: 100%;
+  padding-inline: 10px;
+  box-sizing: border-box;
+}
+
+body[data-page="users-management"] .main-content > .surface-card {
+  width: 100%;
+  max-width: 100%;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+body[data-page="users-management"] .users-search-field,
+body[data-page="users-management"] .users-search-field__control,
+body[data-page="users-management"] .table-wrapper--users,
+body[data-page="users-management"] .table-wrapper--users .data-table {
+  width: 100%;
+  max-width: 100%;
+}
+
+@media (max-width: 380px) {
+  body[data-page="users-management"] .page-content.page-content--wide.main-content {
+    padding-inline: 8px;
+  }
+
+  body[data-page="users-management"] .main-content > .surface-card {
+    padding: 8px;
+  }
+}
+
+@media (min-width: 768px) {
+  body[data-page="users-management"] .app-shell.app-shell--wide {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin-inline: 0 !important;
+  }
+
+  body[data-page="users-management"] .page-content.page-content--wide.main-content {
+    padding-inline: 12px !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- L’interface "Gestion Admin" avait des marges latérales trop larges et des cartes/tables trop étroites par rapport au reste de l’application.
- Le champ de recherche et le tableau utilisateurs n’étaient pas alignés sur les mêmes bords que les cartes de la page.
- Il fallait appliquer des gutters plus fins et uniformes et assurer un rendu réactif sur petites et grandes écrans.

### Description
- Ajout de règles CSS ciblées pour `body[data-page="users-management"]` afin de forcer `.app-shell.app-shell--wide` et la zone principale à occuper toute la largeur disponible et utiliser des marges internes horizontales réduites (`padding-inline: 10px`).
- Les cartes principales (`.surface-card`) ont été mises à largeur pleine avec un `padding: 10px` pour conserver un léger padding interne et éviter les cartes trop étroites.
- Le champ de recherche, le wrapper du tableau et la table ont été forcés à `width: 100%` pour aligner parfaitement la carte "Maintenance de la page", la carte des statistiques, le champ de recherche et le tableau.
- Ajout de media queries pour petits écrans (`padding-inline: 8px` sous 380px) et tablettes/desktop (`padding-inline: 12px` à partir de 768px) pour assurer un rendu uniforme et réactif.

### Testing
- Exécution d’un script de vérification automatique (Python) qui a validé la présence des sélecteurs et des valeurs de `padding-inline` attendues dans `css/style.css`, et qui a réussi.
- Recherches automatiques (`rg`) ont confirmé la présence des sélecteurs ciblés appliqués à la page `users-management`, et aucune erreur n’a été remontée.
- Aucun test automatisé visuel/device n’a été exécuté ici; les règles responsive ont été ajoutées pour couvrir les tailles-cibles demandées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a756e91f3ec832ab749ebb503850d35)