### PR TITLE
Reduce password modal vertical spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1578,7 +1578,7 @@ body[data-page="history"] .list-grid {
 }
 
 body[data-page="home"] #siteUnlockDialog .input-group--site-unlock {
-  gap: 0.65rem;
+  gap: 0.35rem;
 }
 
 body[data-page="home"] #siteUnlockDialog .password-wrap--site-unlock {
@@ -1635,6 +1635,12 @@ body[data-page="home"] #siteLockManageDialog .form-info--attempts {
   text-align: left;
   color: var(--muted);
   font-size: 0.82rem;
+}
+
+body[data-page="home"] #siteUnlockDialog .form-info--attempts:empty,
+body[data-page="home"] #siteUnlockDialog .form-error--field:empty {
+  min-height: 0;
+  margin-top: 0;
 }
 
 body[data-page="home"] #siteUnlockDialog .form-info--attempts.form-info--blocked,


### PR DESCRIPTION
### Motivation
- Réduire l’espace vertical inutile sous le champ « Mot de passe » de la modale « Site protégé par un mot de passe » en n’impactant que le style existant concerné.
- Conserver exactement le rendu et le comportement des boutons, du champ, de l’icône et de la validation, et ne pas modifier d’autres modales.

### Description
- Ajustement du `gap` de `body[data-page="home"] #siteUnlockDialog .input-group--site-unlock` de `0.65rem` à `0.35rem` pour rapprocher naturellement les boutons du champ.
- Ajout d’une règle ciblée `body[data-page="home"] #siteUnlockDialog .form-info--attempts:empty, body[data-page="home"] #siteUnlockDialog .form-error--field:empty { min-height: 0; margin-top: 0; }` pour supprimer l’espace réservé lorsque les messages sont vides.

### Testing
- Exécuté les tests unitaires avec `node --test tests/*.test.mjs` et tous les tests sont passés (8 réussis).
- Effectué une vérification de diff/syntax via `git diff --check` sans erreurs signalées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d80b77fac8325b2bd7a0066d33a20)