### PR TITLE
Fix search icon positioning on Page 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4616,6 +4616,7 @@ body[data-page="site-detail"] .page2-search-filter-bar {
 body[data-page="site-detail"] .page2-search-filter-bar .input-group {
   flex: 1;
   min-width: 0;
+  position: relative;
 }
 
 body[data-page="site-detail"] .page2-filter-menu-wrap {


### PR DESCRIPTION
### Motivation
- La petite icône de recherche débordait à gauche du champ sur la page 2 ; l'objectif est de l'intégrer à l'intérieur du champ sans modifier sa taille, son conteneur ni le bouton filtre.

### Description
- Ajout de `position: relative` à la règle `body[data-page="site-detail"] .page2-search-filter-bar .input-group` dans `css/style.css` pour permettre à l'icône de se positionner correctement à l'intérieur du champ sans changer d'autres styles.

### Testing
- Exécuté `git diff --check` et validé qu'il n'y a pas d'erreurs de style, puis `git commit` du fichier modifié (`css/style.css`), les commandes ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a781909d2d88324af525bc4a6c90103)