### PR TITLE
Aligner le compteur « Préciser le magasin » à droite en réutilisant la même mise en page

### DIFF
--- a/page2.html
+++ b/page2.html
@@ -178,6 +178,7 @@
             <span>Préciser le magasin</span>
             <input id="itemStoreOtherInput" name="itemStoreOther" type="text" maxlength="15" placeholder=" " />
             <div class="item-input-feedback-row">
+              <p class="form-error form-error--field" aria-live="polite"></p>
               <span id="itemStoreOtherCounter" class="input-char-counter" aria-live="polite">0 / 15</span>
             </div>
           </label>


### PR DESCRIPTION
### Motivation
- Corriger l'alignement du compteur `itemStoreOtherCounter` dans la fenêtre « Nouveau numéro OUT » pour qu'il se comporte visuellement comme le compteur du champ `itemNumberCounter` sans toucher à la logique ou aux limites existantes.

### Description
- Ajout d'un élément `<p class="form-error form-error--field" aria-live="polite"></p>` avant le `span#itemStoreOtherCounter` dans `page2.html` pour réutiliser la même structure `.item-input-feedback-row` et bénéficier des règles CSS existantes qui alignent le compteur à droite.
- Aucune modification de JavaScript n'a été effectuée et le `maxlength="15"` ainsi que l'identifiant dynamique `itemStoreOtherCounter` sont conservés.

### Testing
- Exécuté `git diff --check` et la vérification est passée avec succès.
- Vérifié l'état et le commit avec `git status --short` et `git log -1 --oneline`, qui confirment la modification appliquée et commitée.
- Aucun suite de tests automatisés spécifique n'était disponible dans le dépôt, seules des vérifications de cohérence du dépôt ont été effectuées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83de31ef40832892ef50f3f57c3f83)