### PR TITLE
Fix decimal detail completion status

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,7 @@
 import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js';
 import { addDoc, collection, deleteDoc, doc, getDoc, getDocs, orderBy, query, serverTimestamp, updateDoc } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
+import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual } from './detail-status.js';
 
 (function () {
   const { StorageService, UiService } = window;
@@ -296,25 +297,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
     return null;
   }
 
-  function computeEcart(detail) {
-    const qteSortie = Number(detail?.qteSortie) || 0;
-    const qtePosee = Number(detail?.qtePosee) || 0;
-    const qteRetour = Number(detail?.qteRetour) || 0;
-    const qteRebus = Number(detail?.qteRebus) || 0;
-
-    if (qtePosee === 0 && qteRetour === 0 && qteRebus === 0) {
-      return '';
-    }
-
-    return qteSortie - (qtePosee + qteRetour + qteRebus);
-  }
-
   function formatEcartDisplay(value) {
     if (value === '') {
       return '';
     }
 
-    const numericValue = Number(value);
+    const numericValue = normalizeQuantity(value);
     if (!Number.isFinite(numericValue)) {
       return '0';
     }
@@ -331,7 +319,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
 
   function getEcartNumericValue(field) {
     const rawValue = field?.dataset.ecartValue ?? field?.value ?? 0;
-    return Number(rawValue);
+    return normalizeQuantity(rawValue);
   }
 
   function updateEcartFieldDisplay(field, value) {
@@ -4976,13 +4964,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         return filterKey === 'all';
       }
       const ecart = computeEcart(detail);
-      const qteSortie = Number(detail?.qteSortie) || 0;
-      const qtePosee = Number(detail?.qtePosee) || 0;
-      const qteRetour = Number(detail?.qteRetour) || 0;
-      const qteRebus = Number(detail?.qteRebus) || 0;
-      const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
-      const isDone = ecart === 0 && (qteRebus <= qteSortie || qteRetour <= qteSortie);
-      const isAttention = hasActivity && ecart !== 0;
+      const qtePosee = normalizeQuantity(detail?.qtePosee);
+      const qteRetour = normalizeQuantity(detail?.qteRetour);
+      const qteRebus = normalizeQuantity(detail?.qteRebus);
+      const hasActivity = !quantitiesAreEqual(qtePosee, 0) || !quantitiesAreEqual(qteRetour, 0) || !quantitiesAreEqual(qteRebus, 0);
+      const isDone = isDetailCompleted(detail);
+      const isAttention = hasActivity && !quantitiesAreEqual(ecart, 0);
       if (filterKey === 'done') {
         return isDone;
       }
@@ -7119,18 +7106,6 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       return escapeHtml(rawValue).replace(pattern, '<span class="search-highlight">$1</span>');
     }
 
-    function isDetailCompleted(detail) {
-      const qteSortie = Number(detail?.qteSortie) || 0;
-      const qtePosee = Number(detail?.qtePosee) || 0;
-      const qteRetour = Number(detail?.qteRetour) || 0;
-      const qteRebus = Number(detail?.qteRebus) || 0;
-      const ecart = computeEcart(detail);
-
-      return (qtePosee > 0 && ecart === 0)
-        || qteSortie === qteRebus
-        || qteSortie === qteRetour;
-    }
-
     function matchesDetailFilter(detail, filterKey) {
       const isKoStatus = normalizeDetailStatut(detail.statut) === 'K.O';
       if (filterKey === 'ko') {
@@ -7141,12 +7116,12 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
 
       const ecart = computeEcart(detail);
-      const qtePosee = Number(detail?.qtePosee) || 0;
-      const qteRetour = Number(detail?.qteRetour) || 0;
-      const qteRebus = Number(detail?.qteRebus) || 0;
-      const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
+      const qtePosee = normalizeQuantity(detail?.qtePosee);
+      const qteRetour = normalizeQuantity(detail?.qteRetour);
+      const qteRebus = normalizeQuantity(detail?.qteRebus);
+      const hasActivity = !quantitiesAreEqual(qtePosee, 0) || !quantitiesAreEqual(qteRetour, 0) || !quantitiesAreEqual(qteRebus, 0);
       const isDone = isDetailCompleted(detail);
-      const isAttention = hasActivity && ecart !== 0;
+      const isAttention = hasActivity && !quantitiesAreEqual(ecart, 0);
 
       if (filterKey === 'done') {
         return isDone;
@@ -7483,18 +7458,21 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
       }
 
       const isKoStatus = normalizeDetailStatut(row.querySelector('[data-field="statut"]')?.value) === 'K.O';
-      const qteSortie = Number(row.querySelector('[data-field="qteSortie"]')?.value ?? 0);
-      const qtePosee = Number(row.querySelector('[data-field="qtePosee"]')?.value ?? 0);
-      const qteRetour = Number(row.querySelector('[data-field="qteRetour"]')?.value ?? 0);
-      const qteRebus = Number(row.querySelector('[data-field="qteRebus"]')?.value ?? 0);
+      const detail = {
+        qteSortie: row.querySelector('[data-field="qteSortie"]')?.value,
+        qtePosee: row.querySelector('[data-field="qtePosee"]')?.value,
+        qteRetour: row.querySelector('[data-field="qteRetour"]')?.value,
+        qteRebus: row.querySelector('[data-field="qteRebus"]')?.value,
+      };
+      const qtePosee = normalizeQuantity(detail.qtePosee);
+      const qteRetour = normalizeQuantity(detail.qteRetour);
+      const qteRebus = normalizeQuantity(detail.qteRebus);
       const ecart = getEcartNumericValue(row.querySelector('[data-col-key="ecart"]'));
-      const hasActivity = qtePosee !== 0 || qteRetour !== 0 || qteRebus !== 0;
-      const isDone = (qtePosee > 0 && ecart === 0)
-        || qteSortie === qteRebus
-        || qteSortie === qteRetour;
+      const hasActivity = !quantitiesAreEqual(qtePosee, 0) || !quantitiesAreEqual(qteRetour, 0) || !quantitiesAreEqual(qteRebus, 0);
+      const isDone = isDetailCompleted(detail);
 
       row.classList.toggle('detail-row--done', !isKoStatus && isDone);
-      row.classList.toggle('detail-row--attention', !isKoStatus && hasActivity && ecart !== 0);
+      row.classList.toggle('detail-row--attention', !isKoStatus && hasActivity && !quantitiesAreEqual(ecart, 0));
     }
 
     function renderTable() {
@@ -7523,7 +7501,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
         .map(
           (detail, index) => {
             const ecart = computeEcart(detail);
-            const ecartClassName = typeof ecart === 'number' && ecart !== 0 ? ' cell-input--ecart-alert' : '';
+            const ecartClassName = typeof ecart === 'number' && !quantitiesAreEqual(ecart, 0) ? ' cell-input--ecart-alert' : '';
             const enterAnimationStyle = animateNextTableRender ? ` style="--detail-row-enter-delay:${Math.min(index, 5) * 40}ms"` : '';
             const isKoStatus = normalizeDetailStatut(detail.statut) === 'K.O';
             const rowClasses = [
@@ -7616,7 +7594,7 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
                 [fieldName]: nextValue,
               });
               updateEcartFieldDisplay(ecartField, nextEcart);
-              ecartField.classList.toggle('cell-input--ecart-alert', typeof nextEcart === 'number' && nextEcart !== 0);
+              ecartField.classList.toggle('cell-input--ecart-alert', typeof nextEcart === 'number' && !quantitiesAreEqual(nextEcart, 0));
             }
             applyDetailRowSemanticState(row);
           }
@@ -7635,15 +7613,16 @@ import { firebaseAuth, firebaseDb } from './firebase-core.js';
               const row = field.closest('tr');
               if (row) {
                 if (field.dataset.field !== 'statut') {
-                  const qteSortie = Number(row.querySelector('[data-field="qteSortie"]')?.value ?? 0);
-                  const qtePosee = Number(row.querySelector('[data-field="qtePosee"]')?.value ?? 0);
-                  const qteRebus = Number(row.querySelector('[data-field="qteRebus"]')?.value ?? 0);
-                  const qteRetour = Number(row.querySelector('[data-field="qteRetour"]')?.value ?? 0);
-                  const ecart = qteSortie - qtePosee - qteRebus - qteRetour;
+                  const ecart = computeEcart({
+                    qteSortie: row.querySelector('[data-field="qteSortie"]')?.value,
+                    qtePosee: row.querySelector('[data-field="qtePosee"]')?.value,
+                    qteRebus: row.querySelector('[data-field="qteRebus"]')?.value,
+                    qteRetour: row.querySelector('[data-field="qteRetour"]')?.value,
+                  });
                   const ecartField = row.querySelector('[data-col-key="ecart"]');
                   if (ecartField) {
                     updateEcartFieldDisplay(ecartField, ecart);
-                    ecartField.classList.toggle('cell-input--ecart-alert', ecart !== 0);
+                    ecartField.classList.toggle('cell-input--ecart-alert', !quantitiesAreEqual(ecart, 0));
                   }
                 }
                 applyDetailRowSemanticState(row);

--- a/js/detail-status.js
+++ b/js/detail-status.js
@@ -1,0 +1,44 @@
+export const DETAIL_QUANTITY_EPSILON = 0.000001;
+
+export function normalizeQuantity(value) {
+  if (value === null || value === undefined || value === '') {
+    return 0;
+  }
+
+  const normalizedValue = typeof value === 'string'
+    ? value.trim().replace(',', '.')
+    : value;
+  const numericValue = Number(normalizedValue);
+
+  return Number.isFinite(numericValue) ? numericValue : 0;
+}
+
+export function quantitiesAreEqual(leftValue, rightValue, epsilon = DETAIL_QUANTITY_EPSILON) {
+  return Math.abs(normalizeQuantity(leftValue) - normalizeQuantity(rightValue)) < epsilon;
+}
+
+export function computeEcart(detail) {
+  const qteSortie = normalizeQuantity(detail?.qteSortie);
+  const qtePosee = normalizeQuantity(detail?.qtePosee);
+  const qteRetour = normalizeQuantity(detail?.qteRetour);
+  const qteRebus = normalizeQuantity(detail?.qteRebus);
+
+  if (quantitiesAreEqual(qtePosee, 0) && quantitiesAreEqual(qteRetour, 0) && quantitiesAreEqual(qteRebus, 0)) {
+    return '';
+  }
+
+  return qteSortie - (qtePosee + qteRetour + qteRebus);
+}
+
+export function isDetailCompleted(detail) {
+  const qteSortie = normalizeQuantity(detail?.qteSortie);
+  const qtePosee = normalizeQuantity(detail?.qtePosee);
+  const qteRetour = normalizeQuantity(detail?.qteRetour);
+  const qteRebus = normalizeQuantity(detail?.qteRebus);
+  const justifiedQuantity = qtePosee + qteRebus + qteRetour;
+  const ecart = computeEcart(detail);
+
+  return !quantitiesAreEqual(qteSortie, 0)
+    && quantitiesAreEqual(ecart, 0)
+    && quantitiesAreEqual(justifiedQuantity, qteSortie);
+}

--- a/tests/detail-status.test.mjs
+++ b/tests/detail-status.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual } from '../js/detail-status.js';
+
+test('normalizes decimal comma quantities', () => {
+  assert.equal(normalizeQuantity('0,5'), 0.5);
+  assert.equal(normalizeQuantity(null), 0);
+  assert.equal(normalizeQuantity(undefined), 0);
+  assert.equal(normalizeQuantity(''), 0);
+});
+
+test('marks integer rebus total as completed', () => {
+  assert.equal(isDetailCompleted({ qteSortie: 1, qtePosee: 0, qteRebus: 1, qteRetour: 0 }), true);
+});
+
+test('marks 0,5 rebus plus 0,5 retour as completed', () => {
+  assert.equal(isDetailCompleted({ qteSortie: '1', qtePosee: '0', qteRebus: '0,5', qteRetour: '0,5' }), true);
+});
+
+test('marks 0,3 rebus plus 0,7 retour as completed', () => {
+  assert.equal(isDetailCompleted({ qteSortie: '1', qtePosee: '0', qteRebus: '0,3', qteRetour: '0,7' }), true);
+});
+
+test('handles floating point precision for 0.1 + 0.2', () => {
+  const detail = { qteSortie: '0,3', qtePosee: 0, qteRebus: '0,1', qteRetour: '0,2' };
+  assert.equal(isDetailCompleted(detail), true);
+  assert.equal(quantitiesAreEqual(computeEcart(detail), 0), true);
+});
+
+test('does not mark totals lower than sortie as completed', () => {
+  assert.equal(isDetailCompleted({ qteSortie: 1, qtePosee: 0, qteRebus: 0.4, qteRetour: 0.5 }), false);
+});
+
+test('does not mark totals greater than sortie as completed', () => {
+  assert.equal(isDetailCompleted({ qteSortie: 1, qtePosee: 0, qteRebus: 0.6, qteRetour: 0.5 }), false);
+});


### PR DESCRIPTION
### Motivation
- The logic that determines when a detail row is "Terminée" failed for decimal quantities because it relied on strict numeric equality and simple `Number(...)` conversions, causing cases like `0,5 + 0,5 === 1` to be missed due to floating-point and input-format issues.
- The business rule requires that a line is completed when `Qté posée + Qté rebus + Qté retour = Qté sortie` within a small tolerance and while keeping existing behaviour for integer quantities.

### Description
- Added a new module `js/detail-status.js` providing `normalizeQuantity`, `quantitiesAreEqual`, `computeEcart`, and `isDetailCompleted` to normalize inputs (strings, comma decimals, null/undefined) and compare numbers with an epsilon tolerance.
- Updated `js/app.js` to import and use the new helpers, replacing fragile `Number(...)` conversions and strict `===` checks in the completion/filter/row-state code paths (filter "Terminés", row semantic state, ecart display and live recalculation), and to use `computeEcart` consistently.
- Kept the existing ecart-based logic but replaced strict zero/inequality checks with `quantitiesAreEqual(..., 0)` so decimal sums and floating-point imprecision are tolerated while preserving integer behaviour.
- Added unit tests `tests/detail-status.test.mjs` covering integer, decimal-comma, decimal-sum (0.5+0.5), 0.1+0.2 precision, under-total and over-total cases.

### Testing
- Ran `node --check js/app.js` to validate syntax and module integration and it succeeded.
- Ran `node --test tests/detail-status.test.mjs` which executed 7 tests and all passed (covers the 5 required scenarios plus normalization and precision checks).
- The updated behaviour was exercised by the unit tests which confirm that decimal combinations such as `0,5 + 0,5` and `0,3 + 0,7` are now correctly considered "Terminée" while under/over totals are not.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79d81297f08322b2772ca0e9da42b4)