### PR TITLE
Page 3 — Classifier comme « Terminé » quand Ecart vide ou égal à 0

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7125,10 +7125,13 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const qteRetour = Number(detail?.qteRetour) || 0;
       const qteRebus = Number(detail?.qteRebus) || 0;
       const ecart = computeEcart(detail);
+      const normalizedEcart = ecart === '' ? 0 : Number(ecart);
+      const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
 
-      return (qtePosee > 0 && ecart === 0)
+      return (qtePosee > 0 && normalizedEcart === 0)
         || qteSortie === qteRebus
-        || qteSortie === qteRetour;
+        || qteSortie === qteRetour
+        || (hasActivity && normalizedEcart === 0);
     }
 
     function matchesDetailFilter(detail, filterKey) {
@@ -7491,7 +7494,8 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
       const isDone = (qtePosee > 0 && ecart === 0)
         || qteSortie === qteRebus
-        || qteSortie === qteRetour;
+        || qteSortie === qteRetour
+        || (hasActivity && ecart === 0);
 
       row.classList.toggle('detail-row--done', !isKoStatus && isDone);
       row.classList.toggle('detail-row--attention', !isKoStatus && hasActivity && ecart !== 0);


### PR DESCRIPTION
### Motivation
- Corriger la logique de classification du filtre « Terminé » sur la page 3 pour que les lignes dont le champ `Ecart` est vide soient traitées comme `0` et apparaissent correctement dans « Terminé » lorsque le calcul donne zéro.
- Ne modifier que la logique de complément pour les cas où `Ecart` est vide/0, sans écraser ni réinitialiser les statuts existants ni toucher aux autres filtres ou à l'affichage du tableau.

### Description
- Normalise la valeur retournée par `computeEcart(detail)` en traitant `''` (vide) comme `0` lors de l'évaluation de la complétion (`isDetailCompleted`) en ajoutant `normalizedEcart = ecart === '' ? 0 : Number(ecart)` et en réutilisant la logique existante.
- Ajoute la vérification `hasActivity` (présence de `Qté posée`, `Qté Rebus` ou `Qté Retour`) pour considérer une ligne comme « Terminé » si `ecart` est effectivement `0` même lorsque le champ était vide/normalisé à 0.
- Met à jour l'application de l'état sémantique de la ligne (`applyDetailRowSemanticState`) pour utiliser la même règle (tenir compte d'un `ecart` affiché à 0 après normalisation) afin que les modifications de `Qté posée`, `Qté Rebus` et `Qté Retour` recalculent et rafraîchissent automatiquement la classification.
- Les autres statuts (notamment `K.O`) et les autres filtres restent inchangés et la logique métier existante est conservée et prioritaire.

### Testing
- Exécution de la vérification de syntaxe `node --check js/app.js`, qui a réussi.
- Exécution de la vérification statique `git diff --check`, qui n'a pas signalé d'erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79cbab0664832290529d5e24752d53)