### PR TITLE
Add numeric outCount field for sites and reconcile/maintain it

### DIFF
--- a/OUTCOUNT_MIGRATION_REPORT.md
+++ b/OUTCOUNT_MIGRATION_REPORT.md
@@ -1,0 +1,87 @@
+# Rapport de migration `outCount`
+
+## 1. Structure avant
+
+- Les sites sont stockés dans `pages/page1/items`.
+- Les OUT sont stockés dans `pages/page2/items`.
+- Chaque OUT appartient à un site via son champ `siteId`.
+- Le compteur affiché en Page 1 était calculé à partir du nombre de documents OUT chargés depuis `pages/page2/items`, regroupés en mémoire dans `itemsBySite`.
+- La Page 1 dépendait donc du chargement global de `pages/page2/items` pour afficher le nombre d'OUT par site.
+
+## 2. Structure après
+
+Chaque document de site dans `pages/page1/items` contient désormais un champ numérique :
+
+```json
+{
+  "outCount": 15
+}
+```
+
+Ce champ est ajouté ou corrigé par mise à jour partielle uniquement. Les autres champs des sites ne sont pas remplacés.
+
+## 3. Nombre de sites traités
+
+Le nombre exact dépend de l'environnement Firestore exécuté. Au chargement distant, tous les sites chargés depuis `pages/page1/items` sont traités par `reconcileSiteOutCounts()`.
+
+## 4. Nombre d'OUT analysés
+
+Le nombre exact dépend de l'environnement Firestore exécuté. Au chargement distant, les OUT chargés depuis `pages/page2/items` sont comptés par `siteId` pour calculer le nombre réel par site.
+
+## 5. Nombre de `outCount` créés
+
+Calculé à l'exécution par `reconcileSiteOutCounts()` : tout site sans champ `outCount` reçoit le nombre réel d'OUT associés.
+
+## 6. Nombre de `outCount` corrigés
+
+Calculé à l'exécution par `reconcileSiteOutCounts()` : tout site dont `outCount` diffère du nombre réel d'OUT est corrigé uniquement sur le champ `outCount`.
+
+## 7. Nombre d'anomalies
+
+Aucune anomalie structurelle bloquante n'a été détectée dans le code : le compteur existant correspond au nombre d'OUT par site, via `item.siteId`.
+
+## 8. Vérification des compteurs
+
+Rapport généré avant écriture dans la console au chargement distant :
+
+| Site | siteId | outCount | Nombre réel OUT | Résultat |
+|---|---|---:|---:|---|
+| Généré à l'exécution | Généré à l'exécution | Généré à l'exécution | Généré à l'exécution | ✅ si égal après correction |
+
+Après initialisation, chaque site traité reçoit `outCount = nombre réel de documents OUT appartenant au site`.
+
+## 9. Fonctions de création/modification/suppression modifiées
+
+- Création de site : initialise `outCount` à `0`.
+- Création d'OUT : crée l'OUT puis incrémente atomiquement `outCount` de `+1` sur le site.
+- Suppression d'OUT : supprime l'OUT puis décrémente `outCount` via transaction avec minimum à `0`.
+- Modification d'OUT : aucun changement de site n'existe dans le flux actuel identifié ; le renommage d'OUT ne modifie pas `siteId`, donc `outCount` n'est pas modifié.
+- Restauration de site : recrée le site avec un `outCount` égal au nombre d'OUT restaurés.
+- Restauration d'OUT : restaure l'OUT puis incrémente `outCount` du site concerné.
+- Import : les sites importés démarrent avec `outCount: 0`, puis les compteurs des sites importés sont recalculés depuis les OUT réellement importés.
+
+## 10. Impact sur les lectures Firestore
+
+### Avant
+
+Lancement → Page 1 → lecture globale `pages/page2/items` → calcul des compteurs.
+
+### Après cette étape
+
+Lancement → lecture des sites → Page 1 utilise `site.outCount`.
+
+La lecture globale de `pages/page2/items` est conservée dans cette étape, car d'autres fonctions actuelles de Page 2 et de l'état local en dépendent encore. La Page 1 ne lit plus `itemCountsBySite` pour afficher le compteur : elle utilise directement le champ `outCount` du site.
+
+## 11. Risques éventuels
+
+- Si un OUT est créé puis que la mise à jour du compteur échoue à cause d'une indisponibilité Firestore, la réconciliation au prochain chargement distant corrigera `outCount` depuis les données réelles.
+- La décrémentation utilise une transaction pour éviter qu'un compteur devienne négatif.
+- La suppression définitive de la lecture globale `pages/page2/items` n'est pas faite dans cette étape afin de préserver les comportements existants.
+
+## 12. Confirmation qu'aucune donnée existante n'a été supprimée
+
+Aucune donnée existante n'est supprimée par l'initialisation des compteurs. Les mises à jour de migration utilisent des écritures partielles limitées au champ `outCount`.
+
+## Conclusion
+
+✅ outCount correctement initialisé par réconciliation automatique lors du chargement distant et maintenu lors des créations, suppressions, restaurations et imports d'OUT.

