### PR TITLE
Journaliser l'ouverture de la page « Demande matériels »

### DIFF
--- a/js/materiels.js
+++ b/js/materiels.js
@@ -10,6 +10,33 @@ import { firebaseDb } from './firebase-core.js';
   let lastRequestMeta = null;
   let isRequestPngDownloading = false;
   let displayedMaterials = [];
+  let hasRecordedMaterialsPageOpen = false;
+
+
+  function waitForAppPermissionsReady() {
+    if (window.AppPermissions) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      window.addEventListener('app:permissions-ready', () => resolve(), { once: true });
+    });
+  }
+
+  async function recordMaterialsPageOpenHistoryOnce() {
+    if (hasRecordedMaterialsPageOpen) {
+      return;
+    }
+
+    hasRecordedMaterialsPageOpen = true;
+
+    try {
+      await waitForAppPermissionsReady();
+      await window.StorageService?.recordMaterialsPageOpenHistory?.();
+    } catch (_error) {
+      // L'historique ne doit pas bloquer l'ouverture de la page.
+    }
+  }
 
   function getCartItemKey(item = {}) {
     return String(item.code || item.manualKey || '');
@@ -1172,6 +1199,7 @@ import { firebaseDb } from './firebase-core.js';
     try {
       allMaterials = await loadAllMaterials();
       renderMaterials(allMaterials);
+      recordMaterialsPageOpenHistoryOnce();
     } catch (error) {
       console.error('Erreur chargement tous matériels :', error);
       renderMaterials([]);

--- a/js/storage.js
+++ b/js/storage.js
@@ -2187,6 +2187,10 @@ async function recordFilterHistory(filterName, context = {}) {
   await appendHistoryEntry(`a appliqué le filtre « ${label} »`, context);
 }
 
+async function recordMaterialsPageOpenHistory() {
+  await appendHistoryEntry('a cliqué sur « Demande matériels ».');
+}
+
 async function listHistoriques() {
   const snapshot = await getDocs(query(historyCollection(), orderBy('createdAt', 'desc')));
   return snapshot.docs.map(normalizeHistoryDocument);
@@ -2435,6 +2439,7 @@ window.StorageService = {
   computeNextNameChangeDate,
   recordSearchHistory,
   recordFilterHistory,
+  recordMaterialsPageOpenHistory,
   listHistoriques,
   subscribeHistoriques,
   getAuthUser: () => clone(state.authUser),


### PR DESCRIPTION
### Motivation
- Ajouter une entrée d'historique unique lorsqu'un utilisateur ouvre avec succès la page « Demande matériels » et conserver le même format que les autres événements de la page « Historiques ». 

### Description
- Ajout de la fonction `recordMaterialsPageOpenHistory` dans `js/storage.js` qui appelle l'infrastructure d'historique existante via `appendHistoryEntry('a cliqué sur « Demande matériels ».')` et est exposée sur `window.StorageService`. 
- Dans `js/materiels.js` ajout d'un flag `hasRecordedMaterialsPageOpen`, d'une aide `waitForAppPermissionsReady()` et d'une fonction `recordMaterialsPageOpenHistoryOnce()` pour enregistrer l'événement une seule fois par ouverture de page. 
- Appel de `recordMaterialsPageOpenHistoryOnce()` immédiatement après le chargement et le rendu de la liste des matériels afin d'assurer que l'ouverture a réussi avant de journaliser. 
- La logique existante d'`appendHistoryEntry` conserve l'exclusion du rôle `Admin` et n'altère pas les autres comportements ou fonctionnalités de l'application. 

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/materiels.js` qui a réussi. 
- Exécution de la vérification de syntaxe JavaScript avec `node --check js/storage.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75efb812cc83208bfd7546568614f1)