### PR TITLE
Add admin-only Corbeille (Trash) page and backend trash support

### DIFF
--- a/corbeille.html
+++ b/corbeille.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Corbeille - Suivi Matériel</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body data-page="trash">
+    <div class="app-shell app-shell--wide">
+      <header class="app-header app-header--detail">
+        <div class="app-header__side app-header__side--left">
+          <button class="back-button" type="button" data-back="index.html" aria-label="Retour"><img src="Icon/btn-retour.png" alt="retour" class="btn-retour" /></button>
+        </div>
+        <div class="app-header__center">
+          <div class="header-title"><h1>Corbeille</h1></div>
+        </div>
+        <div class="app-header__side app-header__side--right" aria-hidden="true"></div>
+      </header>
+
+      <main class="page-content page-content--wide main-content">
+        <section class="surface-card details-card">
+          <div class="maintenance-card-header trash-card-header">
+            <h2 class="section-title">Corbeille</h2>
+            <div class="maintenance-toggle-row">
+              <label class="switch" for="trashToggle">
+                <input id="trashToggle" type="checkbox" role="switch" aria-label="Activer ou désactiver la corbeille" />
+                <span class="slider"></span>
+              </label>
+              <span id="trashStatusText" class="maintenance-toggle-row__status">OFF</span>
+            </div>
+          </div>
+        </section>
+        <section class="surface-card table-card trash-list-card">
+          <h2 class="section-title">Éléments supprimés</h2>
+          <div id="trashList" class="trash-list" aria-live="polite"></div>
+        </section>
+      </main>
+
+      <div id="toast" class="toast" aria-live="polite"></div>
+    </div>
+
+    <script type="module" src="js/maintenance-banner.js"></script>
+    <script type="module" src="js/storage.js"></script>
+    <script src="js/ui.js"></script>
+    <script type="module" src="js/app.js"></script>
+  </body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -8544,3 +8544,41 @@ body[data-page="home"] .page1-header #searchInput:focus {
     left: 0.82rem;
   }
 }
+
+body[data-page="trash"] .trash-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+body[data-page="trash"] .trash-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+body[data-page="trash"] .trash-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+body[data-page="trash"] .trash-entry__content {
+  display: grid;
+  gap: 0.25rem;
+  color: var(--text-muted);
+}
+
+body[data-page="trash"] .trash-entry__content strong {
+  color: var(--text);
+}
+
+@media (max-width: 560px) {
+  body[data-page="trash"] .trash-card-header,
+  body[data-page="trash"] .trash-entry {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -82,6 +82,10 @@
             <img src="Icon/Parametre.png" alt="" aria-hidden="true" class="sidebar-item__icon" />
             Paramètres
           </button>
+          <button id="sidebarTrashBtn" class="header-menu__option sidebar-item" type="button" role="menuitem" data-link="corbeille.html" hidden>
+            <img src="Icon/Corbeille.png" alt="" aria-hidden="true" class="sidebar-item__icon" />
+            Corbeille
+          </button>
         </div>
         <footer class="sidebar-footer" role="none">
           <p class="sidebar-footer__title">Suivi matériel © 2026</p>

--- a/js/app.js
+++ b/js/app.js
@@ -1304,6 +1304,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
     const allMaterialsSidebarBtn = homeMenuPanel?.querySelector('#sidebarAllMaterialsBtn') || null;
     const indemnitiesSidebarBtn = homeMenuPanel?.querySelector('#sidebarIndemnitiesBtn') || null;
     const settingsSidebarBtn = homeMenuPanel?.querySelector('#sidebarSettingsBtn') || null;
+    const trashSidebarBtn = homeMenuPanel?.querySelector('#sidebarTrashBtn') || null;
     const sidebarItems = homeMenuPanel ? Array.from(homeMenuPanel.querySelectorAll('.sidebar-item')) : [];
     const siteLockDialog = requireElement('siteLockDialog');
     const siteLockForm = requireElement('siteLockForm');
@@ -3077,6 +3078,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSidebarItemVisible('#sidebarExportBtn', false);
         setSidebarItemVisible('#sidebarUsersBtn', false);
         setSidebarItemVisible('#sidebarSettingsBtn', false);
+        setSidebarItemVisible('#sidebarTrashBtn', false);
         return;
       }
 
@@ -3085,6 +3087,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSidebarItemVisible('#sidebarExportBtn', true);
         setSidebarItemVisible('#sidebarUsersBtn', false);
         setSidebarItemVisible('#sidebarSettingsBtn', false);
+        setSidebarItemVisible('#sidebarTrashBtn', false);
         return;
       }
 
