### PR TITLE
Supprimer la limitation des tentatives de mot de passe des sites

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1680,38 +1680,15 @@ import { getAutomaticUnit } from './automatic-unit.js';
       }
     }
 
-    function scheduleSiteLockManageUnblock(siteId, blockedUntil) {
+    function scheduleSiteLockManageUnblock() {
       clearSiteLockManageBlockTimer();
-      const unblockAt = new Date(blockedUntil || '').getTime();
-      const delayMs = unblockAt - Date.now();
-      if (!Number.isFinite(delayMs) || delayMs <= 0) {
-        return;
-      }
-      updateSiteLockManageCountdownMessage(siteId, blockedUntil);
-      siteLockManageCountdownTimer = window.setInterval(() => {
-        updateSiteLockManageCountdownMessage(siteId, blockedUntil);
-      }, 60 * 1000);
-      siteLockManageBlockTimer = window.setTimeout(() => {
-        if (siteIdPendingLockManage === siteId && siteLockManageDialog?.open) {
-          refreshSiteLockManageProtectionState(siteId);
-        }
-      }, Math.min(delayMs, 24 * 60 * 60 * 1000));
     }
 
-    async function refreshSiteLockManageProtectionState(siteId) {
-      const protection = await StorageService.getSiteUnlockProtectionState(siteId);
-      if (!protection?.ok) {
-        return null;
-      }
+    async function refreshSiteLockManageProtectionState() {
       clearSiteLockManageAttemptsInfo();
-      setSiteLockManageBlockedState(protection.isBlocked);
-      if (protection.isBlocked) {
-        clearSiteLockManageFieldErrorState(siteLockCurrentPasswordInput, siteLockCurrentPasswordError);
-        scheduleSiteLockManageUnblock(siteId, protection.blockedUntil);
-      } else {
-        clearSiteLockManageBlockTimer();
-      }
-      return protection;
+      setSiteLockManageBlockedState(false);
+      clearSiteLockManageBlockTimer();
+      return { ok: true, isBlocked: false };
     }
 
     function clearSiteUnlockFieldErrorState() {
@@ -1743,11 +1720,6 @@ import { getAutomaticUnit } from './automatic-unit.js';
       siteLockFieldStateTimers.set(siteUnlockPasswordInput, timer);
     }
 
-    function formatAttemptsRemainingMessage(attemptsRemaining) {
-      const count = Math.max(0, Number(attemptsRemaining) || 0);
-      return `Il vous reste ${count} ${count === 1 ? 'tentative' : 'tentatives'}.`;
-    }
-
     function setSiteUnlockBlockedState(isBlocked) {
       if (siteUnlockPasswordInput) {
         siteUnlockPasswordInput.disabled = Boolean(isBlocked);
@@ -1770,25 +1742,8 @@ import { getAutomaticUnit } from './automatic-unit.js';
       siteUnlockAttemptsInfo.classList.remove('form-info--blocked');
     }
 
-    function formatSiteUnlockCountdown(blockedUntil) {
-      const unblockDate = new Date(blockedUntil || '');
-      const unblockAt = unblockDate.getTime();
-      const remainingMs = unblockAt - Date.now();
-      if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
-        return '';
-      }
-      const weekday = unblockDate.toLocaleDateString('fr-FR', { weekday: 'long' });
-      const date = unblockDate.toLocaleDateString('fr-FR', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-      });
-      const time = unblockDate.toLocaleTimeString('fr-FR', {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false,
-      }).replace(':', ' h ');
-      return `Vous pourrez réessayer demain << ${weekday}  ${date}  à  ${time} >>.`;
+    function formatSiteUnlockCountdown() {
+      return '';
     }
 
     function updateSiteUnlockCountdownMessage(siteId, blockedUntil) {
@@ -1819,38 +1774,15 @@ import { getAutomaticUnit } from './automatic-unit.js';
       }
     }
 
-    function scheduleSiteUnlockUnblock(siteId, blockedUntil) {
+    function scheduleSiteUnlockUnblock() {
       clearSiteUnlockBlockTimer();
-      const unblockAt = new Date(blockedUntil || '').getTime();
-      const delayMs = unblockAt - Date.now();
-      if (!Number.isFinite(delayMs) || delayMs <= 0) {
-        return;
-      }
-      updateSiteUnlockCountdownMessage(siteId, blockedUntil);
-      siteUnlockCountdownTimer = window.setInterval(() => {
-        updateSiteUnlockCountdownMessage(siteId, blockedUntil);
-      }, 60 * 1000);
-      siteUnlockBlockTimer = window.setTimeout(() => {
-        if (siteIdPendingUnlock === siteId && siteUnlockDialog?.open) {
-          refreshSiteUnlockProtectionState(siteId);
-        }
-      }, Math.min(delayMs, 24 * 60 * 60 * 1000));
     }
 
-    async function refreshSiteUnlockProtectionState(siteId) {
-      const protection = await StorageService.getSiteUnlockProtectionState(siteId);
-      if (!protection?.ok) {
-        return null;
-      }
+    async function refreshSiteUnlockProtectionState() {
       clearSiteUnlockAttemptsInfo();
-      setSiteUnlockBlockedState(protection.isBlocked);
-      if (protection.isBlocked) {
-        clearSiteUnlockFieldErrorState();
-        scheduleSiteUnlockUnblock(siteId, protection.blockedUntil);
-      } else {
-        clearSiteUnlockBlockTimer();
-      }
-      return protection;
+      setSiteUnlockBlockedState(false);
+      clearSiteUnlockBlockTimer();
+      return { ok: true, isBlocked: false };
     }
 
     function setPasswordVisibility(inputElement, toggleButton, isVisible) {
@@ -2491,11 +2423,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSiteLockManageBlockedState(false);
         clearSiteLockManageAttemptsInfo();
         siteLockManageDialog.showModal();
-        refreshSiteLockManageProtectionState(siteId).then((protection) => {
-          if (!protection?.isBlocked) {
-            siteLockCurrentPasswordInput.focus();
-          }
-        });
+        siteLockCurrentPasswordInput.focus();
         return;
       }
 
@@ -2901,11 +2829,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
           setSiteUnlockLoadingState(false);
           setSiteUnlockBlockedState(false);
           siteUnlockDialog.showModal();
-          refreshSiteUnlockProtectionState(siteId).then((protection) => {
-            if (!protection?.isBlocked) {
-              siteUnlockPasswordInput.focus();
-            }
-          });
+          siteUnlockPasswordInput.focus();
         });
       });
 
