### PR TITLE
Ajouter un point vert avant « En ligne » dans la page Gestion Admin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -679,6 +679,21 @@ body.app-content-loading .item-detail-fab-row {
   color: #15803d;
 }
 
+.users-card-online-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.users-card-online-label::before {
+  content: '';
+  flex: 0 0 auto;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #22c55e;
+}
+
 .switch {
   position: relative;
   display: inline-flex;

--- a/js/app.js
+++ b/js/app.js
@@ -8096,7 +8096,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const referenceDate = new Date();
       const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
-      usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br />En ligne : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
+      usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br /><span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
     }
 
     function formatLastActivity(value, referenceDate = new Date()) {

--- a/users.html
+++ b/users.html
@@ -87,7 +87,7 @@
           </section>
         </div>
         <section class="surface-card table-card">
-          <h2 class="section-title" id="usersCardHeader">Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">0</span><br />En ligne : <span class="users-card-stat users-card-stat--online">0</span></h2>
+          <h2 class="section-title" id="usersCardHeader">Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">0</span><br /><span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">0</span></h2>
           <div class="users-search-field input-group">
             <label class="visually-hidden" for="usersSearchInput">Rechercher un utilisateur</label>
             <div class="users-search-field__control">
@@ -249,7 +249,7 @@
         }
         const referenceDate = new Date();
         const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
-        usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br />En ligne : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
+        usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br /><span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
       }
 
       function formatLastActivity(value, referenceDate = new Date()) {


### PR DESCRIPTION
### Motivation

- Améliorer l'affichage des statistiques sur la page "Gestion Admin" en ajoutant un indicateur visuel pour le statut "En ligne" sans modifier le comportement du compteur.

### Description

- Ajout d'une étiquette inline `span` avec la classe `users-card-online-label` autour du libellé `En ligne` dans `users.html` et dans la génération dynamique du titre dans `js/app.js` afin de ne changer que l'apparence du libellé.
- Ajout des styles CSS dans `css/style.css` pour `users-card-online-label` et son pseudo-élément `::before`, qui dessine un point circulaire vert `#22C55E` de `0.55rem` (≈8–10px) et aligne le point et le texte en `inline-flex` avec un espace (`gap`) de `0.45rem` (≈6–8px).
- Aucune logique de comptage ou autre élément de la page n'a été modifié, seule la présentation du libellé a été ajustée.

### Testing

- Exécution de la vérification de code `git diff --check` qui n'a signalé aucune erreur et a réussi.  
- Recherche ciblée avec `rg` confirmant la présence des nouvelles références `users-card-online-label` dans `css/style.css`, `users.html` et `js/app.js`.  
- Vérification manuelle que le rendu dynamique utilise la nouvelle balise et que le compteur `onlineCount` n'a pas été modifié (affichage inchangé côté données).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c8bb09a4832fa6dd090d47889074)