### PR TITLE
Fix: padding-bottom pour le tableau utilisateurs afin d'éviter le chevauchement avec le FAB

### DIFF
--- a/users.html
+++ b/users.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Gestion des utilisateurs - Suivi Matériel</title>
     <link rel="stylesheet" href="css/style.css" />
+    <style>
+      body[data-page="users-management"] .table-wrapper--users {
+        box-sizing: border-box;
+        padding-bottom: calc(5.5rem + env(safe-area-inset-bottom, 0px));
+      }
+    </style>
   </head>
   <body data-page="users-management">
     <div class="app-shell app-shell--wide">


### PR DESCRIPTION
### Motivation
- Garantir que la dernière ligne du tableau des utilisateurs reste entièrement visible au-dessus du bouton FAB en ajoutant un espace de sécurité en bas du conteneur scrollable, sans modifier la position du FAB ni la mise en page existante.

### Description
- Ajout d'un style inline dans `users.html` (immédiatement après l'inclusion `css/style.css`) qui applique `box-sizing: border-box` et `padding-bottom: calc(5.5rem + env(safe-area-inset-bottom, 0px))` à la règle `.table-wrapper--users`, sans toucher aux dimensions, colonnes, lignes, textes ou autres fichiers CSS/HTML.

### Testing
- Tests automatiques exécutés : `git diff --check` (succès) et commit du fichier modifié (`users.html`) (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a788405e928832fbedb50d8962558ce)