### PR TITLE
Remove lock icon from "Statut du site" overlay title

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
       <dialog id="siteLockStatusDialog" class="modal-card">
         <div class="modal-content modal-content--site-lock-status">
           <div class="modal-header modal-header--site-lock-status">
-            <h2><span class="site-lock-status-title-icon" aria-hidden="true">🔒</span>Statut du site</h2>
+            <h2>Statut du site</h2>
           </div>
           <div id="siteLockStatusMessage" class="site-lock-status-message" aria-live="polite"></div>
           <div class="modal-actions modal-actions--split">


### PR DESCRIPTION
### Motivation
- Remove only the lock icon (🔒) displayed to the left of the overlay title « Statut du site » to declutter the header while keeping the title text and all card content (including the lock icon for "Site verrouillé") unchanged.

### Description
- Deleted the `<span class="site-lock-status-title-icon" aria-hidden="true">🔒</span>` from the `h2` inside the `#siteLockStatusDialog` in `index.html`, without modifying any CSS or JS related to site lock status.

### Testing
- Located occurrences with a search, applied the replacement, confirmed the edit with `git diff` and `git diff --check` (no issues), committed the change with `git commit`, and attempted `gh pr create` which failed due to missing GitHub CLI authentication.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7806a5b0b083248cd0d5fe5ce023c1)