### PR TITLE
Réduire l'espace inférieur du header (page 2)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8363,13 +8363,13 @@ body:is([data-page="home"], [data-page="site-detail"]) #siteDeleteForbiddenOverl
 
 /* Page 2: search and status filter integrated into the blue header */
 body[data-page="site-detail"] .page2-header {
-  min-height: 8.34rem;
+  min-height: auto;
   height: auto;
   grid-template-rows: auto auto;
   row-gap: 0.75rem;
   align-items: start;
   padding-top: 0.9rem;
-  padding-bottom: 0.4rem;
+  padding-bottom: 0.625rem;
 }
 
 body[data-page="site-detail"] .page2-header > .page2-search-filter-bar {


### PR DESCRIPTION
### Motivation

- Diminuer uniquement l’espace vide en bas du header bleu de la page 2 pour rapprocher la bordure inférieure du bas du champ de recherche à environ 8–12 px sans toucher les autres éléments.

### Description

- Ajuste le style ciblé `body[data-page="site-detail"] .page2-header` dans `css/style.css` pour retirer la `min-height` fixe et laisser la hauteur suivre le contenu en mettant `min-height: auto`.
- Augmente la `padding-bottom` de `0.4rem` à `0.625rem` pour obtenir ~10px d’espace visuel sous la rangée recherche/filtre.
- La modification est strictement limitée aux règles CSS de la page 2 (`body[data-page="site-detail"] .page2-header`) et ne modifie pas la taille ni la position du champ de recherche, du bouton filtre, du bouton d’export XLS, des titres ou des éléments en dehors du header.

### Testing

- Exécuté le contrôle syntaxique avec `git diff --check` et il n’a retourné d’erreur, test réussi.
- Servi localement avec `python -m http.server` et vérifié la page avec `curl -I http://127.0.0.1:4174/page2.html`, réponse `200 OK` indiquant que la page se charge correctement.
- Vérifié que les règles modifiées apparaissent dans `css/style.css` et sont limitées aux sélecteurs de la page 2, test visuel attendu (pas d’autres pages affectées).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78354a82e48324a6a92b47878e2fcc)