### PR TITLE
Auto-select unité (m / Pcs) depuis la désignation du matériel

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,7 @@ import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/
 import { addDoc, collection, deleteDoc, doc, getDoc, getDocs, orderBy, query, serverTimestamp, updateDoc } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
 import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual } from './detail-status.js';
+import { getAutomaticUnit } from './automatic-unit.js';
 
 (function () {
   const { StorageService, UiService } = window;
@@ -6651,7 +6652,7 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
         return;
       }
       detailForm.reset();
-      requireElement('uniteInput').value = 'm';
+      requireElement('uniteInput').value = getAutomaticUnit('');
       requireElement('statutInput').value = 'OK';
       setDetailFormSavingState(false);
       clearDetailFormError();
@@ -6959,6 +6960,7 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
       codeInput.value = entry.code;
       designationInput.value = entry.designation || '';
       updateDetailInputCounters();
+      requireElement('uniteInput').value = getAutomaticUnit(designationInput.value);
       hideCodeSuggestions();
     }
 
@@ -7792,7 +7794,7 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
           return;
         }
         detailForm.reset();
-        requireElement('uniteInput').value = 'm';
+        requireElement('uniteInput').value = getAutomaticUnit('');
         requireElement('statutInput').value = 'OK';
         updateDetailInputCounters();
         hideCodeSuggestions();
