### PR TITLE
Preserve page 2 search field dimensions on focus (use border-color)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4801,7 +4801,7 @@ body[data-page="site-detail"] #itemSearchInput {
 
 body[data-page="site-detail"] #itemSearchInput:focus {
   outline: none;
-  border: 2px solid var(--detail-primary);
+  border-color: var(--detail-primary);
   box-shadow: 0 0 0 4px rgba(39, 141, 218, 0.12);
 }
 
@@ -8392,7 +8392,7 @@ body[data-page="site-detail"] .page2-header #itemSearchInput {
 }
 
 body[data-page="site-detail"] .page2-header #itemSearchInput:focus {
-  border: 1px solid var(--detail-primary);
+  border-color: var(--detail-primary);
   box-shadow: 0 0 0 3px var(--detail-primary-focus);
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the search field on page 2 displays the blue focus outline while keeping its size, radius, icon and layout unchanged by reusing existing focus variables and styles.

### Description
- Updated `css/style.css` for page 2 to change the focus rules for the search input to set only `border-color: var(--detail-primary)` (replacing `border: ...`) in the selectors targeting `body[data-page="site-detail"] #itemSearchInput:focus` and `body[data-page="site-detail"] .page2-header #itemSearchInput:focus` so the visible blue outline appears on focus without altering border width or dimensions.

### Testing
- No automated tests were executed for this CSS-only change; the modification was validated via local diff inspection and style preview checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7861d07d34832fad425e7cb1d70a25)