### PR TITLE
Page 2 : intégrer le champ Rechercher et le bouton Filtre dans le header bleu (responsive, page2 only)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4599,7 +4599,7 @@ body[data-page="site-detail"] .search-panel--site {
   box-shadow: none;
   padding: 0;
   display: grid;
-  gap: 0.85rem;
+  gap: 0.55rem;
 }
 
 body[data-page="site-detail"] .search-panel--site .input-group {
@@ -6708,12 +6708,15 @@ body.is-loading .header-menu__panel {
 /* Page 2 header centering hard-fix */
 body[data-page="site-detail"] .page2-header {
   display: grid;
-  grid-template-columns: 56px 1fr 56px;
+  grid-template-columns: 48px minmax(0, 1fr) 48px;
   align-items: center;
+  row-gap: 0.45rem;
+  min-height: 128px;
+  padding-block: calc(0.55rem + env(safe-area-inset-top, 0px)) 0.65rem;
 }
 
 body[data-page="site-detail"] .page2-header .app-header__side {
-  width: 56px;
+  width: 48px;
   justify-content: center;
 }
 body[data-page="site-detail"] .btn-export-header {
@@ -6744,9 +6747,38 @@ body[data-page="site-detail"] .page2-header-center {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
+  gap: 0.5rem;
   text-align: center;
+}
+
+body[data-page="site-detail"] .page2-header-title-block {
+  min-width: 0;
+}
+
+body[data-page="site-detail"] .page2-search-filter-bar--header {
+  width: 100%;
+  max-width: 32rem;
+  margin-inline: auto;
+  gap: 0.45rem;
+}
+
+body[data-page="site-detail"] .page2-search-filter-bar--header .input-group {
+  min-height: 2.45rem;
+}
+
+body[data-page="site-detail"] .page2-search-filter-bar--header .search-input {
+  min-height: 2.45rem;
+  height: 2.45rem;
+  font-size: 0.88rem;
+}
+
+body[data-page="site-detail"] .page2-search-filter-bar--header .page2-filter-button {
+  width: 2.45rem;
+  min-width: 2.45rem;
+  height: 2.45rem;
+  min-height: 2.45rem;
 }
 
 body[data-page="site-detail"] .page2-title {

--- a/page2.html
+++ b/page2.html
@@ -14,19 +14,11 @@
           <button class="back-button back-btn" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
         </div>
         <div class="app-header__center page2-header-center">
-          <h1 id="siteTitle" class="page2-title">Chargement...</h1>
-          <div id="itemCount" class="site-detail-subtitle outs-count page2-header-subtitle"><span class="outs-number">0</span><span class="outs-label">OUTS</span></div>
-        </div>
-        <div class="app-header__side app-header__side--right">
-          <button class="btn-export-header" type="button" id="headerExportBtn" aria-label="Exporter">
-            <img src="Icon/Exel.png" alt="" aria-hidden="true" />
-          </button>
-        </div>
-      </header>
-
-      <main class="page-content main-content">
-          <section class="search-panel search-panel--site surface-card section">
-          <div class="page2-search-filter-bar">
+          <div class="page2-header-title-block">
+            <h1 id="siteTitle" class="page2-title">Chargement...</h1>
+            <div id="itemCount" class="site-detail-subtitle outs-count page2-header-subtitle"><span class="outs-number">0</span><span class="outs-label">OUTS</span></div>
+          </div>
+          <div class="page2-search-filter-bar page2-search-filter-bar--header">
             <label class="input-group">
               <span class="sr-only">Rechercher (OUT ou article)</span>
               <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
@@ -51,6 +43,16 @@
               </div>
             </div>
           </div>
+        </div>
+        <div class="app-header__side app-header__side--right">
+          <button class="btn-export-header" type="button" id="headerExportBtn" aria-label="Exporter">
+            <img src="Icon/Exel.png" alt="" aria-hidden="true" />
+          </button>
+        </div>
+      </header>
+
+      <main class="page-content main-content">
+          <section class="search-panel search-panel--site surface-card section">
           <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>
             <span class="auth-required-card__icon" aria-hidden="true">i</span>
             <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>


### PR DESCRIPTION
### Motivation
- Rendre le header bleu de la page 2 compact et propre en plaçant le champ de recherche et le bouton filtre à l’intérieur du header tout en conservant le bouton d’export XLS et en laissant les boutons de période (`Tous / Aujourd’hui / Hier / Plus ancien`) sous le header.
- Éviter les grands espaces vides entre le header et les boutons de filtrage et préserver le comportement existant des contrôles (IDs et interactions JavaScript inchangés).

### Description
- Déplacé le bloc de recherche et le bouton filtre depuis la zone de contenu vers le centre du header de la page 2 en modifiant `page2.html` et en conservant les mêmes `id` pour `itemSearchInput`, `itemStatusFilterButton`, `itemStatusFilterMenu` et `headerExportBtn` afin de ne pas modifier le JS existant.
- Ajouté une petite structure HTML dédiée au header : `page2-header-title-block` et `page2-search-filter-bar--header` pour isoler les changements au composant page 2 uniquement dans `page2.html`.
- Ajusté les styles ciblés dans `css/style.css` sous le sélecteur `body[data-page="site-detail"]` : resserrement des gaps, réduction des largeurs des côtés du header, ajout de `min-height` et d’un espacement vertical, et styles spécifiques pour la version header de la barre de recherche (`page2-search-filter-bar--header`) pour garantir l’affichage sur petits écrans.
- Conservé les boutons de filtrage par date hors du header (la `filter-chip-group` reste sous le header), supprimé l’ancien espace vide et veillé à ce que la disposition reste responsive sans toucher aux composants partagés d’autres pages.

### Testing
- Exécuté `git diff --check` pour vérifier les changements de formatage et erreurs de diff, et l’outil a rapporté aucun problème (succès).
- Vérification automatisée de la présence/ unicité des identifiants importants via un petit script `python3` qui contrôle la présence unique de `id="itemSearchInput"`, `id="itemStatusFilterButton"`, `id="itemStatusFilterMenu"` et `id="headerExportBtn"` (succès).
- Recherches ciblées (`rg`/grep) confirmant que seules `page2.html` et `css/style.css` ont été modifiées et que les sélecteurs `body[data-page="site-detail"]` ont bien été mis à jour (succès).
- Tentative d’aperçu automatisé : démarré un serveur statique (`python3 -m http.server`) pour prévisualisation, mais l’exécution de tests visuels headless par Playwright/Chromium n’a pas pu être réalisée car aucun navigateur headless / Playwright n’était disponible dans l’environnement (bloqué, test visuel non automatisé).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7810d4627c83249bd330e54365ccbc)