### PR TITLE
Page d'accueil : supprimer l'icône et rendre le libellé du compteur de sites singulier/pluriel

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,8 +107,7 @@
 
         <section class="section-heading section-heading--saved">
           <div class="saved-sites-label">
-            <img src="Icon/Site.png" alt="" aria-hidden="true" class="saved-sites-label__icon" />
-            <h2><span class="site-label">Site enregistré :</span> <span id="siteCount" class="site-count" aria-label="Nombre de sites enregistrés">0</span></h2>
+            <h2><span id="siteCountLabel" class="site-label">Nombre total des sites :</span> <span id="siteCount" class="site-count" aria-label="Nombre de sites enregistrés">0</span></h2>
           </div>
         </section>
 

--- a/js/app.js
+++ b/js/app.js
@@ -2664,6 +2664,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const sites = currentSites
         .filter((site) => String(site.nom || '').toUpperCase().includes(query))
         .sort(compareSitesByName);
+      const siteCountLabel = document.getElementById('siteCountLabel');
+      if (siteCountLabel) {
+        siteCountLabel.textContent = sites.length === 1 ? 'Nombre total de site :' : 'Nombre total des sites :';
+      }
       siteCount.textContent = String(sites.length);
 
       if (!sites.length) {


### PR DESCRIPTION
### Motivation
- Adapter le libellé du compteur de sites pour afficher le singulier quand il y a 1 site et supprimer l'icône devant le libellé sans toucher au style ni à la logique existante.

### Description
- Supprimé l'icône `<img class="saved-sites-label__icon">` et remplacé le libellé statique par un `span` `id="siteCountLabel"` dans `index.html`.
- Ajouté une mise à jour dynamique du texte de `siteCountLabel` dans la fonction `renderSites` de `js/app.js` pour afficher `Nombre total de site :` quand `sites.length === 1` et `Nombre total des sites :` sinon, puis laissé `siteCount` afficher la valeur numérique.

### Testing
- Exécuté `node --check js/app.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75a48bf990832f8b63f5b88554a008)