### PR TITLE
Corriger l'en-tête sticky et le scroll du tableau (page 3)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7861,6 +7861,8 @@ body[data-page="item-detail"] .table-container--card {
   min-height: 0;
   height: auto;
   max-height: calc(100dvh - var(--header-height) - 12rem);
+  overflow-x: auto;
+  overflow-y: auto;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
   border-bottom-left-radius: 0;
@@ -7870,7 +7872,14 @@ body[data-page="item-detail"] .table-container--card {
 body[data-page="item-detail"] .table-wrapper--shared {
   height: auto;
   max-height: none !important;
+  overflow: visible;
   padding-bottom: 63px !important;
+}
+
+body[data-page="item-detail"] .data-table th {
+  position: sticky;
+  top: 0;
+  z-index: 20;
 }
 
 /* Demande matériels: mirror the compact, edge-to-edge data table layout. */


### PR DESCRIPTION
### Motivation
- Après l'adoption d'une hauteur dynamique, l'en-tête du tableau de la page 3 ne restait plus collé lors du défilement; il faut que seul le conteneur du tableau défile et que l'en-tête reste visible.
- Conserver la hauteur automatique lorsque peu de lignes sont présentes tout en limitant la hauteur maximale et en activant le scroll interne pour les longues listes.

### Description
- Rendre le conteneur principal du tableau scrollable en ajoutant `overflow-y: auto` (et `overflow-x: auto`) sur `.table-container--card` afin que le défilement vertical se limite à ce conteneur.
- Empêcher que le wrapper interne devienne le conteneur de scroll en forçant `overflow: visible` sur `.table-wrapper--shared`.
- Renforcer le comportement sticky de l'en-tête en ajoutant `position: sticky; top: 0; z-index: 20;` sur `.data-table th` pour garantir que l'en-tête reste au-dessus des lignes lors du scroll.
- Aucune autre fonctionnalité ni position des contrôles externes (recherche, boutons Filtre/Exporter, bouton flottant) n'a été modifiée.

### Testing
- Exécution de `git diff --check` pour valider l'absence d'erreurs de diff — réussite.
- Vérification du diff ciblé via `git diff -- css/style.css` pour s'assurer que les règles CSS attendues ont été ajoutées — réussite.
- Contrôle de l'état du dépôt avec `git status --short` et inspection du fichier modifié (`nl`/affichage des lignes) pour confirmer les changements appliqués — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75b9ca452c832fa3f8e489e5551455)