### PR TITLE
Ajouter compteur (0 / 15) pour le champ « Préciser le magasin »

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3644,6 +3644,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
     const itemStoreError = requireElement('itemStoreError');
     const itemStoreOtherGroup = requireElement('itemStoreOtherGroup');
     const itemStoreOtherInput = requireElement('itemStoreOtherInput');
+    const itemStoreOtherCounter = requireElement('itemStoreOtherCounter');
     const itemNumberCounter = requireElement('itemNumberCounter');
     const itemFormError = requireElement('itemFormError');
     const itemCreateSubmitButton = requireElement('itemCreateSubmitButton');
@@ -5548,6 +5549,10 @@ import { getAutomaticUnit } from './automatic-unit.js';
       return itemNumberInput.maxLength > 0 ? itemNumberInput.maxLength : null;
     }
 
+    function getInputMaxLength(input) {
+      return input?.maxLength > 0 ? input.maxLength : null;
+    }
+
     function normalizeItemNumberInput(rawValue) {
       const normalizedRawValue = String(rawValue || '').trim().replace(/^out-/i, '');
       const digitsOnly = normalizedRawValue.replace(/\D/g, '');
@@ -5572,6 +5577,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       if (shouldShowOtherField) {
         itemStoreOtherGroup.hidden = false;
         itemStoreOtherGroup.classList.remove('is-hiding');
+        updateItemStoreOtherCounter();
         window.requestAnimationFrame(() => {
           itemStoreOtherGroup.classList.add('is-visible');
         });
@@ -5580,6 +5586,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
 
       if (itemStoreOtherInput) {
         itemStoreOtherInput.value = '';
+        updateItemStoreOtherCounter();
       }
 
       if (immediate || itemStoreOtherGroup.hidden) {
@@ -5609,22 +5616,32 @@ import { getAutomaticUnit } from './automatic-unit.js';
       return selectedValue;
     }
 
-    function updateItemNumberCounter() {
-      const maxLength = getItemNumberMaxLength();
-      const currentLength = itemNumberInput.value.length;
-      itemNumberCounter.textContent = `${currentLength} / ${maxLength ?? currentLength}`;
+    function updateItemTextCounter(input, counter, maxLength = getInputMaxLength(input)) {
+      if (!input || !counter) {
+        return;
+      }
+      const currentLength = input.value.length;
+      counter.textContent = `${currentLength} / ${maxLength ?? currentLength}`;
 
-      itemNumberCounter.classList.remove('is-warning', 'is-limit');
+      counter.classList.remove('is-warning', 'is-limit');
       if (!maxLength || maxLength <= 0) {
         return;
       }
 
       const ratio = currentLength / maxLength;
       if (ratio >= 1) {
-        itemNumberCounter.classList.add('is-limit');
+        counter.classList.add('is-limit');
       } else if (ratio >= 0.8) {
-        itemNumberCounter.classList.add('is-warning');
+        counter.classList.add('is-warning');
       }
+    }
+
+    function updateItemNumberCounter() {
+      updateItemTextCounter(itemNumberInput, itemNumberCounter, getItemNumberMaxLength());
+    }
+
+    function updateItemStoreOtherCounter() {
+      updateItemTextCounter(itemStoreOtherInput, itemStoreOtherCounter);
     }
 
     function clearItemFormError() {
@@ -5828,6 +5845,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       itemCreateSubmitButton.disabled = false;
       itemCreateSubmitButton.classList.remove('is-loading');
       updateItemNumberCounter();
+      updateItemStoreOtherCounter();
       updateItemStoreOtherVisibility({ immediate: true });
       itemDialog.showModal();
       itemNumberInput.focus();
@@ -6056,6 +6074,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
     });
 
     itemStoreOtherInput?.addEventListener('input', () => {
+      updateItemStoreOtherCounter();
       clearItemStoreErrorState();
       setItemCreateButtonState();
     });
@@ -6121,6 +6140,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       }, 200);
     });
     updateItemNumberCounter();
+    updateItemStoreOtherCounter();
 
     itemDialog.addEventListener('close', () => {
       clearItemFormError();
@@ -6134,6 +6154,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
       itemCreateSubmitButton.classList.remove('is-loading');
       itemCreateSubmitButton.disabled = false;
       updateItemNumberCounter();
+      updateItemStoreOtherCounter();
       updateItemStoreOtherVisibility({ immediate: true });
       setItemDialogMode(ITEM_DIALOG_MODE_CREATE);
       editingItemId = null;

--- a/page2.html
+++ b/page2.html
@@ -176,7 +176,10 @@
           </label>
           <label id="itemStoreOtherGroup" class="input-group input-group--site-create input-group--item-create" hidden>
             <span>Préciser le magasin</span>
-            <input id="itemStoreOtherInput" name="itemStoreOther" type="text" placeholder=" " />
+            <input id="itemStoreOtherInput" name="itemStoreOther" type="text" maxlength="15" placeholder=" " />
+            <div class="item-input-feedback-row">
+              <span id="itemStoreOtherCounter" class="input-char-counter" aria-live="polite">0 / 15</span>
+            </div>
           </label>
           <div class="modal-actions modal-actions--split modal-actions--site-create modal-actions--item-create">
             <button type="button" class="btn btn-neutral" data-close-dialog>Annuler</button>


### PR DESCRIPTION
### Motivation

- Fournir pour le champ `Préciser le magasin` le même compteur de caractères visible/consistant que celui de `Numéro OUT` et appliquer une limite réelle de 15 caractères en réutilisant la logique existante.

### Description

- Ajout de `maxlength="15"` et d'un span compteur `<span id="itemStoreOtherCounter" class="input-char-counter">0 / 15</span>` sous le champ `#itemStoreOtherInput` dans `page2.html`.
- Réutilisation et factorisation du système de comptage en JS via l'ajout de `getInputMaxLength`, `updateItemTextCounter` et `updateItemStoreOtherCounter` dans `js/app.js` et injection de la référence `itemStoreOtherCounter` via `requireElement`.
- Intégration des mises à jour du compteur aux mêmes moments que pour le compteur existant : affichage/masquage du champ, ouverture/fermeture du modal, et sur l'événement `input` du champ, sans toucher au compteur `Numéro OUT`, à la validation existante ni à la logique de création d'OUT.

### Testing

- Vérification de la syntaxe JavaScript avec `node --check js/app.js`, qui a réussi sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83db7702348328ac851d86640ee4c6)