### PR TITLE
Adjust home header title vertical position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8460,7 +8460,7 @@ body[data-page="home"] .page1-header .app-header__center {
 
 body[data-page="home"] .page1-header .header-title h1 {
   position: static;
-  transform: translateY(4px);
+  transform: translateY(-3px);
   width: 100%;
 }
 


### PR DESCRIPTION
### Motivation

- The home header title "Suivi Matériel" was rendering slightly too low; the intent is to move it up by about 5–8px while leaving header height, menu button, avatar, search bar and all other elements and functionality unchanged.

### Description

- Change `transform: translateY(4px)` to `transform: translateY(-3px)` in `css/style.css` for the selector `body[data-page="home"] .page1-header .header-title h1`, producing an upward shift of ~7px and touching only that single rule.

### Testing

- Ran automated diff/whitespace checks and inspected the modified `css/style.css` lines to confirm the `translateY` change was applied correctly, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a798be065b883229a3acc0441c34fb0)