### PR TITLE
Réserver un emplacement fixe pour les messages de la fenêtre « Site protégé par un mot de passe »

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1620,12 +1620,21 @@ body[data-page="home"] #siteUnlockDialog .password-toggle--site-unlock:focus-vis
   opacity: 1;
 }
 
+body[data-page="home"] #siteUnlockDialog .site-unlock-message-slot {
+  width: 100%;
+  min-height: clamp(3.35rem, 12vw, 4.2rem);
+  display: grid;
+  align-items: center;
+  padding: 0.15rem 0.2rem 0;
+}
+
 body[data-page="home"] #siteUnlockDialog .form-error--field {
-  margin-top: 0.1rem;
-  min-height: 1rem;
-  text-align: left;
+  margin: 0;
+  min-height: 1.15rem;
+  text-align: center;
   color: #c95e68;
   font-size: 0.82rem;
+  line-height: 1.35;
 }
 
 body[data-page="home"] #siteUnlockDialog .form-info--attempts,
@@ -1637,10 +1646,22 @@ body[data-page="home"] #siteLockManageDialog .form-info--attempts {
   font-size: 0.82rem;
 }
 
+body[data-page="home"] #siteUnlockDialog .site-unlock-message-slot .form-info--attempts {
+  margin: 0;
+  min-height: 1.15rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
 body[data-page="home"] #siteUnlockDialog .form-info--attempts:empty,
 body[data-page="home"] #siteUnlockDialog .form-error--field:empty {
-  min-height: 0.75rem;
+  min-height: 1.15rem;
   margin-top: 0;
+}
+
+body[data-page="home"] #siteUnlockDialog .site-unlock-message-slot .form-info--attempts:empty,
+body[data-page="home"] #siteUnlockDialog .site-unlock-message-slot .form-error--field:empty {
+  display: none;
 }
 
 body[data-page="home"] #siteUnlockDialog .form-info--attempts.form-info--blocked,

--- a/index.html
+++ b/index.html
@@ -280,8 +280,10 @@
                 <img src="Icon/Eye_OFF.png" alt="Afficher/Cacher le mot de passe" />
               </button>
             </div>
-            <p id="siteUnlockAttemptsInfo" class="form-info form-info--attempts" aria-live="polite"></p>
-            <p id="siteUnlockError" class="form-error form-error--field" aria-live="assertive"></p>
+            <div class="site-unlock-message-slot">
+              <p id="siteUnlockAttemptsInfo" class="form-info form-info--attempts" aria-live="polite"></p>
+              <p id="siteUnlockError" class="form-error form-error--field" aria-live="assertive"></p>
+            </div>
           </label>
           <div class="modal-actions modal-actions--split modal-actions--password">
             <button type="button" class="btn" data-close-dialog>Annuler</button>


### PR DESCRIPTION
### Motivation
- Augmenter l’espace vertical entre le champ « Mot de passe » et les boutons « Annuler »/« Valider » afin de réserver en permanence une zone pour les messages d’erreur ou de blocage sans déplacer les boutons. 
- Effectuer uniquement une modification visuelle responsive côté HTML/CSS sans toucher à la logique JavaScript, au comptage des tentatives, ni aux éléments existants du formulaire.

### Description
- Ajout d’un conteneur `div.site-unlock-message-slot` autour de `#siteUnlockAttemptsInfo` et `#siteUnlockError` dans `index.html` pour créer un emplacement dédié aux messages. 
- Ajout de règles CSS dans `css/style.css` qui donnent à ce slot une `min-height` responsive (`min-height: clamp(3.35rem, 12vw, 4.2rem)`), le positionnent en grille et centrent le contenu afin que les messages s’affichent dans la zone réservée sans pousser les boutons. 
- Ajustement du style de `.form-error--field` et `.form-info--attempts` pour centrage et hauteur cohérente, et masquage des paragraphes vides à l’intérieur du slot pour éviter les chevauchements tout en conservant l’espace réservé. 
- Aucune modification de la logique JavaScript, des compteurs de tentative, du blocage 24h, du `localStorage`, ni des éléments de champ mot de passe, icône, ou boutons n’a été effectuée.

### Testing
- Exécution d’une recherche de code pour vérifier les emplacements modifiés et s’assurer que seules `index.html` et `css/style.css` ont été touchées, et la vérification a confirmé les changements attendus. 
- Exécution de vérifications automatiques basiques (`git diff --check` et contrôles de statut/fichiers) et inspection du diff pour s’assurer qu’il n’y a pas d’erreurs de format; toutes les vérifications sont passées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d856018008325807b26be1d1aa686)