### PR TITLE
Déplacer visuellement le champ recherche et le bouton filtre sur la page détail site

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6324,12 +6324,23 @@ body[data-page="site-detail"] .site-detail-subtitle {
 
 body[data-page="site-detail"] .page-content {
   padding-inline: clamp(0.75rem, 2.4vw, 1.25rem);
+  padding-top: clamp(0.7rem, 2.2vw, 0.9rem);
   padding-bottom: calc(8.8rem + env(safe-area-inset-bottom, 0px));
 }
 
 body[data-page="site-detail"] .search-panel--site {
   width: min(100%, var(--content-max-width));
-  margin-inline: auto;
+  margin: 0 auto;
+}
+
+body[data-page="site-detail"] .page2-search-filter-bar {
+  width: 100%;
+  flex-wrap: nowrap;
+}
+
+body[data-page="site-detail"] .page2-filter-button {
+  width: 3rem;
+  min-width: 3rem;
 }
 
 body[data-page="site-detail"] #itemSearchInput {


### PR DESCRIPTION
### Motivation
- Reproduire la nouvelle mise en page où le champ « Rechercher (OUT ou article) » apparaît juste sous le header bleu et le bouton filtre est immédiatement à droite, sans toucher à la logique JavaScript, aux filtres, aux cartes OUT, ni aux sources de données.

### Description
- Ajustement CSS unique dans `css/style.css` pour ajouter un `padding-top` sur la zone de contenu, forcer `margin: 0 auto` sur `.search-panel--site`, ajouter la règle `.page2-search-filter-bar { width: 100%; flex-wrap: nowrap; }` et fixer la largeur minimale du bouton filtre avec `.page2-filter-button { width: 3rem; min-width: 3rem; }`, ce qui repositionne visuellement le champ de recherche et le bouton filtre sous le header tout en réutilisant les éléments existants.

### Testing
- Exécution de vérifications automatiques `git diff --check` et `node --check js/app.js` qui ont réussi, et tentative de `python3 -m py_compile ...` qui a échoué car le dépôt n’a pas de fichiers Python à compiler (non applicable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a780c5b2b7883249fe1442d0c80357f)