### PR TITLE
Intégrer la barre de recherche et le bouton filtre dans l'en-tête (Page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8359,3 +8359,78 @@ body:is([data-page="home"], [data-page="site-detail"]) #siteDeleteForbiddenOverl
     transition-duration: 1ms;
   }
 }
+
+/* Page 2: search and status filter integrated into the blue header */
+body[data-page="site-detail"] .page2-header {
+  min-height: 8.6rem;
+  height: auto;
+  grid-template-rows: auto auto;
+  row-gap: 0.75rem;
+  align-items: start;
+  padding-top: 0.9rem;
+  padding-bottom: 1rem;
+}
+
+body[data-page="site-detail"] .page2-header > .page2-search-filter-bar {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  width: 100%;
+  max-width: min(100%, 42rem);
+  justify-self: center;
+  padding-inline: clamp(0.15rem, 1.6vw, 0.6rem);
+}
+
+body[data-page="site-detail"] .page2-header .page2-search-filter-bar .input-group {
+  margin: 0;
+}
+
+body[data-page="site-detail"] .page2-header #itemSearchInput {
+  min-height: 2.9rem;
+  border-color: rgba(255, 255, 255, 0.62);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+}
+
+body[data-page="site-detail"] .page2-header .page2-filter-button {
+  width: 2.9rem;
+  height: 2.9rem;
+  min-height: 2.9rem;
+  border-color: rgba(255, 255, 255, 0.62);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+}
+
+body[data-page="site-detail"] .page2-header .page2-filter-menu {
+  z-index: 60;
+}
+
+@media (max-width: 420px) {
+  body[data-page="site-detail"] .page2-header {
+    grid-template-columns: 48px minmax(0, 1fr) 48px;
+    row-gap: 0.65rem;
+    padding-inline: 0.65rem;
+  }
+
+  body[data-page="site-detail"] .page2-header .app-header__side {
+    width: 48px;
+  }
+
+  body[data-page="site-detail"] .page2-header > .page2-search-filter-bar {
+    gap: 8px;
+    padding-inline: 0;
+  }
+
+  body[data-page="site-detail"] .page2-header #itemSearchInput {
+    min-height: 2.75rem;
+    padding-left: 2.35rem;
+    font-size: 0.86rem;
+  }
+
+  body[data-page="site-detail"] .page2-header .site-search-icon-wrap {
+    left: 0.82rem;
+  }
+
+  body[data-page="site-detail"] .page2-header .page2-filter-button {
+    width: 2.75rem;
+    height: 2.75rem;
+    min-height: 2.75rem;
+  }
+}

--- a/page2.html
+++ b/page2.html
@@ -22,12 +22,8 @@
             <img src="Icon/Exel.png" alt="" aria-hidden="true" />
           </button>
         </div>
-      </header>
-
-      <main class="page-content main-content">
-          <section class="search-panel search-panel--site surface-card section">
-          <div class="page2-search-filter-bar">
-            <label class="input-group">
+        <div class="page2-search-filter-bar">
+          <label class="input-group">
               <span class="sr-only">Rechercher (OUT ou article)</span>
               <span class="site-search-icon-wrap" aria-hidden="true"><img src="Icon/Recherche.png" alt="" class="site-search-icon" /></span>
               <input
@@ -37,8 +33,8 @@
                 placeholder="Rechercher (OUT ou article)"
                 autocomplete="off"
               />
-            </label>
-            <div class="page2-filter-menu-wrap">
+          </label>
+          <div class="page2-filter-menu-wrap">
               <button type="button" id="itemStatusFilterButton" class="page2-filter-button" aria-label="Filtrer les OUT par statut" aria-haspopup="true" aria-expanded="false" aria-controls="itemStatusFilterMenu">
                 <img src="Icon/filtre.png" alt="" aria-hidden="true" class="page2-filter-button__icon" />
               </button>
@@ -49,8 +45,12 @@
                 <button type="button" class="page2-filter-option" data-item-status-filter="fix" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">À corriger</span><span class="page2-filter-option__count">0</span></button>
                 <button type="button" class="page2-filter-option" data-item-status-filter="ko" role="menuitemradio" aria-checked="false"><span class="page2-filter-option__label">K.O</span><span class="page2-filter-option__count">0</span></button>
               </div>
-            </div>
           </div>
+        </div>
+      </header>
+
+      <main class="page-content main-content">
+          <section class="search-panel search-panel--site surface-card section">
           <section class="auth-required-card auth-required-card--embedded section" data-auth-required-card hidden>
             <span class="auth-required-card__icon" aria-hidden="true">i</span>
             <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>


### PR DESCRIPTION
### Motivation
- Rapprocher visuellement le champ de recherche et le bouton filtre du header bleu de la Page 2 pour respecter la maquette fournie tout en conservant le comportement existant.
- Préserver l’emplacement et le fonctionnement des chips de filtrage par date situés sous le header (ne pas les déplacer).

### Description
- Déplacé le bloc HTML existant de la barre de recherche et du bouton filtre de la zone de contenu vers l’en-tête de la Page 2 sans renommer les `id` ni modifier les classes afin de garder la logique JS intacte (`page2.html`).
- Ajouté des règles CSS scoped à `body[data-page="site-detail"]` pour positionner la barre dans le header bleu, conserver le style blanc arrondi (ombres/bordures) et adapter les dimensions en mobile (`css/style.css`).
- Le menu de statut et toutes les options (`Tous`, `Terminés`, etc.) sont réutilisés tels quels et conservent leurs identifiants et attributs ARIA pour ne pas altérer la logique de filtrage existante.
- Aucune modification apportée aux pages 1 ou 3 ni aux chips/filtres de date (leurs éléments HTML sont restés à l’emplacement d’origine).

### Testing
- Validation HTML automatisée avec `html.parser` pour `page2.html`, `index.html` et `page3.html`, qui a réussi sans erreurs.
- Démarrage d’un serveur HTTP statique local et vérification par `curl -I http://127.0.0.1:8000/page2.html`, qui a renvoyé `200 OK` indiquant que la page est servie correctement.
- Pas de tests d’UI automatisés headless exécutés car aucun navigateur/headless runner n’était disponible dans l’environnement; les identifiants et classes des contrôles ont été conservés pour garantir la compatibilité avec les scripts existants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78151f1fc08324abdeb310f65cd68a)