### PR TITLE
Corrige la navigation du menu « Corbeille » dans la sidebar

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3016,9 +3016,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       trashSidebarBtn.addEventListener('click', (event) => {
         event.preventDefault();
         event.stopPropagation();
-        runSidebarAction(() => {
-          window.location.assign('corbeille.html');
-        });
+        window.location.assign(trashSidebarBtn.dataset.link || 'corbeille.html');
       });
     }
 


### PR DESCRIPTION
### Motivation
- Le clic sur « Corbeille » n’ouvrait pas correctement la page HTML existante car la navigation passait par `runSidebarAction` et la fermeture différée de la sidebar empêchait la navigation directe vers `corbeille.html`.

### Description
- Remplacement du gestionnaire de clic pour `#sidebarTrashBtn` afin d’appeler directement `window.location.assign(trashSidebarBtn.dataset.link || 'corbeille.html')` au lieu d’exécuter `runSidebarAction(...)`, sans toucher au design, à l’icône ou à la page `corbeille.html`.

### Testing
- Vérification de syntaxe avec `node --check js/app.js` réussie.
- Exécution des tests unitaires avec `node --test tests/*.test.mjs` et tous les tests sont passés.
- Vérification que `corbeille.html` existe et que la nouvelle instruction `window.location.assign(trashSidebarBtn.dataset.link || 'corbeille.html')` est présente dans `js/app.js` effectuée avec `rg` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e01140c90832e9009b109ce847a73)