@@ -7907,6 +7909,7 @@ import { computeEcart, isDetailCompleted, normalizeQuantity, quantitiesAreEqual 
         clearDetailFormError();
         clearDetailFieldErrorState('designation');
         updateInputCharCounter(designationInput, designationInputCounter);
+        requireElement('uniteInput').value = getAutomaticUnit(designationInput.value);
       });
       designationInput.addEventListener('beforeinput', (event) => {
         enforceMaxLengthOnBeforeInput(event, designationInput);

--- a/js/automatic-unit.js
+++ b/js/automatic-unit.js
@@ -1,0 +1,61 @@
+const PIECE_UNIT = 'Pcs';
+const LENGTH_UNIT = 'm';
+
+const PIECE_KEYWORDS = [
+  'cosse',
+  'vis',
+  'ecrou',
+  'rondelle',
+  'connecteur',
+  'disjoncteur',
+  'prise',
+  'interrupteur',
+  'collier',
+  'embout',
+  'fusible',
+  'relais',
+];
+
+const LENGTH_KEYWORDS = [
+  'fil',
+  'cable',
+  'fibre',
+  'gaine',
+  'tube',
+  'tuyau',
+  'conducteur',
+];
+
+function normalizeAutomaticUnitDesignation(designation) {
+  return String(designation || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function containsAutomaticUnitKeyword(normalizedDesignation, keywords) {
+  return keywords.some((keyword) => {
+    const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(^|\\s)${escapedKeyword}s?(?=\\s|$)`).test(normalizedDesignation);
+  });
+}
+
+export function getAutomaticUnit(designation) {
+  const normalizedDesignation = normalizeAutomaticUnitDesignation(designation);
+  if (!normalizedDesignation) {
+    return PIECE_UNIT;
+  }
+
+  if (containsAutomaticUnitKeyword(normalizedDesignation, PIECE_KEYWORDS)) {
+    return PIECE_UNIT;
+  }
+
+  if (containsAutomaticUnitKeyword(normalizedDesignation, LENGTH_KEYWORDS)) {
+    return LENGTH_UNIT;
+  }
+
+  return PIECE_UNIT;
+}

--- a/js/storage.js
+++ b/js/storage.js
@@ -16,6 +16,7 @@ import {
 } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
 import { APP_CONFIG } from './config.js';
+import { getAutomaticUnit } from './automatic-unit.js';
 
 const OFFLINE_CACHE_KEY = 'suiviMateriel.offlineCache.v1';
 const OFFLINE_CACHE_TTL_MS = 180 * 1000;
@@ -2000,7 +2001,7 @@ async function createDetail(siteId, itemId, payload) {
     code: sanitizeText(payload.code, true),
     designation,
     qteSortie: payload.qteSortie === '' ? '' : sanitizeNumber(payload.qteSortie),
-    unite: sanitizeText(payload.unite || 'm', false) || 'm',
+    unite: sanitizeText(payload.unite || getAutomaticUnit(designation), false) || getAutomaticUnit(designation),
     qteHorsBtrs: '',
     qteRetour: 0,
     dateRetour: '',

--- a/tests/automatic-unit.test.mjs
+++ b/tests/automatic-unit.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getAutomaticUnit } from '../js/automatic-unit.js';
+
+const cases = [
+  ['FIL DE CUIVRE', 'm'],
+  ['fil de cuivre', 'm'],
+  ['CABLE ELECTRIQUE', 'm'],
+  ['Câble réseau', 'm'],
+  ['GAINE ELECTRIQUE', 'm'],
+  ['TUBE PVC', 'm'],
+  ['COSSE A SERTIR 240-M12', 'Pcs'],
+  ['CONNECTEUR', 'Pcs'],
+  ['VIS', 'Pcs'],
+  ['ECROU', 'Pcs'],
+  ['', 'Pcs'],
+  ['cables ethernet', 'm'],
+  ['GAINE POUR CABLE ELECTRIQUE', 'm'],
+  ['COSSE POUR CABLE', 'Pcs'],
+];
+
+test('returns the automatic detail unit from the material designation', () => {
+  for (const [designation, expectedUnit] of cases) {
+    assert.equal(getAutomaticUnit(designation), expectedUnit, designation);
+  }
+});


### PR DESCRIPTION
### Motivation

- Automatiser la sélection de l'unité (`m` ou `Pcs`) dans le formulaire « Ajouter une donnée » selon la désignation du matériel pour respecter la règle métier (matériaux vendus en longueur → `m`, pièces comptées → `Pcs`).
- Centraliser la logique de détection dans une fonction réutilisable pour éviter la duplication et assurer un comportement cohérent partout.
- Conserver la possibilité pour l'utilisateur de modifier manuellement l'unité et préserver les unités déjà enregistrées dans les données existantes.

### Description

- Ajout de la fonction centralisée `getAutomaticUnit(designation)` dans `js/automatic-unit.js` qui normalise la désignation (suppression d'accents, casse insensible, suppression d'espaces/ponctuation), prend en charge des pluriels simples et applique une priorité aux mots-clés « pièce » avant les mots-clés mesurés en longueur; elle retourne soit `m` soit `Pcs` et renvoie `Pcs` si la désignation est vide.
- Intégration dans `js/app.js` : import de `getAutomaticUnit`, initialisation automatique de l'input `unite` à l'ouverture du modal, recalcul à chaque `input` sur le champ `designation`, et mise à jour lorsque l'utilisateur applique une suggestion de code/désignation, tout en laissant le `select` d'unité éditable manuellement.
- Intégration côté stockage dans `js/storage.js` : import de `getAutomaticUnit` et usage comme valeur par défaut côté serveur lors de la création d'une nouvelle donnée seulement si aucune unité n'est fournie par le formulaire, garantissant que les anciennes données conservent leur unité enregistrée.
- Ajout de tests unitaires `tests/automatic-unit.test.mjs` couvrant les exemples fournis (p. ex. `FIL DE CUIVRE`→`m`, `COSSE A SERTIR 240-M12`→`Pcs`, cas vide, pluriels et priorité `COSSE POUR CABLE`→`Pcs`).

### Testing

- Exécution de `node --test tests/*.test.mjs` qui exécute le nouveau test d'unité automatique et les tests existants, et tous les tests sont passés (8/8 verts). 
- Les tests couvrent les cas demandés : majuscules/minuscules, accents, variantes/pluriels, priorité mots-clés et désignation vide.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aaf90d2d88322bc9ce28636a1341f)