### PR TITLE
Réduire la taille du bouton "+ Créer une demande"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3272,6 +3272,11 @@ body[data-page="item-detail"] .header-top,
   gap: 12px;
 }
 
+body[data-page="all-materials"] .page3-summary-header {
+  align-items: center;
+  gap: clamp(10px, 3vw, 16px);
+}
+
 body[data-page="item-detail"] .title-block,
 .page3 .page3-title-block {
   min-width: 0;
@@ -3286,14 +3291,28 @@ body[data-page="item-detail"] .title-block .section-title,
 }
 
 
-.page3 .page3-title-block #openManualMaterialBtn {
-  display: block;
-  margin-top: 16px;
-  margin-bottom: 20px;
-  padding: 0.72rem 1.05rem;
-  font-weight: 600;
-  min-width: 205px;
+.page3 #openManualMaterialBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  margin: 0;
+  min-width: 168px;
+  min-height: 36px;
   width: fit-content;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.05;
+  white-space: nowrap;
+}
+
+@media (max-width: 360px) {
+  .page3 #openManualMaterialBtn {
+    min-width: 0;
+    padding-inline: 0.75rem;
+    font-size: 0.86rem;
+  }
 }
 
 .page3-sub-info {


### PR DESCRIPTION
### Motivation

- Rendre le bouton `+ Créer une demande` plus compact et mieux proportionné par rapport au titre `Tableau des matériels` et au bouton `Exporter`, tout en conservant le style très arrondi et les couleurs existantes.

### Description

- Modifications apportées au fichier `css/style.css` pour ajuster le bouton ciblé par le sélecteur `#openManualMaterialBtn` sur la page matériels en réduisant sa largeur minimale à `168px`, sa hauteur minimale à `36px`, son padding et sa taille de texte (`font-size: 0.9rem`).
- Remplacement de l’ancien comportement bloquant par `display: inline-flex` et centrage interne via `align-items: center; justify-content: center;` pour assurer un meilleur alignement vertical avec le titre.
- Ajout d’une règle responsive `@media (max-width: 360px)` pour conserver le comportement compact sur petits écrans Android.
- Ajout d’une règle spécifique `body[data-page="all-materials"] .page3-summary-header` avec `gap: clamp(10px, 3vw, 16px)` pour équilibrer l’espace entre le titre et le bouton sans modifier les coins arrondis ni les couleurs globales.

### Testing

- Exécution de `git diff --check` a réussi et a montré uniquement les modifications CSS prévues.
- Vérification de l’état du dépôt avec `git status --short` a confirmé les modifications en attente puis le fichier a été validé localement.
- Tentative de création automatique de la PR via `gh pr create` a échoué en raison d’une absence d’authentification (`gh auth login` / `GH_TOKEN` requis), et aucun test visuel headless n’a pu être effectué car Playwright et les navigateurs ne sont pas installés dans l’environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75a0ba43f4832fa845ccc726f32037)