### PR TITLE
Ne pas créer d'entrées d'historique pour le rôle Admin

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -2125,6 +2125,10 @@ async function appendHistoryEntry(actionText, context = {}) {
   }
   try {
     const profile = await getCurrentUserProfile();
+    if (normalizeRole(profile?.role) === 'admin') {
+      return;
+    }
+
     const username = normalizeUsername(profile?.username) || normalizeUsername(state.authUser?.displayName) || 'Utilisateur inconnu';
     const siteId = sanitizeText(context?.siteId, false);
     const siteName = resolveSiteNameForHistory(siteId, context?.siteName);


### PR DESCRIPTION
### Motivation
- Empêcher que les comptes possédant réellement le rôle `Admin` écrivent des entrées dans la collection `historiques` tout en laissant le reste du comportement inchangé.
- Conserver la journalisation normale pour les autres rôles, y compris `Adjoint Admin` qui doit toujours être tracé.

### Description
- Ajout d'une garde dans la fonction `appendHistoryEntry` située dans `js/storage.js` qui récupère le profil courant via `getCurrentUserProfile()` et renvoie immédiatement si `normalizeRole(profile?.role) === 'admin'`.
- Aucune autre logique de création d'entrée d'historique n'a été modifiée et la suppression des écritures concerne exclusivement les utilisateurs dont le rôle normalisé est `admin`.
- Le reste du flux (prune, enregistrement d'activité utilisateur, etc.) reste inchangé pour ne pas bloquer ou altérer les autres fonctionnalités.

### Testing
- Exécution de la vérification de syntaxe via `node --check js/storage.js` réussie.
- Exécution de `git diff --check` (vérifications d'espaces/erreurs de diff) réussie.
- Aucun test automatisé supplémentaire n'a échoué pendant la modification du fichier `js/storage.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75ec38d1c083209de59ca9878e4bc0)