### PR TITLE
Mask creator email in "Suppression impossible" dialog

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -24,6 +24,22 @@ import { getAutomaticUnit } from './automatic-unit.js';
     return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
+  function maskEmailForDisplay(email) {
+    const normalizedEmail = String(email || '').trim();
+    const atIndex = normalizedEmail.indexOf('@');
+    if (atIndex <= 0) {
+      return normalizedEmail;
+    }
+
+    const localPart = normalizedEmail.slice(0, atIndex);
+    const domainPart = normalizedEmail.slice(atIndex);
+    const firstLetter = localPart.charAt(0);
+    const finalLocalPart = localPart.length > 2 ? localPart.slice(-2) : localPart.slice(1);
+    const hiddenLength = Math.max(localPart.length - firstLetter.length - finalLocalPart.length, 12);
+
+    return `${firstLetter}${'*'.repeat(hiddenLength)}${finalLocalPart}${domainPart}`;
+  }
+
   const DEFAULT_PURCHASE_IMAGE_SRC = 'Icon/Image.png';
 
   const EXPORT_FILE_NAME_HISTORY_KEY = 'suiviMateriel.exportFileNames.v1';
@@ -2170,7 +2186,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
         creatorName.textContent = getSiteCreatorName(site);
       }
       if (creatorEmail) {
-        creatorEmail.textContent = getSiteCreatorEmail(site);
+        creatorEmail.textContent = maskEmailForDisplay(getSiteCreatorEmail(site));
       }
 
       const close = () => {


### PR DESCRIPTION
### Motivation
- Protect user privacy by hiding most of the site creator's email address in the "Suppression impossible" dialog while keeping the domain visible.
- Perform masking only for display in the dialog and avoid changing stored data or application logic.

### Description
- Added a display helper `maskEmailForDisplay(email)` in `js/app.js` that preserves the first character, keeps the final local-part characters and the domain, and replaces the middle with asterisks; the function handles malformed values safely.
- Updated the site-delete forbidden overlay rendering to set `#siteDeleteForbiddenCreatorEmail` using `maskEmailForDisplay(getSiteCreatorEmail(site))` so the masking is applied only to the dialog display.
- No other dialog fields, data sources, or deletion logic were modified.

### Testing
- Ran `node --check js/app.js` to validate syntax, which succeeded.
- Executed a small Node snippet that verifies `andrainaina@gmail.com` → `a************na@gmail.com`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7da990ec208325a1e6b8f8aacb9984)