@@ -3462,10 +3386,6 @@ import { getAutomaticUnit } from './automatic-unit.js';
         return;
       }
       clearSiteUnlockFieldErrorState();
-      const protection = await refreshSiteUnlockProtectionState(siteIdPendingUnlock);
-      if (protection?.isBlocked) {
-        return;
-      }
       const passwordValue = siteUnlockPasswordInput?.value || '';
       if (!passwordValue.trim()) {
         showSiteUnlockFieldError('Veuillez entrer le mot de passe.');
@@ -3486,20 +3406,12 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSiteUnlockLoadingState(true);
         const passwordHash = await hashPassword(passwordValue);
         if (passwordHash !== targetSite.passwordHash) {
-          const failure = await StorageService.registerSiteUnlockFailure(siteIdPendingUnlock);
-          await StorageService.recordSiteUnlockFailureHistory(siteIdPendingUnlock, failure?.attemptsRemaining);
+          await StorageService.recordSiteUnlockFailureHistory(siteIdPendingUnlock);
           clearSiteUnlockAttemptsInfo();
-          if (failure?.isBlocked) {
-            setSiteUnlockBlockedState(true);
-            clearSiteUnlockFieldErrorState();
-            scheduleSiteUnlockUnblock(siteIdPendingUnlock, failure.blockedUntil);
-          } else {
-            showSiteUnlockFieldError(`Mot de passe incorrect. ${formatAttemptsRemainingMessage(failure?.attemptsRemaining)}`);
-          }
+          showSiteUnlockFieldError('Mot de passe incorrect.');
           setSiteUnlockLoadingState(false);
           return;
         }
-        await StorageService.resetSiteUnlockProtection(siteIdPendingUnlock);
         await StorageService.recordSiteUnlockHistory(siteIdPendingUnlock);
         const openSiteId = siteIdPendingUnlock;
         siteUnlockDialog?.close();
@@ -3526,11 +3438,6 @@ import { getAutomaticUnit } from './automatic-unit.js';
       }
 
       clearSiteLockManageErrors();
-      const protection = await refreshSiteLockManageProtectionState(siteIdPendingLockManage);
-      if (protection?.isBlocked) {
-        return;
-      }
-
       const currentPasswordValue = siteLockCurrentPasswordInput?.value || '';
       const newPasswordValue = siteLockNewPasswordInput?.value || '';
       const targetSite = getLatestSiteState(siteIdPendingLockManage);
