### PR TITLE
item-detail: ajouter 100px de padding-bottom pour éviter le chevauchement du FAB

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7851,7 +7851,7 @@ body[data-page="item-detail"] .table-container--card {
 body[data-page="item-detail"] .table-wrapper--shared {
   height: 100%;
   max-height: none !important;
-  padding-bottom: 0 !important;
+  padding-bottom: 100px !important;
 }
 
 /* Gestion Admin: keep the admin page aligned with the app's compact mobile gutters. */


### PR DESCRIPTION
### Motivation
- Le FloatingActionButton recouvre la dernière ligne du tableau sur la page de détail, empêchant l'élément final d'être entièrement visible.
- Il faut ajouter un espace de défilement bas (entre 90 et 110px) sans déplacer le FAB ni réduire la hauteur du tableau.

### Description
- Modifie `css/style.css` pour remplacer `padding-bottom: 0 !important;` par `padding-bottom: 100px !important;` dans le sélecteur `body[data-page="item-detail"] .table-wrapper--shared` afin d'ajouter de l'espace de scroll en bas.
- La modification préserve l'apparence du conteneur blanc et ne change pas la position du bouton flottant.

### Testing
- `git diff --check` a été exécuté et n'a retourné aucune erreur.
- `git status --short --branch` a été utilisé pour vérifier l'état de l'arbre de travail et confirmer la modification du fichier `css/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a758ce0e07c832a8f804ad3a7d136f0)