### PR TITLE
Réduire à 2 la limite quotidienne de suppression des OUT non-créés

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4571,7 +4571,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       overlay.innerHTML = `
         <article class="maintenance-card item-delete-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="outDeleteLimitTitle">
           <h3 id="outDeleteLimitTitle">Limite de suppression atteinte</h3>
-          <p>Vous avez atteint la limite de <strong>6 suppressions de OUT par jour</strong></p>
+          <p>Vous avez atteint la limite de <strong>2 suppressions de OUT par jour</strong>.</p>
           <p>Veuillez réessayer demain.</p>
           <div class="modal-actions item-delete-confirm-actions">
             <button type="button" class="btn item-delete-confirm-button site-delete-forbidden-close-button" id="outDeleteLimitCloseButton">OK</button>

--- a/js/storage.js
+++ b/js/storage.js
@@ -755,7 +755,7 @@ function outDeletionLimitDocRef(userId, dateKey = getOutDeletionLimitDateKey()) 
   return doc(state.db, 'users', userId, 'outDeletionLimits', dateKey);
 }
 
-async function hasReachedOutDeletionLimit(userId, limit = 6) {
+async function hasReachedOutDeletionLimit(userId, limit = 2) {
   if (!userId) {
     return true;
   }


### PR DESCRIPTION
### Motivation
- Adapter la règle de suppression pour que les utilisateurs qui ne sont pas les créateurs d’un OUT puissent supprimer au maximum **2 OUT par jour** au lieu de 6, tout en conservant les exceptions existantes pour le créateur et pour l’Admin (ne pas étendre aux « Adjoint Admin » si le code ne le prévoit pas). 

### Description
- Modifié la valeur par défaut du paramètre `limit` dans la fonction `hasReachedOutDeletionLimit` de `6` à `2` dans `js/storage.js` afin de limiter le comptage des suppressions pour les non-créateurs.
- Mis à jour le texte du dialogue d’alerte affiché quand la limite est atteinte dans `js/app.js` pour indiquer « 2 suppressions de OUT par jour », en conservant le libellé et le bouton `OK` existants.
- Aucune autre logique de comptabilisation ou d’exception (créateur, rôle `Admin`) n’a été modifiée.

### Testing
- Exécution des vérifications de syntaxe JavaScript avec `node --check js/app.js` et `node --check js/storage.js`, toutes réussies.
- Vérification statique du code utilisée pendant la modification (aucune erreur signalée par les contrôles lancés pendant l’edition).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77672f9df88320ae810a81cd314967)