### PR TITLE
Move page 1 site search into header (reuse page2 header styling)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8440,3 +8440,67 @@ body[data-page="site-detail"] .page2-header .page2-filter-menu {
     min-height: 2.75rem;
   }
 }
+
+/* Page 1: site search integrated into the blue header */
+body[data-page="home"] .page1-header {
+  min-height: auto;
+  height: auto;
+  grid-template-rows: auto auto;
+  row-gap: 0.75rem;
+  align-items: start;
+  padding-top: 0.9rem;
+  padding-bottom: 0.625rem;
+}
+
+body[data-page="home"] .page1-header > .page1-search-filter-bar {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  width: 100%;
+  max-width: min(100%, 42rem);
+  justify-self: center;
+  padding-inline: clamp(0.15rem, 1.6vw, 0.6rem);
+}
+
+body[data-page="home"] .page1-header .page1-search-filter-bar .input-group {
+  position: relative;
+  gap: 0;
+  margin: 0;
+}
+
+body[data-page="home"] .page1-header #searchInput {
+  width: 100%;
+  min-height: 2.9rem;
+  border-color: rgba(255, 255, 255, 0.62);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+}
+
+body[data-page="home"] .page1-header #searchInput:focus {
+  border-color: var(--detail-primary);
+  box-shadow: 0 0 0 3px var(--detail-primary-focus);
+}
+
+@media (max-width: 420px) {
+  body[data-page="home"] .page1-header {
+    grid-template-columns: 48px minmax(0, 1fr) 48px;
+    row-gap: 0.65rem;
+    padding-inline: 0.65rem;
+  }
+
+  body[data-page="home"] .page1-header .app-header__side {
+    width: 48px;
+  }
+
+  body[data-page="home"] .page1-header > .page1-search-filter-bar {
+    padding-inline: 0;
+  }
+
+  body[data-page="home"] .page1-header #searchInput {
+    min-height: 2.75rem;
+    padding-left: 2.35rem;
+    font-size: 0.86rem;
+  }
+
+  body[data-page="home"] .page1-header .search-input__icon-wrap {
+    left: 0.82rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -36,6 +36,15 @@
             U
           </button>
         </div>
+        <div class="page1-search-filter-bar">
+          <label class="input-group">
+            <span class="sr-only">Recherche</span>
+            <span class="search-input__icon-wrap" aria-hidden="true">
+              <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
+            </span>
+            <input id="searchInput" class="search-input" type="search" placeholder="Rechercher un site..." autocomplete="off" />
+          </label>
+        </div>
       </header>
 
       
@@ -87,16 +96,6 @@
       </div>
 
       <main class="page-content main-content">
-        <section class="search-panel search-panel--inline section">
-          <label class="input-group">
-            <span class="sr-only">Recherche</span>
-            <span class="search-input__icon-wrap" aria-hidden="true">
-              <img src="Icon/Recherche.png" alt="" class="search-input__icon" />
-            </span>
-            <input id="searchInput" class="search-input" type="search" placeholder="Rechercher un site..." autocomplete="off" />
-          </label>
-        </section>
-
         <section class="auth-required-card section" data-auth-required-card hidden>
           <span class="auth-required-card__icon" aria-hidden="true">i</span>
           <p class="auth-required-card__message">Vous devez vous connecter pour modifier les données.</p>


### PR DESCRIPTION
### Motivation
- Intégrer visuellement le champ « Rechercher un site... » à l’intérieur du header bleu de PAGE 1 en reprenant le même principe d’intégration déjà utilisé dans PAGE 2 tout en conservant la logique de recherche existante et le comportement responsive.

### Description
- Déplacé le bloc HTML du champ de recherche de la zone principale vers l’en-tête de `index.html` en conservant `id="searchInput"` pour préserver la connexion avec la logique JavaScript existante.
- Supprimé l’ancien bloc de recherche du `main` pour éviter les doublons et ajouté une nouvelle wrapper `div.page1-search-filter-bar` placée sous le titre « Suivi Matériel » dans le header.
- Ajouté des règles CSS dédiées dans `css/style.css` (`body[data-page="home"] .page1-header` et sélecteurs associés) qui reproduisent le positionnement, le style, le focus et les adaptations mobile déjà employés pour PAGE 2.
- Réutilisation des classes existantes (`search-input`, `search-input__icon-wrap`, `input-group`) pour éviter de créer un nouveau système de styles et préserver l’apparence et le comportement.

### Testing
- Exécution d’une assertion Python vérifiant qu’il n’existe qu’un seul élément `id="searchInput"`, que le `placeholder` reste `"Rechercher un site..."` et que la nouvelle wrapper `page1-search-filter-bar` est présente, et que l’ancien bloc n’existe plus; l’assertion a réussi.
- Exécution de `git diff --check` pour vérifier les problèmes de format/espaces; la vérification a réussi.
- Inspection rapide des styles et du DOM généré (recherches par motifs) pour s’assurer que les sélecteurs de PAGE 2 ont été repris et adaptés pour PAGE 1; cette vérification automatique a confirmé la présence des règles CSS attendues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a797b0e9298832f840e2200e47c1276)