@@ -3559,24 +3466,15 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSiteLockManageActionLoadingState(submittedAction, true);
         const currentPasswordHash = await hashPassword(currentPasswordValue);
         if (currentPasswordHash !== targetSite.passwordHash) {
-          const failure = await StorageService.registerSiteUnlockFailure(siteIdPendingLockManage);
           clearSiteLockManageAttemptsInfo();
-          if (failure?.isBlocked) {
-            setSiteLockManageBlockedState(true);
-            clearSiteLockManageFieldErrorState(siteLockCurrentPasswordInput, siteLockCurrentPasswordError);
-            scheduleSiteLockManageUnblock(siteIdPendingLockManage, failure.blockedUntil);
-          } else {
-            showSiteLockManageFieldError(
-              siteLockCurrentPasswordInput,
-              siteLockCurrentPasswordError,
-              `Mot de passe actuel incorrect. ${formatAttemptsRemainingMessage(failure?.attemptsRemaining)}`,
-            );
-          }
+          showSiteLockManageFieldError(
+            siteLockCurrentPasswordInput,
+            siteLockCurrentPasswordError,
+            'Mot de passe actuel incorrect.',
+          );
           setSiteLockManageActionLoadingState(submittedAction, false);
           return;
         }
-
-        await StorageService.resetSiteUnlockProtection(siteIdPendingLockManage);
 
         if (submittedAction === 'unlock') {
           const result = await StorageService.clearSiteLock(siteIdPendingLockManage);

--- a/js/storage.js
+++ b/js/storage.js
@@ -1500,19 +1500,11 @@ async function recordSiteUnlockHistory(siteId) {
   await appendHistoryEntry('a déverrouillé le site', { siteId });
 }
 
-function formatSiteUnlockFailureAttemptsMessage(attemptsRemaining) {
-  const count = Math.max(0, Number(attemptsRemaining) || 0);
-  if (count === 0) {
-    return 'Il ne reste plus aucun essai.';
-  }
-  return `Il reste ${count} ${count === 1 ? 'essai' : 'essais'}.`;
-}
-
-async function recordSiteUnlockFailureHistory(siteId, attemptsRemaining) {
+async function recordSiteUnlockFailureHistory(siteId) {
   const profile = await getCurrentUserProfile();
   const username = normalizeUsername(profile?.username) || normalizeUsername(state.authUser?.displayName) || 'Utilisateur inconnu';
   const siteName = resolveSiteNameForHistory(siteId);
-  const action = `${username} a essayé d'ouvrir le site « ${siteName || 'Site inconnu'} » avec un mot de passe incorrect. ${formatSiteUnlockFailureAttemptsMessage(attemptsRemaining)}`;
+  const action = `${username} a essayé d'ouvrir le site « ${siteName || 'Site inconnu'} » avec un mot de passe incorrect.`;
   await appendHistoryEntry(action, { siteId, siteName });
 }
 
@@ -1524,131 +1516,12 @@ async function recordExcelExportHistory(siteId, siteName = '') {
   await appendHistoryEntry(action, { siteId, siteName: resolvedSiteName });
 }
 
-function getAuthenticatedUnlockProtectionUid() {
-  return String(state.authUser?.uid || state.userId || firebaseAuth.currentUser?.uid || '').trim();
-}
-
-function buildSiteUnlockProtectionKey(siteId) {
-  const uid = getAuthenticatedUnlockProtectionUid();
-  const normalizedSiteId = String(siteId || '').trim();
-  return uid && normalizedSiteId ? `${normalizedSiteId}_${uid}` : '';
-}
-
-function isLocalUnlockProtectionEnabled() {
-  return !getAuthenticatedUnlockProtectionUid() && typeof window !== 'undefined' && window.localStorage;
-}
-
-function buildLocalSiteUnlockProtectionKey(siteId) {
-  const normalizedSiteId = String(siteId || '').trim();
-  return normalizedSiteId ? `security_attempts_${normalizedSiteId}` : '';
-}
-
-function readLocalSiteUnlockProtection(siteId) {
-  if (!isLocalUnlockProtectionEnabled()) {
-    return {};
-  }
-  const storageKey = buildLocalSiteUnlockProtectionKey(siteId);
-  if (!storageKey) {
-    return {};
-  }
-  try {
-    const rawValue = window.localStorage.getItem(storageKey);
-    const parsedValue = rawValue ? JSON.parse(rawValue) : null;
-    return parsedValue && typeof parsedValue === 'object' ? parsedValue : {};
-  } catch (_error) {
-    return {};
-  }
-}
-
-function writeLocalSiteUnlockProtection(siteId, protection) {
-  if (!isLocalUnlockProtectionEnabled()) {
-    return false;
-  }
-  const storageKey = buildLocalSiteUnlockProtectionKey(siteId);
-  if (!storageKey) {
-    return false;
-  }
-  try {
-    window.localStorage.setItem(storageKey, JSON.stringify({
-      attemptsRemaining: protection.attemptsRemaining,
-      blockedUntil: protection.blockedUntil || null,
-      hasAttempted: Boolean(protection.hasAttempted),
-    }));
-    return true;
-  } catch (_error) {
-    return false;
-  }
-}
-
-function readSiteUnlockProtection(site, siteId) {
-  const normalizedSiteId = String(siteId || site?.id || '').trim();
-  if (isLocalUnlockProtectionEnabled()) {
-    return readLocalSiteUnlockProtection(normalizedSiteId);
-  }
-  const protectionKey = buildSiteUnlockProtectionKey(normalizedSiteId);
-  const protections = site?.unlockProtections && typeof site.unlockProtections === 'object' ? site.unlockProtections : {};
-  const scopedProtection = protectionKey ? protections[protectionKey] : null;
-  return scopedProtection && typeof scopedProtection === 'object' ? scopedProtection : {};
-}
-
-function normalizeUnlockProtection(site, siteId) {
-  const scopedProtection = readSiteUnlockProtection(site, siteId);
-  const blockedUntilRaw = scopedProtection?.blockedUntil || null;
-  const blockedUntilDate = blockedUntilRaw ? new Date(blockedUntilRaw) : null;
-  const blockedUntilMs = blockedUntilDate && !Number.isNaN(blockedUntilDate.getTime()) ? blockedUntilDate.getTime() : 0;
-  if (blockedUntilMs > Date.now()) {
-    return {
-      attemptsRemaining: 0,
-      blockedUntil: new Date(blockedUntilMs).toISOString(),
-      hasAttempted: true,
-      isBlocked: true,
-    };
-  }
-  const attempts = Number(scopedProtection?.attemptsRemaining);
-  const hasAttempted = Boolean(scopedProtection?.hasAttempted);
-  return {
-    attemptsRemaining: Number.isInteger(attempts) && attempts >= 0 && attempts <= 3 ? attempts : 3,
-    blockedUntil: null,
-    hasAttempted,
-    isBlocked: false,
-  };
-}
-
 async function resetSiteUnlockProtection(siteId) {
-  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
-  if (siteIndex === -1) {
+  const site = state.sites.find((item) => item.id === siteId);
+  if (!site) {
     return { ok: false, reason: 'site_not_found' };
   }
-  if (isLocalUnlockProtectionEnabled()) {
-    writeLocalSiteUnlockProtection(siteId, {
-      attemptsRemaining: 3,
-      blockedUntil: null,
-      hasAttempted: false,
-    });
-    return { ok: true, ...normalizeUnlockProtection(state.sites[siteIndex], siteId) };
-  }
-  const protectionKey = buildSiteUnlockProtectionKey(siteId);
-  if (!protectionKey) {
-    return { ok: false, reason: 'auth_required' };
-  }
-  const unlockProtections = {
-    ...(state.sites[siteIndex].unlockProtections && typeof state.sites[siteIndex].unlockProtections === 'object'
-      ? state.sites[siteIndex].unlockProtections
-      : {}),
-    [protectionKey]: {
-      attemptsRemaining: 3,
-      blockedUntil: null,
-    },
-  };
-  const payload = { unlockProtections };
-  await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true });
-  state.sites[siteIndex] = {
-    ...state.sites[siteIndex],
-    unlockProtections,
-  };
-  persistOfflineState();
-  emitAll();
-  return { ok: true, ...normalizeUnlockProtection(state.sites[siteIndex], siteId) };
+  return { ok: true, isBlocked: false };
 }
 
 async function getSiteUnlockProtectionState(siteId) {
@@ -1656,55 +1529,15 @@ async function getSiteUnlockProtectionState(siteId) {
   if (!site) {
     return { ok: false, reason: 'site_not_found' };
   }
-  const protection = normalizeUnlockProtection(site, siteId);
-  const scopedProtection = readSiteUnlockProtection(site, siteId);
-  if (!protection.isBlocked && scopedProtection.blockedUntil) {
-    return resetSiteUnlockProtection(siteId);
-  }
-  return { ok: true, ...protection };
+  return { ok: true, isBlocked: false };
 }
 
 async function registerSiteUnlockFailure(siteId) {
-  const siteIndex = state.sites.findIndex((site) => site.id === siteId);
-  if (siteIndex === -1) {
+  const site = state.sites.find((item) => item.id === siteId);
+  if (!site) {
     return { ok: false, reason: 'site_not_found' };
   }
-  const current = normalizeUnlockProtection(state.sites[siteIndex], siteId);
-  if (current.isBlocked) {
-    return { ok: true, ...current };
-  }
-  const attemptsRemaining = Math.max(0, current.attemptsRemaining - 1);
-  const blockedUntil = attemptsRemaining === 0 ? new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() : null;
-  if (isLocalUnlockProtectionEnabled()) {
-    writeLocalSiteUnlockProtection(siteId, {
-      attemptsRemaining,
-      blockedUntil,
-      hasAttempted: true,
-    });
-    return { ok: true, attemptsRemaining, blockedUntil, hasAttempted: true, isBlocked: Boolean(blockedUntil) };
-  }
-  const protectionKey = buildSiteUnlockProtectionKey(siteId);
-  if (!protectionKey) {
-    return { ok: false, reason: 'auth_required' };
-  }
-  const unlockProtections = {
-    ...(state.sites[siteIndex].unlockProtections && typeof state.sites[siteIndex].unlockProtections === 'object'
-      ? state.sites[siteIndex].unlockProtections
-      : {}),
-    [protectionKey]: {
-      attemptsRemaining,
-      blockedUntil,
-    },
-  };
-  const payload = { unlockProtections };
-  await setDoc(doc(state.db, 'pages', 'page1', 'items', siteId), payload, { merge: true });
-  state.sites[siteIndex] = {
-    ...state.sites[siteIndex],
-    unlockProtections,
-  };
-  persistOfflineState();
-  emitAll();
-  return { ok: true, attemptsRemaining, blockedUntil, isBlocked: Boolean(blockedUntil) };
+  return { ok: true, isBlocked: false };
 }
 
 async function removeSite(siteId) {


### PR DESCRIPTION
### Motivation
- Mettre en place le nouveau comportement où aucun site protégé par mot de passe ne peut être temporairement bloqué et où les utilisateurs peuvent tenter le mot de passe autant de fois qu’ils le souhaitent.
- Conserver la journalisation immédiate de chaque tentative incorrecte dans la page « Historiques » au format demandé.
- Ne plus afficher de message de délai (« Vous pourrez réessayer demain ») ni compter/enregistrer de compteur d’essais.

### Description
- Simplification côté stockage : `resetSiteUnlockProtection`, `getSiteUnlockProtectionState` et `registerSiteUnlockFailure` ont été modifiées pour ne plus lire/écrire de compteur ni de champ `blockedUntil` et retournent systématiquement un état non bloqué (suppression de la logique de protection et du stockage local lié aux essais). (fichier modifié : `js/storage.js`).
- Journalisation conservée et adaptée : `recordSiteUnlockFailureHistory(siteId)` crée désormais immédiatement une entrée d’historique au format « <NomUtilisateur> a essayé d'ouvrir le site « <NOM DU SITE> » avec un mot de passe incorrect. » sans ajouter de message sur les essais restants. (fichier modifié : `js/storage.js`).
- Interface utilisateur : suppression des messages et timers relatifs au décompte et au blocage; la validation d’ouverture de site n’appelle plus l’API d’enregistrement d’un échec qui mettrait à jour des compteurs, et affiche uniquement `Mot de passe incorrect.` lorsqu’il y a une erreur; le champ reste disponible immédiatement pour resaisir le mot de passe. (fichier modifié : `js/app.js`).
- Suppression des routines de planification / minuterie de déblocage et des formats d’affichage « Vous pourrez réessayer demain », tout en conservant le comportement normal lorsque le mot de passe est correct (ouverture et journalisation du déverrouillage). (fichiers modifiés : `js/app.js`, `js/storage.js`).

### Testing
- `node --check js/app.js` — OK.
- `node --check js/storage.js` — OK.
- `git diff --check` — OK (aucune erreur de diff-check détectée).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bed943b74832298f15fe389c40b24)