### PR TITLE
Add 10-char counter for "Préciser le magasin" in New OUT modal

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3644,6 +3644,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
     const itemStoreError = requireElement('itemStoreError');
     const itemStoreOtherGroup = requireElement('itemStoreOtherGroup');
     const itemStoreOtherInput = requireElement('itemStoreOtherInput');
+    const itemStoreOtherCounter = requireElement('itemStoreOtherCounter');
     const itemNumberCounter = requireElement('itemNumberCounter');
     const itemFormError = requireElement('itemFormError');
     const itemCreateSubmitButton = requireElement('itemCreateSubmitButton');
@@ -5558,6 +5559,10 @@ import { getAutomaticUnit } from './automatic-unit.js';
       return digitsOnly.slice(0, maxLength);
     }
 
+    function updateItemStoreOtherCounter() {
+      updateInputCharCounter(itemStoreOtherInput, itemStoreOtherCounter);
+    }
+
     function updateItemStoreOtherVisibility(options = {}) {
       if (!itemStoreSelect || !itemStoreOtherGroup) {
         return;
@@ -5572,6 +5577,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       if (shouldShowOtherField) {
         itemStoreOtherGroup.hidden = false;
         itemStoreOtherGroup.classList.remove('is-hiding');
+        updateItemStoreOtherCounter();
         window.requestAnimationFrame(() => {
           itemStoreOtherGroup.classList.add('is-visible');
         });
@@ -5581,6 +5587,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       if (itemStoreOtherInput) {
         itemStoreOtherInput.value = '';
       }
+      updateItemStoreOtherCounter();
 
       if (immediate || itemStoreOtherGroup.hidden) {
         itemStoreOtherGroup.classList.remove('is-visible', 'is-hiding');
@@ -5828,6 +5835,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       itemCreateSubmitButton.disabled = false;
       itemCreateSubmitButton.classList.remove('is-loading');
       updateItemNumberCounter();
+      updateItemStoreOtherCounter();
       updateItemStoreOtherVisibility({ immediate: true });
       itemDialog.showModal();
       itemNumberInput.focus();
@@ -6055,8 +6063,17 @@ import { getAutomaticUnit } from './automatic-unit.js';
       setItemCreateButtonState();
     });
 
+    itemStoreOtherInput?.addEventListener('beforeinput', (event) => {
+      enforceMaxLengthOnBeforeInput(event, itemStoreOtherInput);
+    });
+
+    itemStoreOtherInput?.addEventListener('paste', (event) => {
+      enforceMaxLengthOnPaste(event, itemStoreOtherInput, itemStoreOtherCounter);
+    });
+
     itemStoreOtherInput?.addEventListener('input', () => {
       clearItemStoreErrorState();
+      updateItemStoreOtherCounter();
       setItemCreateButtonState();
     });
 
@@ -6121,6 +6138,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       }, 200);
     });
     updateItemNumberCounter();
+    updateItemStoreOtherCounter();
 
     itemDialog.addEventListener('close', () => {
       clearItemFormError();
@@ -6134,6 +6152,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       itemCreateSubmitButton.classList.remove('is-loading');
       itemCreateSubmitButton.disabled = false;
       updateItemNumberCounter();
+      updateItemStoreOtherCounter();
       updateItemStoreOtherVisibility({ immediate: true });
       setItemDialogMode(ITEM_DIALOG_MODE_CREATE);
       editingItemId = null;

--- a/page2.html
+++ b/page2.html
@@ -176,7 +176,10 @@
           </label>
           <label id="itemStoreOtherGroup" class="input-group input-group--site-create input-group--item-create" hidden>
             <span>Préciser le magasin</span>
-            <input id="itemStoreOtherInput" name="itemStoreOther" type="text" placeholder=" " />
+            <input id="itemStoreOtherInput" name="itemStoreOther" type="text" maxlength="10" placeholder=" " />
+            <div class="item-input-feedback-row">
+              <span id="itemStoreOtherCounter" class="input-char-counter" aria-live="polite">0 / 10</span>
+            </div>
           </label>
           <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
             <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>


### PR DESCRIPTION
### Motivation
- Le champ « Préciser le magasin » doit se comporter exactement comme le champ « Numéro OUT » en affichant un compteur de caractères et en appliquant une limite réelle de 10 caractères.
- Réutiliser la logique et le composant/CSS de comptage existant pour garantir un comportement visuel et fonctionnel cohérent avec l’application.

### Description
- Ajout de `maxlength="10"` sur l’input `#itemStoreOtherInput` et insertion d’un élément de compteur `<span id="itemStoreOtherCounter" class="input-char-counter">0 / 10</span>` dans le template du modal (`page2.html`).
- Branche le nouveau compteur dans le script en récupérant `itemStoreOtherCounter` via `requireElement` et en ajoutant `updateItemStoreOtherCounter()` qui réutilise `updateInputCharCounter` existante (`js/app.js`).
- Synchronise l’affichage et la valeur du compteur avec la visibilité du champ via `updateItemStoreOtherVisibility`, en réinitialisant le compteur lorsque le champ est masqué et en le mettant à jour lorsqu’il apparaît.
- Réutilisation des protections existantes : ajout de gestionnaires `beforeinput` et `paste` pour `itemStoreOtherInput` en appelant `enforceMaxLengthOnBeforeInput` et `enforceMaxLengthOnPaste` afin d’empêcher la saisie ou le collage au-delà de 10 caractères, sans dupliquer la logique de comptage ni modifier d’autres comportements.

### Testing
- `git diff --check` a été exécuté et n’a rapporté aucune erreur.
- `node --check js/app.js` a été exécuté et a réussi sans erreurs.
- `node tests/automatic-unit.test.mjs && node tests/detail-status.test.mjs` ont été exécutés et les deux suites de tests sont passées (tous les tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83170507388331be1acf71e64b218c)