### PR TITLE
Improve site lock status dialog design

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8034,3 +8034,153 @@ body[data-page="users-management"] .table-wrapper--users .data-table {
     padding-inline: 12px !important;
   }
 }
+
+body[data-page="home"] #siteLockStatusDialog {
+  width: min(92vw, 30rem);
+}
+
+body[data-page="home"] #siteLockStatusDialog::backdrop {
+  background: rgba(15, 23, 42, 0.48);
+  backdrop-filter: blur(3px);
+}
+
+body[data-page="home"] .modal-content--site-lock-status {
+  display: flex;
+  min-height: 18rem;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(1.25rem, 4vw, 1.75rem);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 20px;
+  background: linear-gradient(160deg, #ffffff 0%, #f8fbff 100%);
+  box-shadow: 0 24px 56px rgba(15, 23, 42, 0.16);
+}
+
+body[data-page="home"] .modal-header--site-lock-status {
+  justify-content: flex-start;
+  margin-bottom: 1rem;
+}
+
+body[data-page="home"] .modal-header--site-lock-status h2 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0;
+  color: #0f172a;
+  font-size: clamp(1.25rem, 4vw, 1.55rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+body[data-page="home"] .site-lock-status-title-icon {
+  display: inline-flex;
+  width: 2.35rem;
+  height: 2.35rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background: rgba(25, 118, 210, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(25, 118, 210, 0.16);
+  font-size: 1.2rem;
+}
+
+body[data-page="home"] .site-lock-status-message {
+  margin: 0 0 1.25rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: left;
+}
+
+body[data-page="home"] .site-lock-status-card {
+  padding: clamp(1rem, 4vw, 1.25rem);
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+}
+
+body[data-page="home"] .site-lock-status-card__title {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0 0 0.65rem;
+  font-size: clamp(1.08rem, 3.5vw, 1.25rem);
+  font-weight: 800;
+}
+
+body[data-page="home"] .site-lock-status-message--locked .site-lock-status-card__title {
+  color: #dc2626;
+}
+
+body[data-page="home"] .site-lock-status-message--unlocked .site-lock-status-card__title {
+  color: #16a34a;
+}
+
+body[data-page="home"] .site-lock-status-card__description {
+  margin: 0;
+  color: #334155;
+  font-size: 0.98rem;
+}
+
+body[data-page="home"] .site-lock-status-card__actor {
+  display: grid;
+  gap: 0.3rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+body[data-page="home"] .site-lock-status-card__actor-label {
+  color: #475569;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+body[data-page="home"] .site-lock-status-card__actor-name {
+  color: #1976d2;
+  font-size: 1.05rem;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+body[data-page="home"] .modal-content--site-lock-status .modal-actions--split {
+  justify-content: flex-end;
+}
+
+body[data-page="home"] #siteLockStatusCloseButton {
+  width: min(100%, 140px);
+  min-height: 2.85rem;
+  border: 0;
+  border-radius: 999px;
+  background: #1976d2;
+  color: #ffffff;
+  font-weight: 800;
+  box-shadow: 0 10px 22px rgba(25, 118, 210, 0.22);
+  transition: background-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+body[data-page="home"] #siteLockStatusCloseButton:hover,
+body[data-page="home"] #siteLockStatusCloseButton:focus-visible {
+  background: #1565c0;
+  box-shadow: 0 12px 26px rgba(25, 118, 210, 0.28);
+  transform: translateY(-1px);
+}
+
+@media (max-width: 480px) {
+  body[data-page="home"] #siteLockStatusDialog {
+    width: min(94vw, 25rem);
+  }
+
+  body[data-page="home"] .modal-content--site-lock-status {
+    min-height: 16rem;
+    border-radius: 18px;
+  }
+
+  body[data-page="home"] .modal-content--site-lock-status .modal-actions--split {
+    justify-content: stretch;
+  }
+
+  body[data-page="home"] #siteLockStatusCloseButton {
+    width: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -252,10 +252,10 @@
 
       <dialog id="siteLockStatusDialog" class="modal-card">
         <div class="modal-content modal-content--site-lock-status">
-          <div class="modal-header">
-            <h2>Détail du statut</h2>
+          <div class="modal-header modal-header--site-lock-status">
+            <h2><span class="site-lock-status-title-icon" aria-hidden="true">🔒</span>Statut du site</h2>
           </div>
-          <p id="siteLockStatusMessage" class="site-lock-status-message" aria-live="polite"></p>
+          <div id="siteLockStatusMessage" class="site-lock-status-message" aria-live="polite"></div>
           <div class="modal-actions modal-actions--split">
             <button id="siteLockStatusCloseButton" type="button" class="btn" data-close-dialog>Fermer</button>
           </div>

--- a/js/app.js
+++ b/js/app.js
@@ -2806,9 +2806,23 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               ? resolveSiteLockActorLabel(targetSite?.lockedBy, targetSite?.lockedByName, userNamesByEmail)
               : resolveSiteLockActorLabel(targetSite?.unlockedBy, targetSite?.unlockedByName, userNamesByEmail);
             const icon = targetIsLocked ? '🔒' : '🔓';
-            const actionLabel = targetIsLocked ? 'verrouillé' : 'déverrouillé';
+            const statusTitle = targetIsLocked ? 'Site verrouillé' : 'Site déverrouillé';
+            const statusDescription = targetIsLocked
+              ? 'Ce site est actuellement verrouillé.'
+              : 'Ce site est actuellement déverrouillé.';
+            const actorHeading = targetIsLocked ? 'Verrouillé par' : 'Dernier déverrouillage effectué par';
+            const actorName = actorLabel || 'Utilisateur inconnu';
             if (siteLockStatusMessage) {
-              siteLockStatusMessage.textContent = `${icon} Site ${actionLabel} par ${actorLabel || 'Utilisateur inconnu'}`;
+              siteLockStatusMessage.innerHTML = `
+                <article class="site-lock-status-card">
+                  <h3 class="site-lock-status-card__title"><span aria-hidden="true">${icon}</span>${escapeHtml(statusTitle)}</h3>
+                  <p class="site-lock-status-card__description">${escapeHtml(statusDescription)}</p>
+                  <div class="site-lock-status-card__actor">
+                    <span class="site-lock-status-card__actor-label">${escapeHtml(actorHeading)}</span>
+                    <strong class="site-lock-status-card__actor-name">${escapeHtml(actorName)}</strong>
+                  </div>
+                </article>
+              `;
               siteLockStatusMessage.classList.toggle('site-lock-status-message--locked', targetIsLocked);
               siteLockStatusMessage.classList.toggle('site-lock-status-message--unlocked', !targetIsLocked);
             }


### PR DESCRIPTION
### Motivation

- Moderniser et clarifier l’interface affichée lors du clic sur le statut de verrouillage pour une présentation plus professionnelle et responsive, sans toucher à la logique métier existante.
- Rendre l’information de verrouillage/déverrouillage plus lisible en mettant en évidence le titre, la couleur du statut et l’acteur responsable avec un fallback clair.

### Description

- Remplacé l’en-tête du dialogue `siteLockStatusDialog` par `Statut du site` avec une icône de cadenas et titre en gras dans `index.html` tout en conservant les mêmes identifiants de dialogue et bouton (`siteLockStatusDialog`, `siteLockStatusCloseButton`).
- Remplacé le rendu textuel plat par une carte structurée dans `js/app.js` qui affiche dynamiquement le titre (`Site verrouillé` / `Site déverrouillé`), la description, le libellé d’acteur (`Verrouillé par` / `Dernier déverrouillage effectué par`) et le nom de l’utilisateur avec fallback `Utilisateur inconnu` et échappement via `escapeHtml`.
- Ajouté des styles dans `css/style.css` pour la modale et la carte (coins arrondis 18–20px, ombre légère, espacement harmonieux, texte descriptif en gris foncé, titre rouge/vert selon l’état, nom en bleu gras, icône cohérente), ainsi que le style du bouton `Fermer` en bleu `#1976D2`, texte blanc, coins arrondis et effet de survol et adaptation mobile responsive.
- Aucune logique métier modifiée; seuls le DOM et le CSS de la fenêtre de dialogue ont été touchés.

### Testing

- `node --check js/app.js` a été exécuté et a réussi.
- `git diff --check` a été exécuté et a réussi.
- Contrôle d’environnement pour rendu headless : `node -e "require('playwright')"` a échoué car `playwright` n’est pas installé dans l’environnement.  
- Vérification de navigateur (`which chromium-browser || which chromium || which google-chrome`) n’a retourné aucun binaire disponible, et la création de PR via `gh pr create` a échoué pour cause d’authentification (`gh auth login` / `GH_TOKEN` requis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75a96c3898832f86651609de488b1c)