### PR TITLE
Harmonise les espacements verticaux de la page "Tableau des données"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7767,8 +7767,7 @@ body[data-page="item-detail"] .table-container--card {
 }
 
 body[data-page="item-detail"] .search-panel--inline {
-  padding-left: 0 !important;
-  padding-right: 0 !important;
+  padding: 0 !important;
 }
 
 body[data-page="item-detail"] .auth-required-card--embedded {


### PR DESCRIPTION
### Motivation
- Harmoniser les espacements verticaux de la page "Tableau des données" avec ceux de la page "Demande matériels" afin d'obtenir le même rythme visuel sans toucher aux tailles des contrôles ni aux marges horizontales.

### Description
- Remplacement de `padding-left`/`padding-right` par `padding: 0 !important;` pour le sélecteur `body[data-page="item-detail"] .search-panel--inline` dans `css/style.css` afin de réduire l'espacement vertical autour du champ de recherche.

### Testing
- `git status --short` et `git log -1 --oneline` ont été exécutés avec succès pour vérifier l'état du dépôt et le dernier commit. 
- Le commit contenant la modification a été créé (`Harmonise data table vertical spacing`).
- Tentative de création de la PR via `gh pr create` échouée à cause d'une authentification manquante (`gh auth login` ou `GH_TOKEN` requis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a759a1a1404832f89a6c63853b05d00)