### PR TITLE
Enable Trash sidebar item to open Corbeille page

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3012,6 +3012,16 @@ import { getAutomaticUnit } from './automatic-unit.js';
       });
     }
 
+    if (trashSidebarBtn) {
+      trashSidebarBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        runSidebarAction(() => {
+          window.location.assign('corbeille.html');
+        });
+      });
+    }
+
 
     if (allMaterialsSidebarBtn) {
       allMaterialsSidebarBtn.addEventListener('click', (event) => {


### PR DESCRIPTION
### Motivation
- The sidebar item “Corbeille” did not respond to clicks and must open the existing `corbeille.html` page using the app's current navigation flow without changing design, icon, or authorization logic.

### Description
- Added a click handler for `#sidebarTrashBtn` in `js/app.js` that uses the existing `runSidebarAction` flow to navigate to `corbeille.html`, preserving the current sidebar design and admin-only visibility.

### Testing
- Ran `node --check js/app.js` and `node --check js/storage.js` with no errors; both succeeded.
- Executed `node tests/detail-status.test.mjs` and `node tests/automatic-unit.test.mjs` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dfbcc5eac832ea3a590a09d5cab3a)