@@ -3093,6 +3096,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
         setSidebarItemVisible('#sidebarExportBtn', true);
         setSidebarItemVisible('#sidebarUsersBtn', true);
         setSidebarItemVisible('#sidebarSettingsBtn', true);
+        setSidebarItemVisible('#sidebarTrashBtn', true);
         return;
       }
 
@@ -3100,6 +3104,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       setSidebarItemVisible('#sidebarExportBtn', false);
       setSidebarItemVisible('#sidebarUsersBtn', false);
       setSidebarItemVisible('#sidebarSettingsBtn', false);
+      setSidebarItemVisible('#sidebarTrashBtn', false);
     }
 
     function mettreAJourPermissionsUI(nextPermissions) {
@@ -8790,6 +8795,77 @@ import { getAutomaticUnit } from './automatic-unit.js';
     }
   }
 
+
+  async function initTrashPage(permissions) {
+    if (!permissions?.isAdmin) {
+      window.location.replace('index.html');
+      return;
+    }
+    const trashToggle = document.getElementById('trashToggle');
+    const trashStatusText = document.getElementById('trashStatusText');
+    const trashList = document.getElementById('trashList');
+    let ignoreToggleEvent = false;
+
+    const formatDateTime = (value) => {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString('fr-FR');
+    };
+    const getRemainingText = (value) => {
+      const deletedAt = Date.parse(value || '');
+      if (!Number.isFinite(deletedAt)) return '-';
+      const remaining = Math.max(0, (24 * 60 * 60 * 1000) - (Date.now() - deletedAt));
+      const hours = Math.floor(remaining / (60 * 60 * 1000));
+      const minutes = Math.ceil((remaining % (60 * 60 * 1000)) / (60 * 1000));
+      return remaining <= 0 ? 'Expiré' : `${hours} h ${minutes} min`;
+    };
+    const getEntryTitle = (entry) => {
+      const payload = entry?.payload || {};
+      if (entry.type === 'site') return payload.site?.nom || entry.originalId;
+      if (entry.type === 'item') return payload.item?.numero || entry.originalId;
+      if (entry.type === 'detail') return payload.detail?.designation || entry.originalId;
+      if (entry.type === 'user') return payload.user?.username || payload.user?.email || entry.originalId;
+      return entry.originalId || '-';
+    };
+    const renderEntries = (entries = []) => {
+      if (!trashList) return;
+      trashList.innerHTML = entries.length ? entries.map((entry) => `
+        <article class="trash-entry surface-card">
+          <div class="trash-entry__content">
+            <strong>${escapeHtml(entry.type || '-')} — ${escapeHtml(getEntryTitle(entry))}</strong>
+            <span>Identifiant : ${escapeHtml(entry.originalId || '-')}</span>
+            <span>Supprimé le : ${escapeHtml(formatDateTime(entry.deletedAtIso))}</span>
+            <span>Utilisateur : ${escapeHtml(entry.deletedBy?.name || entry.deletedBy?.email || 'Utilisateur inconnu')}</span>
+            <span>Temps restant : ${escapeHtml(getRemainingText(entry.deletedAtIso))}</span>
+          </div>
+          <button type="button" class="btn btn-success" data-trash-restore="${escapeHtml(entry.id)}">Restaurer</button>
+        </article>`).join('') : '<p class="users-empty-cell">Aucun élément dans la corbeille.</p>';
+      trashList.querySelectorAll('[data-trash-restore]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          button.disabled = true;
+          const restored = await StorageService.restoreTrashEntry(button.dataset.trashRestore);
+          UiService.showToast(restored ? 'Élément restauré.' : 'Restauration impossible.');
+        });
+      });
+    };
+
+    StorageService.subscribeTrashSettings((settings) => {
+      ignoreToggleEvent = true;
+      if (trashToggle) {
+        trashToggle.checked = Boolean(settings.enabled);
+      }
+      if (trashStatusText) {
+        trashStatusText.textContent = settings.enabled ? 'ON' : 'OFF';
+      }
+      ignoreToggleEvent = false;
+    }, () => UiService.showToast('Impossible de lire l’état de la corbeille.'));
+    StorageService.subscribeTrashEntries(renderEntries, () => UiService.showToast('Impossible de charger la corbeille.'));
+    trashToggle?.addEventListener('change', async () => {
+      if (ignoreToggleEvent) return;
+      await StorageService.setTrashEnabled(trashToggle.checked);
+      UiService.showToast(trashToggle.checked ? 'Corbeille activée.' : 'Corbeille désactivée.');
+    });
+  }
+
   async function bootstrap() {
     UiService.bindDialogCloser();
     setupBackButtons();
@@ -8831,6 +8907,9 @@ import { getAutomaticUnit } from './automatic-unit.js';
     }
     if (page === 'settings') {
       initSettingsPage(permissions);
+    }
+    if (page === 'trash') {
+      await initTrashPage(permissions);
     }
     if (page === 'history') {
       await initHistoryPage();

--- a/js/storage.js
+++ b/js/storage.js
@@ -156,6 +156,14 @@ function maintenanceDocRef() {
   return doc(state.db, 'appSettings', 'maintenance');
 }
 
+function trashSettingsDocRef() {
+  return doc(state.db, 'appSettings', 'trash');
+}
+
+function trashCollection() {
+  return collection(state.db, 'trash');
+}
+
 function parseFirestoreDate(value) {
   if (!value) {
     return null;
@@ -549,6 +557,10 @@ async function deleteUser(userId) {
   const targetId = String(userId || '').trim();
   if (!targetId) {
     return false;
+  }
+  const snap = await getDoc(userDocRef(targetId));
+  if (await isTrashEnabled() && snap.exists()) {
+    await addTrashEntry('user', targetId, { user: { id: targetId, ...(snap.data() || {}) } });
   }
   await deleteDoc(userDocRef(targetId));
   await recordCurrentUserActivity();
@@ -1540,6 +1552,92 @@ async function registerSiteUnlockFailure(siteId) {
   return { ok: true, isBlocked: false };
 }
 
+
+async function isTrashEnabled() {
+  const snapshot = await getDoc(trashSettingsDocRef());
+  return Boolean(snapshot.exists() && snapshot.data()?.enabled);
+}
+
+function normalizeTrashEntry(snapshot) {
+  const data = snapshot.data() || {};
+  const deletedAtIso = typeof data.deletedAtIso === 'string' ? data.deletedAtIso : parseFirestoreDate(data.deletedAt)?.toISOString?.() || '';
+  return { id: snapshot.id, ...data, deletedAtIso };
+}
+
+async function purgeExpiredTrashEntries() {
+  const entries = await getDocs(trashCollection());
+  const now = Date.now();
+  const expired = entries.docs.filter((entry) => {
+    const deletedAt = Date.parse(normalizeTrashEntry(entry).deletedAtIso || '');
+    return Number.isFinite(deletedAt) && now - deletedAt >= DAY_IN_MS;
+  });
+  await Promise.all(expired.map((entry) => deleteDoc(entry.ref)));
+}
+
+async function addTrashEntry(type, originalId, payload) {
+  const profile = await getCurrentUserProfile();
+  const deletedBy = {
+    id: profile?.id || state.userId || null,
+    name: normalizeUsername(profile?.username) || normalizeUsername(state.authUser?.displayName) || 'Utilisateur inconnu',
+    email: resolveCurrentUserEmail(),
+  };
+  const deletedAtIso = nowIso();
+  await addDoc(trashCollection(), {
+    type,
+    originalId: sanitizeText(originalId, false),
+    payload: clone(payload),
+    deletedAt: serverTimestamp(),
+    deletedAtIso,
+    deletedBy,
+  });
+}
+
+async function setTrashEnabled(enabled) {
+  await setDoc(trashSettingsDocRef(), { enabled: Boolean(enabled), updatedAt: serverTimestamp() }, { merge: true });
+  return Boolean(enabled);
+}
+
+function subscribeTrashSettings(onChange, onError) {
+  return onSnapshot(trashSettingsDocRef(), (snapshot) => onChange({ enabled: Boolean(snapshot.exists() && snapshot.data()?.enabled) }), onError);
+}
+
+function subscribeTrashEntries(onChange, onError) {
+  purgeExpiredTrashEntries().catch(() => {});
+  return onSnapshot(query(trashCollection(), orderBy('deletedAtIso', 'desc')), (snapshot) => {
+    const now = Date.now();
+    onChange(snapshot.docs.map(normalizeTrashEntry).filter((entry) => {
+      const deletedAt = Date.parse(entry.deletedAtIso || '');
+      return !Number.isFinite(deletedAt) || now - deletedAt < DAY_IN_MS;
+    }));
+  }, onError);
+}
+
+async function restoreTrashEntry(entryId) {
+  const ref = doc(state.db, 'trash', String(entryId || '').trim());
+  const snapshot = await getDoc(ref);
+  if (!snapshot.exists()) {
+    return false;
+  }
+  const entry = normalizeTrashEntry(snapshot);
+  const deletedAt = Date.parse(entry.deletedAtIso || '');
+  if (Number.isFinite(deletedAt) && Date.now() - deletedAt >= DAY_IN_MS) {
+    await deleteDoc(ref);
+    return false;
+  }
+  let restored = false;
+  if (entry.type === 'site') restored = await restoreSite(entry.payload);
+  if (entry.type === 'item') restored = await restoreItem(entry.payload);
+  if (entry.type === 'detail') restored = await restoreDetail(entry.payload);
+  if (entry.type === 'user' && entry.payload?.user?.id) {
+    await setDoc(userDocRef(entry.payload.user.id), withoutId(entry.payload.user));
+    restored = true;
+  }
+  if (restored) {
+    await deleteDoc(ref);
+  }
+  return restored;
+}
+
 async function removeSite(siteId) {
   const siteIndex = state.sites.findIndex((site) => site.id === siteId);
   if (siteIndex === -1) {
@@ -1557,6 +1655,15 @@ async function removeSite(siteId) {
   }
 
   const itemsToDelete = clone(state.itemsBySite.get(siteId) || []);
+  const detailsSnapshot = [];
+  Array.from(state.detailsByItem.entries()).forEach(([key, details]) => {
+    if (key.startsWith(`${siteId}:`)) {
+      detailsSnapshot.push(...clone(details));
+    }
+  });
+  if (await isTrashEnabled()) {
+    await addTrashEntry('site', siteId, { site: clone(siteToRemove), items: itemsToDelete, details: detailsSnapshot });
+  }
   const detailDeletePromises = [];
   Array.from(state.detailsByItem.entries()).forEach(([key, details]) => {
     if (key.startsWith(`${siteId}:`)) {
@@ -1707,6 +1814,10 @@ async function removeItem(siteId, itemId) {
     return { limitReached: true };
   }
 
+  if (await isTrashEnabled()) {
+    await addTrashEntry('item', itemId, { item: clone(itemToRemove), details: clone(state.detailsByItem.get(`${siteId}:${itemId}`) || []) });
+  }
+
   await deleteDoc(doc(state.db, 'pages', 'page2', 'items', itemId));
 
   const [item] = items.splice(itemIndex, 1);
@@ -1810,6 +1921,22 @@ async function restoreItem(snapshot) {
     return false;
   }
 
+  persistOfflineState();
+  emitAll();
+  return true;
+}
+
+async function restoreDetail(snapshot) {
+  const detail = snapshot?.detail;
+  if (!detail?.id || !detail.siteId || !detail.itemId) return false;
+  try {
+    const detailPayload = withoutId(detail);
+    const createdDetail = await addDoc(makePageItemsCollection('page3'), detailPayload);
+    const nextDetail = { ...detailPayload, id: createdDetail.id };
+    const key = `${nextDetail.siteId}:${nextDetail.itemId}`;
+    if (!state.detailsByItem.has(key)) state.detailsByItem.set(key, []);
+    state.detailsByItem.get(key).push(nextDetail);
+  } catch (_error) { return false; }
   persistOfflineState();
   emitAll();
   return true;
@@ -1930,6 +2057,10 @@ async function removeDetail(siteId, itemId, detailId) {
   const detailIndex = details.findIndex((detail) => detail.id === detailId);
   if (detailIndex === -1) {
     return false;
+  }
+
+  if (await isTrashEnabled()) {
+    await addTrashEntry('detail', detailId, { detail: clone(details[detailIndex]) });
   }
 
   await deleteDoc(doc(state.db, 'pages', 'page3', 'items', detailId));
@@ -2240,6 +2371,10 @@ window.StorageService = {
   getSiteUnlockProtectionState,
   registerSiteUnlockFailure,
   resetSiteUnlockProtection,
+  setTrashEnabled,
+  subscribeTrashSettings,
+  subscribeTrashEntries,
+  restoreTrashEntry,
   removeSite,
   restoreSite,
   createItem,


### PR DESCRIPTION
### Motivation
- Provide an admin-only "Corbeille" feature visible in the Sidebar next to "Paramètres" that stores deleted entities for 24 hours and allows restore. 
- Reuse existing icons, role checks and UI components so the new feature integrates with current navigation and permission logic.

### Description
- Adds a Sidebar entry that uses the existing icon at `Icon/Corbeille.png` and is shown only for ADMIN by reusing the existing sidebar visibility technique (`index.html`, `js/app.js`).
- Adds a dedicated Corbeille page (`corbeille.html`) with the same header/navigation style, an ON/OFF toggle (default OFF) and a list area for deleted entries, and CSS for responsive styling (`css/style.css`).
- Implements client-side page initialization `initTrashPage` in `js/app.js` to enforce admin-only access, bind the toggle, render deleted entries with metadata and remaining time, and provide a "Restaurer" action.
- Extends `js/storage.js` with Firestore support for trash: `trashSettingsDocRef`, `trashCollection`, `addTrashEntry`, `isTrashEnabled`, purge of expired entries, `setTrashEnabled`, `subscribeTrashSettings`, `subscribeTrashEntries`, `restoreTrashEntry`, and restore helpers; integrates adding trash entries when sites, items, details or users are deleted while trash is enabled (deleted payload includes id, type, payload, deletedAtIso and deleting user), and enforces automatic permanent deletion after 24 hours from `deletedAtIso`.
- Does not create or modify any icon files and uses `Icon/Corbeille.png` directly as requested.

### Testing
- Ran `node --check js/app.js` to verify syntax for the UI logic and it succeeded.
- Ran `node --check js/storage.js` to verify syntax for the storage/trash logic and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dc67c57e4832792f677488d64a317)