### PR TITLE
Fix empty quantity fields on page 3

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -297,9 +297,23 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
     return null;
   }
 
+  function isEmptyQuantityValue(value) {
+    return value === null || value === undefined || String(value).trim() === '';
+  }
+
+  function formatEditableQuantityValue(value) {
+    return isEmptyQuantityValue(value) ? '0' : String(value);
+  }
+
+  function normalizeEmptyQuantityInputValue(field) {
+    if (field && isEmptyQuantityValue(field.value)) {
+      field.value = '0';
+    }
+  }
+
   function formatEcartDisplay(value) {
     if (value === '') {
-      return '';
+      return '0';
     }
 
     const numericValue = normalizeQuantity(value);
@@ -7513,11 +7527,11 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
               <td><span class="field-badge">${getHighlightedHtml(detail.champ, searchQuery)}</span></td>
               <td><input class="cell-input cell-input--compact-dynamic cell-input--left" data-col-key="code" data-field="code" type="text" maxlength="120" value="${escapeHtml(detail.code)}" /></td>
               <td><textarea class="cell-input cell-textarea cell-input--autosize cell-input--designation designation-field cell-input--left" data-field="designation" maxlength="120" rows="1">${escapeHtml(detail.designation)}</textarea></td>
-              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteSortie" data-field="qteSortie" type="number" min="0" step="1" maxlength="120" value="${escapeHtml(detail.qteSortie)}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteSortie" data-field="qteSortie" type="text" inputmode="decimal" maxlength="120" value="${escapeHtml(formatEditableQuantityValue(detail.qteSortie))}" /></td>
               <td><span class="meta-value">${getHighlightedHtml(detail.unite, searchQuery)}</span></td>
-              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qtePosee" data-field="qtePosee" type="number" min="0" step="1" maxlength="120" value="${detail.qtePosee}" /></td>
-              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRebus" data-field="qteRebus" type="number" min="0" step="1" maxlength="120" value="${detail.qteRebus ?? 0}" /></td>
-              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRetour" data-field="qteRetour" type="number" min="0" step="1" maxlength="120" value="${detail.qteRetour}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qtePosee" data-field="qtePosee" type="text" inputmode="decimal" maxlength="120" value="${escapeHtml(formatEditableQuantityValue(detail.qtePosee))}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRebus" data-field="qteRebus" type="text" inputmode="decimal" maxlength="120" value="${escapeHtml(formatEditableQuantityValue(detail.qteRebus))}" /></td>
+              <td><input class="cell-input cell-input--compact-dynamic" data-col-key="qteRetour" data-field="qteRetour" type="text" inputmode="decimal" maxlength="120" value="${escapeHtml(formatEditableQuantityValue(detail.qteRetour))}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic date-retour-field" data-col-key="dateRetour" data-field="dateRetour" type="date" value="${escapeHtml(detail.dateRetour || '')}" /></td>
               <td><input class="cell-input cell-input--compact-dynamic${ecartClassName}" data-col-key="ecart" type="text" maxlength="120" value="${formatEcartDisplay(ecart)}" data-ecart-value="${ecart}" readonly aria-label="Ecart" /></td>
               <td><input data-col-key="observation" data-field="observation" type="text" maxlength="120" class="cell-input cell-input--compact-dynamic" value="${escapeHtml(detail.observation)}" /></td>
@@ -7550,7 +7564,15 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
         applyDetailRowSemanticState(row);
       });
 
+      const editableQuantityFields = new Set(['qteSortie', 'qtePosee', 'qteRebus', 'qteRetour']);
+
       detailTableBody.querySelectorAll('[data-field]').forEach((field) => {
+        if (editableQuantityFields.has(field.dataset.field)) {
+          field.addEventListener('blur', () => {
+            normalizeEmptyQuantityInputValue(field);
+          });
+        }
+
         field.addEventListener('change', async (event) => {
           const row = event.target.closest('tr');
           const fieldName = event.target.dataset.field;
@@ -7565,7 +7587,14 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
             return;
           }
 
-          const nextValue = fieldName === 'statut' ? normalizeDetailStatut(event.target.value) : event.target.value;
+          const nextValue = fieldName === 'statut'
+            ? normalizeDetailStatut(event.target.value)
+            : editableQuantityFields.has(fieldName) && isEmptyQuantityValue(event.target.value)
+              ? 0
+              : event.target.value;
+          if (editableQuantityFields.has(fieldName) && isEmptyQuantityValue(event.target.value)) {
+            event.target.value = '0';
+          }
           if (String(currentDetail[fieldName] ?? '') === String(nextValue ?? '')) {
             return;
           }

--- a/js/storage.js
+++ b/js/storage.js
@@ -706,7 +706,8 @@ function sanitizeNumber(value) {
   if (value === '' || value === null || value === undefined) {
     return '';
   }
-  const parsed = Number(value);
+  const normalizedValue = typeof value === 'string' ? value.trim().replace(',', '.') : value;
+  const parsed = Number(normalizedValue);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
 

--- a/page3.html
+++ b/page3.html
@@ -134,7 +134,7 @@
               <div class="detail-form-row detail-form-row--qte-unit">
                 <label class="input-group detail-form-field detail-form-field--qte">
                   <span>Qté Sortie</span>
-                  <input id="qteSortieInput" name="qteSortie" type="number" min="0" step="1" />
+                  <input id="qteSortieInput" name="qteSortie" type="text" inputmode="decimal" />
                 </label>
                 <label class="input-group detail-form-field detail-form-field--unit">
                   <span>Unité</span>


### PR DESCRIPTION
### Motivation
- Ensure the five quantity fields on page 3 (`qteSortie`, `qtePosee`, `qteRebus`, `qteRetour`, `ecart`) display `0` when they are empty outside of editing.
- Preserve the UX while editing so users can temporarily clear a field without the UI immediately reinjecting `0` and breaking input of decimals. 
- Keep existing calculation logic and status detection unchanged while normalizing displayed empties to `0`.

### Description
- Added helpers `isEmptyQuantityValue`, `formatEditableQuantityValue` and `normalizeEmptyQuantityInputValue` to `js/app.js` and used them to render empty quantities as `0` when not being edited. 
- Changed table quantity inputs from `type="number"` to `type="text" inputmode="decimal"` so decimal comma values like `0,5` are preserved during user input. 
- Added a `blur` handler for the editable quantity fields to convert an empty input to `'0'` on loss of focus, and adjusted the `change` handler to persist `0` for empty quantity fields while still allowing a temporarily-empty value during editing. 
- Updated `formatEcartDisplay` to show `0` for empty ecarts and modified `sanitizeNumber` in `js/storage.js` to accept decimal comma strings by normalizing `','` to `'.'` before parsing. 
- Files modified: `js/app.js`, `js/storage.js`, `page3.html`.

### Testing
- Ran static checks with `node --check js/app.js` and `node --check js/storage.js`, both succeeded. 
- Executed unit tests with `node tests/detail-status.test.mjs` and all tests passed. 
- Verified that decimal values (`0,5`, `0,25`), temporary empty state during edit, and the existing "Terminé" / completion logic remain working after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aa0aab7bc83229e7fee927639a587)