### PR TITLE
Aligner le titre du header (page d’accueil) avec les autres pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8445,11 +8445,23 @@ body[data-page="site-detail"] .page2-header .page2-filter-menu {
 body[data-page="home"] .page1-header {
   min-height: auto;
   height: auto;
+  grid-template-columns: var(--header-side-width) minmax(0, 1fr) var(--header-side-width);
   grid-template-rows: auto auto;
   row-gap: 0.75rem;
-  align-items: start;
+  align-items: center;
   padding-top: 0.9rem;
   padding-bottom: 0.625rem;
+}
+
+body[data-page="home"] .page1-header .app-header__center {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+body[data-page="home"] .page1-header .header-title h1 {
+  position: static;
+  transform: none;
+  width: 100%;
 }
 
 body[data-page="home"] .page1-header > .page1-search-filter-bar {


### PR DESCRIPTION
### Motivation
- Assurer que le titre « Suivi Matériel » de la page d’accueil utilise exactement le même système de centrage que les autres headers, et qu’il reste parfaitement centré indépendamment des boutons/avatars latéraux.

### Description
- Mise à jour du CSS dans `css/style.css` pour que `body[data-page="home"] .page1-header` utilise `grid-template-columns: var(--header-side-width) minmax(0, 1fr) var(--header-side-width)` et `align-items: center` afin d’obtenir des côtés symétriques comme les autres headers.
- Ajout de règles qui positionnent le conteneur central (`.app-header__center`) dans la colonne centrale du grid et remettent `.header-title h1` en `position: static` avec `transform: none` pour réutiliser exactement la logique d’alignement existante sans modifier la taille ou le style du texte.

### Testing
- Exécution de `git diff --check` qui a renvoyé sans erreurs.
- Démarrage d’un serveur local avec `python3 -m http.server` et vérification de `curl -I http://127.0.0.1:8000/index.html` qui a retourné `200 OK`, confirmant que les fichiers sont servis correctement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79856671d883229d0d0bc3651659e1)