### PR TITLE
Fix users table email display: single-line emails, ellipsis, uniform row height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2447,9 +2447,18 @@ body[data-page="users-management"] .table-wrapper--users {
 }
 
 body[data-page="users-management"] .table-wrapper--users .data-table {
-  min-width: 52rem;
+  min-width: 68rem;
   table-layout: fixed;
 }
+
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(1) { width: 5rem; }
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(2) { width: 5rem; }
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(3) { width: 13rem; }
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(4) { width: 12rem; }
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(5) { width: 18rem; }
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(6) { width: 10rem; }
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(7) { width: 12rem; }
+body[data-page="users-management"] .table-wrapper--users .data-table th:nth-child(8) { width: 5rem; }
 
 body[data-page="users-management"] .table-wrapper--users .data-table th,
 body[data-page="users-management"] .table-wrapper--users .data-table td {
@@ -2459,6 +2468,13 @@ body[data-page="users-management"] .table-wrapper--users .data-table td {
   vertical-align: middle;
 }
 
+body[data-page="users-management"] .table-wrapper--users .data-table td {
+  height: 3.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 body[data-page="users-management"] .table-wrapper--users .data-table th {
   font-size: 0.84rem;
   letter-spacing: 0.02em;
@@ -2466,15 +2482,19 @@ body[data-page="users-management"] .table-wrapper--users .data-table th {
   color: #3b4a5f;
 }
 
-body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(3) {
+body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(3),
+body[data-page="users-management"] .users-email-cell {
   min-width: 0;
-  max-width: 15rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(5) select {
+body[data-page="users-management"] .users-email-cell {
+  max-width: 18rem;
+}
+
+body[data-page="users-management"] .table-wrapper--users .data-table td:nth-child(6) select {
   max-width: 100%;
 }
 
@@ -7099,7 +7119,7 @@ body[data-page="item-detail"] .search-highlight {
   }
 
   body[data-page="users-management"] .table-wrapper--users .data-table {
-    min-width: 64rem;
+    min-width: 76rem;
   }
 
   body[data-page="item-detail"] .data-table {

--- a/js/app.js
+++ b/js/app.js
@@ -8132,7 +8132,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
             </td>
             <td>${escapeHtml(resolveDisplayName(user))}</td>
             <td class="users-last-activity-cell">${escapeHtml(formatLastActivity(user.lastActivity))}</td>
-            <td class="users-email-cell">${escapeHtml(cleanText(user.email) || '-')}</td>
+            <td class="users-email-cell" title="${escapeHtml(cleanText(user.email) || '-')}">${escapeHtml(cleanText(user.email) || '-')}</td>
             <td>
               ${cleanText(user.email).toLowerCase() === 'andrainaaina@gmail.com' ? 'admin' : `
               <select data-user-role="${user.id}">

--- a/users.html
+++ b/users.html
@@ -362,7 +362,7 @@
                 <td>${avatarMarkup}</td>
                 <td>${escapeHtml(displayName)}</td>
                 <td class="users-last-activity-cell">${formatLastActivity(user.lastActivity)}</td>
-                <td class="users-email-cell">${escapeHtml(email) || '-'}</td>
+                <td class="users-email-cell" title="${escapeHtml(email) || '-'}">${escapeHtml(email) || '-'}</td>
                 <td>
                   ${isPrimaryAdmin ? 'admin' : `
                   <select class="users-role-select" data-user-role="${user.id}">


### PR DESCRIPTION
### Motivation
- Les adresses e-mail s'affichaient sur plusieurs lignes dans le tableau des utilisateurs, augmentant inutilement la hauteur des lignes et réduisant la lisibilité.
- Il faut forcer l'affichage d'un e-mail sur une seule ligne, désactiver le retour à la ligne et tronquer les adresses trop longues avec des points de suspension.
- Conserver une hauteur de ligne uniforme et ajuster la largeur des colonnes pour améliorer la lisibilité sur mobile et desktop.

### Description
- Mise à jour de `css/style.css` pour augmenter la `min-width` du tableau et définir des largeurs par colonne avec `table-layout: fixed` afin de préserver la mise en page et la lisibilité des e-mails.
- Ajout d'une règle globale pour les cellules de la table : `height: 3.8rem`, `overflow: hidden`, `text-overflow: ellipsis` et `white-space: nowrap` pour garantir une hauteur de ligne uniforme et empêcher le retour à la ligne.
- Application du comportement `ellipsis`/`nowrap` spécifiquement à la cellule e-mail via la classe `.users-email-cell` et limitation de sa largeur (`max-width: 18rem`).
- Ajout de l'attribut `title` sur la cellule e-mail dans `users.html` et `js/app.js` pour permettre d'afficher l'adresse complète au survol malgré la troncature visuelle.

### Testing
- `node --check js/app.js` — succès.
- `git diff --check` — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75702919dc832a9cdda128071a6ee3)