### PR TITLE
Compact site unlock message area

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1622,16 +1622,17 @@ body[data-page="home"] #siteUnlockDialog .password-toggle--site-unlock:focus-vis
 
 body[data-page="home"] #siteUnlockDialog .site-unlock-message-slot {
   width: 100%;
-  min-height: clamp(3.35rem, 12vw, 4.2rem);
+  min-height: clamp(1.7rem, 6vw, 2.1rem);
   display: grid;
-  align-items: center;
-  padding: 0.15rem 0.2rem 0;
+  align-content: start;
+  row-gap: 0.12rem;
+  padding: 0.1rem 0.2rem 0;
 }
 
 body[data-page="home"] #siteUnlockDialog .form-error--field {
   margin: 0;
   min-height: 1.15rem;
-  text-align: center;
+  text-align: left;
   color: #c95e68;
   font-size: 0.82rem;
   line-height: 1.35;
@@ -1649,7 +1650,7 @@ body[data-page="home"] #siteLockManageDialog .form-info--attempts {
 body[data-page="home"] #siteUnlockDialog .site-unlock-message-slot .form-info--attempts {
   margin: 0;
   min-height: 1.15rem;
-  text-align: center;
+  text-align: left;
   line-height: 1.35;
 }
 


### PR DESCRIPTION
### Motivation
- Reduce the excessive vertical gap between the `Mot de passe` field and the action buttons in the "Site protégé par un mot de passe" dialog while keeping a fixed reserved area so error messages can appear without shifting the buttons, and align error text to the left for better readability.

### Description
- Adjusted `css/style.css` for `body[data-page="home"] #siteUnlockDialog .site-unlock-message-slot` to reduce the reserved height via `min-height: clamp(1.7rem, 6vw, 2.1rem)`, set `align-content: start`, added a small `row-gap`, and tightened padding to make the block more compact.
- Changed `text-align` for `body[data-page="home"] #siteUnlockDialog .form-error--field` and the `.form-info--attempts` inside the message slot from `center` to `left` so error/info lines are left-aligned.
- No JavaScript or functional logic was modified; only CSS/layout rules were changed and the password field and buttons were left untouched.

### Testing
- Ran `git diff --check` which reported no issues with the stylesheet changes (success). 
- Started a local Python static server with `python3 -m http.server 4173` which launched successfully (server PID returned). 
- Executed `node -e "try{require('playwright'); console.log('playwright yes')}catch(e){console.log('no playwright')}"` which returned `no playwright`, so automated browser/visual tests could not be executed in this environment. 
- Attempt to create a PR with `gh pr create` failed due to missing GitHub authentication in the environment, so PR publication was not performed automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d88e577548325b3fc92860d17238f)