--- a/js/app.js
+++ b/js/app.js
@@ -2683,7 +2683,7 @@ import { getAutomaticUnit } from './automatic-unit.js';
 
       siteList.innerHTML = sites
         .map((site) => {
-          const outCount = itemCountsBySite[site.id] || 0;
+          const outCount = Number.isFinite(Number(site.outCount)) ? Math.max(0, Math.trunc(Number(site.outCount))) : 0;
           const createdDateTime = buildDateAndTimeLabel(site?.dateCreation);
           const createdBy = resolveActorLabel(site?.createdBy, userNamesById, site?.createdByName);
           const canChangeCreator = canCurrentUserChangeSiteCreator();

--- a/js/storage.js
+++ b/js/storage.js
@@ -6,6 +6,7 @@ import {
   doc,
   getDoc,
   getDocs,
+  increment,
   onSnapshot,
   orderBy,
   query,
@@ -14,6 +15,7 @@ import {
   setDoc,
   Timestamp,
   updateDoc,
+  runTransaction,
 } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
 import { firebaseAuth, firebaseDb } from './firebase-core.js';
 import { APP_CONFIG } from './config.js';
@@ -810,6 +812,106 @@ function normalizeDocData(docSnapshot) {
   return { id: docSnapshot.id, ...data };
 }
 
+function normalizeOutCount(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.trunc(numeric) : 0;
+}
+
+function getActualOutCountForSite(siteId) {
+  return (state.itemsBySite.get(String(siteId || '')) || []).length;
+}
+
+function applySiteOutCount(siteId, outCount) {
+  const site = state.sites.find((item) => item.id === siteId);
+  if (site) {
+    site.outCount = normalizeOutCount(outCount);
+  }
+}
+
+function siteDocRef(siteId) {
+  return doc(state.db, 'pages', 'page1', 'items', siteId);
+}
+
+async function setSiteOutCount(siteId, outCount) {
+  const normalizedSiteId = sanitizeText(siteId, false);
+  if (!normalizedSiteId) {
+    return false;
+  }
+  const normalizedCount = normalizeOutCount(outCount);
+  await setDoc(siteDocRef(normalizedSiteId), { outCount: normalizedCount }, { merge: true });
+  applySiteOutCount(normalizedSiteId, normalizedCount);
+  return true;
+}
+
+async function incrementSiteOutCount(siteId, delta) {
+  const normalizedSiteId = sanitizeText(siteId, false);
+  const numericDelta = Number(delta);
+  if (!normalizedSiteId || !Number.isFinite(numericDelta) || numericDelta === 0) {
+    return false;
+  }
+  if (numericDelta > 0) {
+    await updateDoc(siteDocRef(normalizedSiteId), { outCount: increment(Math.trunc(numericDelta)) });
+    const currentSite = state.sites.find((site) => site.id === normalizedSiteId);
+    applySiteOutCount(normalizedSiteId, normalizeOutCount(currentSite?.outCount) + Math.trunc(numericDelta));
+    return true;
+  }
+
+  await runTransaction(state.db, async (transaction) => {
+    const ref = siteDocRef(normalizedSiteId);
+    const snap = await transaction.get(ref);
+    const currentCount = normalizeOutCount(snap.exists() ? snap.data()?.outCount : 0);
+    transaction.set(ref, { outCount: Math.max(0, currentCount + Math.trunc(numericDelta)) }, { merge: true });
+  });
+  const currentSite = state.sites.find((site) => site.id === normalizedSiteId);
+  applySiteOutCount(normalizedSiteId, Math.max(0, normalizeOutCount(currentSite?.outCount) + Math.trunc(numericDelta)));
+  return true;
+}
+
+function buildOutCountMigrationRows(siteIds = null) {
+  const limitedSiteIds = siteIds ? new Set(Array.from(siteIds).map((siteId) => String(siteId || '')).filter(Boolean)) : null;
+  return state.sites
+    .filter((site) => !limitedSiteIds || limitedSiteIds.has(site.id))
+    .map((site) => {
+      const actualOutCount = getActualOutCountForSite(site.id);
+      const currentOutCount = site.__outCountWasMissing === true ? null : (Object.prototype.hasOwnProperty.call(site, 'outCount') ? normalizeOutCount(site.outCount) : null);
+      return {
+        siteName: sanitizeText(site.nom, false),
+        siteId: site.id,
+        actualOutCount,
+        currentOutCount,
+        needsUpdate: currentOutCount !== actualOutCount,
+        missing: currentOutCount === null,
+      };
+    });
+}
+
+async function reconcileSiteOutCounts(siteIds = null, { logReport = false } = {}) {
+  const rows = buildOutCountMigrationRows(siteIds);
+  if (logReport && rows.length) {
+    console.table(rows.map((row) => ({
+      Site: row.siteName,
+      siteId: row.siteId,
+      'Nombre réel d\'OUT': row.actualOutCount,
+      'outCount actuel': row.currentOutCount === null ? 'absent' : row.currentOutCount,
+    })));
+  }
+  await Promise.all(rows.filter((row) => row.needsUpdate).map((row) => setSiteOutCount(row.siteId, row.actualOutCount)));
+  rows.forEach((row) => {
+    const site = state.sites.find((item) => item.id === row.siteId);
+    if (site && Object.prototype.hasOwnProperty.call(site, '__outCountWasMissing')) {
+      delete site.__outCountWasMissing;
+    }
+  });
+  return {
+    rows,
+    sitesProcessed: rows.length,
+    outsAnalyzed: rows.reduce((total, row) => total + row.actualOutCount, 0),
+    created: rows.filter((row) => row.missing).length,
+    corrected: rows.filter((row) => !row.missing && row.needsUpdate).length,
+    anomalies: 0,
+  };
+}
+
 function persistOfflineState() {
   const items = [];
   state.itemsBySite.forEach((value) => items.push(...value));
@@ -927,6 +1029,15 @@ function applySnapshot(snapshot) {
     state.itemsBySite.get(siteId).push(item);
   });
 
+  state.sites.forEach((site) => {
+    if (!Object.prototype.hasOwnProperty.call(site, 'outCount')) {
+      Object.defineProperty(site, '__outCountWasMissing', { value: true, configurable: true });
+      site.outCount = getActualOutCountForSite(site.id);
+    } else {
+      site.outCount = normalizeOutCount(site.outCount);
+    }
+  });
+
   state.detailsByItem = new Map();
   (Array.isArray(snapshot.page3) ? snapshot.page3 : []).forEach((detail) => {
     const siteId = String(detail.siteId || '');
@@ -1028,6 +1139,7 @@ async function init() {
     try {
       const remote = await loadRemoteSnapshot();
       applySnapshot(remote);
+      await reconcileSiteOutCounts(null, { logReport: true });
       persistOfflineState();
     } catch (_error) {
       if (!offlineState?.snapshot) {
@@ -1039,6 +1151,7 @@ async function init() {
     try {
       const remote = await loadRemoteSnapshot();
       applySnapshot(remote);
+      await reconcileSiteOutCounts(null, { logReport: true });
       persistOfflineState();
     } catch (_error) {
       applySnapshot({ page1: [], page2: [], page3: [] });
@@ -1052,7 +1165,8 @@ function getSiteInactivityThresholdDays() {
 }
 
 function getSiteOutCount(siteId) {
-  return (state.itemsBySite.get(String(siteId || '')) || []).length;
+  const site = state.sites.find((item) => item.id === String(siteId || ''));
+  return normalizeOutCount(site?.outCount ?? getActualOutCountForSite(siteId));
 }
 
 function isCurrentUserSiteCreator(site) {
@@ -1488,6 +1602,7 @@ async function createSite(name) {
   const creatorName = await resolveCurrentUserName();
   const sitePayload = {
     nom: siteName,
+    outCount: 0,
     ownerId: state.userId,
     createdBy: state.userId,
     createdByName: creatorName,
@@ -1881,6 +1996,7 @@ async function createItem(siteId, numberValue, options = {}) {
     dateModification: timestamp,
   };
   const created = await addDoc(makePageItemsCollection('page2'), itemPayload);
+  await incrementSiteOutCount(siteId, 1);
   const item = { id: created.id, ...itemPayload };
 
   const siteIndex = state.sites.findIndex((site) => site.id === siteId);
@@ -1982,6 +2098,7 @@ async function removeItem(siteId, itemId) {
   }
 
   await deleteDoc(doc(state.db, 'pages', 'page2', 'items', itemId));
+  await incrementSiteOutCount(siteId, -1);
 
   const [item] = items.splice(itemIndex, 1);
   const detailsKey = `${siteId}:${itemId}`;
@@ -2004,8 +2121,9 @@ async function restoreSite(snapshot) {
   }
 
   try {
-    const createdSite = await addDoc(makePageItemsCollection('page1'), withoutId(site));
-    const nextSite = { ...clone(site), id: createdSite.id };
+    const restoredSitePayload = { ...withoutId(site), outCount: Array.isArray(snapshot.items) ? snapshot.items.length : 0 };
+    const createdSite = await addDoc(makePageItemsCollection('page1'), restoredSitePayload);
+    const nextSite = { ...clone(site), ...restoredSitePayload, id: createdSite.id };
     const itemIdMap = new Map();
     const restoredItems = [];
 
@@ -2060,6 +2178,7 @@ async function restoreItem(snapshot) {
   try {
     const itemPayload = { ...withoutId(item) };
     const createdItem = await addDoc(makePageItemsCollection('page2'), itemPayload);
+    await incrementSiteOutCount(itemPayload.siteId, 1);
     const nextItem = { ...itemPayload, id: createdItem.id };
     if (!state.itemsBySite.has(nextItem.siteId)) {
       state.itemsBySite.set(nextItem.siteId, []);
@@ -2453,6 +2572,7 @@ async function importData(payload) {
     const localId = sanitizeText(site.id || uid(), false) || uid();
     const sitePayload = { ...site };
     delete sitePayload.id;
+    sitePayload.outCount = 0;
     const createdSite = await addDoc(makePageItemsCollection('page1'), sitePayload);
     const nextSite = { id: createdSite.id, ...sitePayload };
     siteIdMap.set(localId, nextSite.id);
@@ -2505,6 +2625,7 @@ async function importData(payload) {
     state.detailsByItem.get(detailsKey).push(detail);
   });
 
+  await reconcileSiteOutCounts(new Set([...addedSites.map((site) => site.id), ...addedItems.map((item) => item.siteId)]));
   sortState();
   persistOfflineState();
   emitAll();
@@ -2524,6 +2645,7 @@ window.StorageService = {
   subscribeSites,
   subscribeItems,
   subscribeItemCounts,
+  reconcileSiteOutCounts,
   subscribeDetails,
   subscribeDetailCounts,
   subscribeDetailDesignations,


### PR DESCRIPTION
### Motivation

- Avoid Page 1 having to load all `pages/page2/items` at startup to compute per-site OUT counters by storing a numeric `outCount` on each site document. 
- Ensure counters are accurate, safe to update concurrently, and do not remove or alter existing data or page behaviours.

### Description

- Add a numeric `outCount` field initialization and normalization logic in `js/storage.js` and expose `reconcileSiteOutCounts()` to compute and correct `outCount` from existing `page2` items. 
- Introduce `setSiteOutCount`, `incrementSiteOutCount` (uses Firestore `increment` for +1 and `runTransaction` to safely decrement with floor at 0), and helper functions `normalizeOutCount`, `getActualOutCountForSite` and `applySiteOutCount` to keep `state.sites` and Firestore in sync. 
- Update site/item lifecycle code to maintain `outCount`: initialize `outCount: 0` on site creation and import, call `incrementSiteOutCount(..., +1)` after creating/restoring an OUT, and call `incrementSiteOutCount(..., -1)` after deleting an OUT; restore flows set `outCount` to restored item counts. 
- Change Page 1 rendering in `js/app.js` to read `site.outCount` (normalized) instead of deriving the display count from `itemCountsBySite`, and add `OUTCOUNT_MIGRATION_REPORT.md` documenting the migration, impacts and safety guarantees. 

### Testing

- Ran syntax checks with `node --check js/storage.js` and `node --check js/app.js`, which succeeded. 
- Ran unit tests with `node --test tests/*.test.mjs`, all tests passed. 
- Ran repository checks (`git diff --check`) during development and found no check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87d9c8d64c8322825a0dfee33d81bf)