### PR TITLE
Reduce page 2 blue header height by ~3%

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8363,7 +8363,7 @@ body:is([data-page="home"], [data-page="site-detail"]) #siteDeleteForbiddenOverl
 
 /* Page 2: search and status filter integrated into the blue header */
 body[data-page="site-detail"] .page2-header {
-  min-height: 8.6rem;
+  min-height: 8.34rem;
   height: auto;
   grid-template-rows: auto auto;
   row-gap: 0.75rem;


### PR DESCRIPTION
### Motivation
- Réduire légèrement (≈3%) la hauteur du header bleu de la page 2 tout en conservant exactement les mêmes éléments, leur disposition et le comportement responsive.

### Description
- Mise à jour de `css/style.css` : dans le sélecteur `body[data-page="site-detail"] .page2-header` la valeur `min-height` est passée de `8.6rem` à `8.34rem` pour réduire uniquement la hauteur du header de la page 2.

### Testing
- Exécutions automatiques vérifiées : `git diff -- css/style.css` et `git diff --check` (aucune erreur), et `git status --short --branch` montrant la modification; commit réalisé avec le message `Reduce page 2 header height`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a782ed94130832496aa5fcc4abdc9cc)