### PR TITLE
Corrige le défilement du tableau (Page 3) — en-tête fixe

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7862,7 +7862,7 @@ body[data-page="item-detail"] .table-container--card {
   height: auto;
   max-height: calc(100dvh - var(--header-height) - 12rem);
   overflow-x: auto;
-  overflow-y: auto;
+  overflow-y: hidden;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
   border-bottom-left-radius: 0;
@@ -7871,9 +7871,11 @@ body[data-page="item-detail"] .table-container--card {
 
 body[data-page="item-detail"] .table-wrapper--shared {
   height: auto;
-  max-height: none !important;
-  overflow: visible;
+  max-height: calc(100dvh - var(--header-height) - 12rem) !important;
+  overflow-x: visible;
+  overflow-y: auto;
   padding-bottom: 63px !important;
+  -webkit-overflow-scrolling: touch;
 }
 
 body[data-page="item-detail"] .data-table th {


### PR DESCRIPTION
### Motivation
- L'en-tête du tableau sur la Page 3 défilait avec le reste du tableau, rendant les labels de colonnes invisibles lorsqu'on scrollait les lignes de données.

### Description
- Déplacement du défilement vertical du conteneur externe vers le wrapper interne en modifiant `css/style.css` pour que `body[data-page="item-detail"] .table-container--card` utilise `overflow-y: hidden` et que `body[data-page="item-detail"] .table-wrapper--shared` gère le scroll vertical avec `overflow-y: auto` et `max-height: calc(100dvh - var(--header-height) - 12rem) !important`.
- Autorisation du scroll horizontal sur le conteneur externe en conservant `overflow-x: auto/visible` afin de préserver le comportement horizontal existant.
- Maintien de l'en-tête fixe en conservant `position: sticky; top: 0; z-index: 20` sur les `th`, et ajout de `-webkit-overflow-scrolling: touch` pour inertie tactile sur mobile.

### Testing
- Exécution de `git diff --check` qui n'a révélé d'erreurs (succès).
- Exécution d'un script Python de vérification du CSS (recherche des blocs modifiés et des règles `overflow-y` / `position: sticky`) qui a validé la présence des changements attendus (succès).
- Vérification de disponibilité de Playwright/navigateur par un test `node -e` pour capture d'écran automatique échouée en raison de l'absence des dépendances d'environnement (échec signalé).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75bc54a4e8832fa54acfd617684c94)