### PR TITLE
Reduce back arrow icon size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -516,8 +516,8 @@ body[data-page="home"] .header-menu__panel.is-closing {
 }
 
 .back-button .btn-retour {
-  width: 2rem;
-  height: 2rem;
+  width: 1.55rem;
+  height: 1.55rem;
   object-fit: contain;
   display: block;
 }


### PR DESCRIPTION
### Motivation
- Réduire la taille de la flèche blanche du bouton de retour d’environ 20–25 % sur toutes les pages tout en conservant exactement la même taille, position et centrage du cercle du bouton et sans toucher à d’autres éléments ou fonctionnalités.

### Description
- Modifié le sélecteur `.back-button .btn-retour` dans `css/style.css` pour ajuster `width` et `height` de `2rem` à `1.55rem`, sans autre changement de style ou de fichier.

### Testing
- Vérifications automatisées effectuées : recherche du sélecteur mis à jour avec `rg` et contrôles Git (`git status`, `git log -1`), toutes les vérifications ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79ae56b9948322a4ba79399f6737a2)