### PR TITLE
Page 2 : contour du champ de recherche au focus en orange

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8392,8 +8392,8 @@ body[data-page="site-detail"] .page2-header #itemSearchInput {
 }
 
 body[data-page="site-detail"] .page2-header #itemSearchInput:focus {
-  border-color: var(--detail-primary);
-  box-shadow: 0 0 0 3px var(--detail-primary-focus);
+  border-color: #f97316;
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.18);
 }
 
 body[data-page="site-detail"] .page2-header .page2-filter-button {


### PR DESCRIPTION
### Motivation
- Remplacer le contour bleu affiché au focus du champ de recherche de la page 2 par un orange tout en conservant l’épaisseur, la taille, la hauteur, la largeur, le `border-radius` et les styles de focus existants.

### Description
- Mise à jour du sélecteur `body[data-page="site-detail"] .page2-header #itemSearchInput:focus` dans `css/style.css` pour utiliser `border-color: #f97316;` et `box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.18);` à la place des variables de couleur précédentes.

### Testing
- Exécuté `git diff --check` et `git status --short`, les contrôles automatiques locaux ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7863bf7d20832f9d02fe52476dd3bb)