### PR TITLE
Page 2: reuse existing focus styling for header search input

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8391,6 +8391,11 @@ body[data-page="site-detail"] .page2-header #itemSearchInput {
   box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
 }
 
+body[data-page="site-detail"] .page2-header #itemSearchInput:focus {
+  border: 1px solid var(--detail-primary);
+  box-shadow: 0 0 0 3px var(--detail-primary-focus);
+}
+
 body[data-page="site-detail"] .page2-header .page2-filter-button {
   width: 2.9rem;
   height: 2.9rem;


### PR DESCRIPTION
### Motivation
- Afficher l’indication visuelle (bordure de focus) uniquement lorsque l’utilisateur saisit dans le champ « Rechercher (OUT ou article) » de la page 2 en réutilisant les styles de focus déjà présents dans le projet, sans modifier la taille du champ ni d’autres éléments visuels.

### Description
- Ajouté une règle CSS ciblée dans `css/style.css`: `body[data-page="site-detail"] .page2-header #itemSearchInput:focus` appliquant `border: 1px solid var(--detail-primary)` et `box-shadow: 0 0 0 3px var(--detail-primary-focus)` pour réutiliser les variables de focus existantes et éviter tout changement de taille, position de l’icône, du bouton filtre ou du bouton « X ». 

### Testing
- Exécuté `git diff --check` (aucune erreur) et validé la modification en commit (`git commit`) sur `css/style.css`, et les contrôles locaux ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a783c107fc88324815bb08d9ac5b487)