### PR TITLE
Ajouter le menu « Paramètres » (visible uniquement pour ADMIN) et page vide

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,10 @@
             <img src="Icon/Admin.png" alt="" aria-hidden="true" class="sidebar-item__icon" />
             Gestion des utilisateurs
           </button>
+          <button id="sidebarSettingsBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="parametres.html" hidden>
+            <img src="Icon/Parametre.png" alt="" aria-hidden="true" class="sidebar-item__icon" />
+            Paramètres
+          </button>
         </div>
         <footer class="sidebar-footer" role="none">
           <p class="sidebar-footer__title">Suivi matériel © 2026</p>

--- a/js/app.js
+++ b/js/app.js
@@ -1303,6 +1303,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
     const historySidebarBtn = homeMenuPanel?.querySelector('#sidebarHistoryBtn') || null;
     const allMaterialsSidebarBtn = homeMenuPanel?.querySelector('#sidebarAllMaterialsBtn') || null;
     const indemnitiesSidebarBtn = homeMenuPanel?.querySelector('#sidebarIndemnitiesBtn') || null;
+    const settingsSidebarBtn = homeMenuPanel?.querySelector('#sidebarSettingsBtn') || null;
     const sidebarItems = homeMenuPanel ? Array.from(homeMenuPanel.querySelectorAll('.sidebar-item')) : [];
     const siteLockDialog = requireElement('siteLockDialog');
     const siteLockForm = requireElement('siteLockForm');
@@ -3002,6 +3003,15 @@ import { getAutomaticUnit } from './automatic-unit.js';
     }
 
 
+    if (settingsSidebarBtn) {
+      settingsSidebarBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        window.location.assign('parametres.html');
+      });
+    }
+
+
     if (allMaterialsSidebarBtn) {
       allMaterialsSidebarBtn.addEventListener('click', (event) => {
         event.preventDefault();
@@ -3066,6 +3076,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSidebarItemVisible('#sidebarImportBtn', false);
         setSidebarItemVisible('#sidebarExportBtn', false);
         setSidebarItemVisible('#sidebarUsersBtn', false);
+        setSidebarItemVisible('#sidebarSettingsBtn', false);
         return;
       }
 
@@ -3073,6 +3084,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSidebarItemVisible('#sidebarImportBtn', true);
         setSidebarItemVisible('#sidebarExportBtn', true);
         setSidebarItemVisible('#sidebarUsersBtn', false);
+        setSidebarItemVisible('#sidebarSettingsBtn', false);
         return;
       }
 
@@ -3080,12 +3092,14 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSidebarItemVisible('#sidebarImportBtn', true);
         setSidebarItemVisible('#sidebarExportBtn', true);
         setSidebarItemVisible('#sidebarUsersBtn', true);
+        setSidebarItemVisible('#sidebarSettingsBtn', true);
         return;
       }
 
       setSidebarItemVisible('#sidebarImportBtn', false);
       setSidebarItemVisible('#sidebarExportBtn', false);
       setSidebarItemVisible('#sidebarUsersBtn', false);
+      setSidebarItemVisible('#sidebarSettingsBtn', false);
     }
 
     function mettreAJourPermissionsUI(nextPermissions) {
@@ -8768,6 +8782,14 @@ import { getAutomaticUnit } from './automatic-unit.js';
       });
   }
 
+
+  function initSettingsPage(permissions) {
+    if (!permissions.isAdmin) {
+      UiService.navigate('index.html');
+      return;
+    }
+  }
+
   async function bootstrap() {
     UiService.bindDialogCloser();
     setupBackButtons();
@@ -8806,6 +8828,9 @@ import { getAutomaticUnit } from './automatic-unit.js';
     }
     if (page === 'users-management') {
       await initUsersPage(permissions);
+    }
+    if (page === 'settings') {
+      initSettingsPage(permissions);
     }
     if (page === 'history') {
       await initHistoryPage();

--- a/parametres.html
+++ b/parametres.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Paramètres - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body data-page="settings">
+    <div class="app-shell">
+      <header class="app-header app-header--detail">
+        <div class="app-header__side app-header__side--left">
+          <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
+        </div>
+        <div class="app-header__center">
+          <div class="header-title"><h1>Paramètres</h1></div>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
+      </header>
+
+      <main class="page-content main-content"></main>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script type="module" src="js/maintenance-banner.js"></script>
+    <script type="module" src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script type="module" src="js/app.js"></script>
+
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Ajouter un accès « Paramètres » dans le sidebar réutilisant l’icône existante pour permettre à l’ADMIN d’ouvrir une page dédiée de configuration ultérieure sans changer le système de rôles existant.

### Description
- Ajout d’un bouton de menu dans `index.html` avec `id="sidebarSettingsBtn"` qui réutilise directement l’icône `Icon/Parametre.png` et reprend le même markup/classes que les autres éléments du sidebar.
- Ajout d’un écouteur dans `js/app.js` qui réutilise le même pattern que les autres boutons du sidebar pour naviguer vers `parametres.html` lorsque l’ADMIN clique sur l’élément.
- Réutilisation de la logique existante de visibilité via `setSidebarItemVisible(...)` et `updateSidebarPermissions()` pour que le menu soit uniquement visible pour les permissions ADMIN (aucun nouveau système de rôles créé ni modification des règles existantes).
- Création de `parametres.html` contenant la structure standard (header avec bouton retour `data-back="index.html"`, header title, scripts et un `main` vide) pour respecter le style et la navigation des autres pages, et ajout d’une fonction `initSettingsPage(permissions)` qui redirige les non-admins vers l’accueil.

### Testing
- `git diff --check` exécuté et sans erreurs détectées (succès). 
- `node --check js/app.js` exécuté pour la vérification de syntaxe JavaScript et sans erreurs (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7db3cb603c8327a4f3e7fa15780eca)