### PR TITLE
Align page 1 header row

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8445,19 +8445,26 @@ body[data-page="site-detail"] .page2-header .page2-filter-menu {
 body[data-page="home"] .page1-header {
   min-height: auto;
   height: auto;
-  grid-template-rows: auto auto;
+  display: flex;
+  flex-direction: column;
   row-gap: 0.75rem;
-  align-items: start;
+  align-items: stretch;
   padding-top: 0.9rem;
   padding-bottom: 0.625rem;
 }
 
+body[data-page="home"] .page1-header-row {
+  display: grid;
+  grid-template-columns: var(--header-side-width) minmax(0, 1fr) var(--header-side-width);
+  align-items: center;
+  min-height: 2.65rem;
+  column-gap: 0.55rem;
+}
+
 body[data-page="home"] .page1-header > .page1-search-filter-bar {
-  grid-column: 1 / -1;
-  grid-row: 2;
   width: 100%;
   max-width: min(100%, 42rem);
-  justify-self: center;
+  align-self: center;
   padding-inline: clamp(0.15rem, 1.6vw, 0.6rem);
 }
 
@@ -8481,9 +8488,12 @@ body[data-page="home"] .page1-header #searchInput:focus {
 
 @media (max-width: 420px) {
   body[data-page="home"] .page1-header {
-    grid-template-columns: 48px minmax(0, 1fr) 48px;
     row-gap: 0.65rem;
     padding-inline: 0.65rem;
+  }
+
+  body[data-page="home"] .page1-header-row {
+    grid-template-columns: 48px minmax(0, 1fr) 48px;
   }
 
   body[data-page="home"] .page1-header .app-header__side {

--- a/index.html
+++ b/index.html
@@ -11,30 +11,32 @@
   <body data-page="home" class="page1">
     <div class="app-shell">
       <header class="app-header app-header--home page1-header">
-        <div class="app-header__side app-header__side--left">
-          <div class="header-menu">
-            <button
-              id="homeMenuButton"
-              class="back-button header-action-btn menu-btn header-menu__trigger"
-              type="button"
-              aria-label="Plus d'options"
-              aria-haspopup="menu"
-              aria-expanded="false"
-            >
-              <img src="Icon/menu-burger.png" alt="" aria-hidden="true" class="header-menu__icon" />
+        <div class="page1-header-row">
+          <div class="app-header__side app-header__side--left">
+            <div class="header-menu">
+              <button
+                id="homeMenuButton"
+                class="back-button header-action-btn menu-btn header-menu__trigger"
+                type="button"
+                aria-label="Plus d'options"
+                aria-haspopup="menu"
+                aria-expanded="false"
+              >
+                <img src="Icon/menu-burger.png" alt="" aria-hidden="true" class="header-menu__icon" />
+              </button>
+            </div>
+          </div>
+          <div class="app-header__center">
+            <div class="header-title">
+              <h1>Suivi Matériel</h1>
+            </div>
+          </div>
+          <div class="app-header__side app-header__side--right">
+            <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
+            <button id="userAvatarButton" class="avatar-button header-action-btn avatar-btn" type="button" aria-label="Profil" hidden>
+              U
             </button>
           </div>
-        </div>
-        <div class="app-header__center">
-          <div class="header-title">
-            <h1>Suivi Matériel</h1>
-          </div>
-        </div>
-        <div class="app-header__side app-header__side--right">
-          <button id="openLoginButton" class="header-login-button" type="button" hidden>Se connecter</button>
-          <button id="userAvatarButton" class="avatar-button header-action-btn avatar-btn" type="button" aria-label="Profil" hidden>
-            U
-          </button>
         </div>
         <div class="page1-search-filter-bar">
           <label class="input-group">


### PR DESCRIPTION
### Motivation
- Corriger l'alignement du header de la PAGE 1 pour que le bouton hamburger, le titre « Suivi Matériel » et l'avatar soient sur la même ligne et centrés verticalement sans utiliser de positionnement fixe.
- Garder la barre de recherche sous cette ligne, préserver le comportement responsive et réutiliser les classes existantes autant que possible.

### Description
- Ajout d'un conteneur `div.page1-header-row` dans `index.html` pour regrouper le menu gauche, le titre central et l'avatar droit sur une même ligne header-row. 
- Remplacement du comportement précédent en CSS pour PAGE 1 en passant `body[data-page="home"] .page1-header` à une structure en colonne flexible et ajout de `body[data-page="home"] .page1-header-row` en `display: grid` avec `grid-template-columns: var(--header-side-width) minmax(0, 1fr) var(--header-side-width)` et `align-items: center` afin d'aligner verticalement les éléments sans valeurs fixes.
- Ajustements responsive : la règle mobile `(max-width:420px)` applique la même répartition de colonnes à `.page1-header-row` et la largeur latérale des `.app-header__side` reste à `48px` pour éviter chevauchements.
- Conservation du champ de recherche sous le header en modifiant son alignement à `align-self: center` et sans toucher aux cartes, au contenu sous le header ni à PAGE 2.

### Testing
- `git diff --check` exécuté et sans erreurs détectées (succès). 
- Parse HTML via `python3` + `html.parser.HTMLParser` sur `index.html` (succès).
- Tentative de test visuel avec `npx playwright --version` bloquée par le registre npm (`403 Forbidden`) donc Playwright n'a pas pu être exécuté (échec pour ce test).
- Les changements ont été commités localement (`git commit`) et les fichiers modifiés sont `index.html` et `css/style.css` (opération de commit réussie).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a797d0b59f0832fbfa501174ab9df44)