### PR TITLE
Descendre le titre du header (page d'accueil) de 10px

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8460,7 +8460,7 @@ body[data-page="home"] .page1-header .app-header__center {
 
 body[data-page="home"] .page1-header .header-title h1 {
   position: static;
-  transform: none;
+  transform: translateY(10px);
   width: 100%;
 }
 


### PR DESCRIPTION
### Motivation
- Ajuster verticalement le titre « Suivi Matériel » dans le bandeau bleu de la page d'accueil pour qu'il soit visuellement centré sans modifier la hauteur du header ni la position du bouton menu, de l'avatar ou de la barre de recherche.

### Description
- Mise à jour de `css/style.css` : dans le sélecteur `body[data-page="home"] .page1-header .header-title h1` remplacer `transform: none;` par `transform: translateY(10px);` pour abaisser le titre d'environ 10px en conservant l'alignement horizontal.

### Testing
- Vérification de contenu CSS via un script Python (`from pathlib import Path` assert) confirmant la présence de `transform: translateY(10px);` — succès.
- Tentative d'accès statique à `index.html` via `curl` contre un serveur local de test — échec parce que le serveur local n'a pas pu être atteint dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7989b202588322a44a7b51bf0c69d0)