### PR TITLE
Display exact retry date/time in site unlock blocked message

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1771,24 +1771,24 @@ import { getAutomaticUnit } from './automatic-unit.js';
     }
 
     function formatSiteUnlockCountdown(blockedUntil) {
-      const unblockAt = new Date(blockedUntil || '').getTime();
+      const unblockDate = new Date(blockedUntil || '');
+      const unblockAt = unblockDate.getTime();
       const remainingMs = unblockAt - Date.now();
       if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
         return '';
       }
-      const totalMinutes = Math.ceil(remainingMs / (60 * 1000));
-      if (totalMinutes <= 1) {
-        return "Réessayez dans moins d'une minute";
-      }
-      const hours = Math.floor(totalMinutes / 60);
-      const minutes = totalMinutes % 60;
-      if (hours <= 0) {
-        return `Réessayez dans ${minutes} min`;
-      }
-      if (minutes <= 0) {
-        return `Réessayez dans ${hours} h`;
-      }
-      return `Réessayez dans ${hours} h ${minutes} min`;
+      const weekday = unblockDate.toLocaleDateString('fr-FR', { weekday: 'long' });
+      const date = unblockDate.toLocaleDateString('fr-FR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      });
+      const time = unblockDate.toLocaleTimeString('fr-FR', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }).replace(':', ' h ');
+      return `Vous pourrez réessayer ${weekday} ${date} à ${time}.`;
     }
 
     function updateSiteUnlockCountdownMessage(siteId, blockedUntil) {


### PR DESCRIPTION
### Motivation
- Replace the existing relative countdown message (e.g. "Réessayer dans 23 h 4 min") with an exact local date and time for when the 24-hour block ends, while keeping all existing attempt counting, block logic, storage, and UI elements unchanged.

### Description
- Modified `formatSiteUnlockCountdown` in `js/app.js` to compute the unblock `Date` and format the weekday, date and time with `toLocaleDateString`/`toLocaleTimeString('fr-FR')`, returning a message like `Vous pourrez réessayer mercredi 12/08/2026 à 11 h 20.` and preserving the empty-string return when the block has expired.

### Testing
- Ran `node --check js/app.js` which succeeded.
- Ran `git diff --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae41f87208322bde588daa1e77012)