### PR TITLE
Inverser l'ordre «En ligne» / «Tous les utilisateurs» sur la page Gestion Admin

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -8096,7 +8096,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
       const referenceDate = new Date();
       const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
-      usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br /><span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
+      usersCardHeader.innerHTML = `<span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">${onlineCount}</span><br />Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span>`;
     }
 
     function formatLastActivity(value, referenceDate = new Date()) {

--- a/users.html
+++ b/users.html
@@ -87,7 +87,7 @@
           </section>
         </div>
         <section class="surface-card table-card">
-          <h2 class="section-title" id="usersCardHeader">Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">0</span><br /><span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">0</span></h2>
+          <h2 class="section-title" id="usersCardHeader"><span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">0</span><br />Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">0</span></h2>
           <div class="users-search-field input-group">
             <label class="visually-hidden" for="usersSearchInput">Rechercher un utilisateur</label>
             <div class="users-search-field__control">
@@ -249,7 +249,7 @@
         }
         const referenceDate = new Date();
         const onlineCount = users.filter((user) => isUserOnline(user, referenceDate)).length;
-        usersCardHeader.innerHTML = `Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span><br /><span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">${onlineCount}</span>`;
+        usersCardHeader.innerHTML = `<span class="users-card-online-label">En ligne</span> : <span class="users-card-stat users-card-stat--online">${onlineCount}</span><br />Tous les utilisateurs : <span class="users-card-stat users-card-stat--total">${users.length}</span>`;
       }
 
       function formatLastActivity(value, referenceDate = new Date()) {


### PR DESCRIPTION
### Motivation
- Afficher le libellé «En ligne» avant «Tous les utilisateurs» dans l'en-tête de la page Gestion Admin sans toucher aux styles, tailles ou espacements existants.
- Conserver les classes CSS actuelles afin de préserver les couleurs (point vert et nombre en ligne en vert, total en bleu).

### Description
- Mise à jour du markup statique de l'en-tête dans `users.html` pour afficher d'abord `En ligne` puis `Tous les utilisateurs` en conservant les classes existantes (`users-card-online-label`, `users-card-stat--online`, `users-card-stat--total`).
- Ajustement de la mise à jour dynamique dans le script inline de `users.html` pour produire le même ordre d'affichage.
- Synchronisation du même changement dans `js/app.js` afin que le rendu côté application soit cohérent avec le HTML statique.

### Testing
- Exécution de `git diff --check` qui n'a retourné aucune erreur.
- Démarrage d'un serveur local et récupération de la page via `curl` puis vérification par `rg` que la balise `usersCardHeader` contient désormais l'ordre `En ligne` suivi de `Tous les utilisateurs`, ce qui a réussi.
- Recherche dans le dépôt avec `rg` confirmant que l'affichage a été modifié à la fois dans `users.html` et `js/app.js`, sans modification des classes CSS existantes, ce qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75dcbdb920832f8596a51570e121c4)