### PR TITLE
Page 3 : hauteur du conteneur du tableau dynamique

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7800,7 +7800,7 @@ body[data-page="item-detail"] .auth-required-card--embedded {
   }
 }
 
-/* Final page 3 height fix: remove vertical dead space and stretch the table. */
+/* Final page 3 height behavior: let short tables shrink while preserving scroll for long tables. */
 body[data-page="item-detail"] {
   height: 100vh;
   height: 100dvh;
@@ -7857,9 +7857,10 @@ body[data-page="item-detail"] .page3-info-row + .search-panel {
 }
 
 body[data-page="item-detail"] .table-container--card {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-height: 0;
-  height: 100%;
+  height: auto;
+  max-height: calc(100dvh - var(--header-height) - 12rem);
   margin-top: 0 !important;
   margin-bottom: 0 !important;
   border-bottom-left-radius: 0;
@@ -7867,9 +7868,9 @@ body[data-page="item-detail"] .table-container--card {
 }
 
 body[data-page="item-detail"] .table-wrapper--shared {
-  height: 100%;
+  height: auto;
   max-height: none !important;
-  padding-bottom: 70px !important;
+  padding-bottom: 0 !important;
 }
 
 /* Demande matériels: mirror the compact, edge-to-edge data table layout. */


### PR DESCRIPTION
### Motivation
- Permettre au conteneur du tableau sur la page 3 de s'ajuster à la hauteur des lignes affichées au lieu d'occuper une hauteur fixe, tout en conservant le comportement de défilement pour de grandes quantités de données et en laissant le bouton flottant (+) fixé en bas à droite.

### Description
- Remplacement de `flex: 1 1 auto` / `height: 100%` par `flex: 0 1 auto` et `height: auto` pour `.table-container--card` dans `css/style.css` afin que le conteneur rétrécisse quand il y a peu de lignes.
- Ajout d'un `max-height: calc(100dvh - var(--header-height) - 12rem)` sur `.table-container--card` pour préserver le scroll lorsque le tableau contient beaucoup de lignes.
- Passage de la `.table-wrapper--shared` à `height: auto` et suppression du grand `padding-bottom` forcé pour éviter l'espace vide sous le tableau court, sans modifier bordures, coins arrondis, espacements ou autres fonctionnalités.
- Aucune modification JavaScript ou des fonctionnalités de recherche/filtre/export/pagination/tri n'a été effectuée, seul le comportement de hauteur était ciblé.

### Testing
- Exécution de `git diff --check` qui a renvoyé sans erreurs.
- Vérification de l'état avec `git status --short` et inspection du diff appliqué sur `css/style.css` (OK).
- Commit réalisé avec `git commit` (succès) et vérification du dernier commit via `git log -1 --oneline` (succès).
- Tentative automatique de création de PR via `gh pr create` a échoué en raison d'une authentification GitHub manquante (`gh auth login` ou `GH_TOKEN` requis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75b46b346c832f9065064675c14544)