### PR TITLE
Journaliser l'historique de recherche uniquement au blur

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -115,7 +115,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
   }
 
   function createSearchAndFilterHistoryLogger(siteId, siteNameResolver) {
-    let searchTimer = null;
     let lastRecordedSearch = '';
 
     const getContext = () => ({
@@ -133,20 +132,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     };
 
     return {
-      scheduleSearch(searchText) {
-        if (searchTimer) {
-          window.clearTimeout(searchTimer);
-        }
-        searchTimer = window.setTimeout(() => {
-          searchTimer = null;
-          recordSearch(searchText);
-        }, 500);
-      },
-      flushSearch(searchText) {
-        if (searchTimer) {
-          window.clearTimeout(searchTimer);
-          searchTimer = null;
-        }
+      recordSearchOnBlur(searchText) {
         recordSearch(searchText);
       },
       recordFilter(filterName) {
@@ -6251,16 +6237,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
           clearSearchReadIdsStorage();
         }
       }
-      siteDetailHistoryLogger.scheduleSearch(itemSearchInput.value);
       renderActiveTabContent({
         flashSearchMatches: isOutSearchInput,
       });
     });
 
-    itemSearchInput.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter') {
-        siteDetailHistoryLogger.flushSearch(itemSearchInput.value);
-      }
+    itemSearchInput.addEventListener('blur', () => {
+      siteDetailHistoryLogger.recordSearchOnBlur(itemSearchInput.value);
     });
 
     if (itemStatusFilterButton && itemStatusFilterMenu && itemStatusFilterOptions.length) {
@@ -7860,13 +7843,10 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
     if (detailSearchInput) {
       detailSearchInput.addEventListener('input', () => {
-        detailHistoryLogger.scheduleSearch(detailSearchInput.value);
         renderTable();
       });
-      detailSearchInput.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter') {
-          detailHistoryLogger.flushSearch(detailSearchInput.value);
-        }
+      detailSearchInput.addEventListener('blur', () => {
+        detailHistoryLogger.recordSearchOnBlur(detailSearchInput.value);
       });
       const toggleClearButton = () => {
         if (!detailSearchInput || !clearSearchBtn) {


### PR DESCRIPTION
### Motivation
- Supprimer le système de debounce à 500 ms qui créait des entrées d'historique pendant la frappe.
- Conserver la recherche en temps réel pour l'UX tout en s'assurant qu'aucun log n'est créé pendant la saisie.
- Enregistrer l'historique uniquement quand le champ perd le focus (`blur`), sans créer d'entrées vides ni de doublons.

### Description
- Suppression du `searchTimer` et des méthodes `scheduleSearch` / `flushSearch` dans `createSearchAndFilterHistoryLogger` et ajout de `recordSearchOnBlur` qui appelle la logique de `recordSearch` existante.
- Remplacement des appels de scheduling par des écouteurs `blur` sur `itemSearchInput` et `detailSearchInput` qui invoquent `siteDetailHistoryLogger.recordSearchOnBlur(...)` et `detailHistoryLogger.recordSearchOnBlur(...)`.
- Conserver la normalisation et la déduplication via `normalizeLoggedSearchText` et `lastRecordedSearch`, et garder intact l'appel à `StorageService.recordSearchHistory`.
- Aucune autre fonctionnalité modifiée; les enregistrements de filtre restent gérés par `recordFilter`.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check js/app.js`, qui a réussi sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75e7340a0483209074c465b86a9c38)